### PR TITLE
fix: standardize ontology YAML field naming to hyphen-case

### DIFF
--- a/templates/.claude/ontology/schema.yaml
+++ b/templates/.claude/ontology/schema.yaml
@@ -67,7 +67,7 @@ entity_types:
     properties:
       name: { type: string, required: true }
       description: { type: string, required: true }
-      user_invocable: { type: boolean, default: true }
+      user-invocable: { type: boolean, default: true }
       model_invocable: { type: boolean, default: true }
 
   Rule:

--- a/templates/.claude/ontology/skills.yaml
+++ b/templates/.claude/ontology/skills.yaml
@@ -74,7 +74,7 @@ skills:
   airflow-best-practices:
     class: BestPracticeSkill
     description: "Apache Airflow best practices for DAG authoring, testing, and production deployment"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Best practices for Airflow DAG authoring, scheduling, testing, and production deployment"
     keywords: [airflow, dag, scheduling, orchestration, testing, performance]
@@ -83,7 +83,7 @@ skills:
   audit-agents:
     class: ManagementSkill
     description: "Audit agent dependencies and references"
-    user_invocable: true
+    user-invocable: true
     model_invocable: true
     summary: "Audit agent dependencies to ensure all skill and guide references are valid"
     keywords: [audit, dependencies, validation, references]
@@ -92,7 +92,7 @@ skills:
   aws-best-practices:
     class: BestPracticeSkill
     description: "AWS patterns from Well-Architected Framework"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "AWS Well-Architected Framework patterns for scalable, secure cloud infrastructure"
     keywords: [aws, cloud, well-architected, security, performance, cost]
@@ -101,7 +101,7 @@ skills:
   claude-code-bible:
     class: ManagementSkill
     description: "Fetch and verify Claude Code official documentation. Use when checking official spec compliance or updating local reference docs."
-    user_invocable: true
+    user-invocable: true
     model_invocable: false
     summary: "Maintain up-to-date local copies of Claude Code official documentation"
     keywords: [claude-code, documentation, spec, compliance, verification]
@@ -110,7 +110,7 @@ skills:
   create-agent:
     class: ManagementSkill
     description: "Create a new agent with complete structure"
-    user_invocable: true
+    user-invocable: true
     model_invocable: false
     summary: "Create a new agent with complete directory structure and validation"
     keywords: [create, agent, structure, validation]
@@ -119,7 +119,7 @@ skills:
   dbt-best-practices:
     class: BestPracticeSkill
     description: "dbt best practices for SQL modeling, testing, and analytics engineering workflows"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Best practices for dbt project structure, modeling, testing, and documentation"
     keywords: [dbt, sql, modeling, testing, analytics-engineering]
@@ -128,7 +128,7 @@ skills:
   de-lead-routing:
     class: RoutingSkill
     description: "Routes data engineering tasks to the correct DE expert agent. Use when user requests data pipeline design, DAG authoring, SQL modeling, stream processing, or warehouse optimization."
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Routes data engineering tasks to appropriate DE expert agents"
     keywords: [routing, data-engineering, pipeline, airflow, dbt, spark, kafka, snowflake]
@@ -138,7 +138,7 @@ skills:
   dev-lead-routing:
     class: RoutingSkill
     description: "Routes development tasks to the correct language or framework expert agent. Use when user requests code review, implementation, refactoring, or debugging."
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Routes development tasks to appropriate language or framework expert agents"
     keywords: [routing, development, code-review, implementation, refactoring]
@@ -155,7 +155,7 @@ skills:
   dev-refactor:
     class: DevelopmentSkill
     description: "Refactor code for better structure and patterns"
-    user_invocable: true
+    user-invocable: true
     model_invocable: true
     summary: "Refactor code using language-specific expert agents for better structure and patterns"
     keywords: [refactor, structure, patterns, naming, complexity]
@@ -164,7 +164,7 @@ skills:
   dev-review:
     class: DevelopmentSkill
     description: "Review code against language-specific best practices"
-    user_invocable: true
+    user-invocable: true
     model_invocable: true
     summary: "Review code for best practices using language-specific expert agents"
     keywords: [review, code-review, best-practices, quality]
@@ -173,7 +173,7 @@ skills:
   docker-best-practices:
     class: BestPracticeSkill
     description: "Docker patterns for optimized containerization"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Docker patterns for building optimized and secure container images"
     keywords: [docker, container, multi-stage, security, optimization]
@@ -182,7 +182,7 @@ skills:
   fastapi-best-practices:
     class: BestPracticeSkill
     description: "FastAPI patterns for high-performance async APIs"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "FastAPI patterns for building high-performance async APIs with Python"
     keywords: [fastapi, python, async, api, performance]
@@ -191,7 +191,7 @@ skills:
   fix-refs:
     class: ManagementSkill
     description: "Fix broken agent references and symlinks"
