### PR TITLE
fix(docs): correct qa-qa-engineer typo in README_ko.md

### DIFF
--- a/README_ko.md
+++ b/README_ko.md
@@ -87,7 +87,7 @@ secretary (라우팅 스킬)
 dev-lead (라우팅 스킬)
   ├── lang-golang:sonnet   — Go 구현
   ├── lang-python:sonnet   — Python 구현
-  └── qa-qa-engineer:sonnet— 테스트 생성
+  └── qa-engineer:sonnet   — 테스트 생성
 ```
 
 ### 내장 슬래시 커맨드


### PR DESCRIPTION
## Summary
- Fix typo in README_ko.md sub-agent model diagram: `qa-qa-engineer:sonnet` → `qa-engineer:sonnet`

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)