### PR TITLE
chore: CI/CD pipeline improvements — checkout v6, bun caching, model env var

### DIFF
--- a/.github/scripts/analyze-issue.ts
+++ b/.github/scripts/analyze-issue.ts
@@ -54,7 +54,7 @@ const CONFIG = {
   anthropicApiKey: process.env.ANTHROPIC_API_KEY,
   githubToken: process.env.GITHUB_TOKEN,
   githubRepo: process.env.GITHUB_REPOSITORY,
-  model: 'claude-sonnet-4-20250514',
+  model: process.env.CLAUDE_MODEL || 'claude-sonnet-4-20250514',
   maxTokens: 8000,
 };
 

--- a/.github/scripts/generate-release-notes.ts
+++ b/.github/scripts/generate-release-notes.ts
@@ -196,7 +196,7 @@ async function generateReleaseNotes(version?: string): Promise<string> {
   });
 
   const message = await client.messages.create({
-    model: "claude-sonnet-4-20250514",
+    model: process.env.CLAUDE_MODEL || 'claude-sonnet-4-20250514',
     max_tokens: 2048,
     messages: [
       {

--- a/.github/scripts/validate-docs.ts
+++ b/.github/scripts/validate-docs.ts
@@ -267,7 +267,7 @@ async function validateDocs(): Promise<string> {
   const client = new Anthropic();
 
   const message = await client.messages.create({
-    model: 'claude-sonnet-4-20250514',
+    model: process.env.CLAUDE_MODEL || 'claude-sonnet-4-20250514',
     max_tokens: 2048,
     messages: [
       {

--- a/.github/scripts/verify-claude-native.ts
+++ b/.github/scripts/verify-claude-native.ts
@@ -519,7 +519,7 @@ ${JSON.stringify(projectStructure.rules.filter((r) => r.is_unique), null, 2)}
 Respond with ONLY valid JSON, no markdown formatting.`;
 
   const response = await client.messages.create({
-    model: 'claude-sonnet-4-20250514',
+    model: process.env.CLAUDE_MODEL || 'claude-sonnet-4-20250514',
     max_tokens: 4096,
     messages: [{ role: 'user', content: prompt }],
   });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -72,26 +72,3 @@ jobs:
           fi
 
           echo "Coverage check passed: Function $FUNC_COV%, Line $LINE_COV% (threshold: $THRESHOLD%)"
-
-  security-audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    needs: [lint, test]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Run security audit
-        run: |
-          # Generate package-lock.json for npm audit (bun uses bun.lock)
-          npm i --package-lock-only --ignore-scripts 2>/dev/null || true
-          # Run npm audit (fails on high/critical vulnerabilities)
-          npm audit --audit-level=high

--- a/.github/workflows/claude-native-check.yml
+++ b/.github/workflows/claude-native-check.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "Guardrail: check Claude template"
         id: guard
@@ -48,6 +48,15 @@ jobs:
       - name: Setup Bun
         if: steps.guard.outputs.skip != 'true'
         uses: oven-sh/setup-bun@v2
+
+      - name: Cache Bun dependencies
+        if: steps.guard.outputs.skip != 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Install dependencies
         if: steps.guard.outputs.skip != 'true'

--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -28,10 +28,10 @@ jobs:
           fi
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Checkout wiki
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ github.repository }}.wiki
           path: wiki-repo
@@ -101,7 +101,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check README structure consistency
         run: |

--- a/.github/workflows/docs-validator.yml
+++ b/.github/workflows/docs-validator.yml
@@ -25,10 +25,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -68,6 +68,14 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/reusable-claude-native.yml
+++ b/.github/workflows/reusable-claude-native.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout caller repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: project
 
@@ -54,7 +54,7 @@ jobs:
 
       - name: Checkout oh-my-customcode (scripts only)
         if: steps.guard.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: baekenough/oh-my-customcode
           ref: develop
@@ -68,6 +68,15 @@ jobs:
       - name: Set up Bun
         if: steps.guard.outputs.skip != 'true'
         uses: oven-sh/setup-bun@v2
+
+      - name: Cache Bun dependencies
+        if: steps.guard.outputs.skip != 'true'
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('scripts/bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Install dependencies
         if: steps.guard.outputs.skip != 'true'

--- a/.github/workflows/reusable-daily-report.yml
+++ b/.github/workflows/reusable-daily-report.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout oh-my-customcode (scripts only)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: baekenough/oh-my-customcode
           ref: develop
@@ -48,6 +48,14 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install --production

--- a/.github/workflows/reusable-issue-analyzer.yml
+++ b/.github/workflows/reusable-issue-analyzer.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout oh-my-customcode (scripts only)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: baekenough/oh-my-customcode
           ref: develop
@@ -68,6 +68,14 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/sync-check.yml
+++ b/.github/workflows/sync-check.yml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
       - name: Checkout oh-my-customcode
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: oh-my-customcode
 
       - name: Checkout source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: baekenough/baekgom-agents
           token: ${{ secrets.OMCUSTOM_MASTER }}


### PR DESCRIPTION
## Summary

- Unify `actions/checkout` from v4 to v6 across 8 workflows
- Add Bun dependency caching (`actions/cache@v4`) to 6 workflows for faster CI
- Extract Claude API model to `CLAUDE_MODEL` environment variable in 4 scripts
- Switch ci.yml test runner from `macos-latest` to `ubuntu-latest`
- Remove duplicate `security-audit` job from ci.yml (standalone `security-audit.yml` is sufficient)

## Changes (13 files, +67/-40)

### P1: actions/checkout v6 unification (8 workflows)
| File | Instances Updated |
|------|------------------|
| docs-validator.yml | 1 |
| docs-sync.yml | 3 |
| sync-check.yml | 2 |
| claude-native-check.yml | 1 |
| reusable-claude-native.yml | 2 |
| reusable-daily-report.yml | 1 |
| reusable-issue-analyzer.yml | 1 |
| release-notes.yml | 1 |

### P1: Bun dependency caching (6 workflows)
Added `actions/cache@v4` with `~/.bun/install/cache` path and `bun.lock` hash key.
Skipped `docs-sync.yml` and `sync-check.yml` (no `bun install`).

### P1: Claude model env var (4 scripts)
```typescript
// Before
model: 'claude-sonnet-4-20250514'
// After
model: process.env.CLAUDE_MODEL || 'claude-sonnet-4-20250514'
```

### P2: CI optimization
- `ci.yml` test job: `macos-latest` → `ubuntu-latest` (2x cheaper, faster provisioning)
- Removed duplicate `security-audit` job from `ci.yml` (standalone workflow already covers PRs + weekly schedule)

## Verification

| Check | Result |
|-------|--------|
| TypeScript typecheck | ✅ Pass |
| Biome lint (53 files) | ✅ Pass |
| Tests (824/824) | ✅ Pass |
| Coverage (99.14% func / 98.08% line) | ✅ Pass |
| No v4 checkout refs remaining | ✅ Verified |
| Cache entries count (6) | ✅ Correct |
| CLAUDE_MODEL in all 4 scripts | ✅ Verified |
| YAML syntax (13 workflows) | ✅ Valid |

## Test plan

- [ ] CI workflow triggers correctly on this PR (lint + test)
- [ ] Bun cache hits on subsequent runs
- [ ] CLAUDE_MODEL env var override works (set in workflow)
- [ ] No regression in existing workflow behavior

Ref: #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)