-    user_invocable: true
+    user-invocable: true
     model_invocable: false
     summary: "Fix broken references, missing symlinks, and agent dependency issues"
     keywords: [fix, references, symlinks, dependencies]
@@ -200,7 +200,7 @@ skills:
   go-backend-best-practices:
     class: BestPracticeSkill
     description: "Go backend patterns from Uber style and standard layout"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Go backend patterns for building production-ready services"
     keywords: [go, golang, backend, uber-style, standard-layout]
@@ -209,7 +209,7 @@ skills:
   go-best-practices:
     class: BestPracticeSkill
     description: "Idiomatic Go patterns from Effective Go"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Idiomatic Go patterns and best practices from official documentation"
     keywords: [go, golang, effective-go, formatting, naming, concurrency]
@@ -218,7 +218,7 @@ skills:
   help:
     class: SystemSkill
     description: "Show help information for commands and system"
-    user_invocable: true
+    user-invocable: true
     model_invocable: true
     summary: "Show help information for commands, agents, and system rules"
     keywords: [help, documentation, commands, agents, rules]
@@ -227,7 +227,7 @@ skills:
   intent-detection:
     class: IntentSkill
     description: "Automatically detect user intent and route to appropriate agent"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Detect user intent and route to appropriate agent with transparency"
     keywords: [intent, detection, routing, confidence, transparency]
@@ -236,7 +236,7 @@ skills:
   kafka-best-practices:
     class: BestPracticeSkill
     description: "Apache Kafka best practices for event streaming, topic design, and producer-consumer patterns"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Best practices for Kafka producer-consumer patterns, topic design, and performance"
     keywords: [kafka, streaming, event, producer, consumer, performance]
@@ -245,7 +245,7 @@ skills:
   kotlin-best-practices:
     class: BestPracticeSkill
     description: "Idiomatic Kotlin patterns from JetBrains conventions"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Idiomatic Kotlin patterns and best practices from official JetBrains documentation"
     keywords: [kotlin, jetbrains, naming, null-safety, coroutines]
@@ -254,7 +254,7 @@ skills:
   lists:
     class: SystemSkill
     description: "Show all available commands"
-    user_invocable: true
+    user-invocable: true
     model_invocable: true
     summary: "Show all available commands with optional filtering and detailed information"
     keywords: [lists, commands, categories, system]
@@ -263,7 +263,7 @@ skills:
   memory-management:
     class: MemorySkill
     description: "Memory persistence operations using claude-mem"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Provide memory persistence operations using claude-mem for session context"
     keywords: [memory, claude-mem, persistence, session, context]
@@ -272,7 +272,7 @@ skills:
   memory-recall:
     class: MemorySkill
     description: "Search and recall memories from claude-mem"
-    user_invocable: true
+    user-invocable: true
     model_invocable: true
     summary: "Search and recall relevant memories from claude-mem using semantic search"
     keywords: [memory, recall, search, semantic, claude-mem]
@@ -281,7 +281,7 @@ skills:
   memory-save:
     class: MemorySkill
     description: "Save current session context to claude-mem"
-    user_invocable: true
+    user-invocable: true
     model_invocable: false
     summary: "Save current session context to claude-mem for persistence across compaction"
     keywords: [memory, save, session, context, claude-mem]
@@ -290,7 +290,7 @@ skills:
   monitoring-setup:
     class: MonitoringSkill
     description: "Enable/disable OpenTelemetry console monitoring for Claude Code usage tracking"
-    user_invocable: true
+    user-invocable: true
     model_invocable: true
     summary: "Enable or disable OpenTelemetry console monitoring for usage metrics"
     keywords: [monitoring, telemetry, otel, metrics, usage]
@@ -299,7 +299,7 @@ skills:
   npm-audit:
     class: PackageSkill
     description: "Audit npm dependencies for security and updates"
-    user_invocable: true
+    user-invocable: true
     model_invocable: true
     summary: "Audit npm dependencies for security vulnerabilities and outdated packages"
     keywords: [npm, audit, security, dependencies, vulnerabilities]
@@ -308,7 +308,7 @@ skills:
   npm-publish:
     class: PackageSkill
     description: "Publish package to npm registry with pre-checks"
-    user_invocable: true
+    user-invocable: true
     model_invocable: false
     summary: "Publish package to npm registry with comprehensive pre-publish checks"
     keywords: [npm, publish, package, registry, validation]
@@ -317,7 +317,7 @@ skills:
   npm-version:
     class: PackageSkill
     description: "Manage semantic versions for npm packages"
-    user_invocable: true
+    user-invocable: true
     model_invocable: false
     summary: "Manage semantic versions for npm packages with changelog and git integration"
     keywords: [npm, version, semantic, changelog, git]
