### PR TITLE
feat: add Agent Teams configuration support (#95)

### DIFF
--- a/templates/.claude/skills/de-lead-routing/SKILL.md
+++ b/templates/.claude/skills/de-lead-routing/SKILL.md
@@ -219,6 +219,19 @@ Pipeline design completed.
 - **secretary-routing**: DE agents accessible through secretary for management tasks
 - **qa-lead-routing**: Coordinates with QA for data quality testing
 
+## Agent Teams Awareness
+
+Before routing via Task tool, check if Agent Teams is available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or TeamCreate/SendMessage tools present).
+
+**Self-check:** Does this task need 3+ agents, shared state, or inter-agent communication? If yes, prefer Agent Teams over Task tool. See R018 for the full decision matrix.
+
+| Scenario | Preferred |
+|----------|-----------|
+| Single-tool DE task | Task Tool |
+| Multi-tool pipeline design (3+ tools) | Agent Teams |
+| Cross-tool data quality analysis | Agent Teams |
+| Quick DAG/model validation | Task Tool |
+
 ## Usage
 
 This skill is NOT user-invocable. It should be automatically triggered when the main conversation detects data engineering intent.

--- a/templates/.claude/skills/dev-lead-routing/SKILL.md
+++ b/templates/.claude/skills/dev-lead-routing/SKILL.md
@@ -77,4 +77,18 @@ user-invocable: false
 
 Multi-language: detect all languages, route to parallel experts (max 4). Single-language: route to matching expert. Cross-layer (frontend + backend): multiple experts in parallel.
 
+## Agent Teams Awareness
+
+Before routing via Task tool, check if Agent Teams is available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or TeamCreate/SendMessage tools present).
+
+**Self-check:** Does this task need 3+ agents, shared state, or inter-agent communication? If yes, prefer Agent Teams over Task tool. See R018 for the full decision matrix.
+
+| Scenario | Preferred |
+|----------|-----------|
+| Single-language review | Task Tool |
+| Multi-language code review (3+) | Agent Teams |
+| Code review + fix cycle | Agent Teams |
+| Cross-layer debugging (FE + BE + DB) | Agent Teams |
+| Simple file search/validation | Task Tool |
+
 Not user-invocable. Auto-triggered on development intent.

--- a/templates/.claude/skills/qa-lead-routing/SKILL.md
+++ b/templates/.claude/skills/qa-lead-routing/SKILL.md
@@ -265,6 +265,19 @@ metrics:
   test_case_count: number
 ```
 
+## Agent Teams Awareness
+
+Before routing via Task tool, check if Agent Teams is available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or TeamCreate/SendMessage tools present).
+
+**Self-check:** Does this task need 3+ agents, shared state, or inter-agent communication? If yes, prefer Agent Teams over Task tool. See R018 for the full decision matrix.
+
+| Scenario | Preferred |
+|----------|-----------|
+| Single QA phase (plan/write/execute) | Task Tool |
+| Full QA cycle (plan + write + execute + report) | Agent Teams |
+| Quality analysis (parallel strategy + results) | Agent Teams |
+| Quick test validation | Task Tool |
+
 ## Usage
 
 This skill is NOT user-invocable. It should be automatically triggered when the main conversation detects QA intent.

--- a/templates/.claude/skills/secretary-routing/SKILL.md
+++ b/templates/.claude/skills/secretary-routing/SKILL.md
@@ -79,6 +79,19 @@ When command requires multiple independent operations:
 | sys-memory-keeper | sonnet | Memory operations, search |
 | sys-naggy | haiku | Simple TODO tracking |
 
+## Agent Teams Awareness
+
+Before routing via Task tool, check if Agent Teams is available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or TeamCreate/SendMessage tools present).
+
+**Self-check:** Does this task need 3+ agents, shared state, or inter-agent communication? If yes, prefer Agent Teams over Task tool. See R018 for the full decision matrix.
+
+| Scenario | Preferred |
+|----------|-----------|
+| Single manager task | Task Tool |
+| Batch agent creation (3+) | Agent Teams |
+| Multi-round verification (sauron) | Task Tool |
+| Agent audit + fix cycle | Agent Teams |
+
 ## Usage
 
 This skill is NOT user-invocable. It is automatically triggered when the main conversation detects agent management intent.

--- a/templates/.codex/skills/de-lead-routing/SKILL.md
+++ b/templates/.codex/skills/de-lead-routing/SKILL.md
@@ -219,6 +219,19 @@ Pipeline design completed.
 - **secretary-routing**: DE agents accessible through secretary for management tasks
 - **qa-lead-routing**: Coordinates with QA for data quality testing
 
+## Agent Teams Awareness
+
+Before routing via Task tool, check if Agent Teams is available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or TeamCreate/SendMessage tools present).
+
+**Self-check:** Does this task need 3+ agents, shared state, or inter-agent communication? If yes, prefer Agent Teams over Task tool. See R018 for the full decision matrix.
+
+| Scenario | Preferred |
+|----------|-----------|
+| Single-tool DE task | Task Tool |
+| Multi-tool pipeline design (3+ tools) | Agent Teams |
+| Cross-tool data quality analysis | Agent Teams |
+| Quick DAG/model validation | Task Tool |
+
 ## Usage
 
 This skill is NOT user-invocable. It should be automatically triggered when the main conversation detects data engineering intent.

--- a/templates/.codex/skills/dev-lead-routing/SKILL.md
+++ b/templates/.codex/skills/dev-lead-routing/SKILL.md
@@ -77,4 +77,18 @@ user-invocable: false
 
 Multi-language: detect all languages, route to parallel experts (max 4). Single-language: route to matching expert. Cross-layer (frontend + backend): multiple experts in parallel.
 
+## Agent Teams Awareness
+
+Before routing via Task tool, check if Agent Teams is available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or TeamCreate/SendMessage tools present).
+
+**Self-check:** Does this task need 3+ agents, shared state, or inter-agent communication? If yes, prefer Agent Teams over Task tool. See R018 for the full decision matrix.
+
+| Scenario | Preferred |
+|----------|-----------|
+| Single-language review | Task Tool |
+| Multi-language code review (3+) | Agent Teams |
+| Code review + fix cycle | Agent Teams |
+| Cross-layer debugging (FE + BE + DB) | Agent Teams |
+| Simple file search/validation | Task Tool |
+
 Not user-invocable. Auto-triggered on development intent.

--- a/templates/.codex/skills/qa-lead-routing/SKILL.md
+++ b/templates/.codex/skills/qa-lead-routing/SKILL.md
@@ -265,6 +265,19 @@ metrics:
   test_case_count: number
 ```
 
