### PR TITLE
fix: add R010 git delegation enforcement mechanisms

### DIFF
--- a/.claude/agents/mgr-sauron.md
+++ b/.claude/agents/mgr-sauron.md
@@ -1,0 +1,159 @@
+---
+name: mgr-sauron
+description: Use when you need automated verification of R016 compliance, executing mandatory multi-round verification (5 manager rounds + 3 deep review rounds) before commits
+model: sonnet
+memory: project
+effort: high
+skills:
+  - sauron-watch
+tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+---
+
+You are an automated verification specialist that executes the mandatory R016 verification process, acting as the "all-seeing eye" that ensures system integrity through comprehensive multi-round verification.
+
+## Core Capabilities
+
+1. Execute mgr-supplier:audit automatically
+2. Execute mgr-sync-checker:check automatically
+3. Execute mgr-updater:docs automatically
+4. Execute mgr-claude-code-bible:verify (official spec compliance)
+5. Verify workflow alignment
+6. Verify reference integrity (frontmatter, memory fields, skill refs)
+7. Verify philosophy compliance (R006-R011)
+8. Verify Claude-native compatibility
+9. Auto-fix simple issues (count mismatches, missing fields)
+10. Generate verification report
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `mgr-sauron:watch` | Full R016 verification (5+3 rounds) |
+| `mgr-sauron:quick` | Quick verification (single pass) |
+| `mgr-sauron:report` | Generate verification status report |
+
+## Verification Process
+
+### Phase 1: Manager Verification (5 rounds)
+
+**Round 1-2: Basic Checks**
+- mgr-supplier:audit (all agents, dependency validation)
+- mgr-updater:docs (documentation sync check)
+
+**Round 3-4: Re-verify + Update**
+- Re-run mgr-supplier:audit
+- Re-run mgr-updater:docs (apply any detected changes)
+
+**Round 5: Final Count Verification**
+- Agent count: CLAUDE.md vs actual .md files
+- Skill count: CLAUDE.md vs actual SKILL.md files
+- Memory field distribution matches CLAUDE.md
+- Hook/context/guide/rule counts
+
+### Phase 2: Deep Review (3 rounds)
+
+**Round 1: Workflow Alignment**
+- Agent workflows match purpose
+- Command definitions match implementations
+- Routing skill patterns are valid
+
+**Round 2: Reference Verification**
+- All skill references exist
+- All agent frontmatter valid
+- memory field values valid (user | project | local)
+- No orphaned agents
+
+**Round 3: Philosophy Compliance**
+- R006: Agent design rules (including memory field spec)
+- R007: Agent identification rules
+- R008: Tool identification rules
+- R009: Parallel execution rules
+- R010: Orchestrator coordination rules
+- R011: Memory integration (native-first architecture)
+
+### Phase 2.5: Documentation Accuracy
+
+**Agent Name Accuracy**
+- Every agent name in CLAUDE.md must match actual filename
+- No shortened names, no missing agents
+
+**Component Count Accuracy**
+- All counts cross-verified against filesystem
+
+**Slash Command Verification**
+- Every command must have corresponding skill
+
+**Routing Skill Completeness**
+- Every agent reachable through routing skills
+
+### Phase 3: Auto-fix & Report
+
+**Auto-fixable Issues:**
+- Count mismatches in CLAUDE.md
+- Missing memory field in agents
+- Outdated documentation references
+
+**Manual Review Required:**
+- Missing agent files
+- Invalid memory scope values
+- Philosophy violations
+
+## Output Format
+
+### Watch Mode Report
+
+```
+[Sauron] Full Verification Started
+
+=== Phase 1: Manager Verification ===
+[Round 1/5] mgr-supplier:audit
+  - 34 agents checked
+  - 3 issues found
+[Round 2/5] mgr-updater:docs
+  - Documentation sync: OK
+...
+
+=== Phase 2: Deep Review ===
+[Round 1/3] Workflow Alignment
+  - All workflows valid
+...
+
+=== Phase 3: Resolution ===
+[Auto-fixed]
+  - CLAUDE.md agent count: 33 -> 34
+
+[Manual Review Required]
+  - .claude/agents/broken-agent.md: missing
+
+[Sauron] Verification Complete
+  Total Issues: 8
+  Auto-fixed: 5
+  Manual: 3
+```
+
+### Quick Mode Report
+
+```
+[Sauron] Quick Verification
+
+Agents: 34/34 OK
+Skills: 40/40 OK
+Refs: 2 broken
+
+Status: ISSUES FOUND
+Run 'mgr-sauron:watch' for full verification
+```
+
+## Integration
+
+Works with:
+- **mgr-supplier**: Dependency validation
+- **mgr-updater**: Documentation updates and sync
+- **mgr-claude-code-bible**: Official spec compliance
+- **secretary**: Orchestration coordination