@@ -326,7 +326,7 @@ skills:
   optimize-analyze:
     class: OptimizationSkill
     description: "Analyze bundle size and performance metrics"
-    user_invocable: true
+    user-invocable: true
     model_invocable: true
     summary: "Analyze bundle size and performance metrics for web applications"
     keywords: [optimize, analyze, bundle, performance, metrics]
@@ -335,7 +335,7 @@ skills:
   optimize-bundle:
     class: OptimizationSkill
     description: "Apply bundle size optimizations"
-    user_invocable: true
+    user-invocable: true
     model_invocable: false
     summary: "Apply bundle size optimizations to reduce build output and improve performance"
     keywords: [optimize, bundle, size, performance, build]
@@ -344,7 +344,7 @@ skills:
   optimize-report:
     class: OptimizationSkill
     description: "Generate comprehensive optimization report"
-    user_invocable: true
+    user-invocable: true
     model_invocable: true
     summary: "Generate comprehensive optimization report with analysis, metrics, and recommendations"
     keywords: [optimize, report, analysis, metrics, recommendations]
@@ -353,7 +353,7 @@ skills:
   pipeline-architecture-patterns:
     class: BestPracticeSkill
     description: "Data pipeline architecture patterns for ETL/ELT design, orchestration, and data quality frameworks"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Architecture patterns for ETL/ELT pipelines, orchestration, and data quality"
     keywords: [pipeline, architecture, etl, elt, orchestration, data-quality]
@@ -362,7 +362,7 @@ skills:
   postgres-best-practices:
     class: BestPracticeSkill
     description: "PostgreSQL best practices for database design, query optimization, and performance tuning"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "PostgreSQL best practices for query optimization, indexing, and performance tuning"
     keywords: [postgres, postgresql, database, optimization, performance]
@@ -371,7 +371,7 @@ skills:
   python-best-practices:
     class: BestPracticeSkill
     description: "Pythonic patterns from PEP 8 and PEP 20"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Idiomatic Python patterns and best practices from official Python documentation"
     keywords: [python, pep8, pep20, zen, idioms]
@@ -380,7 +380,7 @@ skills:
   qa-lead-routing:
     class: RoutingSkill
     description: "Coordinates QA workflow across planning, writing, and execution agents. Use when user requests testing, quality assurance, or test documentation."
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Coordinates QA team activities by routing tasks to qa-planner, qa-writer, and qa-engineer"
     keywords: [routing, qa, testing, quality-assurance, coordination]
@@ -390,7 +390,7 @@ skills:
   react-best-practices:
     class: BestPracticeSkill
     description: "React/Next.js performance optimization with 40+ rules in 8 categories"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "React/Next.js performance optimization patterns and best practices"
     keywords: [react, nextjs, performance, optimization, bundle]
@@ -399,7 +399,7 @@ skills:
   redis-best-practices:
     class: BestPracticeSkill
     description: "Redis best practices for caching, data structures, and in-memory data architecture"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Redis best practices for caching patterns, data structures, and performance"
     keywords: [redis, cache, data-structures, in-memory, performance]
@@ -408,7 +408,7 @@ skills:
   result-aggregation:
     class: IntentSkill
     description: "Aggregate parallel agent results into concise output"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Aggregate and format results from multiple parallel agent executions"
     keywords: [aggregation, parallel, batch, results, ecomode]
@@ -417,7 +417,7 @@ skills:
   rust-best-practices:
     class: BestPracticeSkill
     description: "Idiomatic Rust patterns from official guidelines"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Idiomatic Rust patterns and best practices from official documentation"
     keywords: [rust, ownership, borrowing, safety, concurrency]
@@ -426,7 +426,7 @@ skills:
   skills-sh-search:
     class: ExternalSkillSourceSkill
     description: "Search and install skills from skills.sh marketplace when internal skills are insufficient"
-    user_invocable: true
+    user-invocable: true
     model_invocable: true
     summary: "Search skills.sh marketplace for external skills and install them into the project"
     keywords: [skills-sh, marketplace, external, install, search, discover, npx]
@@ -435,7 +435,7 @@ skills:
   sauron-watch:
     class: VerificationSkill
     description: "Full R017 verification (5+3 rounds) before commit"
-    user_invocable: true
+    user-invocable: true
     model_invocable: false
     summary: "Execute full R017 verification with 5 rounds of manager verification and 3 rounds of deep review"
     keywords: [verification, r017, sync, validation, compliance]
@@ -444,7 +444,7 @@ skills:
   secretary-routing:
     class: RoutingSkill
     description: "Routes agent management tasks to the correct manager agent. Use when user requests agent creation, updates, audits, git operations, sync checks, or verification."
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Routes agent management tasks to appropriate manager agents"
     keywords: [routing, management, agent-creation, git, memory, verification]
