### PR TITLE
feat(security): add path traversal validation for preserveFiles

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,7 +3,13 @@
  */
 
 import { join } from 'node:path';
-import { ensureDirectory, fileExists, readJsonFile, writeJsonFile } from '../utils/fs.js';
+import {
+  ensureDirectory,
+  fileExists,
+  readJsonFile,
+  validatePreserveFilePath,
+  writeJsonFile,
+} from '../utils/fs.js';
 import { debug, warn } from '../utils/logger.js';
 import type { ProviderPreference } from './layout.js';
 
@@ -166,7 +172,7 @@ export async function loadConfig(targetDir: string): Promise<OmccConfig> {
   if (await fileExists(configPath)) {
     try {
       const config = await readJsonFile<Partial<OmccConfig>>(configPath);
-      const merged = mergeConfig(getDefaultConfig(), config);
+      const merged = mergeConfig(getDefaultConfig(), config, targetDir);
 
       // Migrate if needed
       if (merged.configVersion < CURRENT_CONFIG_VERSION) {
@@ -216,7 +222,40 @@ function deduplicateCustomComponents(components: CustomComponentConfig[]): Custo
 /**
  * Merge configuration with defaults
  */
-export function mergeConfig(defaults: OmccConfig, overrides: Partial<OmccConfig>): OmccConfig {
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Security validation adds necessary complexity
+export function mergeConfig(
+  defaults: OmccConfig,
+  overrides: Partial<OmccConfig>,
+  targetDir?: string
+): OmccConfig {
+  // Merge preserveFiles arrays
+  let mergedPreserveFiles: string[] | undefined;
+  if (overrides.preserveFiles) {
+    const allFiles = [...new Set([...(defaults.preserveFiles || []), ...overrides.preserveFiles])];
+
+    // Validate paths if targetDir is provided
+    if (targetDir) {
+      const validatedFiles: string[] = [];
+      for (const filePath of allFiles) {
+        const validation = validatePreserveFilePath(filePath, targetDir);
+        if (validation.valid) {
+          validatedFiles.push(filePath);
+        } else {
+          warn('config.invalid_preserve_path', {
+            path: filePath,
+            reason: validation.reason ?? 'Invalid path',
+          });
+        }
+      }
+      mergedPreserveFiles = validatedFiles;
+    } else {
+      // No validation if targetDir not provided (backward compatibility)
+      mergedPreserveFiles = allFiles;
+    }
+  } else {
+    mergedPreserveFiles = defaults.preserveFiles;
+  }
+
   return {
     ...defaults,
     ...overrides,
@@ -234,9 +273,7 @@ export function mergeConfig(defaults: OmccConfig, overrides: Partial<OmccConfig>
       ...defaults.agents,
       ...overrides.agents,
     },
-    preserveFiles: overrides.preserveFiles
-      ? [...new Set([...(defaults.preserveFiles || []), ...overrides.preserveFiles])]
-      : defaults.preserveFiles,
+    preserveFiles: mergedPreserveFiles,
     customComponents: overrides.customComponents
       ? deduplicateCustomComponents([
           ...(defaults.customComponents || []),
@@ -277,7 +314,7 @@ export async function updateConfig(
   updates: Partial<OmccConfig>
 ): Promise<OmccConfig> {
   const current = await loadConfig(targetDir);
-  const updated = mergeConfig(current, updates);
+  const updated = mergeConfig(current, updates, targetDir);
   await saveConfig(targetDir, updated);
   return updated;
 }

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -10,6 +10,7 @@ import {
   readJsonFile,
   readTextFile,
   resolveTemplatePath,
+  validatePreserveFilePath,
   writeJsonFile,
   writeTextFile,
 } from '../utils/fs.js';
@@ -280,41 +281,85 @@ function resolveConfigPreserveFiles(options: UpdateOptions, config: OmccConfig):
     return [];
   }
 
-  return config.preserveFiles || [];
+  const preserveFiles = config.preserveFiles || [];
+
+  // Validate each path for security
+  const validatedPaths: string[] = [];
+  for (const filePath of preserveFiles) {
+    const validation = validatePreserveFilePath(filePath, options.targetDir);
+    if (validation.valid) {
+      validatedPaths.push(filePath);
+    } else {
+      warn('preserve_files.invalid_path', {
+        path: filePath,
+        reason: validation.reason ?? 'Invalid path',
+      });
+    }
+  }
+
+  return validatedPaths;
 }
 
 /**
  * Resolve customizations from manifest and config
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Security validation adds necessary complexity
 function resolveCustomizations(
   customizations: CustomizationManifest | null,
-  configPreserveFiles: string[]
+  configPreserveFiles: string[],
+  targetDir: string
 ): CustomizationManifest | null {
-  // No preserve files from either source
-  if (!customizations && configPreserveFiles.length === 0) {
-    return null;
+  // Validate manifest preserveFiles
+  const validatedManifestFiles: string[] = [];
+  if (customizations && customizations.preserveFiles.length > 0) {
+    for (const filePath of customizations.preserveFiles) {
+      const validation = validatePreserveFilePath(filePath, targetDir);
+      if (validation.valid) {
+        validatedManifestFiles.push(filePath);
+      } else {
+        warn('preserve_files.invalid_path', {
+          path: filePath,
+          reason: validation.reason ?? 'Invalid path',
+          source: 'manifest',
+        });
+      }
+    }
+  }
+
+  // No preserve files from either source after validation
+  if (validatedManifestFiles.length === 0 && configPreserveFiles.length === 0) {
+    return customizations && customizations.modifiedFiles.length > 0 ? customizations : null;
   }
 
   // Merge both sources
-  if (customizations && configPreserveFiles.length > 0) {
-    customizations.preserveFiles = [
-      ...new Set([...customizations.preserveFiles, ...configPreserveFiles]),
-    ];
-    return customizations;
+  if (validatedManifestFiles.length > 0 && configPreserveFiles.length > 0) {
+    const merged = customizations || {
+      modifiedFiles: [],
+      preserveFiles: [],
+      customComponents: [],
+      lastUpdated: new Date().toISOString(),
+    };
+    merged.preserveFiles = [...new Set([...validatedManifestFiles, ...configPreserveFiles])];
+    return merged;
   }
 
   // Only config has preserve files
   if (configPreserveFiles.length > 0) {
     return {
-      modifiedFiles: [],
+      modifiedFiles: customizations?.modifiedFiles || [],
       preserveFiles: configPreserveFiles,
-      customComponents: [],
+      customComponents: customizations?.customComponents || [],
       lastUpdated: new Date().toISOString(),
     };
   }
 
-  // Only manifest has data
-  return customizations;
+  // Only manifest has preserve files
+  if (customizations) {
+    customizations.preserveFiles = validatedManifestFiles;
+    return customizations;
+  }
+
+  return null;
 }
 
 /**
@@ -398,7 +443,11 @@ export async function update(options: UpdateOptions): Promise<UpdateResult> {
     // Load preservation config from BOTH sources
     const manifestCustomizations = await resolveManifestCustomizations(options, options.targetDir);
     const configPreserveFiles = resolveConfigPreserveFiles(options, config);
-    const customizations = resolveCustomizations(manifestCustomizations, configPreserveFiles);
+    const customizations = resolveCustomizations(
+      manifestCustomizations,
+      configPreserveFiles,
+      options.targetDir
+    );
 
     // Update all components
     const components = options.components || getAllUpdateComponents();

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -2,8 +2,72 @@
  * File system utilities
  */
 
-import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { dirname, isAbsolute, join, normalize, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+/**
+ * Result of path validation
+ */
+export interface PathValidationResult {
+  /** Whether the path is valid */
+  valid: boolean;
+  /** Reason for rejection (if invalid) */
+  reason?: string;
+}
+
+/**
+ * Validate a preserveFiles path for security (path traversal prevention)
+ *
+ * @param filePath - The file path to validate
+ * @param projectRoot - The project root directory
+ * @returns Validation result with reason if invalid
+ */
+export function validatePreserveFilePath(
+  filePath: string,
+  projectRoot: string
+): PathValidationResult {
+  // Reject empty strings
+  if (!filePath || filePath.trim() === '') {
+    return {
+      valid: false,
+      reason: 'Path cannot be empty',
+    };
+  }
+
+  // Reject absolute paths
+  if (isAbsolute(filePath)) {
+    return {
+      valid: false,
+      reason: 'Absolute paths are not allowed',
+    };
+  }
+
+  // Normalize the path to resolve . and .. segments
+  const normalizedPath = normalize(filePath);
+
+  // Check if normalized path tries to escape project root
+  // This catches patterns like ../../etc/passwd
+  if (normalizedPath.startsWith('..')) {
+    return {
+      valid: false,
+      reason: 'Path cannot traverse outside project root',
+    };
+  }
+
+  // Additional check: resolve path and verify it's within project root
+  const resolvedPath = resolve(projectRoot, normalizedPath);
+  const relativePath = relative(projectRoot, resolvedPath);
+
+  // If relative path starts with .. or is absolute, it escaped the project root
+  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
+    return {
+      valid: false,
+      reason: 'Resolved path escapes project root',
+    };
+  }
+
+  return { valid: true };
+}
 
 /**
  * Options for copying directories

--- a/tests/unit/core/preserve-files.test.ts
+++ b/tests/unit/core/preserve-files.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../src/core/config.js';
 import { getProviderLayout } from '../../../src/core/layout.js';
 import { update } from '../../../src/core/updater.js';
-import { copyDirectory, fileExists } from '../../../src/utils/fs.js';
+import { copyDirectory, fileExists, validatePreserveFilePath } from '../../../src/utils/fs.js';
 
 describe('preserveFiles feature', () => {
   let tempDir: string;
@@ -370,6 +370,89 @@ describe('preserveFiles feature', () => {
       // preserveCustomizations:false skips manifest, but still respects config.preserveFiles
       expect(result.preservedFiles.length).toBe(1);
       expect(result.preservedFiles).toContain('.claude/rules/custom.md');
+    });
+  });
+
+  describe('path traversal validation', () => {
+    it('should reject path traversal attempts (../../)', () => {
+      const result = validatePreserveFilePath('../../etc/passwd', tempDir);
+
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBeDefined();
+      expect(result.reason).toContain('outside project root');
+    });
+
+    it('should reject path traversal with more segments', () => {
+      const result = validatePreserveFilePath('../other-project/.env', tempDir);
+
+      expect(result.valid).toBe(false);
+      expect(result.reason).toBeDefined();
+    });
+
+    it('should reject absolute paths', () => {
+      const result = validatePreserveFilePath('/absolute/path', tempDir);
+
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain('Absolute paths');
+    });
+
+    it('should normalize and accept safe paths with ..', () => {
+      const result = validatePreserveFilePath('./foo/../bar', tempDir);
+
+      expect(result.valid).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('should accept valid relative paths', () => {
+      const result = validatePreserveFilePath('.claude/rules/custom.md', tempDir);
+
+      expect(result.valid).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('should accept directory paths', () => {
+      const result = validatePreserveFilePath('.claude/skills/my-skill/', tempDir);
+
+      expect(result.valid).toBe(true);
+      expect(result.reason).toBeUndefined();
+    });
+
+    it('should reject empty strings', () => {
+      const result = validatePreserveFilePath('', tempDir);
+
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain('empty');
+    });
+
+    it('should reject whitespace-only strings', () => {
+      const result = validatePreserveFilePath('   ', tempDir);
+
+      expect(result.valid).toBe(false);
+      expect(result.reason).toContain('empty');
+    });
+
+    it('should validate complex traversal attempts', () => {
+      // Try various sneaky paths
+      const maliciousPaths = [
+        '../../..',
+        './../../../etc/passwd',
+        'foo/../../..',
+        './.././../sensitive',
+      ];
+
+      for (const path of maliciousPaths) {
+        const result = validatePreserveFilePath(path, tempDir);
+        expect(result.valid).toBe(false);
+      }
+    });
+
+    it('should accept deeply nested valid paths', () => {
+      const result = validatePreserveFilePath(
+        '.claude/skills/my-skill/deeply/nested/file.md',
+        tempDir
+      );
+
+      expect(result.valid).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `validatePreserveFilePath()` in `src/utils/fs.ts` to prevent path traversal attacks
- Apply validation in `config.ts` (mergeConfig) and `updater.ts` (resolveConfigPreserveFiles, resolveCustomizations)
- Log warnings for rejected paths (defense-in-depth, not throwing errors)

## Changes
- `src/utils/fs.ts`: New `validatePreserveFilePath()` function
- `src/core/config.ts`: Validate paths during config merge
- `src/core/updater.ts`: Validate paths in both manifest and config sources
- `tests/unit/core/preserve-files.test.ts`: 9 new test cases

## Test plan
- [x] All 718 tests pass (0 failures)
- [x] Path traversal attempts rejected (../../, ../, absolute paths)
- [x] Valid relative paths accepted (.claude/rules/custom.md)
- [x] Empty/whitespace strings rejected
- [x] Normalized paths accepted (./foo/../bar → bar)

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)