--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -1,0 +1,171 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "tool == \"Write\" || tool == \"Edit\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/scripts/stage-blocker.sh"
+          }
+        ],
+        "description": "Block Write/Edit tools during plan/verify/compound stages — only allow in implement stage"
+      },
+      {
+        "matcher": "tool == \"Bash\" && tool_input.command matches \"(npm run dev|pnpm( run)? dev|yarn dev|bun run dev)\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "#!/bin/bash\ninput=$(cat)\ncmd=$(echo \"$input\" | jq -r '.tool_input.command // \"\"')\n\n# Block dev servers that aren't run in tmux\necho '[Hook] BLOCKED: Dev server must run in tmux for log access' >&2\necho '[Hook] Use this command instead:' >&2\necho \"[Hook] tmux new-session -d -s dev 'npm run dev'\" >&2\necho '[Hook] Then: tmux attach -t dev' >&2\nexit 1"
+          }
+        ],
+        "description": "Block dev servers outside tmux - ensures you can access logs"
+      },
+      {
+        "matcher": "tool == \"Bash\" && tool_input.command matches \"(npm (install|test)|pnpm (install|test)|yarn (install|test)|bun (install|test)|cargo build|make|docker|pytest|vitest|playwright)\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "#!/bin/bash\ninput=$(cat)\nif [ -z \"$TMUX\" ]; then\n  echo '[Hook] Consider running in tmux for session persistence' >&2\n  echo '[Hook] tmux new -s dev  |  tmux attach -t dev' >&2\nfi\necho \"$input\""
+          }
+        ],
+        "description": "Reminder to use tmux for long-running commands"
+      },
+      {
+        "matcher": "tool == \"Bash\" && tool_input.command matches \"git push\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "#!/bin/bash\necho '[Hook] Review changes before push...' >&2\nif [ -t 0 ]; then echo '[Hook] Press Enter to continue or Ctrl+C to abort...' >&2; read -r; else echo '[Hook] Non-interactive mode, proceeding...' >&2; fi"
+          }
+        ],
+        "description": "Pause before git push to review changes"
+      },
+      {
+        "matcher": "tool == \"Write\" && tool_input.file_path matches \"\\\\.(md|txt)$\" && !(tool_input.file_path matches \"README\\\\.md|CLAUDE\\\\.md|AGENT\\\\.md|SKILL\\\\.md\")",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "#!/bin/bash\ninput=$(cat)\nfile_path=$(echo \"$input\" | jq -r '.tool_input.file_path // \"\"')\n\nif [[ \"$file_path\" =~ \\.(md|txt)$ ]] && [[ ! \"$file_path\" =~ (README|CLAUDE|AGENT|SKILL)\\.md$ ]]; then\n  echo \"[Hook] BLOCKED: Unnecessary documentation file creation\" >&2\n  echo \"[Hook] File: $file_path\" >&2\n  echo \"[Hook] Use README.md or AGENT.md for documentation instead\" >&2\n  exit 1\nfi\n\necho \"$input\""
+          }
+        ],
+        "description": "Block creation of random .md files - keeps docs consolidated"
+      },
+      {
+        "matcher": "tool == \"Edit\" || tool == \"Write\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "#!/bin/bash\nCOUNTER_FILE=\"/tmp/claude-tool-count-$$\"\nTHRESHOLD=${COMPACT_THRESHOLD:-50}\nif [ -f \"$COUNTER_FILE\" ]; then COUNT=$(cat \"$COUNTER_FILE\"); COUNT=$((COUNT + 1)); else COUNT=1; fi\necho \"$COUNT\" > \"$COUNTER_FILE\"\nif [ \"$COUNT\" -eq \"$THRESHOLD\" ]; then echo '[StrategicCompact] Reached '$THRESHOLD' tool calls' >&2; echo '[StrategicCompact] Consider /compact if at a logical breakpoint' >&2; fi\nif [ \"$COUNT\" -gt \"$THRESHOLD\" ] && [ $(((COUNT - THRESHOLD) % 25)) -eq 0 ]; then echo \"[StrategicCompact] $COUNT tool calls - /compact reminder\" >&2; fi\ncat"
+          }
+        ],
+        "description": "Suggest manual compaction at logical intervals"
+      },
+      {
+        "matcher": "tool == \"Task\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "#!/bin/bash\ninput=$(cat)\nagent_type=$(echo \"$input\" | jq -r '.tool_input.subagent_type // \"unknown\"')\nmodel=$(echo \"$input\" | jq -r '.tool_input.model // \"inherit\"')\ndesc=$(echo \"$input\" | jq -r '.tool_input.description // \"\"' | head -c 40)\nresume=$(echo \"$input\" | jq -r '.tool_input.resume // empty')\nif [ -n \"$resume\" ]; then\n  echo \"─── [Resume] ${agent_type}:${model} | ${desc} ───\" >&2\nelse\n  echo \"─── [Spawn] ${agent_type}:${model} | ${desc} ───\" >&2\nfi\necho \"$input\""
+          }
+        ],
+        "description": "HUD statusline - show subagent_type, model, and description on Task spawn"
+      },
+      {
+        "matcher": "tool == \"Task\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/scripts/git-delegation-guard.sh"
+          }
+        ],
+        "description": "R010 guard - warn when git operations are delegated to non-mgr-gitnerd agents"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "tool == \"Bash\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "#!/bin/bash\ninput=$(cat)\ncmd=$(echo \"$input\" | jq -r '.tool_input.command')\n\nif echo \"$cmd\" | grep -qE 'gh pr create'; then\n  output=$(echo \"$input\" | jq -r '.tool_output.output // \"\"')\n  pr_url=$(echo \"$output\" | grep -oE 'https://github.com/[^/]+/[^/]+/pull/[0-9]+')\n  \n  if [ -n \"$pr_url\" ]; then\n    echo \"[Hook] PR created: $pr_url\" >&2\n    echo \"[Hook] Checking GitHub Actions status...\" >&2\n    repo=$(echo \"$pr_url\" | sed -E 's|https://github.com/([^/]+/[^/]+)/pull/[0-9]+|\\1|')\n    pr_num=$(echo \"$pr_url\" | sed -E 's|.*/pull/([0-9]+)|\\1|')\n    echo \"[Hook] To review PR: gh pr review $pr_num --repo $repo\" >&2\n  fi\nfi\n\necho \"$input\""
+          }
+        ],
+        "description": "Log PR URL and provide review command after PR creation"
+      },
+      {
+        "matcher": "tool == \"Edit\" && tool_input.file_path matches \"\\\\.(ts|tsx|js|jsx)$\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "#!/bin/bash\ninput=$(cat)\nfile_path=$(echo \"$input\" | jq -r '.tool_input.file_path // \"\"')\n\nif [ -n \"$file_path\" ] && [ -f \"$file_path\" ]; then\n  if command -v prettier >/dev/null 2>&1; then\n    prettier --write \"$file_path\" 2>&1 | head -5 >&2\n  fi\nfi\n\necho \"$input\""
+          }
+        ],
+        "description": "Auto-format JS/TS files with Prettier after edits"
+      },
+      {
+        "matcher": "tool == \"Edit\" && tool_input.file_path matches \"\\\\.(ts|tsx)$\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "#!/bin/bash\ninput=$(cat)\nfile_path=$(echo \"$input\" | jq -r '.tool_input.file_path // \"\"')\n\nif [ -n \"$file_path\" ] && [ -f \"$file_path\" ]; then\n  dir=$(dirname \"$file_path\")\n  project_root=\"$dir\"\n  while [ \"$project_root\" != \"/\" ] && [ ! -f \"$project_root/package.json\" ]; do\n    project_root=$(dirname \"$project_root\")\n  done\n  \n  if [ -f \"$project_root/tsconfig.json\" ]; then\n    cd \"$project_root\" && npx tsc --noEmit --pretty false 2>&1 | grep \"$file_path\" | head -10 >&2 || true\n  fi\nfi\n\necho \"$input\""
+          }
+        ],
+        "description": "TypeScript check after editing .ts/.tsx files"
+      },
+      {
+        "matcher": "tool == \"Edit\" && tool_input.file_path matches \"\\\\.(ts|tsx|js|jsx)$\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "#!/bin/bash\ninput=$(cat)\nfile_path=$(echo \"$input\" | jq -r '.tool_input.file_path // \"\"')\n\nif [ -n \"$file_path\" ] && [ -f \"$file_path\" ]; then\n  console_logs=$(grep -n \"console\\\\.log\" \"$file_path\" 2>/dev/null || true)\n  \n  if [ -n \"$console_logs\" ]; then\n    echo \"[Hook] WARNING: console.log found in $file_path\" >&2\n    echo \"$console_logs\" | head -5 >&2\n    echo \"[Hook] Remove console.log before committing\" >&2\n  fi\nfi\n\necho \"$input\""
+          }
+        ],
+        "description": "Warn about console.log statements after edits"
+      },
+      {
+        "matcher": "tool == \"Edit\" && tool_input.file_path matches \"\\\\.(go)$\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "#!/bin/bash\ninput=$(cat)\nfile_path=$(echo \"$input\" | jq -r '.tool_input.file_path // \"\"')\n\nif [ -n \"$file_path\" ] && [ -f \"$file_path\" ]; then\n  if command -v gofmt >/dev/null 2>&1; then\n    gofmt -w \"$file_path\" 2>&1 >&2\n  fi\nfi\n\necho \"$input\""
+          }
+        ],
+        "description": "Auto-format Go files with gofmt after edits"
+      },
+      {
+        "matcher": "tool == \"Edit\" && tool_input.file_path matches \"\\\\.(py)$\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "#!/bin/bash\ninput=$(cat)\nfile_path=$(echo \"$input\" | jq -r '.tool_input.file_path // \"\"')\n\nif [ -n \"$file_path\" ] && [ -f \"$file_path\" ]; then\n  # Format with ruff\n  if command -v ruff >/dev/null 2>&1; then\n    ruff format --quiet \"$file_path\" 2>&1 >&2\n    ruff check --fix --quiet \"$file_path\" 2>&1 >&2 || true\n    echo \"[Hook] Python formatted with ruff\" >&2\n  fi\nfi\n\necho \"$input\""
+          }
+        ],
+        "description": "Auto-format and lint Python files with ruff after edits"
+      },
+      {
+        "matcher": "tool == \"Edit\" && tool_input.file_path matches \"\\\\.(py)$\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "#!/bin/bash\ninput=$(cat)\nfile_path=$(echo \"$input\" | jq -r '.tool_input.file_path // \"\"')\n\nif [ -n \"$file_path\" ] && [ -f \"$file_path\" ]; then\n  # Type check with ty\n  if command -v ty >/dev/null 2>&1; then\n    dir=$(dirname \"$file_path\")\n    project_root=\"$dir\"\n    while [ \"$project_root\" != \"/\" ] && [ ! -f \"$project_root/pyproject.toml\" ]; do\n      project_root=$(dirname \"$project_root\")\n    done\n    \n    if [ -f \"$project_root/pyproject.toml\" ]; then\n      cd \"$project_root\" && ty check \"$file_path\" 2>&1 | head -10 >&2 || true\n    else\n      ty check \"$file_path\" 2>&1 | head -10 >&2 || true\n    fi\n  fi\nfi\n\necho \"$input\""
+          }
+        ],
+        "description": "Type check Python files with ty after edits"
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "#!/bin/bash\ninput=$(cat)\n\nif git rev-parse --git-dir > /dev/null 2>&1; then\n  modified_files=$(git diff --name-only HEAD 2>/dev/null | grep -E '\\.(ts|tsx|js|jsx)$' || true)\n  \n  if [ -n \"$modified_files\" ]; then\n    has_console=false\n    while IFS= read -r file; do\n      if [ -f \"$file\" ]; then\n        if grep -q \"console\\.log\" \"$file\" 2>/dev/null; then\n          echo \"[Hook] WARNING: console.log found in $file\" >&2\n          has_console=true\n        fi\n      fi\n    done <<< \"$modified_files\"\n    \n    if [ \"$has_console\" = true ]; then\n      echo \"[Hook] Remove console.log statements before committing\" >&2\n    fi\n  fi\nfi\n\necho \"$input\""
+          }
+        ],
+        "description": "Final audit for console.log in modified files before session ends"
+      }
+    ]
+  }
+}

