### PR TITLE
fix(tests): locale-agnostic E2E + claude-native workflow integration

### DIFF
--- a/.github/scripts/verify-claude-native.ts
+++ b/.github/scripts/verify-claude-native.ts
@@ -45,7 +45,7 @@ const HASH_FILE = path.join(PROJECT_ROOT, '.claude/claude-native-hash.txt');
 const LOCAL_DOCS_DIR = path.join(process.env.HOME || '~', '.claude/references/claude-code');
 const LOCAL_DOCS_MAX_AGE_DAYS = 7;
 
-const BAEKGOM_UNIQUE_RULES = ['R007', 'R008', 'R009', 'R010', 'R017', 'R000'];
+const BAEKGOM_UNIQUE_RULES = ['R000', 'R007', 'R008', 'R009', 'R010', 'R016', 'R017', 'R018'];
 
 // ============================================================================
 // TypeScript Interfaces
@@ -118,7 +118,9 @@ interface UniqueFeaturesStatus {
   orchestrator: 'preserved' | 'at_risk' | 'missing' | 'unknown';
   agent_id: 'preserved' | 'at_risk' | 'missing' | 'unknown';
   tool_id: 'preserved' | 'at_risk' | 'missing' | 'unknown';
+  continuous_improvement: 'preserved' | 'at_risk' | 'missing' | 'unknown';
   sync_verify: 'preserved' | 'at_risk' | 'missing' | 'unknown';
+  agent_teams: 'preserved' | 'at_risk' | 'missing' | 'unknown';
 }
 
 interface Analysis {
@@ -507,7 +509,9 @@ ${JSON.stringify(projectStructure.rules.filter((r) => r.is_unique), null, 2)}
         "orchestrator": "preserved|at_risk|missing",
         "agent_id": "preserved|at_risk|missing",
         "tool_id": "preserved|at_risk|missing",
-        "sync_verify": "preserved|at_risk|missing"
+        "continuous_improvement": "preserved|at_risk|missing",
+        "sync_verify": "preserved|at_risk|missing",
+        "agent_teams": "preserved|at_risk|missing"
     },
     "summary": "Brief overall assessment"
 }
@@ -548,7 +552,9 @@ Respond with ONLY valid JSON, no markdown formatting.`;
         orchestrator: 'unknown',
         agent_id: 'unknown',
         tool_id: 'unknown',
+        continuous_improvement: 'unknown',
         sync_verify: 'unknown',
+        agent_teams: 'unknown',
       },
       summary: `Analysis failed: ${error}`,
       raw_response: responseText,
@@ -659,7 +665,9 @@ async function createGithubIssue(analysis: Analysis, dryRun: boolean = false): P
     orchestrator: 'R010: Orchestrator Coordination',
     agent_id: 'R007: Agent Identification',
     tool_id: 'R008: Tool Identification',
+    continuous_improvement: 'R016: Continuous Improvement',
     sync_verify: 'R017: Sync Verification',
+    agent_teams: 'R018: Agent Teams',
   };
 
   const statusEmoji: Record<string, string> = {

--- a/.github/workflows/claude-native-check.yml
+++ b/.github/workflows/claude-native-check.yml
@@ -1,0 +1,60 @@
+name: Claude Native Check
+
+on:
+  schedule:
+    # Run weekly: every Sunday at 19:00 UTC (Monday 04:00 KST)
+    - cron: '0 19 * * 0'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run mode (no issue creation)'
+        type: boolean
+        default: false
+      force:
+        description: 'Force verification even if docs unchanged'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  verify:
+    name: Verify Claude Native Compliance
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --production
+
+      - name: Run Claude Native Verification
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.DOCS_VALIDATOR }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PROJECT_ROOT: ${{ github.workspace }}/templates
+        run: |
+          ARGS=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then ARGS="$ARGS --dry-run"; fi
+          if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
+          bun run .github/scripts/verify-claude-native.ts $ARGS
+
+      - name: Create summary
+        if: always()
+        run: |
+          echo "## 🔍 Claude Native Verification" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Weekly compliance check against official Claude Code documentation." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Project Root**: \`templates/\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            echo "**Mode**: Dry Run (no issue creation)" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/tests/e2e/doctor.test.ts
+++ b/tests/e2e/doctor.test.ts
@@ -123,9 +123,12 @@ describe('E2E: omcustom doctor', { timeout: 30000 }, () => {
       expect(result.exitCode).toBe(0);
       const output = result.stdout + result.stderr;
 
-      // Should show checking message
+      // Should show checking message (Korean: "진단 검사 실행 중" or English: "check"/"diagnos")
       expect(
-        output.toLowerCase().includes('check') || output.toLowerCase().includes('diagnos')
+        output.includes('진단') ||
+          output.includes('검사') ||
+          output.toLowerCase().includes('check') ||
+          output.toLowerCase().includes('diagnos')
       ).toBe(true);
     });
 
@@ -293,10 +296,14 @@ invalid yaml content:
       const result = await runCli('doctor');
 
       const output = result.stdout;
-      // Should detect invalid agent files
-      expect(output.toLowerCase()).toContain('agent');
+      // Should detect invalid agent files (contains agent reference in Korean or English)
+      expect(output.toLowerCase().includes('agent') || output.includes('에이전트')).toBe(true);
       expect(
-        output.includes('[FAIL]') || output.includes('fail') || output.includes('invalid')
+        output.includes('[FAIL]') ||
+          output.includes('fail') ||
+          output.includes('invalid') ||
+          output.includes('실패') ||
+          output.includes('잘못')
       ).toBe(true);
     });
 

--- a/tests/e2e/list.test.ts
+++ b/tests/e2e/list.test.ts
@@ -242,7 +242,10 @@ Rule content here.
 
       expect(result.exitCode).toBe(0);
       const output = result.stdout + result.stderr;
-      expect(output.toLowerCase()).toContain('scan');
+      // Should show scanning message (Korean: "검색 중" or English: "scan")
+      expect(
+        output.includes('검색') || output.includes('스캔') || output.toLowerCase().includes('scan')
+      ).toBe(true);
     });
 
     it('should list all component types with default command', async () => {


### PR DESCRIPTION
## Summary
- Fix 3 E2E test failures caused by locale-dependent assertions (Korean vs English)
- Add R016 and R018 to `BAEKGOM_UNIQUE_RULES` in verify-claude-native.ts
- Create `claude-native-check.yml` caller workflow (weekly + manual dispatch)

## Changes
### E2E Test Fixes
- `tests/e2e/doctor.test.ts`: Accept Korean/English keywords for diagnostic messages
- `tests/e2e/list.test.ts`: Accept Korean/English keywords for scanning messages

### Claude Native Verification
- `.github/scripts/verify-claude-native.ts`: Add R016, R018 to unique rules + update interfaces
- `.github/workflows/claude-native-check.yml`: New caller workflow

## Test Results
- Before: 479 pass / 3 fail
- After: 482 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)