### PR TITLE
chore: unify Claude API secrets

### DIFF
--- a/.github/workflows/docs-validator.yml
+++ b/.github/workflows/docs-validator.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Validate documentation
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.DOCS_VALIDATOR }}
+          ANTHROPIC_API_KEY: ${{ secrets.OH_MY_CUSTOMCODE }}
         run: python .github/scripts/validate_docs.py > validation_result.md
 
       - name: Upload validation result

--- a/.github/workflows/issue-analyzer.yml
+++ b/.github/workflows/issue-analyzer.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Analyze issue with Claude
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ISSUE_ANALYZER }}
+          ANTHROPIC_API_KEY: ${{ secrets.OH_MY_CUSTOMCODE }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
           ISSUE_BODY: ${{ github.event.issue.body }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Generate release notes
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.RELEASE_BOT }}
+          ANTHROPIC_API_KEY: ${{ secrets.OH_MY_CUSTOMCODE }}
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
           PREVIOUS_TAG: ${{ inputs.previous_tag }}
         run: |


### PR DESCRIPTION
## Summary

Replace separate secret names (DOCS_VALIDATOR, ISSUE_ANALYZER, RELEASE_BOT) with unified OH_MY_CUSTOMCODE secret for all Claude API workflows.

## Changes

- `.github/workflows/docs-validator.yml`: Updated to use `OH_MY_CUSTOMCODE` secret
- `.github/workflows/issue-analyzer.yml`: Updated to use `OH_MY_CUSTOMCODE` secret
- `.github/workflows/release-notes.yml`: Updated to use `OH_MY_CUSTOMCODE` secret

## Motivation

Simplifies secret management by using a single unified secret for all Claude API interactions instead of maintaining three separate secrets.

## Checklist

- [x] All workflow files updated
- [x] Pre-commit checks passed
- [x] Tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)