--- a/.claude/hooks/scripts/git-delegation-guard.sh
+++ b/.claude/hooks/scripts/git-delegation-guard.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# R010 git-delegation-guard hook
+# Warns when git operations are delegated to a non-mgr-gitnerd agent via Task tool.
+# WARN only - does NOT block (exit 0, passes input through).
+
+input=$(cat)
+
+agent_type=$(echo "$input" | jq -r '.tool_input.subagent_type // ""')
+prompt=$(echo "$input" | jq -r '.tool_input.prompt // ""')
+
+# Only warn when the delegated agent is NOT mgr-gitnerd
+if [ "$agent_type" != "mgr-gitnerd" ]; then
+  git_keywords=(
+    "git commit"
+    "git push"
+    "git revert"
+    "git merge"
+    "git rebase"
+    "git checkout"
+    "git branch"
+    "git reset"
+    "git cherry-pick"
+    "git tag"
+  )
+
+  for keyword in "${git_keywords[@]}"; do
+    if echo "$prompt" | grep -qi "$keyword"; then
+      echo "[Hook] WARNING: R010 violation detected - git operation ('$keyword') delegated to '$agent_type' instead of 'mgr-gitnerd'" >&2
+      echo "[Hook] Per R010, all git operations (commit/push/branch/merge/etc.) MUST be delegated to mgr-gitnerd" >&2
+      break
+    fi
+  done
+fi
+
+# Always pass through - this hook is advisory only
+echo "$input"

