### PR TITLE
feat: enable custom statusline for omcustom init users

### DIFF
--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -6,11 +6,13 @@ import { readFile as fsReadFile, writeFile as fsWriteFile, rename } from 'node:f
 import { basename, join } from 'node:path';
 import {
   copyDirectory,
+  copyFile,
   ensureDirectory,
   fileExists,
   getPackageRoot,
   readJsonFile,
   resolveTemplatePath,
+  writeJsonFile,
 } from '../utils/fs.js';
 import { debug, error, info, success, warn } from '../utils/logger.js';
 import { loadConfig, saveConfig } from './config.js';
@@ -217,6 +219,75 @@ async function installSingleComponent(
 }
 
 /**
+ * Install statusline.sh to the target directory and make it executable
+ */
+async function installStatusline(
+  targetDir: string,
+  options: InstallOptions,
+  _result: InstallResult
+): Promise<void> {
+  const layout = getProviderLayout();
+  const srcPath = resolveTemplatePath(join(layout.rootDir, 'statusline.sh'));
+  const destPath = join(targetDir, layout.rootDir, 'statusline.sh');
+
+  if (!(await fileExists(srcPath))) {
+    debug('install.statusline_not_found', { path: srcPath });
+    return;
+  }
+
+  if (await fileExists(destPath)) {
+    if (!options.force && !options.backup) {
+      debug('install.statusline_skipped', { reason: 'exists' });
+      return;
+    }
+  }
+
+  await copyFile(srcPath, destPath);
+
+  const fs = await import('node:fs/promises');
+  await fs.chmod(destPath, 0o755);
+
+  debug('install.statusline_installed', {});
+}
+
+/**
+ * Create or merge settings.local.json with statusLine configuration
+ */
+async function installSettingsLocal(targetDir: string, result: InstallResult): Promise<void> {
+  const layout = getProviderLayout();
+  const settingsPath = join(targetDir, layout.rootDir, 'settings.local.json');
+
+  const statusLineConfig = {
+    statusLine: {
+      type: 'command' as const,
+      command: '.claude/statusline.sh',
+      padding: 0,
+    },
+  };
+
+  if (await fileExists(settingsPath)) {
+    try {
+      const existing = await readJsonFile<Record<string, unknown>>(settingsPath);
+      if (!existing.statusLine) {
+        existing.statusLine = statusLineConfig.statusLine;
+        await writeJsonFile(settingsPath, existing);
+        debug('install.settings_local_merged', {});
+      } else {
+        debug('install.settings_local_skipped', { reason: 'statusLine exists' });
+      }
+    } catch {
+      result.warnings.push(
+        'Failed to parse existing settings.local.json, skipping statusLine config'
+      );
+    }
+    return;
+  }
+
+  await writeJsonFile(settingsPath, statusLineConfig);
+  debug('install.settings_local_created', {});
+}
+
+/**
  * Install entry doc and track result
  */
 async function installEntryDocWithTracking(
@@ -265,6 +336,8 @@ export async function install(options: InstallOptions): Promise<InstallResult> {
     await verifyTemplateDirectory();
 
     await installAllComponents(options.targetDir, options, result);
+    await installStatusline(options.targetDir, options, result);
+    await installSettingsLocal(options.targetDir, result);
     await installEntryDocWithTracking(options.targetDir, options, result);
     await updateInstallConfig(options.targetDir, options, result.installedComponents);
 

--- a/templates/.claude/statusline.sh
+++ b/templates/.claude/statusline.sh
@@ -4,7 +4,7 @@
 # Reads JSON from stdin (Claude Code statusline API, ~300ms intervals)
 # and outputs a formatted status line, e.g.:
 #
-#   Opus | my-project | develop | CTX:42% | $0.05
+#   $0.05 | my-project | develop | PR #160 | CTX:42%
 #
 # JSON input structure:
 #   {
@@ -71,6 +71,7 @@ IFS=$'\t' read -r model_name project_dir ctx_pct ctx_size cost_usd <<< "$(
 
 # ---------------------------------------------------------------------------
 # 5. Model display name + color (bash 3.2 compatible case pattern matching)
+#    Model detection (kept for internal reference, not displayed in statusline)
 # ---------------------------------------------------------------------------
 case "$model_name" in
     *[Oo]pus*)   model_display="Opus";   model_color="${COLOR_OPUS}" ;;
@@ -78,6 +79,30 @@ case "$model_name" in
     *[Hh]aiku*)  model_display="Haiku";  model_color="${COLOR_HAIKU}" ;;
     *)           model_display="$model_name"; model_color="${COLOR_RESET}" ;;
 esac
