### PR TITLE
feat: session-end auto-save and MCP dependency reclassification

### DIFF
--- a/templates/.claude/agents/sys-memory-keeper.md
+++ b/templates/.claude/agents/sys-memory-keeper.md
@@ -1,6 +1,6 @@
 ---
 name: sys-memory-keeper
-description: Use when you need to manage session memory persistence using claude-mem, save context before compaction, restore context on session start, or query past memories
+description: Use when you need to manage session memory persistence using claude-mem, save context before compaction, restore context on session start, query past memories, or perform session-end dual-system auto-save
 model: sonnet
 memory: project
 effort: medium
@@ -41,3 +41,18 @@ Always include project name. Use task-based, temporal, or topic-based queries. A
 ## Config
 
 Provider: claude-mem | Collection: claude_memories | Archive: ~/.claude-mem/archives/
+
+## Session-End Auto-Save
+
+When triggered by session-end signal from orchestrator:
+
+1. **Collect** session summary: completed tasks, key decisions, open items
+2. **Save to claude-mem** (if available): `mcp__claude-mem__save_memory` with project name, session date, and summary
+3. **Verify episodic-memory** (if available): `mcp__episodic-memory__search` to confirm session is indexed
+4. **Report** results to orchestrator: saved/skipped/failed per system
+
+### Failure Handling
+
+- claude-mem unavailable → skip, report warning
+- episodic-memory unavailable → skip, report warning
+- Both unavailable → warn orchestrator, do not block session end

--- a/templates/.claude/rules/SHOULD-memory-integration.md
+++ b/templates/.claude/rules/SHOULD-memory-integration.md
@@ -37,3 +37,35 @@ Agent frontmatter `memory: project|user|local` enables persistent memory:
 - Keep MEMORY.md under 200 lines
 - Do not store sensitive data or duplicate CLAUDE.md content
 - Memory write failures should not block main task
+
+## Session-End Auto-Save
+
+### Trigger
+
+Session-end detected when user says: "끝", "종료", "마무리", "done", "wrap up", "end session", or explicitly requests session save.
+
+### Flow
+
+```
+User signals session end
+  → Orchestrator delegates to sys-memory-keeper
+    → sys-memory-keeper performs dual-system save:
+       1. claude-mem save (if available)
+       2. episodic-memory verification (if available)
+    → Reports result to orchestrator
+  → Orchestrator confirms to user
+```
+
+### Dual-System Save
+
+| System | Tool | Action | Required |
+|--------|------|--------|----------|
+| claude-mem | `mcp__claude-mem__save_memory` | Save session summary with project, tasks, decisions | No (best-effort) |
+| episodic-memory | `mcp__episodic-memory__search` | Verify session is indexed for future retrieval | No (best-effort) |
+
+### Failure Policy
+
+- Both saves are **non-blocking**: memory failure MUST NOT prevent session from ending
+- If claude-mem unavailable: skip, log warning
+- If episodic-memory unavailable: skip, log warning
+- If both unavailable: warn user, proceed with session end

--- a/templates/CLAUDE.md.en
+++ b/templates/CLAUDE.md.en
@@ -271,7 +271,7 @@ Install via `/plugin install <name>`:
 | obsidian-skills | - | Obsidian markdown support |
 | context7 | claude-plugins-official | Library documentation lookup |
 
-### Required MCP Servers
+### Recommended MCP Servers
 
 | Server | Purpose |
 |--------|---------|

--- a/templates/CLAUDE.md.ko
+++ b/templates/CLAUDE.md.ko
@@ -271,7 +271,7 @@ Claude Code의 Agent Teams 기능이 활성화되어 있으면 (`CLAUDE_CODE_EXP
 | obsidian-skills | - | 옵시디언 마크다운 지원 |
 | context7 | claude-plugins-official | 라이브러리 문서 조회 |
 
-### 필수 MCP 서버
+### 권장 MCP 서버
 
 | 서버 | 용도 |
 |------|------|


### PR DESCRIPTION
## Summary

- Reclassify MCP servers from "Required" to "Recommended" in all CLAUDE.md variants (ko, en)
- Add session-end auto-save behavior to R011 memory integration rules
- Update sys-memory-keeper agent with dual-system (claude-mem + episodic-memory) auto-save workflow

## Changes (7 files)

### CLAUDE.md heading (3 files)
- `CLAUDE.md`: 필수 MCP 서버 → 권장 MCP 서버
- `templates/CLAUDE.md.ko`: 필수 MCP 서버 → 권장 MCP 서버
- `templates/CLAUDE.md.en`: Required MCP Servers → Recommended MCP Servers

### R011 rule (2 files)
- `.claude/rules/SHOULD-memory-integration.md`: Added Session-End Auto-Save section
- `templates/.claude/rules/SHOULD-memory-integration.md`: Same

### sys-memory-keeper agent (2 files)
- `.claude/agents/sys-memory-keeper.md`: Updated description + added Session-End Auto-Save workflow
- `templates/.claude/agents/sys-memory-keeper.md`: Same

## Test plan

- [ ] Verify heading change renders correctly in all 3 CLAUDE.md files
- [ ] Verify R011 Session-End Auto-Save section is well-formed markdown
- [ ] Verify sys-memory-keeper frontmatter is valid YAML
- [ ] Confirm production and template files are in sync

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)