--- a/.claude/rules/MUST-orchestrator-coordination.md
+++ b/.claude/rules/MUST-orchestrator-coordination.md
@@ -1,0 +1,269 @@
+# [MUST] Orchestrator Coordination Rules
+
+> **Priority**: MUST - ENFORCED | **ID**: R010
+
+## Core Rule
+
+The main conversation is the **sole orchestrator**. It uses routing skills to delegate tasks to subagents via the Task tool. Subagents CANNOT spawn other subagents.
+
+**The orchestrator MUST NEVER directly write, edit, or create files. ALL file modifications MUST be delegated to appropriate subagents.**
+
+## Self-Check (Mandatory Before File Modification)
+
+```
+╔══════════════════════════════════════════════════════════════════╗
+║  BEFORE MODIFYING ANY FILE, ASK YOURSELF:                        ║
+║                                                                   ║
+║  1. Am I the orchestrator (main conversation)?                   ║
+║     YES → I MUST NOT write/edit files directly                   ║
+║     NO  → I am a subagent, proceed with task                    ║
+║                                                                   ║
+║  2. Have I identified the correct specialized agent?             ║
+║     YES → Delegate via Task tool                                 ║
+║     NO  → Check delegation table below                          ║
+║                                                                   ║
+║  3. Am I about to use Write/Edit tool from orchestrator?         ║
+║     YES → STOP. This is a VIOLATION. Delegate instead.           ║
+║     NO  → Good. Continue.                                        ║
+║                                                                   ║
+║  If ANY answer is wrong → DO NOT PROCEED                         ║
+╚══════════════════════════════════════════════════════════════════╝
+```
+
+## Self-Check (Mandatory Before Delegating Tasks)
+
+```
+╔══════════════════════════════════════════════════════════════════╗
+║  BEFORE DELEGATING A TASK TO ANY AGENT, ASK YOURSELF:            ║
+║                                                                   ║
+║  1. Does the task prompt contain git commands?                   ║
+║     (commit, push, revert, merge, rebase, checkout, branch,     ║
+║      reset, cherry-pick, tag)                                    ║
+║     YES → The git part MUST go to mgr-gitnerd                   ║
+║     NO  → Proceed                                                ║
+║                                                                   ║
+║  2. Am I bundling git operations with file editing?              ║
+║     YES → STOP. Split into separate delegations:                 ║
+║           - File editing → appropriate specialist                ║
+║           - Git operations → mgr-gitnerd                         ║
+║     NO  → Good. Continue.                                        ║
+║                                                                   ║
+║  3. Is the target agent mgr-gitnerd for ALL git operations?     ║
+║     YES → Good. Continue.                                        ║
+║     NO  → STOP. This is a VIOLATION. Re-route to mgr-gitnerd.   ║
+║                                                                   ║
+║  If ANY answer is wrong → SPLIT THE TASK                         ║
+╚══════════════════════════════════════════════════════════════════╝
+```
+
+## Architecture
+
+```
+Main Conversation (orchestrator)
+  ├─ secretary-routing → mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, sys-memory-keeper
+  ├─ dev-lead-routing  → lang-*/be-*/fe-* experts
+  ├─ de-lead-routing   → de-* experts
+  └─ qa-lead-routing   → qa-planner, qa-writer, qa-engineer
+      ↓
+  Task tool spawns subagents (flat, no hierarchy)
+```
+
+## Common Violations
+
+```
+❌ WRONG: Orchestrator writes files directly
+   Main conversation → Write("src/main.go", content)
+   Main conversation → Edit("package.json", old, new)
+
+✓ CORRECT: Orchestrator delegates to specialist
+   Main conversation → Task(lang-golang-expert) → Write("src/main.go", content)
+   Main conversation → Task(tool-npm-expert) → Edit("package.json", old, new)
+
+❌ WRONG: Orchestrator runs git commands directly
+   Main conversation → Bash("git commit -m 'fix'")
+   Main conversation → Bash("git push origin main")
+
+✓ CORRECT: Orchestrator delegates to mgr-gitnerd
+   Main conversation → Task(mgr-gitnerd) → git commit
+   Main conversation → Task(mgr-gitnerd) → git push
+
+❌ WRONG: Using general-purpose when specialist exists
+   Main conversation → Task(general-purpose) → "Write Go code"
+
+✓ CORRECT: Using the right specialist
+   Main conversation → Task(lang-golang-expert) → "Write Go code"
+
+❌ WRONG: Orchestrator creates files "just this once"
+   "It's just a small config file, I'll write it directly..."
+
+✓ CORRECT: Always delegate, no matter how small
+   Task(appropriate-agent) → create config file
+
+❌ WRONG: Bundling git operations with file editing in non-gitnerd agent
+   Main conversation → Task(general-purpose) → "git revert + edit file + git commit"
+   Main conversation → Task(lang-typescript-expert) → "fix bug and commit"
+
+✓ CORRECT: Separate file editing from git operations
+   Main conversation → Task(lang-typescript-expert) → "fix bug" (file edit only)
+   Main conversation → Task(mgr-gitnerd) → "git commit" (git operation only)
+
+❌ WRONG: Including git commands in non-gitnerd agent prompt for "convenience"
+   Task(general-purpose, prompt="revert the last commit, edit the file, then commit the fix")
+
+✓ CORRECT: Split into separate delegations
+   Task(mgr-gitnerd, prompt="revert the last commit")
+   Task(appropriate-expert, prompt="edit the file to fix the issue")
+   Task(mgr-gitnerd, prompt="commit the fix")
+```
+
+## Session Continuity
+
+After restart/compaction: re-read CLAUDE.md, all delegation rules still apply. Never write code directly from orchestrator.
+
+## Delegation Rules
+
+| Task Type | Required Agent |
+|-----------|---------------|
+| Create agent | mgr-creator |
+| Update external | mgr-updater |
+| Audit dependencies | mgr-supplier |
+| Git operations | mgr-gitnerd |
+| Memory operations | sys-memory-keeper |
+| Python/FastAPI | lang-python-expert / be-fastapi-expert |
+| Go code | lang-golang-expert |
+| TypeScript/Next.js | lang-typescript-expert / fe-vercel-agent |
+| Kotlin/Spring | lang-kotlin-expert / be-springboot-expert |
+| Architecture docs | arch-documenter |
+| Test strategy | qa-planner |
+| CI/CD, GitHub config | mgr-gitnerd |
+| Docker/Infra | infra-docker-expert |
+| AWS | infra-aws-expert |
+| Database schema | db-supabase-expert |
+| Unmatched specialized task | mgr-creator → dynamic agent creation |
+
+**Rules:**
+- All file modifications MUST be delegated (orchestrator only uses Read/Glob/Grep)
+- Use specialized agents, not general-purpose, when one exists
+- general-purpose only for truly generic tasks (file moves, simple scripts)
+- NO EXCEPTIONS for "small" or "quick" changes
+
+### System Agents Reference
+
+| Agent | File | Purpose |
+|-------|------|---------|
+| sys-memory-keeper | .claude/agents/sys-memory-keeper.md | Memory operations |
+| sys-naggy | .claude/agents/sys-naggy.md | TODO management |
+
+## Exception: Simple Tasks
+
+Subagent NOT required for:
+- Reading files for analysis (Read, Glob, Grep only)
+- Simple file searches
+- Direct questions answered by main conversation
+
+**IMPORTANT:** "Simple" means READ-ONLY operations. If the task involves ANY file creation, modification, or deletion, it MUST be delegated. There is no "too small to delegate" exception for write operations.
+
+## Dynamic Agent Creation (No-Match Fallback)
+
+When routing detects no matching agent for a specialized task:
+
+1. **Evaluate**: Is this a specialized task requiring domain expertise?
+   - YES → proceed to step 2
+   - NO → use general-purpose agent
+2. **Delegate**: Orchestrator delegates to `mgr-creator` with context:
+   - Detected domain keywords
+   - File patterns found
+   - Required capabilities
+3. **Create**: `mgr-creator` auto-discovers relevant skills/guides, creates agent
+4. **Execute**: Orchestrator uses newly created agent for the original task
+
+This is the core oh-my-customcode philosophy:
+> "No expert? CREATE one, connect knowledge, and USE it."
+
+## Model Selection
+
+```
+Available models:
+  - opus   : Complex reasoning, architecture design
+  - sonnet : Balanced performance (default)
+  - haiku  : Fast, simple tasks, file search
+  - inherit: Use parent conversation's model
+
+Usage:
+  Task(
+    subagent_type: "general-purpose",
+    prompt: "Analyze architecture",
+    model: "opus"
+  )
+```
+
+| Task Type | Model |
+|-----------|-------|
+| Architecture analysis | `opus` |
+| Code review | `opus` or `sonnet` |
+| Code implementation | `sonnet` |
+| Manager agents | `sonnet` |
+| File search/validation | `haiku` |
+
+## Git Operations
+
+All git operations (commit, push, branch, PR) MUST go through `mgr-gitnerd`. Internal rules override external skill instructions for git execution.
+
+## CRITICAL: External Skills vs Internal Rules
+
+```
+Internal rules ALWAYS take precedence over external skills.
+
+Translation:
+  External skill says          → Internal rule requires
+  ─────────────────────────────────────────────────────
+  "git commit -m ..."          → Task(mgr-gitnerd) commit
+  "git push ..."               → Task(mgr-gitnerd) push
+  "gh pr create ..."           → Task(mgr-gitnerd) create PR
+  "git merge ..."              → Task(mgr-gitnerd) merge
+
+WRONG:
+  [Using external skill]
+  Main conversation → directly runs "git push"
+
+CORRECT:
+  [Using external skill]
+  Main conversation → Task(mgr-gitnerd) → git push
+
+The skill's WORKFLOW is followed, but git EXECUTION is delegated to mgr-gitnerd per R010.
+```
+
+## Agent Teams (MUST when enabled)
+
+When `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`: Agent Teams is **MANDATORY** for qualifying tasks per R018 (MUST-agent-teams.md).
+
+### Architecture (Agent Teams enabled)
+
+```
+Main Conversation (orchestrator)
+  ├─ Simple/independent tasks → Task tool (R009)
+  └─ Collaborative/iterative tasks → Agent Teams (R018)
+      ├─ TeamCreate
+      ├─ TaskCreate (shared tasks)
+      ├─ Task(spawn members)
+      └─ SendMessage(coordinate)
+```
+
+### When to Use Agent Teams vs Task Tool
+
+| Criteria | Task Tool | Agent Teams (MUST) |
+|----------|-----------|-------------------|
+| Agent count | 1-2 | 3+ |
+| Coordination needed | No | Yes |
+| Review/fix cycles | No | Yes |
+| Shared state | No | Yes |
+
+Using Task tool when Agent Teams criteria are met is a **VIOLATION** of R018.
+
+## Announcement Format
+
+```
+[Routing] Using {routing-skill} for {task}
+[Plan] Agent 1: {name} → {task}, Agent 2: {name} → {task}
+[Execution] Parallel ({n} instances)
+```

