### PR TITLE
feat: add Claude Code statusline script (#162)

### DIFF
--- a/scripts/sync-core.ts
+++ b/scripts/sync-core.ts
@@ -88,29 +88,44 @@ function countAgents(agentsDir: string): number {
 }
 
 /**
- * Count SKILL.md files in skills directory
+ * Count subdirectories (not files) in a directory.
+ * Used for skills and guides, which are measured by directory count.
  */
-function countSkills(skillsDir: string): number {
-  return countFiles(skillsDir, /^SKILL\.md$/);
+function countDirectories(dir: string): number {
+  if (!fs.existsSync(dir)) {
+    return 0;
+  }
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  return entries.filter((entry) => entry.isDirectory()).length;
 }
 
 /**
- * Count guide topics (index.yaml files in guide subdirectories)
+ * Count skill directories in .claude/skills/
+ * Each skill is a subdirectory (not a SKILL.md file count).
  */
-function countGuides(guidesDir: string): number {
-  if (!fs.existsSync(guidesDir)) {
+function countSkillDirectories(skillsDir: string): number {
+  return countDirectories(skillsDir);
+}
+
+/**
+ * Count all files recursively including one level of subdirectories.
+ * Used for ontology, which stores files both at root and in subdirectories.
+ */
+function countFilesRecursive(dir: string): number {
+  if (!fs.existsSync(dir)) {
     return 0;
   }
 
   let count = 0;
-  const entries = fs.readdirSync(guidesDir, { withFileTypes: true });
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
 
   for (const entry of entries) {
-    if (entry.isDirectory()) {
-      const indexYaml = path.join(guidesDir, entry.name, 'index.yaml');
-      if (fs.existsSync(indexYaml)) {
-        count++;
-      }
+    if (entry.isFile()) {
+      count++;
+    } else if (entry.isDirectory()) {
+      const subEntries = fs.readdirSync(path.join(dir, entry.name), { withFileTypes: true });
+      count += subEntries.filter((e) => e.isFile()).length;
     }
   }
 
@@ -132,13 +147,15 @@ function updateManifest(templatesDir: string): void {
 
   // Update file counts for each component
   // Updated for official Claude Code format (agents and skills in .claude/)
+  // Counting methods must match test expectations in template-validation.test.ts
   const componentCounts: Record<string, number> = {
-    rules: countFiles(path.join(templatesDir, '.claude/rules'), /\.(md|yaml)$/),
+    rules: countFiles(path.join(templatesDir, '.claude/rules'), /\.md$/),
     agents: countAgents(path.join(templatesDir, '.claude/agents')),
-    skills: countSkills(path.join(templatesDir, '.claude/skills')),
-    guides: countGuides(path.join(templatesDir, 'guides')),
-    hooks: countFiles(path.join(templatesDir, '.claude/hooks')),
-    contexts: countFiles(path.join(templatesDir, '.claude/contexts')),
+    skills: countSkillDirectories(path.join(templatesDir, '.claude/skills')),
+    guides: countDirectories(path.join(templatesDir, 'guides')),
+    hooks: countFiles(path.join(templatesDir, '.claude/hooks'), /\.json$/),
+    contexts: countFiles(path.join(templatesDir, '.claude/contexts'), /\.md$/),
+    ontology: countFilesRecursive(path.join(templatesDir, '.claude/ontology')),
   };
 
   // Update manifest

--- a/templates/.claude/rules/SHOULD-hud-statusline.md
+++ b/templates/.claude/rules/SHOULD-hud-statusline.md
@@ -2,31 +2,75 @@
 
 > **Priority**: SHOULD | **ID**: R012
 
-## Format
+## Two-System Architecture
 
-```
-─── [Agent] {name} | [Progress] {n}/{total} | [Parallel] {count} ───
-```
+| Aspect | HUD Events | Statusline API |
+|--------|-----------|----------------|
+| Channel | stderr (hooks) | stdout (dedicated statusline) |
+| Location | Inline in conversation log | Persistent bar at screen bottom |
+| Trigger | PreToolUse (Task matcher) | Message update cycle (~300ms) |
+| Role | Event notifications | Persistent session status |
 
-## When to Display
+## HUD Events (Hook-based)
 
-Multi-step tasks, parallel execution, long-running operations. Skip for single brief operations.
-
-## Hook Implementation
-
-Implemented in `.claude/hooks/hooks.json` (PreToolUse → Task matcher):
+### Format
 
 ```
 ─── [Spawn] {subagent_type}:{model} | {description} ───
 ─── [Resume] {subagent_type}:{model} | {description} ───
 ```
 
-## Display with Parallel
+### When to Display
+
+Multi-step tasks, parallel execution, long-running operations. Skip for single brief operations.
+
+### Implementation
+
+Implemented in `.claude/hooks/hooks.json` (PreToolUse → Task matcher).
+
+### Parallel Display
 
 ```
 ─── [Agent] secretary | [Parallel] 4 ───
   [1] Task(mgr-creator):sonnet → Create agent
   [2] Task(lang-golang-expert):haiku → Code review
 ```
+
+## Statusline API (Command-based)
+
+### Format
+
+```
+{Model} | {project} | {branch} | CTX:{usage}% | ${cost}
+```
+
+Example: `Opus | my-project | develop | CTX:42% | $0.05`
+
+### Configuration
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": ".claude/statusline.sh",
+    "padding": 0
+  }
+}
+```
+
+Set in `.claude/settings.local.json`. The command receives JSON via stdin with model, workspace, context window, and cost data.
+
+### Color Coding
+
+| Element | Condition | Color |
+|---------|-----------|-------|
+| Model: Opus | — | Magenta (bold) |
+| Model: Sonnet | — | Cyan |
+| Model: Haiku | — | Green |
+| Context | < 60% | Green |
+| Context | 60-79% | Yellow |
+| Context | >= 80% | Red |
+
+## Integration
 
 Integrates with R007 (Agent ID), R008 (Tool ID), R009 (Parallel).

--- a/templates/.claude/statusline.sh
+++ b/templates/.claude/statusline.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# statusline.sh — Claude Code statusline renderer
+#
+# Reads JSON from stdin (Claude Code statusline API, ~300ms intervals)
+# and outputs a formatted status line, e.g.:
+#
+#   Opus | my-project | develop | CTX:42% | $0.05
+#
+# JSON input structure:
+#   {
+#     "model": { "display_name": "claude-opus-4-6" },
+#     "workspace": { "current_dir": "/path/to/project" },
+#     "context_window": { "used_percentage": 42, "context_window_size": 200000 },
+#     "cost": { "total_cost_usd": 0.05 }
+#   }
+
+# ---------------------------------------------------------------------------
+# 1. Color detection
+# ---------------------------------------------------------------------------
+if [[ -n "${NO_COLOR}" || "${TERM}" == "dumb" ]]; then
+    # Colors disabled
+    COLOR_RESET=""
+    COLOR_OPUS=""
+    COLOR_SONNET=""
+    COLOR_HAIKU=""
+    COLOR_CTX_OK=""
+    COLOR_CTX_WARN=""
+    COLOR_CTX_CRIT=""
+else
+    COLOR_RESET="\033[0m"
+    COLOR_OPUS="\033[1;35m"    # Magenta bold
+    COLOR_SONNET="\033[0;36m"  # Cyan
+    COLOR_HAIKU="\033[0;32m"   # Green
+    COLOR_CTX_OK="\033[0;32m"  # Green   (< 60%)
+    COLOR_CTX_WARN="\033[0;33m" # Yellow (60-79%)
+    COLOR_CTX_CRIT="\033[0;31m" # Red    (>= 80%)
+fi
+
+# ---------------------------------------------------------------------------
+# 2. jq availability check
+# ---------------------------------------------------------------------------
+if ! command -v jq >/dev/null 2>&1; then
+    echo "statusline: jq required"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Read stdin into variable
+# ---------------------------------------------------------------------------
+json="$(cat)"
+
+# Guard against empty input
+if [[ -z "$json" ]]; then
+    echo "statusline: no input"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Single jq call — extract all fields as TSV
+#    Fields: model_name, project_dir, ctx_pct, ctx_size, cost_usd
+# ---------------------------------------------------------------------------
+read -r model_name project_dir ctx_pct ctx_size cost_usd <<< "$(
+    printf '%s' "$json" | jq -r '[
+        (.model.display_name // "unknown"),
+        (.workspace.current_dir // ""),
+        (.context_window.used_percentage // 0),
+        (.context_window.context_window_size // 0),
+        (.cost.total_cost_usd // 0)
+    ] | @tsv'
+)"
+
+# ---------------------------------------------------------------------------
+# 5. Model display name + color (bash 3.2 compatible case pattern matching)
+# ---------------------------------------------------------------------------
+case "$model_name" in
+    *[Oo]pus*)   model_display="Opus";   model_color="${COLOR_OPUS}" ;;
+    *[Ss]onnet*) model_display="Sonnet"; model_color="${COLOR_SONNET}" ;;
+    *[Hh]aiku*)  model_display="Haiku";  model_color="${COLOR_HAIKU}" ;;
+    *)           model_display="$model_name"; model_color="${COLOR_RESET}" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 6. Project name — basename of workspace current_dir
+# ---------------------------------------------------------------------------
+if [[ -n "$project_dir" ]]; then
+    project_name="${project_dir##*/}"
+else
+    project_name="unknown"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Git branch — read .git/HEAD directly (no subprocess, fast)
+# ---------------------------------------------------------------------------
+git_head_file="${project_dir}/.git/HEAD"
+git_branch=""
+if [[ -f "$git_head_file" ]]; then
+    git_head="$(cat "$git_head_file")"
+    case "$git_head" in
+        "ref: refs/heads/"*)
+            # Normal branch: strip the prefix
+            git_branch="${git_head#ref: refs/heads/}"
+            ;;
+        *)
+            # Detached HEAD: show first 7 chars of commit hash
+            git_branch="${git_head:0:7}"
+            ;;
+    esac
+fi
+
+# ---------------------------------------------------------------------------
+# 8. Context percentage with color
+# ---------------------------------------------------------------------------
+# ctx_pct may arrive as a float (e.g. 42.5); truncate to integer for comparison
+ctx_int="${ctx_pct%%.*}"
+# Ensure it's a valid integer (fallback to 0)
+if ! [[ "$ctx_int" =~ ^[0-9]+$ ]]; then
+    ctx_int=0
+fi
+
+if [[ "$ctx_int" -ge 80 ]]; then
+    ctx_color="${COLOR_CTX_CRIT}"
+elif [[ "$ctx_int" -ge 60 ]]; then
+    ctx_color="${COLOR_CTX_WARN}"
+else
+    ctx_color="${COLOR_CTX_OK}"
+fi
+
+ctx_display="CTX:${ctx_int}%"
+
+# ---------------------------------------------------------------------------
+# 9. Cost formatting — always two decimal places
+# ---------------------------------------------------------------------------
+cost_display="$(printf '$%.2f' "$cost_usd")"
+
+# ---------------------------------------------------------------------------
+# 10. Assemble and output the status line
+# ---------------------------------------------------------------------------
+# Build segments; omit git branch segment when unavailable
+if [[ -n "$git_branch" ]]; then
+    printf "${model_color}%s${COLOR_RESET} | %s | %s | ${ctx_color}%s${COLOR_RESET} | %s\n" \
+        "$model_display" \
+        "$project_name" \
+        "$git_branch" \
+        "$ctx_display" \
+        "$cost_display"
+else
+    printf "${model_color}%s${COLOR_RESET} | %s | ${ctx_color}%s${COLOR_RESET} | %s\n" \
+        "$model_display" \
+        "$project_name" \
+        "$ctx_display" \
+        "$cost_display"
+fi

--- a/templates/.claude/statusline.sh
+++ b/templates/.claude/statusline.sh
@@ -59,7 +59,7 @@ fi
 # 4. Single jq call — extract all fields as TSV
 #    Fields: model_name, project_dir, ctx_pct, ctx_size, cost_usd
 # ---------------------------------------------------------------------------
-read -r model_name project_dir ctx_pct ctx_size cost_usd <<< "$(
+IFS=$'\t' read -r model_name project_dir ctx_pct ctx_size cost_usd <<< "$(
     printf '%s' "$json" | jq -r '[
         (.model.display_name // "unknown"),
         (.workspace.current_dir // ""),

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "0.3.0",
-  "lastUpdated": "2026-02-27T04:35:43.279Z",
+  "lastUpdated": "2026-02-27T04:39:05.943Z",
   "components": [
     {
       "name": "rules",

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "0.3.0",
-  "lastUpdated": "2026-02-27T04:28:32.239Z",
+  "lastUpdated": "2026-02-27T04:35:43.279Z",
   "components": [
     {
       "name": "rules",

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "0.3.0",
-  "lastUpdated": "2026-02-18T00:00:00.000Z",
+  "lastUpdated": "2026-02-27T04:28:32.239Z",
   "components": [
     {
       "name": "rules",


### PR DESCRIPTION
## Summary

- `.claude/statusline.sh` 생성: 모델, 프로젝트, 브랜치, 컨텍스트 사용률 표시
- `.claude/settings.local.json`에 statusLine 설정 추가
- R012 HUD 규칙을 두 시스템 아키텍처(HUD Events + Statusline API) 문서로 확장
- `sync-core.ts` manifest 카운팅 로직을 테스트와 일치하도록 수정
- 템플릿 동기화 완료

## Statusline Output

```
Opus | my-project | develop | CTX:42%
```

- ANSI 색상: 모델별 (Opus=Magenta, Sonnet=Cyan, Haiku=Green), 컨텍스트별 (<60%=Green, 60-79%=Yellow, >=80%=Red)
- macOS bash 3.2 호환, `NO_COLOR` 환경 지원
- jq 미설치 시 폴백 메시지 출력

## Test Plan

- [x] 906 tests passing (0 failures)
- [x] Edge cases: empty JSON, empty stdin, NO_COLOR, high context (>=80%)
- [x] IFS tab-only parsing for model names with spaces
- [x] Build succeeds (CLI + library bundles)

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)