### PR TITLE
chore: bump version to 0.16.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-customcode",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Version bump from 0.16.2 to 0.16.3

## Changes in this release
- feat: R018 Agent Teams SHOULD→MUST 승격 (조건부 강제)
- chore: double-shot-latte 플러그인 필수 목록에서 제거
- docs: Hook 수량 불일치 수정 (1→2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)