### PR TITLE
chore: address non-blocking warnings from PR #161 review

### DIFF
--- a/.github/scripts/analyze-issue.ts
+++ b/.github/scripts/analyze-issue.ts
@@ -214,10 +214,10 @@ async function analyzeIssueWithClaude(issue: IssueData): Promise<AnalysisResult>
       ],
     });
 
-    // Extract text content
+    // Extract text content using type narrowing (ContentBlock is a discriminated union)
     const textContent = message.content
-      .filter((block) => block.type === 'text')
-      .map((block) => (block as any).text)
+      .filter((block): block is Anthropic.TextBlock => block.type === 'text')
+      .map((block) => block.text)
       .join('\n');
 
     // Parse JSON response (handle code blocks)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,16 +63,18 @@ jobs:
           set +e
           rm -f /tmp/coverage-output.txt
           bun test --coverage 2>&1 | tee /tmp/coverage-output.txt
+          # PIPESTATUS is bash-specific (requires shell: bash above)
           TEST_EXIT=${PIPESTATUS[0]}
           set -e
 
           COVERAGE_OUTPUT=$(cat /tmp/coverage-output.txt)
 
-          # Fail if tests themselves failed (not just coverage)
+          # Workaround: bun test --coverage may exit non-zero even when tests pass
+          # This heuristic checks actual test results in output (fragile if bun changes output format)
+          # TODO(bun-update): Re-evaluate after bun stable release (currently using latest)
           if [ $TEST_EXIT -ne 0 ]; then
-            # Check if tests actually passed but exit code is non-zero (bun coverage quirk)
             if echo "$COVERAGE_OUTPUT" | grep -qE "[0-9]+ pass" && ! echo "$COVERAGE_OUTPUT" | grep -qE "[0-9]+ fail"; then
-              echo "::warning::bun test exited with $TEST_EXIT but tests passed. Continuing..."
+              echo "::warning::bun test exited with $TEST_EXIT but tests passed (known bun coverage quirk). Continuing..."
             else
               echo "::error::Tests failed with exit code $TEST_EXIT"
               exit 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-customcode",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/hooks/hooks.json
+++ b/templates/.claude/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash templates/.claude/hooks/scripts/stage-blocker.sh"
+            "command": "bash .claude/hooks/scripts/stage-blocker.sh"
           }
         ],
         "description": "Block Write/Edit tools during plan/verify/compound stages — only allow in implement stage"

--- a/templates/.claude/hooks/hooks.json
+++ b/templates/.claude/hooks/hooks.json
@@ -7,7 +7,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [ -f /tmp/.claude-dev-stage ]; then stage=$(cat /tmp/.claude-dev-stage | tr -d '[:space:]'); if [ -z \"$stage\" ]; then exit 0; fi; case \"$stage\" in plan|verify-plan|verify-impl|compound|done) echo \"⛔ BLOCKED: Write/Edit disabled in '$stage' stage. Only allowed during 'implement' stage. Use 'echo implement > /tmp/.claude-dev-stage' to transition.\"; exit 2;; esac; fi"
+            "command": "bash templates/.claude/hooks/scripts/stage-blocker.sh"
           }
         ],
         "description": "Block Write/Edit tools during plan/verify/compound stages — only allow in implement stage"

--- a/templates/.claude/hooks/scripts/stage-blocker.sh
+++ b/templates/.claude/hooks/scripts/stage-blocker.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Stage-blocking hook: blocks Write/Edit in non-implement stages
+if [ -f /tmp/.claude-dev-stage ]; then
+  stage=$(cat /tmp/.claude-dev-stage | tr -d '[:space:]')
+  if [ -z "$stage" ]; then exit 0; fi
+  case "$stage" in
+    plan|verify-plan|verify-impl|compound|done)
+      echo "⛔ BLOCKED: Write/Edit disabled in '$stage' stage. Only allowed during 'implement' stage. Use 'echo implement > /tmp/.claude-dev-stage' to transition."
+      exit 2
+      ;;
+  esac
+fi

--- a/tests/unit/core/hooks-validation.test.ts
+++ b/tests/unit/core/hooks-validation.test.ts
@@ -293,7 +293,7 @@ describe('Hooks Validation', () => {
       expect(stageBlockingHook?.hooks[0].type).toBe('command');
     });
 