+
+# ---------------------------------------------------------------------------
+# 5b. Cost display — format and colorize session API cost
+# ---------------------------------------------------------------------------
+# Ensure cost_usd is a valid number (fallback to 0)
+if [[ -z "$cost_usd" ]] || ! printf '%f' "$cost_usd" >/dev/null 2>&1; then
+    cost_usd="0"
+fi
+
+cost_display=$(printf '$%.2f' "$cost_usd")
+
+# Color by cost threshold (cents for integer comparison)
+cost_cents=$(printf '%.0f' "$(echo "$cost_usd * 100" | bc 2>/dev/null || echo 0)")
+if ! [[ "$cost_cents" =~ ^[0-9]+$ ]]; then
+    cost_cents=0
+fi
+
+if [[ "$cost_cents" -ge 500 ]]; then
+    cost_color="${COLOR_CTX_CRIT}"    # Red    (>= $5.00)
+elif [[ "$cost_cents" -ge 100 ]]; then
+    cost_color="${COLOR_CTX_WARN}"    # Yellow ($1.00 - $4.99)
+else
+    cost_color="${COLOR_CTX_OK}"      # Green  (< $1.00)
+fi
 
 # ---------------------------------------------------------------------------
 # 6. Project name — basename of workspace current_dir
@@ -108,7 +133,85 @@ if [[ -f "$git_head_file" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# 8. Context percentage with color
+# 7b. Branch URL — for OSC 8 clickable link
+# ---------------------------------------------------------------------------
+branch_url=""
+if [[ -n "$git_branch" && -n "$project_dir" ]]; then
+    # Get remote URL from git config
+    git_config="${project_dir}/.git/config"
+    if [[ -f "$git_config" ]]; then
+        # Extract remote origin URL from git config (no subprocess)
+        remote_url=""
+        in_remote_origin=false
+        while IFS= read -r line; do
+            case "$line" in
+                '[remote "origin"]')
+                    in_remote_origin=true
+                    ;;
+                '['*)
+                    in_remote_origin=false
+                    ;;
+                *)
+                    if $in_remote_origin; then
+                        case "$line" in
+                            *url\ =*)
+                                remote_url="${line#*url = }"
+                                ;;
+                        esac
+                    fi
+                    ;;
+            esac
+        done < "$git_config"
+
+        # Convert remote URL to HTTPS browse URL
+        if [[ -n "$remote_url" ]]; then
+            case "$remote_url" in
+                git@github.com:*)
+                    # git@github.com:owner/repo.git → https://github.com/owner/repo
+                    repo_path="${remote_url#git@github.com:}"
+                    repo_path="${repo_path%.git}"
+                    branch_url="https://github.com/${repo_path}/tree/${git_branch}"
+                    ;;
+                https://github.com/*)
+                    # https://github.com/owner/repo.git → https://github.com/owner/repo
+                    repo_path="${remote_url#https://github.com/}"
+                    repo_path="${repo_path%.git}"
+                    branch_url="https://github.com/${repo_path}/tree/${git_branch}"
+                    ;;
+            esac
+        fi
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 8. PR number — cached by branch to avoid gh call on every refresh
+# ---------------------------------------------------------------------------
+pr_display=""
+if [[ -n "$git_branch" ]] && command -v gh >/dev/null 2>&1; then
+    cache_file="/tmp/statusline-pr-${project_name}"
+    cached_branch=""
+    cached_pr=""
+
+    if [[ -f "$cache_file" ]]; then
+        IFS=$'\t' read -r cached_branch cached_pr < "$cache_file"
+    fi
+
+    if [[ "$cached_branch" == "$git_branch" ]]; then
+        # Cache hit — use cached PR number
+        pr_number="$cached_pr"
+    else
+        # Cache miss — query gh and update cache
+        pr_number="$(gh pr view --json number -q .number 2>/dev/null || echo "")"
+        printf '%s\t%s\n' "$git_branch" "$pr_number" > "$cache_file"
+    fi
+
+    if [[ -n "$pr_number" ]]; then
+        pr_display="PR #${pr_number}"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 9. Context percentage with color
 # ---------------------------------------------------------------------------
 # ctx_pct may arrive as a float (e.g. 42.5); truncate to integer for comparison
 ctx_int="${ctx_pct%%.*}"
