### PR TITLE
fix(ci): sync-check workflow never creates drift issues

### DIFF
--- a/.github/workflows/sync-check.yml
+++ b/.github/workflows/sync-check.yml
@@ -43,7 +43,9 @@ jobs:
         id: verify
         continue-on-error: true
         working-directory: oh-my-customcode
+        shell: bash
         run: |
+          set -o pipefail
           chmod +x scripts/verify-sync.sh
           ./scripts/verify-sync.sh ../baekgom-agents 2>&1 | sed 's/\x1b\[[0-9;]*m//g' | tee "$RUNNER_TEMP/sync-output.txt"
 


### PR DESCRIPTION
## Root Cause

The `verify-sync.sh` exit code was being swallowed by the pipe to `tee`, causing `steps.verify.outcome` to always be `'success'` even when drift was detected.

This happened because:
1. Pipeline returns the exit code of the **last command** (`tee`) by default
2. `tee` always succeeds (exit code 0) when writing output
3. The actual `verify-sync.sh` failure was lost

As a result, drift issues were never created because the condition:
```yaml
if: steps.verify.outcome == 'failure'
```
was never triggered.

## Fix

Added `set -o pipefail` to the workflow step to:
- Make the pipeline return the exit code of the **first failing command**
- Preserve `verify-sync.sh` exit code even when piped to `tee`

Also explicitly set `shell: bash` to ensure `pipefail` support.

## Testing

This fix will be validated when the next actual drift occurs. The workflow will now properly:
1. Detect drift via `verify-sync.sh` exit code
2. Trigger the issue creation step
3. Create a GitHub issue with drift details

🤖 Generated with [Claude Code](https://claude.com/claude-code)