### PR TITLE
chore: consolidate DOCS_VALIDATOR into OH_MY_CUSTOMCODE

### DIFF
--- a/.github/workflows/claude-native-check.yml
+++ b/.github/workflows/claude-native-check.yml
@@ -37,11 +37,11 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Validate DOCS_VALIDATOR
+      - name: Validate OH_MY_CUSTOMCODE
         if: steps.guard.outputs.skip != 'true'
         run: |
-          if [ -z "${{ secrets.DOCS_VALIDATOR }}" ]; then
-            echo "::error::DOCS_VALIDATOR secret is required for Claude Native Verification"
+          if [ -z "${{ secrets.OH_MY_CUSTOMCODE }}" ]; then
+            echo "::error::OH_MY_CUSTOMCODE secret is required for Claude Native Verification"
             exit 1
           fi
 
@@ -58,7 +58,7 @@ jobs:
         env:
           DRY_RUN_INPUT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' && 'true' || 'false' }}
           FORCE_INPUT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force == 'true' && 'true' || 'false' }}
-          ANTHROPIC_API_KEY: ${{ secrets.DOCS_VALIDATOR }}
+          ANTHROPIC_API_KEY: ${{ secrets.OH_MY_CUSTOMCODE }}
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PROJECT_ROOT: ${{ github.workspace }}/templates


### PR DESCRIPTION
## Summary
- Replace `DOCS_VALIDATOR` secret references with `OH_MY_CUSTOMCODE` in `claude-native-check.yml` workflow
- Both secrets contain Anthropic API keys - consolidating to reduce secret count

## Changes
- Updated secret validation step name: `Validate DOCS_VALIDATOR` → `Validate OH_MY_CUSTOMCODE`
- Updated secret reference in validation check
- Updated `ANTHROPIC_API_KEY` environment variable to use `OH_MY_CUSTOMCODE`

## Post-Merge Action Required
After this PR is merged, delete the `DOCS_VALIDATOR` secret from repository settings:
- Navigate to: Settings → Secrets and variables → Actions
- Delete: `DOCS_VALIDATOR`

## Test Plan
- [ ] Workflow passes validation step
- [ ] Claude Native verification runs successfully with `OH_MY_CUSTOMCODE` secret
- [ ] Manual workflow dispatch completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)