@@ -128,25 +231,33 @@ fi
 ctx_display="CTX:${ctx_int}%"
 
 # ---------------------------------------------------------------------------
-# 9. Cost formatting — always two decimal places
-# ---------------------------------------------------------------------------
-cost_display="$(printf '$%.2f' "$cost_usd")"
-
-# ---------------------------------------------------------------------------
 # 10. Assemble and output the status line
 # ---------------------------------------------------------------------------
-# Build segments; omit git branch segment when unavailable
-if [[ -n "$git_branch" ]]; then
-    printf "${model_color}%s${COLOR_RESET} | %s | %s | ${ctx_color}%s${COLOR_RESET} | %s\n" \
-        "$model_display" \
-        "$project_name" \
-        "$git_branch" \
-        "$ctx_display" \
-        "$cost_display"
+# Format branch with optional OSC 8 hyperlink
+if [[ -n "$branch_url" && -n "${COLOR_RESET}" ]]; then
+    # OSC 8 hyperlink: ESC]8;;URL BEL visible-text ESC]8;; BEL
+    branch_display=$'\033]8;;'"${branch_url}"$'\a'"${git_branch}"$'\033]8;;\a'
 else
-    printf "${model_color}%s${COLOR_RESET} | %s | ${ctx_color}%s${COLOR_RESET} | %s\n" \
-        "$model_display" \
+    branch_display="$git_branch"
+fi
+
+# Build the PR segment (with separator) if present
+pr_segment=""
+if [[ -n "$pr_display" ]]; then
+    pr_segment=" | ${pr_display}"
+fi
+
+if [[ -n "$git_branch" ]]; then
+    printf "${cost_color}%s${COLOR_RESET} | %s | %s%s | ${ctx_color}%s${COLOR_RESET}\n" \
+        "$cost_display" \
         "$project_name" \
-        "$ctx_display" \
-        "$cost_display"
+        "$branch_display" \
+        "$pr_segment" \
+        "$ctx_display"
+else
+    printf "${cost_color}%s${COLOR_RESET} | %s%s | ${ctx_color}%s${COLOR_RESET}\n" \
+        "$cost_display" \
+        "$project_name" \
+        "$pr_segment" \
+        "$ctx_display"
 fi

--- a/tests/unit/core/installer.test.ts
+++ b/tests/unit/core/installer.test.ts
@@ -368,6 +368,119 @@ describe('installer', () => {
     });
   });
 