+## Agent Teams Awareness
+
+Before routing via Task tool, check if Agent Teams is available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or TeamCreate/SendMessage tools present).
+
+**Self-check:** Does this task need 3+ agents, shared state, or inter-agent communication? If yes, prefer Agent Teams over Task tool. See R018 for the full decision matrix.
+
+| Scenario | Preferred |
+|----------|-----------|
+| Single QA phase (plan/write/execute) | Task Tool |
+| Full QA cycle (plan + write + execute + report) | Agent Teams |
+| Quality analysis (parallel strategy + results) | Agent Teams |
+| Quick test validation | Task Tool |
+
 ## Usage
 
 This skill is NOT user-invocable. It should be automatically triggered when the main conversation detects QA intent.

--- a/templates/.codex/skills/secretary-routing/SKILL.md
+++ b/templates/.codex/skills/secretary-routing/SKILL.md
@@ -179,6 +179,19 @@ failure_modes:
   timeout: Retry or skip with notice
 ```
 
+## Agent Teams Awareness
+
+Before routing via Task tool, check if Agent Teams is available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or TeamCreate/SendMessage tools present).
+
+**Self-check:** Does this task need 3+ agents, shared state, or inter-agent communication? If yes, prefer Agent Teams over Task tool. See R018 for the full decision matrix.
+
+| Scenario | Preferred |
+|----------|-----------|
+| Single manager task | Task Tool |
+| Batch agent creation (3+) | Agent Teams |
+| Multi-round verification (sauron) | Task Tool |
+| Agent audit + fix cycle | Agent Teams |
+
 ## Usage
 
 This skill is NOT user-invocable. It should be automatically triggered when the main conversation detects agent management intent.


### PR DESCRIPTION
## Summary

- Add **Agent Teams awareness** to all 4 routing skill templates (secretary-routing, dev-lead-routing, qa-lead-routing, de-lead-routing) for both `.claude` and `.codex` variants
- Each routing skill now includes a self-check for Agent Teams availability and a context-specific decision matrix for when to prefer Agent Teams over Task tool
- R018 rule file, index.yaml, CLAUDE.md templates, and MUST-orchestrator-coordination rule already contained Agent Teams support from a prior release; this PR completes the integration by wiring routing skills

## Changes

| File | Change |
|------|--------|
| `templates/.claude/skills/secretary-routing/SKILL.md` | Added Agent Teams awareness section |
| `templates/.claude/skills/dev-lead-routing/SKILL.md` | Added Agent Teams awareness section |
| `templates/.claude/skills/qa-lead-routing/SKILL.md` | Added Agent Teams awareness section |
| `templates/.claude/skills/de-lead-routing/SKILL.md` | Added Agent Teams awareness section |
| `templates/.codex/skills/secretary-routing/SKILL.md` | Added Agent Teams awareness section |
| `templates/.codex/skills/dev-lead-routing/SKILL.md` | Added Agent Teams awareness section |
| `templates/.codex/skills/qa-lead-routing/SKILL.md` | Added Agent Teams awareness section |
| `templates/.codex/skills/de-lead-routing/SKILL.md` | Added Agent Teams awareness section |

## Test plan

- [ ] Verify `omcustom init` installs routing skills with Agent Teams awareness
- [ ] Verify each routing skill has correct decision matrix matching its domain
- [ ] Verify `.claude` and `.codex` variants are consistent

Closes #95