### PR TITLE
fix: correct ontology installed path display in init command

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -42,7 +42,14 @@ export async function checkExistingInstallation(targetDir: string): Promise<bool
 }
 
 /** Components that live under provider root directory */
-const PROVIDER_SUBDIR_COMPONENTS = new Set(['rules', 'hooks', 'contexts', 'agents', 'skills']);
+const PROVIDER_SUBDIR_COMPONENTS = new Set([
+  'rules',
+  'hooks',
+  'contexts',
+  'agents',
+  'skills',
+  'ontology',
+]);
 
 /**
  * Convert component name to its full path


### PR DESCRIPTION
## Summary
- `PROVIDER_SUBDIR_COMPONENTS` in `src/cli/init.ts` was missing `'ontology'`
- This caused `omcustom init` to display `targetDir/ontology` in "Installed paths" output instead of the correct `targetDir/.claude/ontology`
- Actual file installation was unaffected (files were correctly placed in `.claude/ontology/`)

## Changes
- Added `'ontology'` to `PROVIDER_SUBDIR_COMPONENTS` Set in `src/cli/init.ts:45`

## Test plan
- [ ] Run `omcustom init --lang ko` in a test directory
- [ ] Verify "Installed paths" shows `.claude/ontology` instead of `ontology`