### PR TITLE
feat: add PR number display and clickable branch link to statusline

### DIFF
--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "0.3.0",
-  "lastUpdated": "2026-02-27T04:50:37.791Z",
+  "lastUpdated": "2026-02-27T04:55:03.515Z",
   "components": [
     {
       "name": "rules",

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
   "version": "0.3.0",
-  "lastUpdated": "2026-02-27T04:39:05.943Z",
+  "lastUpdated": "2026-02-27T04:50:37.791Z",
   "components": [
     {
       "name": "rules",


### PR DESCRIPTION
## Summary

- PR 번호 표시: 현재 브랜치에 연결된 PR이 있으면 `PR#160` 형식으로 표시
- 브랜치명 클릭 가능: OSC 8 하이퍼링크로 GitHub 원격 브랜치 페이지 연결
- 브랜치 기반 캐싱: `/tmp/statusline-pr-<project>` 파일로 gh CLI 호출 최소화

## Statusline Output

```
Opus | oh-my-customcode | develop | PR#160 | CTX:42%
                          ^^^^^^^ clickable (Cmd+click → GitHub)
```

- PR 없는 브랜치: PR 세그먼트 생략
- 비 GitHub 리모트: 링크 없이 일반 텍스트
- `NO_COLOR` 환경: OSC 8 시퀀스 비활성화
- iTerm2, Kitty, WezTerm에서 클릭 가능 (Terminal.app 미지원)

## Technical Details

- `.git/config` 직접 파싱으로 리모트 URL 추출 (subprocess 없음)
- SSH (`git@github.com:`) 및 HTTPS (`https://github.com/`) 포맷 지원
- OSC 8 터미네이터로 `\a` (BEL) 사용 (공식 문서 권장)

## Test Plan

- [x] 906 tests passing
- [x] PR 있는 브랜치: PR#N 표시
- [x] PR 없는 브랜치: PR 세그먼트 생략
- [x] 캐시 파일 생성 및 히트 확인
- [x] OSC 8 시퀀스 `cat -v`로 검증
- [x] NO_COLOR 환경에서 하이퍼링크 비활성화

🤖 Generated with [Claude Code](https://claude.com/claude-code)