### PR TITLE
feat(ci): require CHANGELOG.md entry for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,22 +112,33 @@ jobs:
         if: steps.ghp_check.outputs.exists == 'false'
         run: git checkout package.json
 
-      # Extract changelog for this version
+      # Extract changelog for this version (REQUIRED)
       - name: Extract Release Notes
         id: changelog
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-          # Extract changelog section for this version
-          if [ -f CHANGELOG.md ]; then
-            NOTES=$(awk "/^## \[${VERSION}\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
-            if [ -n "$NOTES" ]; then
-              echo "notes<<EOF" >> $GITHUB_OUTPUT
-              echo "$NOTES" >> $GITHUB_OUTPUT
-              echo "EOF" >> $GITHUB_OUTPUT
-            fi
+          # CHANGELOG.md is required
+          if [ ! -f CHANGELOG.md ]; then
+            echo "::error::CHANGELOG.md not found. Please create it before releasing."
+            exit 1
           fi
+
+          # Extract changelog section for this version
+          NOTES=$(awk "/^## \[${VERSION}\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
+
+          if [ -z "$NOTES" ]; then
+            echo "::error::No changelog entry found for version ${VERSION}."
+            echo "::error::Please add a '## [${VERSION}]' section to CHANGELOG.md before releasing."
+            exit 1
+          fi
+
+          echo "notes<<EOF" >> $GITHUB_OUTPUT
+          echo "$NOTES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          echo "::notice::Found changelog entry for v${VERSION}"
 
       # Create GitHub Release with changelog
       - name: Create GitHub Release
@@ -153,7 +164,6 @@ jobs:
             ### Links
             - [npm package](https://www.npmjs.com/package/oh-my-customcode/v/${{ steps.changelog.outputs.version }})
             - [GitHub Package](https://github.com/baekenough/oh-my-customcode/pkgs/npm/oh-my-customcode)
-          generate_release_notes: true
           draft: false
           prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-02-05
+
+### Fixed
+- Increase e2e test timeout from 10s to 30s to prevent CI timeouts
+
+## [0.3.0] - 2026-02-05
+
+### Added
+- Claude API automation workflows (#17)
+  - Issue analyzer workflow (Claude-powered)
+  - Documentation validator workflow
+  - Release notes generator workflow
+- Language toggle links in READMEs (English ↔ Korean)
+
+### Changed
+- Sync-check runs daily at 04:00 KST with private repo access
+- CI simplified to macOS only with consolidated coverage checks
+- Clarified release branch publishing workflow in CONTRIBUTING.md
+- Release workflow skips publish if version already exists
+
+### Removed
+- CodeRabbit integration (too heavy for this project)
+
+## [0.2.1] - 2026-01-28
+
+### Fixed
+- Bug fixes and stability improvements
+
+## [0.2.0] - 2026-01-28
+
+### Added
+- Official Claude Code format support (flat agent structure)
+- Updated agent count to 34
+- Updated skill count to 42
+- Updated guide count to 13
+
+### Changed
+- Migrated from nested to flat agent directory structure
+- Updated templates to match baekgom-agents official format
+
 ## [0.1.4] - 2026-01-27
 
 ### Added
@@ -131,7 +171,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nothing yet (initial release)
 
-[Unreleased]: https://github.com/baekenough/oh-my-customcode/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/baekenough/oh-my-customcode/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/baekenough/oh-my-customcode/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/baekenough/oh-my-customcode/compare/v0.2.1...v0.3.0
+[0.2.1]: https://github.com/baekenough/oh-my-customcode/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/baekenough/oh-my-customcode/compare/v0.1.4...v0.2.0
 [0.1.4]: https://github.com/baekenough/oh-my-customcode/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/baekenough/oh-my-customcode/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/baekenough/oh-my-customcode/compare/v0.1.1...v0.1.2


### PR DESCRIPTION
## Summary
- Add missing changelog entries for v0.2.0, v0.2.1, v0.3.0, v0.3.1
- Make CHANGELOG.md entry **required** for releases (workflow fails if missing)
- Remove `generate_release_notes` option (use CHANGELOG.md as single source of truth)

## Why?
When releasing from release/hotfix branches that get deleted after merge, GitHub can't trace commit history, resulting in empty release notes.

## Changes
| File | Change |
|------|--------|
| `CHANGELOG.md` | Add missing version entries |
| `.github/workflows/release.yml` | Fail if changelog entry missing |

## Test plan
- [ ] Push a tag without CHANGELOG entry → should fail
- [ ] Push a tag with CHANGELOG entry → should succeed with proper notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased end-to-end test timeout to prevent timeout failures.

* **Chores**
  * Enhanced release workflow to enforce changelog requirements and improve error handling during release creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->