### PR TITLE
fix: remove --production flag from workflow installs

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -32,7 +32,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: bun install --production
+        run: bun install
 
       - name: Extract version from tag
         id: version

--- a/.github/workflows/reusable-issue-analyzer.yml
+++ b/.github/workflows/reusable-issue-analyzer.yml
@@ -70,7 +70,7 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: bun install --production
+        run: bun install
 
       - name: Analyze issue
         env:


### PR DESCRIPTION
## Summary
- Removed `--production` flag from `bun install` in Issue Analyzer and Release Notes Generator workflows
- `@anthropic-ai/sdk` is in `devDependencies` and was excluded by `--production`, causing "Cannot find module" errors
- Same fix previously applied to docs-validator in PR #33

Closes #34, Closes #35

## Test plan
- [x] Unit tests pass (484 pass, 0 fail)
- [x] Biome lint clean
- [ ] Trigger Issue Analyzer workflow on a test issue
- [ ] Trigger Release Notes Generator on a test tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)