### PR TITLE
fix(ci): update sync-check trigger branch from main to develop

### DIFF
--- a/.github/workflows/sync-check.yml
+++ b/.github/workflows/sync-check.yml
@@ -2,7 +2,7 @@ name: Sync Check
 
 on:
   push:
-    branches: [main]
+    branches: [develop]
     paths:
       - 'templates/**'
       - 'scripts/verify-sync.sh'


### PR DESCRIPTION
## Summary

Updates the sync-check workflow push trigger to use `develop` instead of `main`, since the repository's default branch is `develop` (no `main` branch exists).

This ensures the workflow is triggered on the correct branch.

## Changes

- Updated `.github/workflows/sync-check.yml` push trigger: `main` → `develop`

## Testing

- Pre-commit checks: All passed (types, lint, tests)
- No functional changes, only workflow configuration update

---

🤖 Generated with Claude Code