### PR TITLE
feat: auto-route research requests to Codex with xhigh reasoning effort

### DIFF
--- a/templates/.claude/skills/codex-exec/SKILL.md
+++ b/templates/.claude/skills/codex-exec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: codex-exec
 description: Execute OpenAI Codex CLI prompts and return results
-argument-hint: "<prompt> [--json] [--output <path>] [--model <name>] [--timeout <ms>]"
+argument-hint: "<prompt> [--json] [--output <path>] [--model <name>] [--timeout <ms>] [--effort <level>]"
 ---
 
 # Codex Exec Skill
@@ -18,6 +18,10 @@ Execute OpenAI Codex CLI prompts in non-interactive mode and return structured r
 --timeout <ms>    Execution timeout (default: 120000, max: 600000)
 --full-auto       Enable auto-approval mode (codex -a full-auto)
 --working-dir     Working directory for Codex execution
+--effort <level>  Set reasoning effort level (minimal, low, medium, high, xhigh)
+                  Maps to Codex CLI's model_reasoning_effort config
+                  Default: uses Codex CLI's configured default
+                  Recommended: xhigh for research/analysis tasks
 ```
 
 ## Workflow
@@ -147,3 +151,27 @@ Orchestrator delegates generation task
   → Reviewer validates quality
   → Iterate if needed
 ```
+
+## Research Workflow
+
+When the orchestrator detects a research/information gathering request:
+
+1. **Check Codex availability**: Verify `codex` binary and `OPENAI_API_KEY`
+2. **If available**: Execute with xhigh reasoning effort for thorough research
+3. **If unavailable**: Fall back to Claude's WebFetch/WebSearch
+
+### Research Command Pattern
+
+```
+/codex-exec "Research and analyze: {topic}. Provide structured findings with sources." --effort xhigh --full-auto --json
+```
+
+### Effort Level Guide
+
+| Level | Use Case | Speed | Depth |
+|-------|----------|-------|-------|
+| minimal | Quick lookups | Fastest | Surface |
+| low | Simple queries | Fast | Basic |
+| medium | General tasks | Balanced | Standard |
+| high | Complex analysis | Slower | Deep |
+| xhigh | Research & investigation | Slowest | Maximum |

--- a/templates/.claude/skills/codex-exec/scripts/codex-wrapper.cjs
+++ b/templates/.claude/skills/codex-exec/scripts/codex-wrapper.cjs
@@ -51,6 +51,7 @@ function parseArgs() {
     timeout: DEFAULT_TIMEOUT_MS,
     fullAuto: false,
     workingDir: null,
+    effort: null,
   };
 
   for (let i = 2; i < process.argv.length; i++) {
@@ -89,6 +90,12 @@ function parseArgs() {
       case '--working-dir':
         if (i + 1 < process.argv.length) {
           args.workingDir = process.argv[++i];
+        }
+        break;
+      case '--effort':
+      case '--reasoning-effort':
+        if (i + 1 < process.argv.length) {
+          args.effort = process.argv[++i];
         }
         break;
     }
@@ -158,6 +165,16 @@ function buildCommand(options) {
   // Working directory
   if (options.workingDir) {
     args.push('-C', options.workingDir);
+  }
+
+  // Reasoning effort (maps to -c model_reasoning_effort="value")
+  if (options.effort) {
+    const validEfforts = ['minimal', 'low', 'medium', 'high', 'xhigh'];
+    if (validEfforts.includes(options.effort)) {
+      args.push('-c', `model_reasoning_effort="${options.effort}"`);
+    } else {
+      process.stderr.write(`Warning: Invalid effort level "${options.effort}". Valid: ${validEfforts.join(', ')}\n`);
+    }
   }
 
   // Add prompt as last argument

--- a/templates/.claude/skills/intent-detection/SKILL.md
+++ b/templates/.claude/skills/intent-detection/SKILL.md
@@ -228,3 +228,65 @@ intent_detection:
   max_alternatives: 3
   korean_support: true
 ```
+
+## Research Intent Routing
+
+When a research/information gathering intent is detected:
+
+### Detection Keywords
+
+```yaml
+# Korean
+korean:
+  - "조사" → research
+  - "검색" → search
+  - "리서치" → research
+  - "탐색" → explore
+  - "찾아" → look up
+  - "알아봐" → find out
+  - "자료" → gather materials
+  - "정보 수집" → gather information
+
+# English
+english:
+  - "research"
+  - "investigate"
+  - "search for"
+  - "look up"
+  - "gather information"
+```
+
+### Routing Logic
+
+```
+Research intent detected (confidence >= 70%)
+    ↓
+Check Codex CLI availability
+    ├─ Available (codex binary + OPENAI_API_KEY)
+    │   → Use codex-exec skill with --effort xhigh
+    │   → Prompt: "Research and analyze: {user_request}"
+    │   → Returns: structured findings for orchestrator
+    └─ Unavailable
+        → Fall back to Claude's WebFetch/WebSearch
+        → Orchestrator handles directly or via general-purpose agent
+```
+
+### Confidence Scoring
+
+| Factor | Weight | Example |
+|--------|--------|---------|
+| Research keyword match | +40 | "조사해줘", "research" |
+| Action verb match | +30 | "찾아", "investigate" |
+| URL/topic present | +20 | specific URL or topic mentioned |
+| Context (previous research) | +10 | follow-up research request |
+
+### Output Format
+
+```
+[Intent Detected]
+├── Input: "{user input}"
+├── Workflow: research-workflow
+├── Confidence: {percentage}%
+├── Method: codex-exec (xhigh) | WebFetch fallback
+└── Reason: {explanation}
+```

--- a/templates/.claude/skills/intent-detection/patterns/agent-triggers.yaml
+++ b/templates/.claude/skills/intent-detection/patterns/agent-triggers.yaml
@@ -288,6 +288,42 @@ agents:
     supported_actions: [save, recall, remember]
     base_confidence: 40
 
+  # ---------------------------------------------------------------------------
+  # Research / Information Gathering (skill-based, not agent)
+  # ---------------------------------------------------------------------------
+  research-workflow:
+    keywords:
+      korean:
+        - 조사
+        - 검색
+        - 리서치
+        - 탐색
+        - 찾아
+        - 알아봐
+        - 자료
+        - 정보 수집
+        - 웹에서
+      english:
+        - research
+        - investigate
+        - search for
+        - look up
+        - gather information
+        - web fetch
+        - find out
+        - explore topic
+    file_patterns: []
+    supported_actions:
+      - search
+      - fetch
+      - investigate
+      - research
+      - analyze
+      - gather
+    base_confidence: 50
+    action_weight: 30
+    routing_note: "Uses codex-exec skill with xhigh effort when available, falls back to WebFetch/WebSearch"
+
   # Managers (continued)
   mgr-gitnerd:
     keywords:


### PR DESCRIPTION
## Summary
- Add `--effort` parameter to codex-exec skill (maps to `-c model_reasoning_effort`)
- Support effort levels: minimal, low, medium, high, xhigh
- Add research-workflow triggers to intent-detection (조사, 검색, 리서치, etc.)
- Add Research Intent Routing with Codex availability check and WebFetch fallback
- Sync all changes to templates directory

## Test plan
- [x] 914 tests pass, 0 fail
- [x] TypeScript type check pass
- [ ] Verify codex-exec with --effort xhigh works end-to-end
- [ ] Verify research intent detection triggers correctly

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)