### PR TITLE
fix: graceful fallback when CHANGELOG.md entry is missing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,42 +130,45 @@ jobs:
         if: steps.ghp_check.outputs.exists == 'false'
         run: git checkout package.json
 
-      # Extract changelog for this version (REQUIRED)
+      # Extract changelog for this version (with graceful fallback)
       - name: Extract Release Notes
         id: changelog
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-          # CHANGELOG.md is required
+          # Check for CHANGELOG.md
           if [ ! -f CHANGELOG.md ]; then
-            echo "::error::CHANGELOG.md not found. Please create it before releasing."
-            exit 1
+            echo "::warning::CHANGELOG.md not found. Will use auto-generated release notes."
+            echo "notes=" >> $GITHUB_OUTPUT
+            echo "has_changelog=false" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
           # Extract changelog section for this version
           NOTES=$(awk "/^## \[${VERSION}\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
 
           if [ -z "$NOTES" ]; then
-            echo "::error::No changelog entry found for version ${VERSION}."
-            echo "::error::Please add a '## [${VERSION}]' section to CHANGELOG.md before releasing."
-            exit 1
+            echo "::warning::No changelog entry found for version ${VERSION}."
+            echo "::warning::Will use auto-generated release notes. Consider adding a '## [${VERSION}]' section to CHANGELOG.md."
+            echo "notes=" >> $GITHUB_OUTPUT
+            echo "has_changelog=false" >> $GITHUB_OUTPUT
+          else
+            echo "notes<<EOF" >> $GITHUB_OUTPUT
+            echo "$NOTES" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "has_changelog=true" >> $GITHUB_OUTPUT
+            echo "::notice::Found changelog entry for v${VERSION}"
           fi
 
-          echo "notes<<EOF" >> $GITHUB_OUTPUT
-          echo "$NOTES" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
-          echo "::notice::Found changelog entry for v${VERSION}"
-
-      # Create GitHub Release with changelog
+      # Create GitHub Release with changelog or auto-generated notes
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           body: |
             ## What's Changed
 
-            ${{ steps.changelog.outputs.notes }}
+            ${{ steps.changelog.outputs.notes || '_Auto-generated release notes (CHANGELOG.md entry missing)_' }}
 
             ---
 
@@ -182,6 +185,7 @@ jobs:
             ### Links
             - [npm package](https://www.npmjs.com/package/oh-my-customcode/v/${{ steps.changelog.outputs.version }})
             - [GitHub Package](https://github.com/baekenough/oh-my-customcode/pkgs/npm/oh-my-customcode)
+          generate_release_notes: ${{ steps.changelog.outputs.has_changelog != 'true' }}
           draft: false
           prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
         env:


### PR DESCRIPTION
## Summary

Closes #133

Fixes the release workflow failure when CHANGELOG.md entry is missing by implementing Option A (graceful fallback):

- **Before**: Missing CHANGELOG entry → `exit 1` → GitHub Release creation skipped → Release Notes Generator skipped → half-release state
- **After**: Missing CHANGELOG entry → warning → auto-generated release notes → GitHub Release created → Release Notes Generator runs

## Changes

- `.github/workflows/release.yml`: Replace hard failure with graceful fallback
  - Warning instead of error when CHANGELOG entry not found
  - Use `generate_release_notes: true` as fallback
  - GitHub Release always created regardless of CHANGELOG state

## Impact

- Prevents the half-release state that occurred in v0.12.2 and v0.12.3
- Release Notes Generator workflow now always triggers (depends on release workflow success)
- CHANGELOG-first workflow preserved when entry exists

## Test Plan

- [ ] Verify workflow syntax is valid
- [ ] Test with tag that has CHANGELOG entry → uses CHANGELOG notes
- [ ] Test with tag that lacks CHANGELOG entry → uses auto-generated notes
- [ ] Verify Release Notes Generator workflow triggers in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)