### PR TITLE
fix: upgrade vitepress to 1.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "js-yaml": "^4.1.0",
     "nodemailer": "^8.0.1",
     "typescript": "^5.7.3",
-    "vitepress": "^1.6.3"
+    "vitepress": "^1.6.4"
   },
   "keywords": [
     "claude",


### PR DESCRIPTION
Upgrade vitepress to latest version to resolve npm audit vulnerabilities.

Closes #199