-    it('should have the stage-based hook command referencing /tmp/.claude-dev-stage', async () => {
+    it('should have the stage-based hook command referencing stage-blocker script', async () => {
       const { parsed } = await loadHooksJson();
       const data = parsed as HooksStructure;
       const entries = data.hooks.PreToolUse ?? [];
@@ -303,24 +303,31 @@ describe('Hooks Validation', () => {
       );
 
       expect(stageBlockingHook).toBeDefined();
-      expect(stageBlockingHook?.hooks[0].command).toContain('/tmp/.claude-dev-stage');
+      const command = stageBlockingHook?.hooks[0].command ?? '';
+      expect(command).toContain('stage-blocker.sh');
+
+      // Read the script file to verify it references /tmp/.claude-dev-stage
+      const scriptPath = resolve(
+        import.meta.dir,
+        '../../../templates/.claude/hooks/scripts/stage-blocker.sh'
+      );
+      const scriptContent = await readFile(scriptPath, 'utf-8');
+      expect(scriptContent).toContain('/tmp/.claude-dev-stage');
     });
 
     it('should block Write/Edit in plan, verify-plan, verify-impl, and compound stages', async () => {
-      const { parsed } = await loadHooksJson();
-      const data = parsed as HooksStructure;
-      const entries = data.hooks.PreToolUse ?? [];
-
-      const stageBlockingHook = entries.find(
-        (entry) => entry.matcher === 'tool == "Write" || tool == "Edit"'
+      // Read the stage-blocker script to verify stage names
+      const scriptPath = resolve(
+        import.meta.dir,
+        '../../../templates/.claude/hooks/scripts/stage-blocker.sh'
       );
-      const command = stageBlockingHook?.hooks[0].command ?? '';
+      const scriptContent = await readFile(scriptPath, 'utf-8');
 
-      expect(command).toContain('plan');
-      expect(command).toContain('verify-plan');
-      expect(command).toContain('verify-impl');
-      expect(command).toContain('compound');
-      expect(command).toContain('done');
+      expect(scriptContent).toContain('plan');
+      expect(scriptContent).toContain('verify-plan');
+      expect(scriptContent).toContain('verify-impl');
+      expect(scriptContent).toContain('compound');
+      expect(scriptContent).toContain('done');
     });
 
     it('should have a description for the stage-based hook', async () => {

--- a/tests/unit/core/template-validation.test.ts
+++ b/tests/unit/core/template-validation.test.ts
@@ -195,7 +195,7 @@ async function validateAgentFrontmatter(
   const requiredFields = ['name', 'description', 'model', 'tools'];
   for (const field of requiredFields) {
     // tools may be a multiline array (tools:\n  - Read), so use hasField
-    if (!hasField(result, field) && !result.fields[field]) {
+    if (!hasField(result, field)) {
       errors.push(`${agentFile}: missing required field '${field}'`);
     }
   }


### PR DESCRIPTION
## Summary
- PR #161 코드 리뷰에서 발견된 5개 non-blocking WARNING을 해결합니다
- 기능 변경 없음, 코드 품질/유지보수성 개선만 포함

## Changes

| # | File | Change | Risk |
|---|------|--------|------|
| 1 | `hooks.json` + `stage-blocker.sh` | 300자 인라인 셸 커맨드를 별도 스크립트로 분리 | Low |
| 2 | `ci.yml:66` | PIPESTATUS bash-specific 주석 추가 | Low |
| 3 | `ci.yml:72-79` | bun exit code 휴리스틱 문서화 + TODO 추가 | Low |
| 4 | `analyze-issue.ts:220` | `as any` → SDK discriminated union type narrowing | Low |
| 5 | `template-validation.test.ts:198` | 중복 `hasField` 조건 간소화 | Low |
| 6 | `hooks-validation.test.ts` | 스크립트 분리에 맞춰 테스트 업데이트 | Low |

## Test plan
- [x] `bun test` — 866 pass, 0 fail
- [x] Coverage: Func 99.14%, Line 98.08% (threshold 97%)
- [x] hooks.json valid JSON 확인
- [x] stage-blocker.sh 실행 권한 확인

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)