### PR TITLE
feat: detect git workflow during init (#92)

### DIFF
--- a/src/core/git-workflow.ts
+++ b/src/core/git-workflow.ts
@@ -1,0 +1,373 @@
+/**
+ * Git workflow detection module
+ *
+ * Detects the git branch structure of a project and determines
+ * the workflow type (git-flow, github-flow, trunk-based).
+ */
+
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Detected git workflow type
+ */
+export type GitWorkflowType = 'git-flow' | 'github-flow' | 'trunk-based';
+
+/**
+ * Result of git workflow detection
+ */
+export interface GitWorkflowResult {
+  /** Detected workflow type */
+  type: GitWorkflowType;
+  /** Default/main branch name */
+  defaultBranch: string;
+  /** Whether a develop branch exists */
+  hasDevelop: boolean;
+  /** Detected branch patterns (e.g., feature/*, release/*) */
+  branchPatterns: string[];
+}
+
+/**
+ * Execute a git command in the given directory.
+ *
+ * Clears GIT_DIR/GIT_WORK_TREE env vars to ensure git inspects the
+ * target directory's own repo, not a parent repo (e.g., during pre-commit hooks).
+ *
+ * @param args - Git command arguments
+ * @param cwd - Working directory
+ * @returns stdout trimmed, or empty string on failure
+ */
+function execGit(args: string[], cwd: string): string {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, GIT_DIR: undefined, GIT_WORK_TREE: undefined },
+    }).trim();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Check if the directory is inside a git repository
+ */
+export function isGitRepo(cwd: string): boolean {
+  return execGit(['rev-parse', '--is-inside-work-tree'], cwd) === 'true';
+}
+
+/**
+ * Detect the default branch name
+ *
+ * Tries in order:
+ * 1. Remote HEAD (origin/HEAD) - most reliable
+ * 2. Check for common branch names (main, master, develop)
+ * 3. Current HEAD branch
+ * 4. Fallback to 'main'
+ */
+function detectDefaultBranch(cwd: string): string {
+  // Try remote HEAD first (most reliable for default branch detection)
+  const remoteHead = execGit(['symbolic-ref', 'refs/remotes/origin/HEAD'], cwd);
+  if (remoteHead) {
+    return remoteHead.replace('refs/remotes/origin/', '');
+  }
+
+  // Check which common branches exist locally
+  const branches = getLocalBranches(cwd);
+  for (const candidate of ['main', 'master', 'develop']) {
+    if (branches.includes(candidate)) {
+      return candidate;
+    }
+  }
+
+  // Try current HEAD
+  const head = execGit(['symbolic-ref', '--short', 'HEAD'], cwd);
+  if (head) {
+    return head;
+  }
+
+  return 'main';
+}
+
+/**
+ * Get all local branch names
+ */
+function getLocalBranches(cwd: string): string[] {
+  const output = execGit(['branch', '--format=%(refname:short)'], cwd);
+  if (!output) return [];
+  return output.split('\n').filter(Boolean);
+}
+
+/**
+ * Get all remote branch names (without remote prefix)
+ */
+function getRemoteBranches(cwd: string): string[] {
+  const output = execGit(['branch', '-r', '--format=%(refname:short)'], cwd);
+  if (!output) return [];
+  return output
+    .split('\n')
+    .filter(Boolean)
+    .map((b) => b.replace(/^origin\//, ''))
+    .filter((b) => b !== 'HEAD');
+}
+
+/**
+ * Detect branch patterns from existing branches
+ *
+ * Looks for common prefix patterns like feature/, release/, hotfix/
+ */
+function detectBranchPatterns(branches: string[]): string[] {
+  const prefixes = new Set<string>();
+  const knownPrefixes = ['feature', 'release', 'hotfix', 'bugfix', 'fix', 'chore', 'docs'];
+
+  for (const branch of branches) {
+    const slashIdx = branch.indexOf('/');
+    if (slashIdx > 0) {
+      const prefix = branch.substring(0, slashIdx);
+      if (knownPrefixes.includes(prefix)) {
+        prefixes.add(`${prefix}/*`);
+      }
+    }
+  }
+
+  return [...prefixes].sort();
+}
+
+/**
+ * Determine the workflow type based on detected branch structure
+ */
+function determineWorkflowType(
+  hasDevelop: boolean,
+  branchPatterns: string[],
+  allBranches: string[]
+): GitWorkflowType {
+  // git-flow: has develop + feature/release/hotfix patterns
+  const hasFlowPatterns = branchPatterns.some(
+    (p) => p === 'feature/*' || p === 'release/*' || p === 'hotfix/*'
+  );
+  if (hasDevelop && hasFlowPatterns) {
+    return 'git-flow';
+  }
+
+  // github-flow: has feature branches but no develop
+  const hasFeatureBranches = allBranches.some((b) => b.includes('/'));
+  if (!hasDevelop && hasFeatureBranches) {
+    return 'github-flow';
+  }
+
+  // trunk-based: main/master only, no feature branches
+  if (!hasDevelop && !hasFeatureBranches) {
+    return 'trunk-based';
+  }
+
+  // If develop exists but no flow patterns, still classify as git-flow (develop-based)
+  if (hasDevelop) {
+    return 'git-flow';
+  }
+
+  return 'github-flow';
+}
+
+/**
+ * Detect the git workflow used in a project
+ *
+ * @param cwd - Project directory (must be a git repository)
+ * @returns Detection result, or null if not a git repository
+ */
+export function detectGitWorkflow(cwd: string): GitWorkflowResult | null {
+  if (!isGitRepo(cwd)) {
+    return null;
+  }
+
+  const localBranches = getLocalBranches(cwd);
+  const remoteBranches = getRemoteBranches(cwd);
+  const allBranches = [...new Set([...localBranches, ...remoteBranches])];
+
+  const defaultBranch = detectDefaultBranch(cwd);
+  const hasDevelop = localBranches.includes('develop') || remoteBranches.includes('develop');
+  const branchPatterns = detectBranchPatterns(allBranches);
+  const type = determineWorkflowType(hasDevelop, branchPatterns, allBranches);
+
+  return {
+    type,
+    defaultBranch,
+    hasDevelop,
+    branchPatterns,
+  };
+}
+
+/**
+ * Generate Git Workflow markdown section (English)
+ */
+export function renderGitWorkflowEN(result: GitWorkflowResult): string {
+  switch (result.type) {
+    case 'git-flow':
+      return renderGitFlowEN(result);
+    case 'github-flow':
+      return renderGithubFlowEN(result);
+    case 'trunk-based':
+      return renderTrunkBasedEN(result);
+  }
+}
+
+/**
+ * Generate Git Workflow markdown section (Korean)
+ */
+export function renderGitWorkflowKO(result: GitWorkflowResult): string {
+  switch (result.type) {
+    case 'git-flow':
+      return renderGitFlowKO(result);
+    case 'github-flow':
+      return renderGithubFlowKO(result);
+    case 'trunk-based':
+      return renderTrunkBasedKO(result);
+  }
+}
+
+function renderGitFlowEN(r: GitWorkflowResult): string {
+  const lines = [
+    '## Git Workflow (MUST follow)',
+    '',
+    '| Branch | Purpose |',
+    '|--------|---------|',
+    `| \`${r.defaultBranch}\` | Main development branch (default) |`,
+  ];
+
+  if (r.branchPatterns.includes('feature/*')) {
+    lines.push(`| \`feature/*\` | New features -> PR to ${r.defaultBranch} |`);
+  }
+  if (r.branchPatterns.includes('release/*')) {
+    lines.push('| `release/*` | Release preparation -> **npm publish here only** |');
+  }
+  if (r.branchPatterns.includes('hotfix/*')) {
+    lines.push(
+      `| \`hotfix/*\` | Critical fixes -> tag -> publish -> merge to ${r.defaultBranch} |`
+    );
+  }
+  if (r.branchPatterns.includes('bugfix/*')) {
+    lines.push(`| \`bugfix/*\` | Bug fixes -> PR to ${r.defaultBranch} |`);
+  }
+
+  lines.push('');
+  lines.push('**Key rules:**');
+  lines.push(`- Create feature branches from \`${r.defaultBranch}\``);
+  lines.push('- Use conventional commits: `feat:`, `fix:`, `docs:`, `chore:`');
+  lines.push('- Include "Closes #N" in commit message to auto-close issues');
+
+  return lines.join('\n');
+}
+
+function renderGithubFlowEN(r: GitWorkflowResult): string {
+  const lines = [
+    '## Git Workflow (MUST follow)',
+    '',
+    '| Branch | Purpose |',
+    '|--------|---------|',
+    `| \`${r.defaultBranch}\` | Production-ready code (default) |`,
+    `| \`feature/*\` | New features -> PR to ${r.defaultBranch} |`,
+    '',
+    '**Key rules:**',
+    `- Create feature branches from \`${r.defaultBranch}\``,
+    `- All changes go through PR to \`${r.defaultBranch}\``,
+    '- Use conventional commits: `feat:`, `fix:`, `docs:`, `chore:`',
+    '- Include "Closes #N" in commit message to auto-close issues',
+  ];
+
+  return lines.join('\n');
+}
+
+function renderTrunkBasedEN(r: GitWorkflowResult): string {
+  const lines = [
+    '## Git Workflow (MUST follow)',
+    '',
+    '| Branch | Purpose |',
+    '|--------|---------|',
+    `| \`${r.defaultBranch}\` | Main trunk (default) |`,
+    '',
+    '**Key rules:**',
+    `- Commit directly to \`${r.defaultBranch}\` or use short-lived branches`,
+    '- Keep branches short-lived (merge within 1-2 days)',
+    '- Use conventional commits: `feat:`, `fix:`, `docs:`, `chore:`',
+  ];
+
+  return lines.join('\n');
+}
+
+function renderGitFlowKO(r: GitWorkflowResult): string {
+  const lines = [
+    '## Git 워크플로우 (반드시 준수)',
+    '',
+    '| 브랜치 | 용도 |',
+    '|--------|------|',
+    `| \`${r.defaultBranch}\` | 메인 개발 브랜치 (기본) |`,
+  ];
+
+  if (r.branchPatterns.includes('feature/*')) {
+    lines.push(`| \`feature/*\` | 새 기능 -> ${r.defaultBranch}으로 PR |`);
+  }
+  if (r.branchPatterns.includes('release/*')) {
+    lines.push('| `release/*` | 릴리스 준비 -> **npm 배포는 여기서만** |');
+  }
+  if (r.branchPatterns.includes('hotfix/*')) {
+    lines.push(`| \`hotfix/*\` | 긴급 수정 -> 태그 -> 배포 -> ${r.defaultBranch} 머지 |`);
+  }
+  if (r.branchPatterns.includes('bugfix/*')) {
+    lines.push(`| \`bugfix/*\` | 버그 수정 -> ${r.defaultBranch}으로 PR |`);
+  }
+
+  lines.push('');
+  lines.push('**핵심 규칙:**');
+  lines.push(`- \`${r.defaultBranch}\`에서 feature 브랜치 생성`);
+  lines.push('- Conventional commits 사용: `feat:`, `fix:`, `docs:`, `chore:`');
+  lines.push('- 커밋 메시지에 "Closes #N" 포함시 이슈 자동 종료');
+
+  return lines.join('\n');
+}
+
+function renderGithubFlowKO(r: GitWorkflowResult): string {
+  const lines = [
+    '## Git 워크플로우 (반드시 준수)',
+    '',
+    '| 브랜치 | 용도 |',
+    '|--------|------|',
+    `| \`${r.defaultBranch}\` | 프로덕션 준비 코드 (기본) |`,
+    `| \`feature/*\` | 새 기능 -> ${r.defaultBranch}으로 PR |`,
+    '',
+    '**핵심 규칙:**',
+    `- \`${r.defaultBranch}\`에서 feature 브랜치 생성`,
+    `- 모든 변경은 \`${r.defaultBranch}\`으로 PR을 통해 진행`,
+    '- Conventional commits 사용: `feat:`, `fix:`, `docs:`, `chore:`',
+    '- 커밋 메시지에 "Closes #N" 포함시 이슈 자동 종료',
+  ];
+
+  return lines.join('\n');
+}
+
+function renderTrunkBasedKO(r: GitWorkflowResult): string {
+  const lines = [
+    '## Git 워크플로우 (반드시 준수)',
+    '',
+    '| 브랜치 | 용도 |',
+    '|--------|------|',
+    `| \`${r.defaultBranch}\` | 메인 트렁크 (기본) |`,
+    '',
+    '**핵심 규칙:**',
+    `- \`${r.defaultBranch}\`에 직접 커밋하거나 단기 브랜치 사용`,
+    '- 브랜치는 단기 유지 (1-2일 내 머지)',
+    '- Conventional commits 사용: `feat:`, `fix:`, `docs:`, `chore:`',
+  ];
+
+  return lines.join('\n');
+}
+
+/**
+ * Default fallback workflow result when not in a git repo
+ */
+export function getDefaultWorkflow(): GitWorkflowResult {
+  return {
+    type: 'github-flow',
+    defaultBranch: 'main',
+    hasDevelop: false,
+    branchPatterns: ['feature/*'],
+  };
+}

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -2,7 +2,7 @@
  * Installer module - Install/copy templates
  */
 
-import { copyFile as fsCopyFile, rename } from 'node:fs/promises';
+import { readFile as fsReadFile, writeFile as fsWriteFile, rename } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import {
   copyDirectory,
@@ -14,6 +14,12 @@ import {
 } from '../utils/fs.js';
 import { debug, error, info, success, warn } from '../utils/logger.js';
 import { loadConfig, saveConfig } from './config.js';
+import {
+  detectGitWorkflow,
+  getDefaultWorkflow,
+  renderGitWorkflowEN,
+  renderGitWorkflowKO,
+} from './git-workflow.js';
 import {
   getComponentPath,
   getEntryTemplateName,
@@ -401,8 +407,21 @@ async function installComponent(
   return true;
 }
 
+/** Placeholder in entry doc templates replaced with detected git workflow */
+const GIT_WORKFLOW_PLACEHOLDER = '<!-- omcustom:git-workflow -->';
+
+/**
+ * Render the git workflow section for the detected workflow and language
+ */
+function renderGitWorkflowSection(targetDir: string, language: 'en' | 'ko'): string {
+  const result = detectGitWorkflow(targetDir) ?? getDefaultWorkflow();
+  return language === 'ko' ? renderGitWorkflowKO(result) : renderGitWorkflowEN(result);
+}
+
 /**
  * Install entry doc with the selected language
+ *
+ * Reads the template, injects dynamic git workflow section, and writes to target.
  */
 async function installEntryDoc(
   targetDir: string,
@@ -428,8 +447,15 @@ async function installEntryDoc(
     return false;
   }
 
-  // Copy the template file to entry doc
-  await fsCopyFile(srcPath, destPath);
+  // Read template, inject git workflow, write to destination
+  let content = await fsReadFile(srcPath, 'utf-8');
+
+  if (content.includes(GIT_WORKFLOW_PLACEHOLDER)) {
+    const workflowSection = renderGitWorkflowSection(targetDir, language);
+    content = content.replace(GIT_WORKFLOW_PLACEHOLDER, workflowSection);
+  }
+
+  await fsWriteFile(destPath, content, 'utf-8');
   debug('install.entry_md_installed', { language, entry: layout.entryFile });
   return true;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,14 @@ export {
   type OmccConfig,
   saveConfig,
 } from './core/config.js';
+export {
+  detectGitWorkflow,
+  type GitWorkflowResult,
+  type GitWorkflowType,
+  getDefaultWorkflow,
+  renderGitWorkflowEN,
+  renderGitWorkflowKO,
+} from './core/git-workflow.js';
 // Core modules
 export {
   copyTemplates,

--- a/templates/CLAUDE.md.en
+++ b/templates/CLAUDE.md.en
@@ -279,25 +279,4 @@ npm install -g claude-mem
 claude-mem setup
 ```
 
-## Git Workflow (MUST follow)
-
-| Branch | Purpose |
-|--------|---------|
-| `develop` | Main development branch (default) |
-| `feature/*` | New features -> PR to develop |
-| `release/*` | Release preparation -> **npm publish here only** |
-| `hotfix/*` | Critical fixes -> tag -> publish -> merge to develop |
-
-**Publishing flow:**
-```
-develop → release/x.y.z → npm publish → merge back to develop
-```
-
-**Key rules:**
-- Create feature branches from `develop`
-- **npm publish MUST only happen from release branch**
-- Use conventional commits: `feat:`, `fix:`, `docs:`, `chore:`
-- Include "Closes #N" in commit message to auto-close issues
-- Pre-commit hooks run tests automatically
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed workflow.
+<!-- omcustom:git-workflow -->

--- a/templates/CLAUDE.md.ko
+++ b/templates/CLAUDE.md.ko
@@ -279,25 +279,4 @@ npm install -g claude-mem
 claude-mem setup
 ```
 
-## Git 워크플로우 (반드시 준수)
-
-| 브랜치 | 용도 |
-|--------|------|
-| `develop` | 메인 개발 브랜치 (기본) |
-| `feature/*` | 새 기능 -> develop으로 PR |
-| `release/*` | 릴리스 준비 -> **npm 배포는 여기서만** |
-| `hotfix/*` | 긴급 수정 -> 태그 -> 배포 -> develop 머지 |
-
-**퍼블리싱 흐름:**
-```
-develop → release/x.y.z → npm publish → develop 머지
-```
-
-**핵심 규칙:**
-- `develop`에서 feature 브랜치 생성
-- **npm publish는 반드시 release 브랜치에서만**
-- Conventional commits 사용: `feat:`, `fix:`, `docs:`, `chore:`
-- 커밋 메시지에 "Closes #N" 포함시 이슈 자동 종료
-- Pre-commit 훅이 테스트 자동 실행
-
-자세한 워크플로우는 [CONTRIBUTING.md](CONTRIBUTING.md) 참조.
+<!-- omcustom:git-workflow -->

--- a/tests/unit/core/git-workflow.test.ts
+++ b/tests/unit/core/git-workflow.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { execFileSync } from 'node:child_process';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  detectGitWorkflow,
+  type GitWorkflowResult,
+  getDefaultWorkflow,
+  isGitRepo,
+  renderGitWorkflowEN,
+  renderGitWorkflowKO,
+} from '../../../src/core/git-workflow.js';
+
+/**
+ * Helper to run git commands in the test directory.
+ * Clears GIT_DIR/GIT_WORK_TREE to isolate from parent repo (e.g., during pre-commit hooks).
+ */
+function git(args: string[], cwd: string): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, GIT_DIR: undefined, GIT_WORK_TREE: undefined },
+  }).trim();
+}
+
+/**
+ * Initialize a test git repo with an initial commit.
+ * Disables hooks to prevent parent repo's pre-commit hook from interfering.
+ */
+async function initTestRepo(dir: string): Promise<void> {
+  git(['init', '-b', 'main'], dir);
+  git(['config', 'user.email', 'test@test.com'], dir);
+  git(['config', 'user.name', 'Test'], dir);
+  git(['config', 'core.hooksPath', '/dev/null'], dir);
+  await writeFile(join(dir, 'README.md'), '# Test\n');
+  git(['add', '.'], dir);
+  git(['commit', '-m', 'initial'], dir);
+}
+
+/**
+ * Assert result is non-null and return narrowed type
+ */
+function assertDetected(result: GitWorkflowResult | null): GitWorkflowResult {
+  expect(result).not.toBeNull();
+  // biome-ignore lint/style/noNonNullAssertion: test assertion guarantees non-null
+  return result!;
+}
+
+describe('git-workflow', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `omcustom-git-test-${Date.now()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('isGitRepo', () => {
+    it('should return true for a git repository', async () => {
+      await initTestRepo(tempDir);
+      expect(isGitRepo(tempDir)).toBe(true);
+    });
+
+    it('should return false for a non-git directory', () => {
+      expect(isGitRepo(tempDir)).toBe(false);
+    });
+  });
+
+  describe('detectGitWorkflow', () => {
+    it('should return null for non-git directories', () => {
+      expect(detectGitWorkflow(tempDir)).toBeNull();
+    });
+
+    it('should detect trunk-based workflow (main only, no feature branches)', async () => {
+      await initTestRepo(tempDir);
+
+      const result = assertDetected(detectGitWorkflow(tempDir));
+      expect(result.type).toBe('trunk-based');
+      expect(result.defaultBranch).toBe('main');
+      expect(result.hasDevelop).toBe(false);
+      expect(result.branchPatterns).toEqual([]);
+    });
+
+    it('should detect github-flow workflow (main + feature branches)', async () => {
+      await initTestRepo(tempDir);
+      git(['checkout', '-b', 'feature/add-login'], tempDir);
+      git(['checkout', 'main'], tempDir);
+
+      const result = assertDetected(detectGitWorkflow(tempDir));
+      expect(result.type).toBe('github-flow');
+      expect(result.defaultBranch).toBe('main');
+      expect(result.hasDevelop).toBe(false);
+      expect(result.branchPatterns).toContain('feature/*');
+    });
+
+    it('should detect git-flow workflow (develop + feature/release/hotfix)', async () => {
+      await initTestRepo(tempDir);
+      git(['checkout', '-b', 'develop'], tempDir);
+      git(['checkout', '-b', 'feature/user-auth'], tempDir);
+      git(['checkout', 'develop'], tempDir);
+      git(['checkout', '-b', 'release/1.0.0'], tempDir);
+      git(['checkout', 'develop'], tempDir);
+      git(['checkout', '-b', 'hotfix/fix-crash'], tempDir);
+      git(['checkout', 'develop'], tempDir);
+
+      const result = assertDetected(detectGitWorkflow(tempDir));
+      expect(result.type).toBe('git-flow');
+      expect(result.hasDevelop).toBe(true);
+      expect(result.branchPatterns).toContain('feature/*');
+      expect(result.branchPatterns).toContain('release/*');
+      expect(result.branchPatterns).toContain('hotfix/*');
+    });
+
+    it('should detect git-flow when develop exists without flow patterns', async () => {
+      await initTestRepo(tempDir);
+      git(['checkout', '-b', 'develop'], tempDir);
+
+      const result = assertDetected(detectGitWorkflow(tempDir));
+      expect(result.type).toBe('git-flow');
+      expect(result.hasDevelop).toBe(true);
+    });
+
+    it('should detect master as default branch when no main exists', async () => {
+      const dir = tempDir;
+      git(['init', '-b', 'master'], dir);
+      git(['config', 'user.email', 'test@test.com'], dir);
+      git(['config', 'user.name', 'Test'], dir);
+      git(['config', 'core.hooksPath', '/dev/null'], dir);
+      await writeFile(join(dir, 'README.md'), '# Test\n');
+      git(['add', '.'], dir);
+      git(['commit', '-m', 'initial'], dir);
+
+      const result = assertDetected(detectGitWorkflow(dir));
+      expect(result.defaultBranch).toBe('master');
+    });
+
+    it('should detect bugfix branch pattern', async () => {
+      await initTestRepo(tempDir);
+      git(['checkout', '-b', 'bugfix/typo'], tempDir);
+      git(['checkout', 'main'], tempDir);
+
+      const result = assertDetected(detectGitWorkflow(tempDir));
+      expect(result.branchPatterns).toContain('bugfix/*');
+    });
+  });
+
+  describe('getDefaultWorkflow', () => {
+    it('should return github-flow with main branch', () => {
+      const result = getDefaultWorkflow();
+      expect(result.type).toBe('github-flow');
+      expect(result.defaultBranch).toBe('main');
+      expect(result.hasDevelop).toBe(false);
+      expect(result.branchPatterns).toContain('feature/*');
+    });
+  });
+
+  describe('renderGitWorkflowEN', () => {
+    it('should render git-flow section with detected patterns', () => {
+      const result: GitWorkflowResult = {
+        type: 'git-flow',
+        defaultBranch: 'develop',
+        hasDevelop: true,
+        branchPatterns: ['feature/*', 'hotfix/*', 'release/*'],
+      };
+
+      const rendered = renderGitWorkflowEN(result);
+      expect(rendered).toContain('## Git Workflow (MUST follow)');
+      expect(rendered).toContain('`develop`');
+      expect(rendered).toContain('`feature/*`');
+      expect(rendered).toContain('`release/*`');
+      expect(rendered).toContain('`hotfix/*`');
+      expect(rendered).toContain('Create feature branches from `develop`');
+    });
+
+    it('should render github-flow section', () => {
+      const result: GitWorkflowResult = {
+        type: 'github-flow',
+        defaultBranch: 'main',
+        hasDevelop: false,
+        branchPatterns: ['feature/*'],
+      };
+
+      const rendered = renderGitWorkflowEN(result);
+      expect(rendered).toContain('## Git Workflow (MUST follow)');
+      expect(rendered).toContain('Production-ready code');
+      expect(rendered).toContain('All changes go through PR to `main`');
+    });
+
+    it('should render trunk-based section', () => {
+      const result: GitWorkflowResult = {
+        type: 'trunk-based',
+        defaultBranch: 'main',
+        hasDevelop: false,
+        branchPatterns: [],
+      };
+
+      const rendered = renderGitWorkflowEN(result);
+      expect(rendered).toContain('## Git Workflow (MUST follow)');
+      expect(rendered).toContain('Main trunk');
+      expect(rendered).toContain('short-lived branches');
+    });
+  });
+
+  describe('renderGitWorkflowKO', () => {
+    it('should render git-flow section in Korean', () => {
+      const result: GitWorkflowResult = {
+        type: 'git-flow',
+        defaultBranch: 'develop',
+        hasDevelop: true,
+        branchPatterns: ['feature/*', 'release/*'],
+      };
+
+      const rendered = renderGitWorkflowKO(result);
+      expect(rendered).toContain('## Git 워크플로우 (반드시 준수)');
+      expect(rendered).toContain('메인 개발 브랜치');
+      expect(rendered).toContain('feature 브랜치 생성');
+    });
+
+    it('should render github-flow section in Korean', () => {
+      const result: GitWorkflowResult = {
+        type: 'github-flow',
+        defaultBranch: 'main',
+        hasDevelop: false,
+        branchPatterns: ['feature/*'],
+      };
+
+      const rendered = renderGitWorkflowKO(result);
+      expect(rendered).toContain('프로덕션 준비 코드');
+      expect(rendered).toContain('PR을 통해 진행');
+    });
+
+    it('should render trunk-based section in Korean', () => {
+      const result: GitWorkflowResult = {
+        type: 'trunk-based',
+        defaultBranch: 'main',
+        hasDevelop: false,
+        branchPatterns: [],
+      };
+
+      const rendered = renderGitWorkflowKO(result);
+      expect(rendered).toContain('메인 트렁크');
+      expect(rendered).toContain('단기 브랜치 사용');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/core/git-workflow.ts` module that detects the target project's git branch structure during `omcustom init`
- Detect three workflow types: **git-flow** (develop + feature/release/hotfix), **github-flow** (main + feature branches), **trunk-based** (main only)
- Replace hardcoded Git Workflow section in CLAUDE.md templates with auto-detected, dynamically rendered content
- Support both English and Korean template rendering

## Changes

### New file: `src/core/git-workflow.ts`
- `detectGitWorkflow(cwd)` - Detects default branch, develop existence, branch patterns
- `renderGitWorkflowEN/KO(result)` - Renders markdown section per workflow type
- `getDefaultWorkflow()` - Fallback for non-git directories (github-flow with main)
- Uses `execFileSync` (not `execSync`) for safety
- Clears `GIT_DIR`/`GIT_WORK_TREE` env vars to isolate from parent repos

### Modified: `src/core/installer.ts`
- `installEntryDoc` now reads template, detects git workflow, replaces `<!-- omcustom:git-workflow -->` placeholder, writes result (instead of simple file copy)

### Modified: `templates/CLAUDE.md.en` and `templates/CLAUDE.md.ko`
- Replaced hardcoded git-flow section with `<!-- omcustom:git-workflow -->` placeholder

### New file: `tests/unit/core/git-workflow.test.ts`
- 16 unit tests covering all detection and rendering scenarios
- Tests isolated from parent repo using `GIT_DIR`/`GIT_WORK_TREE` clearing

Closes #92

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>