### PR TITLE
feat: replace Python with uv for MCP server setup

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -6,7 +6,7 @@
 import { join } from 'node:path';
 import { type InstallResult as InstallerResult, install } from '../core/installer.js';
 import { getProviderLayout } from '../core/layout.js';
-import { checkPythonAvailable, generateMCPConfig } from '../core/mcp-config.js';
+import { checkUvAvailable, generateMCPConfig } from '../core/mcp-config.js';
 import { i18n } from '../i18n/index.js';
 import { fileExists } from '../utils/fs.js';
 
@@ -142,17 +142,18 @@ export async function initCommand(options: InitOptions): Promise<InitResult> {
     logInstallResultInfo(installResult);
     logSuccessDetails(installedPaths, installResult.skippedComponents);
 
-    // Generate MCP config for ontology-rag if Python is available
-    const pythonAvailable = await checkPythonAvailable();
-    if (pythonAvailable) {
+    // Generate MCP config for ontology-rag if uv is available
+    const uvAvailable = await checkUvAvailable();
+    if (uvAvailable) {
       try {
         await generateMCPConfig(targetDir);
-      } catch {
-        console.warn('Warning: Failed to generate MCP config. You can configure it manually.');
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        console.warn(`Warning: Failed to setup MCP environment: ${msg}`);
       }
     } else {
-      console.warn('Warning: Python not found. Skipping MCP server configuration.');
-      console.warn('Install Python 3.10+ and ontology-rag to enable MCP integration.');
+      console.warn('Warning: uv not found. Skipping MCP server configuration.');
+      console.warn('Install uv (https://docs.astral.sh/uv/) to enable MCP integration.');
     }
 
     return {

--- a/src/core/mcp-config.ts
+++ b/src/core/mcp-config.ts
@@ -34,11 +34,21 @@ export async function generateMCPConfig(targetDir: string): Promise<void> {
     return;
   }
 
+  // Create venv and install ontology-rag
+  // Note: No user input in commands - safe to use execSync with fixed strings
+  try {
+    execSync('uv venv .venv', { cwd: targetDir, stdio: 'pipe' });
+    execSync('uv pip install ontology-rag', { cwd: targetDir, stdio: 'pipe' });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to setup Python environment: ${msg}`);
+  }
+
   const config: MCPConfig = {
     mcpServers: {
       'ontology-rag': {
         type: 'stdio',
-        command: 'python',
+        command: '.venv/bin/python',
         args: ['-m', 'ontology_rag.mcp_server'],
         env: {
           ONTOLOGY_DIR: ontologyDir,
@@ -70,13 +80,13 @@ export async function generateMCPConfig(targetDir: string): Promise<void> {
 }
 
 /**
- * Check if Python is available for MCP server
- * @returns True if Python 3.x is installed and accessible
+ * Check if uv is available for Python environment management
+ * @returns True if uv is installed and accessible
  */
-export async function checkPythonAvailable(): Promise<boolean> {
+export async function checkUvAvailable(): Promise<boolean> {
   try {
     // Note: No user input - safe to use execSync
-    execSync('python --version', { stdio: 'pipe' });
+    execSync('uv --version', { stdio: 'pipe' });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- Replace `checkPythonAvailable()` with `checkUvAvailable()` for reliable Python env detection
- Create isolated `.venv` via `uv venv` during `omcustom init`
- Install `ontology-rag` into `.venv` via `uv pip install`
- Use `.venv/bin/python` in `.mcp.json` instead of system `python`

## Test plan
- [x] Lint: biome check (50 files, no issues)
- [x] TypeScript: tsc --noEmit pass
- [x] Tests: 768 pass, 0 fail (1755 expect calls)
- [ ] Manual: `omcustom init` with uv installed
- [ ] Manual: `omcustom init` without uv (error message verification)

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)