### PR TITLE
fix(ci): handle race condition in npm publish step (#101)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,16 @@ jobs:
       # Publish to npm (skip if already exists)
       - name: Publish to npm
         if: steps.npm_check.outputs.exists == 'false'
-        run: npm publish --provenance --access public
+        run: |
+          npm publish --provenance --access public 2>&1 || {
+            EXIT_CODE=$?
+            # Check if failure is due to version already existing (race condition with local publish)
+            if npm view oh-my-customcode@${{ steps.npm_check.outputs.version }} version 2>/dev/null; then
+              echo "::notice::Version ${{ steps.npm_check.outputs.version }} was published externally (race condition). Continuing."
+            else
+              exit $EXIT_CODE
+            fi
+          }
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -103,7 +112,16 @@ jobs:
             };
             require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2));
           "
-          npm publish
+          npm publish 2>&1 || {
+            EXIT_CODE=$?
+            # Check if failure is due to version already existing (race condition with local publish)
+            VERSION=${GITHUB_REF#refs/tags/v}
+            if npm view @baekenough/oh-my-customcode@$VERSION version --registry=https://npm.pkg.github.com 2>/dev/null; then
+              echo "::notice::Version $VERSION was published externally (race condition). Continuing."
+            else
+              exit $EXIT_CODE
+            fi
+          }
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Closes #101

## Summary
- Handle 403 errors gracefully when version was already published externally
- Prevents CI failure from race condition between local and CI npm publish
- Applies same fix to both npm and GitHub Packages publish steps

## Changes
- Modified "Publish to npm" step to catch publish failures and check if version exists on registry before failing
- Modified "Publish to GitHub Packages" step with the same race condition handling
- Both steps now continue successfully if the version was published externally (race condition scenario)
- Genuine publish errors (non-403) still fail the workflow as expected

## Test plan
- [ ] Release workflow passes when version already exists on npm
- [ ] Release workflow still fails on genuine publish errors