### PR TITLE
fix: standardize frontmatter field naming to hyphen-case

### DIFF
--- a/templates/.claude/skills/multi-model-verification/SKILL.md
+++ b/templates/.claude/skills/multi-model-verification/SKILL.md
@@ -2,7 +2,7 @@
 name: multi-model-verification
 description: Parallel code verification using multiple models with severity classification
 version: 1.0.0
-user_invocable: false
+user-invocable: false
 ---
 
 # Multi-Model Verification

--- a/templates/.claude/skills/structured-dev-cycle/SKILL.md
+++ b/templates/.claude/skills/structured-dev-cycle/SKILL.md
@@ -2,7 +2,7 @@
 name: structured-dev-cycle
 description: 6-stage structured development cycle with stage-based tool restrictions
 version: 1.0.0
-user_invocable: false
+user-invocable: false
 ---
 
 # Structured Development Cycle


### PR DESCRIPTION
## Summary

- Fixed `user_invocable` → `user-invocable` field naming in 2 skill frontmatter files for consistency with hyphen-case convention
- Files changed:
  - `templates/.claude/skills/structured-dev-cycle/SKILL.md`
  - `templates/.claude/skills/multi-model-verification/SKILL.md`

Closes #195

## Test plan

- [ ] Verify `user-invocable` field is correctly parsed in both modified SKILL.md files
- [ ] Run `/sauron-watch` to confirm frontmatter validation passes
- [ ] Check that no other skill files contain `user_invocable` (snake_case) variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)