+  describe('statusline installation', () => {
+    it('should install statusline.sh during init', async () => {
+      await install({ targetDir: tempDir, skipConfirm: true });
+      const statuslinePath = join(tempDir, '.claude', 'statusline.sh');
+      expect(await fileExists(statuslinePath)).toBe(true);
+    });
+
+    it('should make statusline.sh executable', async () => {
+      await install({ targetDir: tempDir, skipConfirm: true });
+      const statuslinePath = join(tempDir, '.claude', 'statusline.sh');
+      const fs = await import('node:fs/promises');
+      const stats = await fs.stat(statuslinePath);
+      // Check executable bit (owner execute = 0o100)
+      expect(stats.mode & 0o111).toBeGreaterThan(0);
+    });
+
+    it('should skip statusline.sh if already exists and no force', async () => {
+      // First install
+      await install({ targetDir: tempDir, skipConfirm: true });
+      const statuslinePath = join(tempDir, '.claude', 'statusline.sh');
+
+      // Modify to detect overwrite
+      const fs = await import('node:fs/promises');
+      await fs.writeFile(statuslinePath, '#!/bin/bash\n# custom', 'utf-8');
+
+      // Second install without force
+      await install({ targetDir: tempDir, skipConfirm: true });
+
+      // Should still be our custom content
+      const content = await fs.readFile(statuslinePath, 'utf-8');
+      expect(content).toContain('# custom');
+    });
+
+    it('should overwrite statusline.sh with force option', async () => {
+      // First install
+      await install({ targetDir: tempDir, skipConfirm: true });
+      const statuslinePath = join(tempDir, '.claude', 'statusline.sh');
+
+      // Modify to detect overwrite
+      const fs = await import('node:fs/promises');
+      await fs.writeFile(statuslinePath, '#!/bin/bash\n# custom', 'utf-8');
+
+      // Second install with force
+      await install({ targetDir: tempDir, force: true, skipConfirm: true });
+
+      // Should be overwritten (no longer custom)
+      const content = await fs.readFile(statuslinePath, 'utf-8');
+      expect(content).not.toContain('# custom');
+    });
+  });
+
+  describe('settings.local.json installation', () => {
+    it('should create settings.local.json during init', async () => {
+      await install({ targetDir: tempDir, skipConfirm: true });
+      const settingsPath = join(tempDir, '.claude', 'settings.local.json');
+      expect(await fileExists(settingsPath)).toBe(true);
+    });
+
+    it('should include statusLine configuration', async () => {
+      await install({ targetDir: tempDir, skipConfirm: true });
+      const settingsPath = join(tempDir, '.claude', 'settings.local.json');
+      const fs = await import('node:fs/promises');
+      const content = JSON.parse(await fs.readFile(settingsPath, 'utf-8'));
+      expect(content.statusLine).toBeDefined();
+      expect(content.statusLine.type).toBe('command');
+      expect(content.statusLine.command).toBe('.claude/statusline.sh');
+      expect(content.statusLine.padding).toBe(0);
+    });
+
+    it('should merge statusLine into existing settings.local.json', async () => {
+      // Create existing settings.local.json with other settings
+      const settingsPath = join(tempDir, '.claude', 'settings.local.json');
+      const fs = await import('node:fs/promises');
+      await fs.mkdir(join(tempDir, '.claude'), { recursive: true });
+      await fs.writeFile(
+        settingsPath,
+        JSON.stringify({ enableAllProjectMcpServers: true }),
+        'utf-8'
+      );
+
+      await install({ targetDir: tempDir, skipConfirm: true });
+
+      const content = JSON.parse(await fs.readFile(settingsPath, 'utf-8'));
+      // Original setting preserved
+      expect(content.enableAllProjectMcpServers).toBe(true);
+      // statusLine added
+      expect(content.statusLine).toBeDefined();
+      expect(content.statusLine.command).toBe('.claude/statusline.sh');
+    });
+
+    it('should not overwrite existing statusLine configuration', async () => {
+      // Create existing settings with custom statusLine
+      const settingsPath = join(tempDir, '.claude', 'settings.local.json');
+      const fs = await import('node:fs/promises');
+      await fs.mkdir(join(tempDir, '.claude'), { recursive: true });
+      const customSettings = {
+        statusLine: {
+          type: 'command',
+          command: '.claude/custom-statusline.sh',
+          padding: 2,
+        },
+      };
+      await fs.writeFile(settingsPath, JSON.stringify(customSettings), 'utf-8');
+
+      await install({ targetDir: tempDir, skipConfirm: true });
+
+      const content = JSON.parse(await fs.readFile(settingsPath, 'utf-8'));
+      // Should keep custom statusLine, not overwrite
+      expect(content.statusLine.command).toBe('.claude/custom-statusline.sh');
+      expect(content.statusLine.padding).toBe(2);
+    });
+  });
+
   describe('error handling', () => {
     it('should handle template directory not found error (line 211)', async () => {
       // Mock fileExists to return false for template directory check


### PR DESCRIPTION
## Summary

- `templates/.claude/statusline.sh`를 최신 프로젝트 버전으로 동기화 (cost display, PR caching, OSC 8 hyperlinks)
- `installStatusline()` 추가: init 시 statusline.sh 복사 및 chmod 755 실행 권한 설정
- `installSettingsLocal()` 추가: settings.local.json 생성 또는 기존 설정에 statusLine 키 병합
- 기존 사용자 설정 보존 로직 포함 (병합 시 충돌 방지)
- 8개 테스트 추가 (statusline 설치, settings.local.json 생성/병합/보존 시나리오)

## Test Results

```
914 pass, 0 fail
Function coverage: 100.00%
Line coverage: 99.60%
```

## Validation (NuTalk project)

- statusline.sh 설치 확인 (최신 버전, chmod 755)
- settings.local.json 자동 생성 확인
- 기존 설정 보존 + statusLine 키 병합 동작 확인

## Test Plan

- [ ] `omcustom init` 실행 후 `statusline.sh` 존재 및 실행 권한 확인
- [ ] `settings.local.json`에 `statusLine` 키 생성 여부 확인
- [ ] 기존 `settings.local.json` 있을 때 기존 키 보존 확인
- [ ] `bun test` 전체 통과 확인 (914 tests)

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)