### PR TITLE
fix: install ontology-rag from Git URL instead of PyPI

### DIFF
--- a/src/core/mcp-config.ts
+++ b/src/core/mcp-config.ts
@@ -38,7 +38,10 @@ export async function generateMCPConfig(targetDir: string): Promise<void> {
   // Note: No user input in commands - safe to use execSync with fixed strings
   try {
     execSync('uv venv .venv', { cwd: targetDir, stdio: 'pipe' });
-    execSync('uv pip install ontology-rag', { cwd: targetDir, stdio: 'pipe' });
+    execSync(
+      'uv pip install "ontology-rag @ git+https://github.com/baekenough/oh-my-customcode.git#subdirectory=packages/ontology-rag"',
+      { cwd: targetDir, stdio: 'pipe' }
+    );
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     throw new Error(`Failed to setup Python environment: ${msg}`);

--- a/tests/unit/core/mcp-config.test.ts
+++ b/tests/unit/core/mcp-config.test.ts
@@ -119,7 +119,9 @@ describe('mcp-config', () => {
       await generateMCPConfig(tempDir);
 
       expect(execCalls).toContain('uv venv .venv');
-      expect(execCalls).toContain('uv pip install ontology-rag');
+      expect(execCalls).toContain(
+        'uv pip install "ontology-rag @ git+https://github.com/baekenough/oh-my-customcode.git#subdirectory=packages/ontology-rag"'
+      );
     });
 
     it('should throw error if venv creation fails', async () => {


### PR DESCRIPTION
## Summary

- **Bug**: `omcustom init` fails with `"ontology-rag was not found in the package registry"` because `ontology-rag` is not published on PyPI
- **Fix**: Changed the `uv pip install` command to use a PEP 440 direct reference pointing to the package subdirectory in this GitHub repo
- **Test**: Updated the corresponding unit test to assert the new Git URL install command

## Root Cause

`src/core/mcp-config.ts` called `uv pip install ontology-rag`, which requires the package to exist on PyPI. Since `ontology-rag` lives in `packages/ontology-rag/` within this monorepo and has not been published to PyPI, the install step always fails for end users running `omcustom init`.

## Fix Details

Changed the install command from:
```
uv pip install ontology-rag
```

To:
```
uv pip install "ontology-rag @ git+https://github.com/baekenough/oh-my-customcode.git#subdirectory=packages/ontology-rag"
```

This uses the [PEP 440 direct reference](https://peps.python.org/pep-0440/#direct-references) syntax supported by `uv pip install`, installing the package directly from the GitHub repository without requiring a PyPI release.

Closes #152

## Test plan

- [ ] Run `omcustom init` in a fresh directory and verify the Python venv is created and `ontology-rag` installs successfully
- [ ] Verify unit tests pass: `bun test tests/unit/core/mcp-config.test.ts`
- [ ] Confirm `.mcp.json` is generated correctly after init

🤖 Generated with [Claude Code](https://claude.com/claude-code)