@@ -454,7 +454,7 @@ skills:
   snowflake-best-practices:
     class: BestPracticeSkill
     description: "Snowflake best practices for cloud data warehouse design, query optimization, and cost management"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Snowflake best practices for warehouse design, query optimization, and cost management"
     keywords: [snowflake, warehouse, clustering, optimization, cost]
@@ -463,7 +463,7 @@ skills:
   spark-best-practices:
     class: BestPracticeSkill
     description: "Apache Spark best practices for PySpark and Scala distributed data processing"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Apache Spark best practices for performance optimization and resource management"
     keywords: [spark, pyspark, distributed, performance, optimization]
@@ -472,7 +472,7 @@ skills:
   springboot-best-practices:
     class: BestPracticeSkill
     description: "Spring Boot patterns for enterprise Java applications"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Spring Boot patterns for enterprise Java applications with layered architecture"
     keywords: [springboot, java, enterprise, dependency-injection, rest]
@@ -481,7 +481,7 @@ skills:
   status:
     class: SystemSkill
     description: "Show system status and health checks"
-    user_invocable: true
+    user-invocable: true
     model_invocable: true
     summary: "Show comprehensive system status including agents, skills, guides, and health checks"
     keywords: [status, health, system, agents, skills]
@@ -490,7 +490,7 @@ skills:
   supabase-postgres-best-practices:
     class: BestPracticeSkill
     description: "PostgreSQL performance optimization guidelines from Supabase. Apply when writing SQL, designing schemas, configuring RLS, or optimizing database performance."
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Supabase PostgreSQL best practices for query performance, RLS, and schema design"
     keywords: [supabase, postgres, postgresql, rls, performance, security]
@@ -499,7 +499,7 @@ skills:
   typescript-best-practices:
     class: BestPracticeSkill
     description: "Type-safe TypeScript patterns from industry standards"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "Type-safe TypeScript patterns and best practices from industry standards"
     keywords: [typescript, type-safety, strict-mode, interfaces, generics]
@@ -508,7 +508,7 @@ skills:
   update-docs:
     class: ManagementSkill
     description: "Sync documentation with project structure"
-    user_invocable: true
+    user-invocable: true
     model_invocable: false
     summary: "Ensure documentation accurately reflects current project state and agents work together"
     keywords: [update, documentation, sync, validation, consistency]
@@ -517,7 +517,7 @@ skills:
   update-external:
     class: ManagementSkill
     description: "Update agents from external sources (GitHub, docs, etc.)"
-    user_invocable: true
+    user-invocable: true
     model_invocable: false
     summary: "Update agents, skills, and guides from external sources to latest versions"
     keywords: [update, external, github, sources, versioning]
@@ -526,7 +526,7 @@ skills:
   vercel-deploy:
     class: DeploymentSkill
     description: "Deploy applications to Vercel with auto-detection and preview URLs"
-    user_invocable: true
+    user-invocable: true
     model_invocable: true
     summary: "Deploy applications to Vercel with framework auto-detection and preview URLs"
     keywords: [vercel, deploy, deployment, preview, framework]
@@ -535,7 +535,7 @@ skills:
   web-design-guidelines:
     class: WritingSkill
     description: "UI code review with 100+ rules for accessibility, performance, and UX"
-    user_invocable: false
+    user-invocable: false
     model_invocable: true
     summary: "UI code review guidelines for accessibility, performance, and UX best practices"
     keywords: [ui, accessibility, ux, performance, design]
@@ -544,7 +544,7 @@ skills:
   writing-clearly-and-concisely:
     class: WritingSkill
     description: "Apply Strunk's timeless writing rules to ANY prose humans will read—documentation, commit messages, error messages, explanations, reports, or UI text. Makes your writing clearer, stronger, and more professional."
-    user_invocable: true
+    user-invocable: true
     model_invocable: true
     summary: "Apply Strunk's Elements of Style rules to improve clarity and conciseness in writing"
     keywords: [writing, clarity, conciseness, elements-of-style, strunk]


### PR DESCRIPTION
## Summary

- Standardizes `user_invocable` (underscore) to `user-invocable` (hyphen) across ontology template files
- Aligns `templates/.claude/ontology/schema.yaml` and `templates/.claude/ontology/skills.yaml` with the SKILL.md frontmatter convention
- Follow-up to #195 — 53 field name occurrences updated across 2 files

## Test plan

- [ ] Verify `user-invocable` field is consistently used in `templates/.claude/ontology/schema.yaml` (1 occurrence)
- [ ] Verify `user-invocable` field is consistently used in `templates/.claude/ontology/skills.yaml` (52 occurrences)
- [ ] Confirm no remaining `user_invocable` (underscore) references exist in ontology template files
- [ ] Validate YAML structure is intact (no syntax errors introduced)
- [ ] Confirm generated SKILL.md frontmatter consumers parse `user-invocable` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)