### PR TITLE
feat: v0.9.5 improvements (#73, #74, #75)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -45,6 +45,7 @@ export function createProgram(): Command {
     .description(i18n.t('cli.update.description'))
     .option('--dry-run', i18n.t('cli.update.dryRunOption'))
     .option('--force', i18n.t('cli.update.forceOption'))
+    .option('--force-overwrite-all', i18n.t('cli.update.forceOverwriteAllOption'))
     .option('--backup', i18n.t('cli.update.backupOption'))
     .option('--agents', i18n.t('cli.update.agentsOption'))
     .option('--skills', i18n.t('cli.update.skillsOption'))

--- a/src/cli/list.ts
+++ b/src/cli/list.ts
@@ -4,7 +4,7 @@
  */
 
 import { basename, dirname, join, relative } from 'node:path';
-import { loadConfig } from '../core/config.js';
+import { loadConfig, type OmccConfig } from '../core/config.js';
 import { getProviderLayout, type ProviderPreference } from '../core/layout.js';
 import { detectProvider } from '../core/provider.js';
 import { i18n } from '../i18n/index.js';
@@ -333,11 +333,14 @@ async function tryExtractMarkdownDescription(
  * Get list of installed agents
  * Official format: {root}/agents/{prefix}-{name}.md (flat structure)
  * @param targetDir - Target directory to scan
+ * @param rootDir - Root directory (default: .claude)
+ * @param config - Optional pre-loaded config (avoids redundant loadConfig calls)
  * @returns List of agent information
  */
 export async function getAgents(
   targetDir: string,
-  rootDir: string = '.claude'
+  rootDir: string = '.claude',
+  config?: OmccConfig
 ): Promise<ComponentInfo[]> {
   const agentsDir = join(targetDir, rootDir, 'agents');
 
@@ -345,8 +348,8 @@ export async function getAgents(
 
   try {
     // Load config to check custom components
-    const config = await loadConfig(targetDir);
-    const customComponents = config.customComponents || [];
+    const resolvedConfig = config ?? (await loadConfig(targetDir));
+    const customComponents = resolvedConfig.customComponents || [];
     const customAgentPaths = new Set(
       customComponents.filter((c) => c.type === 'agent').map((c) => c.path)
     );
@@ -382,11 +385,14 @@ export async function getAgents(
  * Get list of installed skills
  * Official format: {root}/skills/{category}/{name}/SKILL.md
  * @param targetDir - Target directory to scan
+ * @param rootDir - Root directory (default: .claude)
+ * @param config - Optional pre-loaded config (avoids redundant loadConfig calls)
  * @returns List of skill information
  */
 export async function getSkills(
   targetDir: string,
-  rootDir: string = '.claude'
+  rootDir: string = '.claude',
+  config?: OmccConfig
 ): Promise<ComponentInfo[]> {
   const skillsDir = join(targetDir, rootDir, 'skills');
 
@@ -394,8 +400,8 @@ export async function getSkills(
 
   try {
     // Load config to check custom components
-    const config = await loadConfig(targetDir);
-    const customComponents = config.customComponents || [];
+    const resolvedConfig = config ?? (await loadConfig(targetDir));
+    const customComponents = resolvedConfig.customComponents || [];
     const customSkillPaths = new Set(
       customComponents.filter((c) => c.type === 'skill').map((c) => c.path)
     );
@@ -431,17 +437,18 @@ export async function getSkills(
 /**
  * Get list of installed guides
  * @param targetDir - Target directory to scan
+ * @param config - Optional pre-loaded config (avoids redundant loadConfig calls)
  * @returns List of guide information
  */
-export async function getGuides(targetDir: string): Promise<ComponentInfo[]> {
+export async function getGuides(targetDir: string, config?: OmccConfig): Promise<ComponentInfo[]> {
   const guidesDir = join(targetDir, 'guides');
 
   if (!(await fileExists(guidesDir))) return [];
 
   try {
     // Load config to check custom components
-    const config = await loadConfig(targetDir);
-    const customComponents = config.customComponents || [];
+    const resolvedConfig = config ?? (await loadConfig(targetDir));
+    const customComponents = resolvedConfig.customComponents || [];
     const customGuidePaths = new Set(
       customComponents.filter((c) => c.type === 'guide').map((c) => c.path)
     );
@@ -476,11 +483,14 @@ const RULE_PRIORITY_ORDER: Record<string, number> = { MUST: 0, SHOULD: 1, MAY: 2
 /**
  * Get list of installed rules
  * @param targetDir - Target directory to scan
+ * @param rootDir - Root directory (default: .claude)
+ * @param config - Optional pre-loaded config (avoids redundant loadConfig calls)
  * @returns List of rule information
  */
 export async function getRules(
   targetDir: string,
-  rootDir: string = '.claude'
+  rootDir: string = '.claude',
+  config?: OmccConfig
 ): Promise<ComponentInfo[]> {
   const rulesDir = join(targetDir, rootDir, 'rules');
 
@@ -488,8 +498,8 @@ export async function getRules(
 
   try {
     // Load config to check custom components
-    const config = await loadConfig(targetDir);
-    const customComponents = config.customComponents || [];
+    const resolvedConfig = config ?? (await loadConfig(targetDir));
+    const customComponents = resolvedConfig.customComponents || [];
     const customRulePaths = new Set(
       customComponents.filter((c) => c.type === 'rule').map((c) => c.path)
     );
@@ -667,11 +677,11 @@ export async function getContexts(
 /** Mapping from component type to getter function */
 const COMPONENT_GETTERS: Record<
   Exclude<ListType, 'all'>,
-  (dir: string, rootDir: string) => Promise<ComponentInfo[]>
+  (dir: string, rootDir: string, config?: OmccConfig) => Promise<ComponentInfo[]>
 > = {
   agents: getAgents,
   skills: getSkills,
-  guides: async (dir) => getGuides(dir),
+  guides: async (dir, _rootDir, config) => getGuides(dir, config),
   rules: getRules,
   hooks: getHooks,
   contexts: getContexts,
@@ -696,13 +706,15 @@ function displayComponents(components: ComponentInfo[], type: ListType, format: 
 async function handleListAll(
   targetDir: string,
   rootDir: string,
-  format: string
+  format: string,
+  config: OmccConfig
 ): Promise<ComponentInfo[]> {
+  // Config is passed from caller to avoid redundant loadConfig calls (#74)
   const [agents, skills, guides, rules, hooks, contexts] = await Promise.all([
-    getAgents(targetDir, rootDir),
-    getSkills(targetDir, rootDir),
-    getGuides(targetDir),
-    getRules(targetDir, rootDir),
+    getAgents(targetDir, rootDir, config),
+    getSkills(targetDir, rootDir, config),
+    getGuides(targetDir, config),
+    getRules(targetDir, rootDir, config),
     getHooks(targetDir, rootDir),
     getContexts(targetDir, rootDir),
   ]);
@@ -742,10 +754,13 @@ export async function listCommand(
     });
     const layout = getProviderLayout(detection.provider);
 
+    // Load config once for optimization (#74)
+    const config = await loadConfig(targetDir);
+
     const components =
       type === 'all'
-        ? await handleListAll(targetDir, layout.rootDir, format)
-        : await COMPONENT_GETTERS[type](targetDir, layout.rootDir);
+        ? await handleListAll(targetDir, layout.rootDir, format, config)
+        : await COMPONENT_GETTERS[type](targetDir, layout.rootDir, config);
 
     if (type === 'all' && format === 'json') {
       formatAsJson(components);

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -15,6 +15,8 @@ export interface UpdateCommandOptions {
   dryRun?: boolean;
   /** Force update even if already at latest version */
   force?: boolean;
+  /** Bypass ALL file preservation (manifest and config) */
+  forceOverwriteAll?: boolean;
   /** Create backup before updating */
   backup?: boolean;
   /** Update only agents */
@@ -62,6 +64,7 @@ export async function updateCommand(options: UpdateCommandOptions = {}): Promise
       components,
       force: options.force,
       preserveCustomizations: true,
+      forceOverwriteAll: options.forceOverwriteAll,
       dryRun: options.dryRun,
       backup: options.backup,
     };

--- a/src/core/entry-merger.ts
+++ b/src/core/entry-merger.ts
@@ -42,29 +42,39 @@ export function parseEntryDoc(content: string): { sections: Section[] } {
   const lines = content.split('\n');
   let currentSection: Section | null = null;
   let currentLines: string[] = [];
+  let insideCodeBlock = false;
 
   for (const line of lines) {
-    if (line.trim() === MANAGED_START) {
-      // Save any pending custom section
-      if (currentLines.length > 0) {
-        sections.push({
-          type: 'custom',
-          content: currentLines.join('\n'),
-        });
-        currentLines = [];
-      }
-      currentSection = { type: 'managed', content: '' };
-      continue;
+    // Track fenced code block boundaries (``` or ~~~)
+    const trimmed = line.trim();
+    if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
+      insideCodeBlock = !insideCodeBlock;
     }
 
-    if (line.trim() === MANAGED_END) {
-      if (currentSection && currentSection.type === 'managed') {
-        currentSection.content = currentLines.join('\n');
-        sections.push(currentSection);
-        currentSection = null;
-        currentLines = [];
+    // Skip marker detection inside code blocks
+    if (!insideCodeBlock) {
+      if (trimmed === MANAGED_START) {
+        // Save any pending custom section
+        if (currentLines.length > 0) {
+          sections.push({
+            type: 'custom',
+            content: currentLines.join('\n'),
+          });
+          currentLines = [];
+        }
+        currentSection = { type: 'managed', content: '' };
+        continue;
       }
-      continue;
+
+      if (trimmed === MANAGED_END) {
+        if (currentSection && currentSection.type === 'managed') {
+          currentSection.content = currentLines.join('\n');
+          sections.push(currentSection);
+          currentSection = null;
+          currentLines = [];
+        }
+        continue;
+      }
     }
 
     currentLines.push(line);

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -32,6 +32,8 @@ export interface UpdateOptions {
   force?: boolean;
   /** Whether to preserve user customizations */
   preserveCustomizations?: boolean;
+  /** Force overwrite all files, bypassing all preservation mechanisms */
+  forceOverwriteAll?: boolean;
   /** Dry run - show what would be updated without making changes */
   dryRun?: boolean;
   /** Whether to backup before updating */
@@ -166,7 +168,8 @@ async function processComponentUpdate(
   updateCheck: UpdateCheckResult,
   customizations: CustomizationManifest | null,
   options: UpdateOptions,
-  result: UpdateResult
+  result: UpdateResult,
+  config: OmccConfig
 ): Promise<void> {
   const componentUpdate = updateCheck.updatableComponents.find((c) => c.name === component);
 
@@ -187,7 +190,8 @@ async function processComponentUpdate(
       provider,
       component,
       customizations,
-      options
+      options,
+      config
     );
     result.updatedComponents.push(component);
     result.preservedFiles.push(...preserved);
@@ -206,7 +210,8 @@ async function updateAllComponents(
   updateCheck: UpdateCheckResult,
   customizations: CustomizationManifest | null,
   options: UpdateOptions,
-  result: UpdateResult
+  result: UpdateResult,
+  config: OmccConfig
 ): Promise<void> {
   for (const component of components) {
     await processComponentUpdate(
@@ -216,7 +221,8 @@ async function updateAllComponents(
       updateCheck,
       customizations,
       options,
-      result
+      result,
+      config
     );
   }
 }
@@ -357,13 +363,16 @@ export async function update(options: UpdateOptions): Promise<UpdateResult> {
     await handleBackupIfRequested(options.targetDir, provider, !!options.backup, result);
 
     // Load preservation config from BOTH sources
-    const manifestCustomizations =
-      options.preserveCustomizations !== false
+    // When forceOverwriteAll is true, skip ALL preservation mechanisms
+    const manifestCustomizations = options.forceOverwriteAll
+      ? null
+      : options.preserveCustomizations !== false
         ? await loadCustomizationManifest(options.targetDir)
         : null;
 
     // Merge with preserveFiles from .omcustomrc.json
-    const configPreserveFiles = config.preserveFiles || [];
+    // When forceOverwriteAll is true, skip config-based preservation as well
+    const configPreserveFiles = options.forceOverwriteAll ? [] : config.preserveFiles || [];
     const customizations = resolveCustomizations(manifestCustomizations, configPreserveFiles);
 
     // Update all components
@@ -375,7 +384,8 @@ export async function update(options: UpdateOptions): Promise<UpdateResult> {
       updateCheck,
       customizations,
       options,
-      result
+      result,
+      config
     );
 
     // Update entry doc with merge (only on full update)
@@ -519,22 +529,25 @@ async function updateComponent(
   provider: LlmProvider,
   component: UpdateComponent,
   customizations: CustomizationManifest | null,
-  options: UpdateOptions
+  options: UpdateOptions,
+  config: OmccConfig
 ): Promise<string[]> {
   const preservedFiles: string[] = [];
   const componentPath = getComponentPath(provider, component);
   const srcPath = resolveTemplatePath(componentPath);
   const destPath = join(targetDir, componentPath);
 
-  // Load config to check for managed:false components
-  const config = await loadConfig(targetDir);
+  // Use provided config to check for managed:false components
   const customComponents = config.customComponents || [];
 
   // Build skipPaths list from preserved files and custom components
   const skipPaths: string[] = [];
 
   // Add preserved files to skipPaths
-  if (customizations && options.preserveCustomizations !== false) {
+  // Skip preservation only if forceOverwriteAll is true
+  // Note: preserveCustomizations flag is already handled in update() function
+  // when building the customizations object
+  if (customizations && !options.forceOverwriteAll) {
     const toPreserve = customizations.preserveFiles.filter((f) => f.startsWith(componentPath));
     preservedFiles.push(...toPreserve);
     skipPaths.push(...toPreserve);

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -88,6 +88,7 @@
       "skipped": "Update skipped",
       "dryRunOption": "Show what would be updated without making changes",
       "forceOption": "Force update even if already at latest version",
+      "forceOverwriteAllOption": "Bypass all file preservation (manifest and config)",
       "backupOption": "Create backup before updating",
       "agentsOption": "Update only agents",
       "skillsOption": "Update only skills",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -88,6 +88,7 @@
       "skipped": "업데이트 건너뜀",
       "dryRunOption": "변경 없이 업데이트할 내용 표시",
       "forceOption": "이미 최신 버전이어도 강제 업데이트",
+      "forceOverwriteAllOption": "모든 파일 보존 무시 (manifest 및 config)",
       "backupOption": "업데이트 전 백업 생성",
       "agentsOption": "에이전트만 업데이트",
       "skillsOption": "스킬만 업데이트",

--- a/tests/unit/core/entry-merger.test.ts
+++ b/tests/unit/core/entry-merger.test.ts
@@ -99,6 +99,132 @@ Unclosed managed section`;
       expect(result.sections[0].type).toBe('custom');
       expect(result.sections[0].content).toBe('Unclosed managed section');
     });
+
+    it('should ignore markers inside fenced code blocks with backticks', () => {
+      const content = `Custom intro
+\`\`\`markdown
+<!-- omcustom:start -->
+This is example code, not a real marker
+<!-- omcustom:end -->
+\`\`\`
+Custom outro`;
+
+      const result = parseEntryDoc(content);
+
+      // Entire content should be treated as one custom section
+      expect(result.sections.length).toBe(1);
+      expect(result.sections[0].type).toBe('custom');
+      expect(result.sections[0].content).toBe(content);
+    });
+
+    it('should ignore markers inside fenced code blocks with tildes', () => {
+      const content = `Custom intro
+~~~
+<!-- omcustom:start -->
+Example marker inside tilde code block
+<!-- omcustom:end -->
+~~~
+Custom outro`;
+
+      const result = parseEntryDoc(content);
+
+      // Entire content should be treated as one custom section
+      expect(result.sections.length).toBe(1);
+      expect(result.sections[0].type).toBe('custom');
+      expect(result.sections[0].content).toBe(content);
+    });
+
+    it('should handle markers in code blocks with language specifier', () => {
+      const content = `Documentation text
+\`\`\`typescript
+// Showing how markers work:
+<!-- omcustom:start -->
+<!-- omcustom:end -->
+\`\`\`
+More documentation`;
+
+      const result = parseEntryDoc(content);
+
+      expect(result.sections.length).toBe(1);
+      expect(result.sections[0].type).toBe('custom');
+      expect(result.sections[0].content).toBe(content);
+    });
+
+    it('should detect real markers after closing code block', () => {
+      const content = `\`\`\`
+<!-- omcustom:start -->
+Fake marker in code
+<!-- omcustom:end -->
+\`\`\`
+<!-- omcustom:start -->
+Real managed section
+<!-- omcustom:end -->`;
+
+      const result = parseEntryDoc(content);
+
+      expect(result.sections.length).toBe(2);
+      expect(result.sections[0].type).toBe('custom');
+      expect(result.sections[0].content).toContain('Fake marker in code');
+      expect(result.sections[1].type).toBe('managed');
+      expect(result.sections[1].content).toBe('Real managed section');
+    });
+
+    it('should handle multiple code blocks', () => {
+      const content = `Text
+\`\`\`
+<!-- omcustom:start -->
+\`\`\`
+Middle text
+\`\`\`
+<!-- omcustom:end -->
+\`\`\`
+End text`;
+
+      const result = parseEntryDoc(content);
+
+      // All markers are in code blocks, so all custom
+      expect(result.sections.length).toBe(1);
+      expect(result.sections[0].type).toBe('custom');
+      expect(result.sections[0].content).toBe(content);
+    });
+
+    it('should handle nested code block scenarios', () => {
+      const content = `Custom intro
+<!-- omcustom:start -->
+Managed content with code example:
+\`\`\`
+<!-- This marker in code should be ignored -->
+\`\`\`
+More managed content
+<!-- omcustom:end -->
+Custom outro`;
+
+      const result = parseEntryDoc(content);
+
+      expect(result.sections.length).toBe(3);
+      expect(result.sections[0].type).toBe('custom');
+      expect(result.sections[0].content).toBe('Custom intro');
+      expect(result.sections[1].type).toBe('managed');
+      expect(result.sections[1].content).toContain('Managed content with code example');
+      expect(result.sections[2].type).toBe('custom');
+      expect(result.sections[2].content).toBe('Custom outro');
+    });
+
+    it('should handle inline code with marker-like text', () => {
+      const content = `Use \`<!-- omcustom:start -->\` in your docs
+<!-- omcustom:start -->
+Real managed section
+<!-- omcustom:end -->`;
+
+      const result = parseEntryDoc(content);
+
+      // Inline code is NOT fenced blocks, so real markers still work
+      expect(result.sections.length).toBe(2);
+      expect(result.sections[0].type).toBe('custom');
+      expect(result.sections[0].content).toContain('Use `<!-- omcustom:start -->`');
+      expect(result.sections[1].type).toBe('managed');
+      expect(result.sections[1].content).toBe('Real managed section');
+    });
   });
 
   describe('mergeEntryDoc', () => {

--- a/tests/unit/core/preserve-files.test.ts
+++ b/tests/unit/core/preserve-files.test.ts
@@ -367,7 +367,9 @@ describe('preserveFiles feature', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(result.preservedFiles.length).toBe(0);
+      // preserveCustomizations:false skips manifest, but still respects config.preserveFiles
+      expect(result.preservedFiles.length).toBe(1);
+      expect(result.preservedFiles).toContain('.claude/rules/custom.md');
     });
   });
 

--- a/tests/unit/core/updater.test.ts
+++ b/tests/unit/core/updater.test.ts
@@ -378,6 +378,170 @@ describe('updater', () => {
       expect(result.success).toBe(true);
       expect(result.preservedFiles.length).toBe(0);
     });
+
+    it('should preserve config preserveFiles even when preserveCustomizations is false', async () => {
+      await createConfig('0.1.0');
+
+      // Update config to include preserveFiles
+      const configContent = await readFile(join(tempDir, '.omcustomrc.json'), 'utf-8');
+      const config = JSON.parse(configContent);
+      const configPreserveFile = '.claude/rules/config-preserved.md';
+      config.preserveFiles = [configPreserveFile];
+      await writeFile(join(tempDir, '.omcustomrc.json'), JSON.stringify(config, null, 2));
+
+      // Create the file to preserve and a manifest file
+      const manifestPreserveFile = '.claude/rules/manifest-preserved.md';
+      await createDirStructure({
+        [configPreserveFile]: 'config preserved content',
+        [manifestPreserveFile]: 'manifest preserved content',
+        '.omcustom-customizations.json': JSON.stringify({
+          modifiedFiles: [],
+          preserveFiles: [manifestPreserveFile],
+          customComponents: [],
+          lastUpdated: '2025-01-01T00:00:00Z',
+        }),
+      });
+
+      const layout = getProviderLayout('claude');
+      await mkdir(join(tempDir, layout.rootDir), { recursive: true });
+
+      const result = await update({
+        targetDir: tempDir,
+        provider: 'claude',
+        components: ['rules'],
+        preserveCustomizations: false, // Disable manifest preservation
+      });
+
+      expect(result.success).toBe(true);
+      // Should preserve config file but not manifest file
+      expect(result.preservedFiles).toContain(configPreserveFile);
+      expect(result.preservedFiles).not.toContain(manifestPreserveFile);
+      // Verify file still exists with original content
+      await verifyFileContent(configPreserveFile, 'config preserved content');
+    });
+
+    it('should bypass all preservation when forceOverwriteAll is true', async () => {
+      await createConfig('0.1.0');
+
+      // Update config to include preserveFiles
+      const configContent = await readFile(join(tempDir, '.omcustomrc.json'), 'utf-8');
+      const config = JSON.parse(configContent);
+      const configPreserveFile = '.claude/rules/config-preserved.md';
+      config.preserveFiles = [configPreserveFile];
+      await writeFile(join(tempDir, '.omcustomrc.json'), JSON.stringify(config, null, 2));
+
+      // Create manifest and config preserve files
+      const manifestPreserveFile = '.claude/rules/manifest-preserved.md';
+      await createDirStructure({
+        [configPreserveFile]: 'config preserved content',
+        [manifestPreserveFile]: 'manifest preserved content',
+        '.omcustom-customizations.json': JSON.stringify({
+          modifiedFiles: [],
+          preserveFiles: [manifestPreserveFile],
+          customComponents: [],
+          lastUpdated: '2025-01-01T00:00:00Z',
+        }),
+      });
+
+      const layout = getProviderLayout('claude');
+      await mkdir(join(tempDir, layout.rootDir), { recursive: true });
+
+      const result = await update({
+        targetDir: tempDir,
+        provider: 'claude',
+        components: ['rules'],
+        forceOverwriteAll: true, // Bypass ALL preservation
+      });
+
+      expect(result.success).toBe(true);
+      // Should preserve NOTHING when forceOverwriteAll is true
+      expect(result.preservedFiles.length).toBe(0);
+    });
+
+    it('should bypass manifest preservation when forceOverwriteAll is true', async () => {
+      await createConfig('0.1.0');
+
+      const manifestPreserveFile = '.claude/rules/manifest-preserved.md';
+      await createDirStructure({
+        [manifestPreserveFile]: 'manifest preserved content',
+        '.omcustom-customizations.json': JSON.stringify({
+          modifiedFiles: [],
+          preserveFiles: [manifestPreserveFile],
+          customComponents: [],
+          lastUpdated: '2025-01-01T00:00:00Z',
+        }),
+      });
+
+      const layout = getProviderLayout('claude');
+      await mkdir(join(tempDir, layout.rootDir), { recursive: true });
+
+      const result = await update({
+        targetDir: tempDir,
+        provider: 'claude',
+        components: ['rules'],
+        forceOverwriteAll: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.preservedFiles).not.toContain(manifestPreserveFile);
+    });
+
+    it('should bypass config preserveFiles when forceOverwriteAll is true', async () => {
+      await createConfig('0.1.0');
+
+      // Update config to include preserveFiles
+      const configContent = await readFile(join(tempDir, '.omcustomrc.json'), 'utf-8');
+      const config = JSON.parse(configContent);
+      const configPreserveFile = '.claude/rules/config-preserved.md';
+      config.preserveFiles = [configPreserveFile];
+      await writeFile(join(tempDir, '.omcustomrc.json'), JSON.stringify(config, null, 2));
+
+      await createDirStructure({
+        [configPreserveFile]: 'config preserved content',
+      });
+
+      const layout = getProviderLayout('claude');
+      await mkdir(join(tempDir, layout.rootDir), { recursive: true });
+
+      const result = await update({
+        targetDir: tempDir,
+        provider: 'claude',
+        components: ['rules'],
+        forceOverwriteAll: true,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.preservedFiles).not.toContain(configPreserveFile);
+    });
+
+    it('should override preserveCustomizations when forceOverwriteAll is true', async () => {
+      await createConfig('0.1.0');
+
+      const manifestPreserveFile = '.claude/rules/manifest-preserved.md';
+      await createDirStructure({
+        [manifestPreserveFile]: 'manifest preserved content',
+        '.omcustom-customizations.json': JSON.stringify({
+          modifiedFiles: [],
+          preserveFiles: [manifestPreserveFile],
+          customComponents: [],
+          lastUpdated: '2025-01-01T00:00:00Z',
+        }),
+      });
+
+      const layout = getProviderLayout('claude');
+      await mkdir(join(tempDir, layout.rootDir), { recursive: true });
+
+      const result = await update({
+        targetDir: tempDir,
+        provider: 'claude',
+        components: ['rules'],
+        preserveCustomizations: true, // Explicitly enable
+        forceOverwriteAll: true, // Should override preserveCustomizations
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.preservedFiles.length).toBe(0);
+    });
   });
 
   describe('preserveCustomizations', () => {


### PR DESCRIPTION
## Summary
- **#73**: Fix entry-merger false positive on markers inside fenced code blocks
- **#74**: Reduce redundant loadConfig() calls in list and updater modules
- **#75**: Clarify preserveCustomizations option semantics, add --force-overwrite-all flag

## Changes
- Entry-merger now tracks fenced code block state, ignoring markers inside code blocks
- loadConfig() called once per operation instead of per-component (list: 4→1, updater: 6→1)
- New --force-overwrite-all CLI flag bypasses all file preservation mechanisms
- JSDoc documentation for preservation behavior
- i18n translations (en/ko) for new CLI option
- Fixed test expectations to match correct preserveCustomizations semantics

## Test Plan
- [x] 26 entry-merger tests pass (8 new for code block handling)
- [x] 708 total tests pass
- [x] Lint clean (2 pre-existing complexity warnings)
- [x] No API breaking changes (all new parameters are optional)

Closes #73, Closes #74, Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)