### PR TITLE
chore(release): v0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3] - 2026-02-12
+
+### Added
+- Brand assets (banner, badge, icon) and README/wiki banners (#102)
+
+### Fixed
+- Release workflow race condition in npm publish step (#101, #103)
+
 ## [0.10.1] - 2026-02-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-customcode",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v0.10.3

## Changes
- feat: add brand assets and update README/wiki banners (#102)
- fix(ci): handle race condition in npm publish step (#101, #103)