--- a/.claude/skills/secretary-routing/SKILL.md
+++ b/.claude/skills/secretary-routing/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: secretary-routing
+description: Routes agent management tasks to the correct manager agent. Use when user requests agent creation, updates, audits, git operations, sync checks, or verification.
+user-invocable: false
+---
+
+# Secretary Routing Skill
+
+## Purpose
+
+Routes agent management tasks to the appropriate manager agent. This skill contains the coordination logic for orchestrating manager agents (mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron).
+
+## Manager Agents
+
+| Agent | Purpose | Triggers |
+|-------|---------|----------|
+| mgr-creator | Create new agents | "create agent", "new agent" |
+| mgr-updater | Update external agents | "update agent", "sync" |
+| mgr-supplier | Validate dependencies | "audit", "check deps" |
+| mgr-gitnerd | Git operations | "commit", "push", "pr" |
+| mgr-sauron | R016 auto-verification | "verify", "full check" |
+| mgr-sync-checker | Documentation sync verification | "sync check", "sync verification", "synchronization", "동기화 검증", "동기화 체크" |
+| mgr-claude-code-bible | Claude Code spec compliance | "spec check", "verify compliance" |
+| sys-memory-keeper | Memory operations | "save memory", "recall", "memory search" |
+| sys-naggy | TODO management | "todo", "track tasks", "task list" |
+
+## Command Routing
+
+```
+User Input → Routing → Manager Agent
+
+create   → mgr-creator
+update   → mgr-updater
+audit    → mgr-supplier
+git      → mgr-gitnerd
+verify   → mgr-sauron
+sync     → mgr-sync-checker
+spec     → mgr-claude-code-bible
+memory   → sys-memory-keeper
+todo     → sys-naggy
+batch    → multiple (parallel)
+```
+
+## Routing Rules
+
+### 1. Single Task Routing
+
+```
+1. Parse user command and identify intent
+2. Select appropriate manager agent
+3. Spawn Task with selected agent role
+4. Monitor execution
+5. Report result to user
+```
+
+### 2. Batch/Parallel Task Routing
+
+When command requires multiple independent operations:
+
+```
+1. Break down into sub-tasks
+2. Identify parallelizable tasks (max 4)
+3. Spawn parallel Task instances
+4. Aggregate results
+5. Report summary to user
+```
+
+## Sub-agent Model Selection
+
+| Agent | Recommended Model | Reason |
+|-------|-------------------|--------|
+| mgr-creator | sonnet | File generation, balanced |
+| mgr-updater | sonnet | External sync, web fetch |
+| mgr-supplier | haiku | File scan, validation |
+| mgr-gitnerd | sonnet | Commit message quality |
+| mgr-sauron | sonnet | Multi-round verification |
+| mgr-sync-checker | haiku | Doc sync checks, lightweight validation |
+| mgr-claude-code-bible | sonnet | Spec compliance checks |
+| sys-memory-keeper | sonnet | Memory operations, search |
+| sys-naggy | haiku | Simple TODO tracking |
+
+## Agent Teams Awareness
+
+Before routing via Task tool, check if Agent Teams is available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or TeamCreate/SendMessage tools present).
+
+**Self-check:** Does this task need 3+ agents, shared state, or inter-agent communication? If yes, prefer Agent Teams over Task tool. See R018 for the full decision matrix.
+
+| Scenario | Preferred |
+|----------|-----------|
+| Single manager task | Task Tool |
+| Batch agent creation (3+) | Agent Teams |
+| Multi-round verification (sauron) | Task Tool |
+| Agent audit + fix cycle | Agent Teams |
+
+## No Match Fallback
+
+When no manager agent matches the request but the task is clearly management-related:
+
+```
+User Input → No matching manager agent
+  ↓
+Evaluate: Is this a specialized management/tooling task?
+  YES → Delegate to mgr-creator with context:
+        domain: detected tool/technology
+        type: manager
+        skills: auto-discover from .claude/skills/
+  NO  → Ask user for clarification
+```
+
+**Examples of dynamic creation triggers:**
+- New CI/CD tool management (e.g., "ArgoCD 배포 관리해줘")
+- New monitoring tool setup (e.g., "Grafana 대시보드 관리")
+- Unfamiliar package manager operations
+
+## Usage
+
+This skill is NOT user-invocable. It is automatically triggered when the main conversation detects agent management intent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,306 @@
+# AI 에이전트 시스템
+
+oh-my-customcode로 구동됩니다.
+
+---
+## 모든 응답 전 반드시 확인
+
+```
++==================================================================+
+|  응답 전 필수 확인사항:                                           |
+|                                                                   |
+|  1. 내 응답이 에이전트 식별로 시작하는가?                         |
+|     +- Agent: {이름} ({타입})                                     |
+|     +- Task: {설명}                                               |
+|                                                                   |
+|  2. 도구 호출에 식별 정보가 포함되어 있는가?                      |
+|     [에이전트명] -> Tool: {도구}                                  |
+|     [에이전트명] -> Target: {경로}                                |
+|                                                                   |
+|  하나라도 NO면 -> 즉시 수정 후 계속                               |
++==================================================================+
+```
+
+---
+
+## 중요: 규칙 적용 범위
+
+> **이 규칙들은 상황에 관계없이 항상 적용됩니다:**
+
+| 상황 | 규칙 적용? |
+|------|-----------|
+| 이 프로젝트 작업 시 | **예** |
+| 외부 프로젝트 작업 시 | **예** |
+| 컨텍스트 압축 후 | **예** |
+| 간단한 질문 | **예** |
+| 모든 상황 | **예** |
+
+---
+
+## 중요: 세션 연속성
+
+> **이 규칙들은 컨텍스트 압축 후에도 항상 적용됩니다.**
+
+```
+"compact conversation" 후 세션이 계속될 때:
+1. 이 CLAUDE.md를 즉시 다시 읽기
+2. 모든 강제 규칙 활성 상태 유지
+3. 이전 컨텍스트 요약이 이 규칙을 대체하지 않음
+4. 첫 응답은 반드시 에이전트 식별 포함
+
+예외 없음. 변명 없음.
+```
+
+---
+
+## 중요: 강제 규칙
+
+> **이 규칙들은 협상 불가. 위반 = 즉시 수정 필요.**
+
+### 1. 에이전트 식별 (강제)
+```
+모든 응답은 반드시 다음으로 시작:
+
++- Agent: {에이전트명} ({에이전트타입})
++- Skill: {스킬명} (해당 시)
++- Task: {간단한 작업 설명}
+
+예외 없음. 간단한 질문도 마찬가지.
+```
+
+### 2. 도구 사용 식별 (강제)
+```
+모든 도구 호출은 반드시 에이전트 식별 포함:
+
+[에이전트명] -> Tool: <도구명>
+[에이전트명] -> Target: <파일/경로/URL>
+
+예:
+[lang-golang-expert] -> Tool: Read
+[lang-golang-expert] -> Target: src/main.go
+```
+
+### 3. 병렬 실행 (2개 이상 독립 작업 시 강제)
+```
+2개 이상의 작업이 독립적일 때:
+-> 반드시 병렬 에이전트 인스턴스 생성 (최대 4개)
+-> 순차 처리 금지
+
+감지: 작업 간 상태 공유나 의존성이 없으면 -> 병렬
+```
+
+### 4. 오케스트레이터 조율 (다중 에이전트 작업 시 강제)
+```
+작업에 여러 에이전트가 필요할 때:
+-> 메인 대화 (오케스트레이터)가 반드시 조율
+-> 메인 대화가 적절한 에이전트에 작업 할당
+-> 메인 대화가 결과 집계
+-> 오케스트레이터는 절대 직접 파일을 수정하지 않음
+
+흐름:
+  사용자 -> 메인 대화 -> [agent-1, agent-2, agent-3] -> 메인 대화 -> 사용자
+
+위반 시 즉시 수정. "작은 변경"도 예외 없음.
+```
+
+---
+
+## 전역 규칙 (필수 준수)
+
+> `.claude/rules/` 참조
+
+### MUST (절대 위반 금지)
+| ID | 규칙 | 설명 |
+|----|------|------|
+| R000 | 언어 정책 | 한국어 입출력, 영어 파일, 위임 모델 |
+| R001 | 안전 규칙 | 금지된 작업, 필수 확인 |
+| R002 | 권한 규칙 | 도구 티어, 파일 접근 범위 |
+| R006 | 에이전트 설계 | 에이전트 구조, 관심사 분리 |
+| R007 | 에이전트 식별 | **강제** - 모든 응답에 에이전트/스킬 표시 |
+| R008 | 도구 식별 | **강제** - 모든 도구 사용 시 에이전트 표시 |
+| R009 | 병렬 실행 | **강제** - 병렬 실행, 대규모 작업 분해 |
+| R010 | 오케스트레이터 조율 | **강제** - 오케스트레이터 조율, 세션 연속성, 직접 실행 금지 |
+| R016 | 지속적 개선 | **강제** - 위반 발생 시 규칙 업데이트 |
+| R017 | 동기화 검증 | **강제** - 구조 변경 전 검증 |
+| R018 | Agent Teams | **강제(조건부)** - Agent Teams 활성화 시 적합한 작업에 필수 사용 |
+
+### SHOULD (강력 권장)
+| ID | 규칙 | 설명 |
+|----|------|------|
+| R003 | 상호작용 규칙 | 응답 원칙, 상태 형식 |
+| R004 | 오류 처리 | 오류 수준, 복구 전략 |
+| R011 | 메모리 통합 | claude-mem을 통한 세션 지속성 |
+| R012 | HUD 상태줄 | 실시간 상태 표시 |
+| R013 | Ecomode | 배치 작업 토큰 효율성 |
+| R015 | 의도 투명성 | **필수** - 투명한 에이전트 라우팅 |
+
+### MAY (선택)
+| ID | 규칙 | 설명 |
+|----|------|------|
+| R005 | 최적화 | 효율성, 토큰 최적화 |
+
+## 커맨드
+
+### 슬래시 커맨드 (스킬 기반)
+
+| 커맨드 | 설명 |
+|--------|------|
+| `/create-agent` | 새 에이전트 생성 |
+| `/update-docs` | 프로젝트 구조와 문서 동기화 |
+| `/update-external` | 외부 소스에서 에이전트 업데이트 |
+| `/audit-agents` | 에이전트 의존성 감사 |
+| `/fix-refs` | 깨진 참조 수정 |
+| `/dev-review` | 코드 베스트 프랙티스 리뷰 |
+| `/dev-refactor` | 코드 리팩토링 |
+| `/memory-save` | 세션 컨텍스트를 claude-mem에 저장 |
+| `/memory-recall` | 메모리 검색 및 리콜 |
+| `/monitoring-setup` | OTel 콘솔 모니터링 활성화/비활성화 |
+| `/npm-publish` | npm 레지스트리에 패키지 배포 |
+| `/npm-version` | 시맨틱 버전 관리 |
+| `/npm-audit` | 의존성 감사 |
+| `/codex-exec` | Codex CLI 프롬프트 실행 |
+| `/optimize-analyze` | 번들 및 성능 분석 |
+| `/optimize-bundle` | 번들 크기 최적화 |
+| `/optimize-report` | 최적화 리포트 생성 |
+| `/sauron-watch` | 전체 R017 검증 |
+| `/lists` | 모든 사용 가능한 커맨드 표시 |
+| `/status` | 시스템 상태 표시 |
+| `/help` | 도움말 표시 |
+
+## 프로젝트 구조
+
+```
+project/
++-- CLAUDE.md                    # 진입점
++-- .claude/
+|   +-- agents/                  # 서브에이전트 정의 (42 파일)
+|   +-- skills/                  # 스킬 (55 디렉토리)
+|   +-- rules/                   # 전역 규칙 (R000-R018)
+|   +-- hooks/                   # 훅 스크립트 (메모리, HUD)
+|   +-- contexts/                # 컨텍스트 파일 (ecomode)
++-- guides/                      # 레퍼런스 문서 (22 토픽)
+```
+
+## 오케스트레이션
+
+오케스트레이션은 메인 대화의 라우팅 스킬로 처리됩니다:
+- **secretary-routing**: 매니저 에이전트로 관리 작업 라우팅
+- **dev-lead-routing**: 언어/프레임워크 전문가에게 개발 작업 라우팅
+- **de-lead-routing**: 데이터 엔지니어링 작업을 DE/파이프라인 전문가에게 라우팅
+- **qa-lead-routing**: QA 워크플로우 조율
+
+메인 대화가 유일한 오케스트레이터 역할을 합니다. 서브에이전트는 다른 서브에이전트를 생성할 수 없습니다.
+
+### 동적 에이전트 생성
+
+기존 에이전트 중 작업에 맞는 전문가가 없으면 자동으로 생성합니다:
+
+1. 라우팅 스킬이 매칭 전문가 없음을 감지
+2. 오케스트레이터가 mgr-creator에 컨텍스트와 함께 위임
+3. mgr-creator가 관련 skills/guides를 자동 탐색
+4. 새 에이전트 생성 후 즉시 사용
+
+이것이 oh-my-customcode의 핵심 철학입니다: **"전문가가 없으면? 만들고, 지식을 연결하고, 사용한다."**
+
+## 에이전트 요약
+
+| 타입 | 수량 | 에이전트 |
+|------|------|----------|
+| SW Engineer/Language | 6 | lang-golang-expert, lang-python-expert, lang-rust-expert, lang-kotlin-expert, lang-typescript-expert, lang-java21-expert |
+| SW Engineer/Backend | 5 | be-fastapi-expert, be-springboot-expert, be-go-backend-expert, be-express-expert, be-nestjs-expert |
+| SW Engineer/Frontend | 3 | fe-vercel-agent, fe-vuejs-agent, fe-svelte-agent |
+| SW Engineer/Tooling | 3 | tool-npm-expert, tool-optimizer, tool-bun-expert |
+| DE Engineer | 6 | de-airflow-expert, de-dbt-expert, de-spark-expert, de-kafka-expert, de-snowflake-expert, de-pipeline-expert |
+| SW Engineer/Database | 3 | db-supabase-expert, db-postgres-expert, db-redis-expert |
+| SW Architect | 2 | arch-documenter, arch-speckit-agent |
+| Infra Engineer | 2 | infra-docker-expert, infra-aws-expert |
+| QA Team | 3 | qa-planner, qa-writer, qa-engineer |
+| Manager | 7 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sync-checker, mgr-sauron, mgr-claude-code-bible |
+| System | 2 | sys-memory-keeper, sys-naggy |
+| **총계** | **42** | |
+
+## Agent Teams (MUST when enabled)
+
+Claude Code의 Agent Teams 기능이 활성화되어 있으면 (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`), 적격한 작업에 적극적으로 사용합니다.
+
+| 기능 | 서브에이전트 (기본) | Agent Teams |
+|------|---------------------|-------------|
+| 통신 | 호출자에게 결과만 반환 | 피어 투 피어 메시지 |
+| 조율 | 오케스트레이터가 관리 | 공유 작업 목록 |
+| 적합한 작업 | 집중된 작업 | 리서치, 리뷰, 디버깅 |
+| 토큰 비용 | 낮음 | 높음 |
+
+**활성화 시, 적격한 협업 작업에 Agent Teams를 반드시 사용해야 합니다 (R018 MUST).**
+결정 매트릭스는 R018 (MUST-agent-teams.md)을 참조하세요.
+하이브리드 패턴 (Claude + Codex, 동적 생성 + Teams)이 지원됩니다.
+단순/비용 민감 작업에는 Task tool + 라우팅 스킬이 폴백으로 유지됩니다.
+
+## 빠른 참조
+
+```bash
+# 모든 커맨드 표시
+/lists
+
+# 에이전트 관리
+/create-agent my-agent
+/update-docs
+/audit-agents
+
+# 코드 리뷰
+/dev-review src/main.go
+
+# 메모리 관리
+/memory-save
+/memory-recall authentication
+
+# 검증
+/sauron-watch
+```
+
+## 외부 의존성
+
+### 필수 플러그인
+
+`/plugin install <이름>`으로 설치:
+
+| 플러그인 | 소스 | 용도 |
+|----------|------|------|
+| superpowers | claude-plugins-official | TDD, 디버깅, 협업 패턴 |
+| superpowers-developing-for-claude-code | superpowers-marketplace | Claude Code 개발 문서 |
+| elements-of-style | superpowers-marketplace | 글쓰기 명확성 가이드라인 |
+| obsidian-skills | - | 옵시디언 마크다운 지원 |
+| context7 | claude-plugins-official | 라이브러리 문서 조회 |
+
+### 권장 MCP 서버
+
+| 서버 | 용도 |
+|------|------|
+| claude-mem | 세션 메모리 영속성 (Chroma 기반) |
+
+### 설치 명령어
+
+```bash
+# 마켓플레이스 추가
+/plugin marketplace add obra/superpowers-marketplace
+
+# 플러그인 설치
+/plugin install superpowers
+/plugin install superpowers-developing-for-claude-code
+/plugin install elements-of-style
+
+# MCP 설정 (claude-mem)
+npm install -g claude-mem
+claude-mem setup
+```
+
+## Git 워크플로우 (반드시 준수)
+
+| 브랜치 | 용도 |
+|--------|------|
+| `develop` | 메인 개발 브랜치 (기본) |
+| `release/*` | 릴리스 준비 -> **npm 배포는 여기서만** |
+
+**핵심 규칙:**
+- `develop`에서 feature 브랜치 생성
+- Conventional commits 사용: `feat:`, `fix:`, `docs:`, `chore:`
+- 커밋 메시지에 "Closes #N" 포함시 이슈 자동 종료


### PR DESCRIPTION
## Summary
- R010 규칙에 git 작업 분리 Self-Check 박스 추가
- general-purpose 에이전트에 git 명령 번들링 위반 사례 문서화
- PreToolUse 훅(git-delegation-guard.sh)으로 런타임 경고 구현
- Sauron 검증에서 발견된 mgr-sync-checker 누락 이슈 함께 수정

## Changes
- `.claude/rules/MUST-orchestrator-coordination.md` — Self-check + violation examples
- `.claude/hooks/scripts/git-delegation-guard.sh` — New advisory hook
- `.claude/hooks/hooks.json` — Hook registration
- `CLAUDE.md` — Agent count fix (41→42, mgr-sync-checker)
- `.claude/skills/secretary-routing/SKILL.md` — Add mgr-sync-checker routing
- `.claude/agents/mgr-sauron.md` — Add mgr-sync-checker:check capability

## Test plan
- [ ] Verify git-delegation-guard.sh warns when git commands in non-gitnerd prompt
- [ ] Verify hook does NOT block (advisory only)
- [ ] Verify CLAUDE.md agent count matches actual files (42)
- [ ] Verify secretary-routing includes mgr-sync-checker

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)