### PR TITLE
feat: add skills.sh marketplace integration for external skill discovery

### DIFF
--- a/templates/.claude/ontology/skills.yaml
+++ b/templates/.claude/ontology/skills.yaml
@@ -65,6 +65,10 @@ classes:
     skills: [monitoring-setup]
     description: "Monitoring configuration"
 
+  ExternalSkillSourceSkill:
+    skills: [skills-sh-search]
+    description: "External skill marketplace discovery and installation"
+
 # Skill instances
 skills:
   airflow-best-practices:
@@ -418,6 +422,15 @@ skills:
     summary: "Idiomatic Rust patterns and best practices from official documentation"
     keywords: [rust, ownership, borrowing, safety, concurrency]
     rule_references: []
+
+  skills-sh-search:
+    class: ExternalSkillSourceSkill
+    description: "Search and install skills from skills.sh marketplace when internal skills are insufficient"
+    user_invocable: true
+    model_invocable: true
+    summary: "Search skills.sh marketplace for external skills and install them into the project"
+    keywords: [skills-sh, marketplace, external, install, search, discover, npx]
+    rule_references: [R003, R006]
 
   sauron-watch:
     class: VerificationSkill

--- a/templates/.claude/skills/skills-sh-search/SKILL.md
+++ b/templates/.claude/skills/skills-sh-search/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: skills-sh-search
+description: Search and install skills from skills.sh marketplace when internal skills are insufficient
+argument-hint: "<query> [--install] [--global]"
+---
+
+# Skills.sh Search Skill
+
+Search the [skills.sh](https://skills.sh/) marketplace for reusable AI agent skills when no matching internal skill exists. Install discovered skills directly into the project.
+
+## Prerequisites
+
+- Node.js and npx available in PATH
+- Network access to skills.sh registry
+
+## Options
+
+```
+<query>          Required. Search query describing the capability needed
+--install, -i    Install selected skill after search
+--global, -g     Install to ~/.claude/skills/ instead of project .claude/skills/
+--list, -l       List currently installed skills.sh skills
+--check, -c      Check for updates on installed skills.sh skills
+```
+
+## Workflow
+
+```
+1. Search skills.sh marketplace
+   ├── Run: npx --yes skills find "<query>"
+   ├── Review results (name, description, install count)
+   └── Present top candidates to user
+
+2. User selects skill
+   ├── Confirm selection with user
+   └── Check for namespace conflicts with existing skills
+
+3. Install skill
+   ├── Run: npx --yes skills add <source> [-g]
+   ├── Verify installation in .claude/skills/
+   └── Check installed SKILL.md frontmatter
+
+4. Post-install adaptation
+   ├── Review installed SKILL.md frontmatter
+   ├── Add oh-my-customcode fields if missing:
+   │   ├── user-invocable: true|false
+   │   ├── model-invocable (if not present)
+   │   └── argument-hint (if applicable)
+   └── Add source metadata:
+       ├── source-type: skills-sh
+       └── source-origin: <owner/repo>
+
+5. Ontology sync
+   ├── Notify: run "omcustom ontology build" to register new skill
+   └── Or manually add to skills.yaml if ontology CLI unavailable
+```
+
+## Namespace Conflict Check
+
+Before installing, verify no existing skill shares the same name:
+
+```bash
+# Check for conflict
+ls .claude/skills/ | grep -w "<skill-name>"
+```
+
+If conflict exists:
+- Warn user about the conflict
+- Suggest renaming or skipping
+- Never overwrite existing skills without explicit approval
+
+## Output Format
+
+### Search Results
+```
+[skills-sh-search] Searching marketplace...
+
+Query: "<query>"
+Results: 5 found
+
+  1. owner/skill-name (12.3K installs)
+     Description of the skill
+
+  2. owner/another-skill (8.1K installs)
+     Description of the skill
+
+  3. owner/third-skill (3.5K installs)
+     Description of the skill
+
+Select [1-3] or "skip" to cancel:
+```
+
+### Install Success
+```
+[skills-sh-search] Installed
+
+Skill: <skill-name>
+Source: <owner/repo>
+Location: .claude/skills/<skill-name>/SKILL.md
+Adapted: ✓ (added user-invocable, source metadata)
+
+Next: Run "omcustom ontology build" to register in ontology.
+```
+
+### Install Failure
+```
+[skills-sh-search] Failed
+
+Error: <error_message>
+Suggested Fix: <suggestion>
+```
+
+### No Results
+```
+[skills-sh-search] No Results
+
+Query: "<query>"
+Suggestions:
+  - Try broader search terms
+  - Check https://skills.sh/ directly
+  - Consider creating a custom skill with /create-agent
+```
+
+## Examples
+
+```bash
+# Search for Terraform skills
+/skills-sh-search terraform infrastructure
+
+# Search and install
+/skills-sh-search "react testing patterns" --install
+
+# Install globally
+/skills-sh-search "git workflow" --install --global
+
+# List installed skills.sh skills
+/skills-sh-search --list
+
+# Check for updates
+/skills-sh-search --check
+```
+
+## Integration
+
+### With intent-detection
+When intent-detection finds no matching agent and the domain is identifiable, this skill can be suggested as a fallback to find relevant external skills.
+
+### With update-external
+Installed skills.sh skills are tracked with `source-type: skills-sh` metadata, enabling `update-external` to check for updates via `npx skills check`.
+
+### With create-agent
+If a skills.sh skill provides domain knowledge, `create-agent` can reference it when building a new agent for that domain.
+
+## Safety
+
+- **Read-only by default**: Search does not modify anything
+- **Explicit install**: Installation requires `--install` flag or user confirmation
+- **No auto-execution**: Installed skills are not auto-invoked without ontology registration
+- **Conflict protection**: Never overwrites existing skills
+- **Telemetry opt-out**: Set `DISABLE_TELEMETRY=1` to disable skills CLI telemetry

--- a/templates/.claude/skills/update-external/SKILL.md
+++ b/templates/.claude/skills/update-external/SKILL.md
@@ -37,6 +37,15 @@ web-design-guidelines:
   type: github
 ```
 
+### Skills (from skills.sh marketplace)
+```yaml
+<skill-name>:
+  source: <owner/repo>
+  type: skills-sh
+```
+
+Skills installed via `skills-sh-search` are tracked with `source-type: skills-sh` in their frontmatter. Update checks use `npx skills check`.
+
 ### Guides (reference documentation)
 ```yaml
 golang:
@@ -58,6 +67,7 @@ python:
 
 2. Check for updates
    ├── GitHub: Check releases/commits
+   ├── skills-sh: Run "npx skills check"
    ├── Documentation: Check last-modified
    └── Compare with current version
 
@@ -89,6 +99,14 @@ source:
       date: "2026-01-20"
     - version: "1.2.0"
       date: "2026-01-22"
+
+# skills.sh source
+source:
+  type: external
+  origin: skills-sh
+  registry: https://skills.sh
+  installed_via: "npx skills add <owner/repo>"
+  last_checked: "2026-02-20"
 ```
 
 ## Output Format

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -18,7 +18,7 @@
       "name": "skills",
       "path": ".claude/skills",
       "description": "Reusable skill modules (includes slash commands)",
-      "files": 52
+      "files": 53
     },
     {
       "name": "guides",

--- a/tests/unit/cli/init.test.ts
+++ b/tests/unit/cli/init.test.ts
@@ -94,6 +94,25 @@ describe('init command', () => {
       expect(skillsDirStats.isDirectory()).toBe(true);
     });
 
+    it('should install skills-sh-search skill', async () => {
+      const result = await install({
+        targetDir: tempDir,
+        language: 'en',
+      });
+
+      expect(result.success).toBe(true);
+
+      // Verify skills-sh-search skill is installed with valid SKILL.md
+      const skillMdPath = join(tempDir, '.claude', 'skills', 'skills-sh-search', 'SKILL.md');
+      const skillMdStats = await stat(skillMdPath);
+      expect(skillMdStats.isFile()).toBe(true);
+
+      const { readFile } = await import('node:fs/promises');
+      const content = await readFile(skillMdPath, 'utf-8');
+      expect(content).toContain('name: skills-sh-search');
+      expect(content).toContain('skills.sh');
+    });
+
     it('should create guides directory', async () => {
       const result = await install({
         targetDir: tempDir,

--- a/tests/unit/core/installer.test.ts
+++ b/tests/unit/core/installer.test.ts
@@ -122,6 +122,27 @@ describe('installer', () => {
       expect(componentNames).not.toContain('commands'); // commands removed
       expect(componentNames).not.toContain('pipelines'); // pipelines removed
     });
+
+    it('should have manifest file counts matching actual template directories', async () => {
+      const { readdir } = await import('node:fs/promises');
+      const manifest = await getTemplateManifest();
+      const templateDir = getTemplateDir();
+
+      for (const component of manifest.components) {
+        const resolvedPath = join(templateDir, component.path);
+
+        try {
+          const entries = await readdir(resolvedPath);
+          const count = entries.filter((e) => !e.startsWith('.')).length;
+          expect(count).toBe(
+            component.files,
+            `${component.name}: manifest says ${component.files} files but found ${count}`
+          );
+        } catch {
+          // Skip if directory doesn't exist (handled by other tests)
+        }
+      }
+    });
   });
 
   describe('install', () => {


### PR DESCRIPTION
## Summary

- Add `skills-sh-search` skill for discovering and installing skills from [skills.sh](https://skills.sh/) marketplace (67K+ skills, Claude Code native support)
- Register `ExternalSkillSourceSkill` class in ontology with full metadata
- Extend `update-external` skill to support `skills-sh` as an external source type

Closes #154

## Changes

| File | Change |
|------|--------|
| `templates/.claude/skills/skills-sh-search/SKILL.md` | New skill with search/install workflow, namespace conflict checks, post-install adaptation |
| `templates/.claude/ontology/skills.yaml` | Add `ExternalSkillSourceSkill` class + `skills-sh-search` skill entry |
| `templates/.claude/skills/update-external/SKILL.md` | Add skills.sh source type, `npx skills check` update path |

## Design Decisions

- **Same SKILL.md format**: skills.sh uses identical `SKILL.md` with YAML frontmatter, minimizing adaptation friction
- **Post-install adaptation**: Automatically adds oh-my-customcode fields (`user-invocable`, `source-type: skills-sh`) to installed skills
- **Namespace safety**: Conflict check before install, never overwrites existing skills
- **Ontology sync**: Installed skills registered via `omcustom ontology build`

## Test plan

- [ ] Verify `npx skills find <query>` returns results
- [ ] Verify `npx skills add <source>` installs to `.claude/skills/`
- [ ] Verify installed skill has compatible SKILL.md format
- [ ] Verify no namespace conflicts with existing 52 skills
- [ ] Verify `omcustom ontology build` picks up newly installed skills
- [ ] Verify `update-external` recognizes `skills-sh` source type

🤖 Generated with [Claude Code](https://claude.com/claude-code)