### PR TITLE
feat: add /analysis slash command (#209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-03-06
+
+### Added
+- `/analysis` slash command for automatic project analysis and customization
+- Project tech stack detection with agent/skill mapping for 24+ technologies
+- Gap analysis comparing detected stack with installed components
+- Auto-configuration workflow with dry-run and verbose options
+
 ## [0.19.0] - 2026-03-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ oh-my-customcode로 구동됩니다.
 
 | 커맨드 | 설명 |
 |--------|------|
+| `/analysis` | 프로젝트 분석 및 자동 커스터마이징 |
 | `/create-agent` | 새 에이전트 생성 |
 | `/update-docs` | 프로젝트 구조와 문서 동기화 |
 | `/update-external` | 외부 소스에서 에이전트 업데이트 |
@@ -174,7 +175,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (41 파일)
-|   +-- skills/                  # 스킬 (55 디렉토리)
+|   +-- skills/                  # 스킬 (56 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R018)
 |   +-- hooks/                   # 훅 스크립트 (메모리, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)
@@ -238,6 +239,9 @@ Claude Code의 Agent Teams 기능이 활성화되어 있으면 (`CLAUDE_CODE_EXP
 ## 빠른 참조
 
 ```bash
+# 프로젝트 분석
+/analysis
+
 # 모든 커맨드 표시
 /lists
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Claude Code selects the appropriate model and parallelizes independent tasks (up
 | **QA** | 3 | qa-planner, qa-writer, qa-engineer |
 | **Total** | **41** | |
 
-### Skills (55)
+### Skills (56)
 
 | Category | Count | Skills |
 |----------|-------|--------|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-customcode",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/CLAUDE.md.en
+++ b/templates/CLAUDE.md.en
@@ -145,6 +145,7 @@ Violation = immediate correction. No exception for "small changes".
 
 | Command | Description |
 |---------|-------------|
+| `/analysis` | Analyze project and auto-configure customizations |
 | `/create-agent` | Create a new agent |
 | `/update-docs` | Sync documentation with project structure |
 | `/update-external` | Update agents from external sources |
@@ -174,7 +175,7 @@ project/
 +-- CLAUDE.md                    # Entry point
 +-- .claude/
 |   +-- agents/                  # Subagent definitions (41 files)
-|   +-- skills/                  # Skills (55 directories)
+|   +-- skills/                  # Skills (56 directories)
 |   +-- rules/                   # Global rules (R000-R018)
 |   +-- hooks/                   # Hook scripts (memory, HUD)
 |   +-- contexts/                # Context files (ecomode)
@@ -238,6 +239,9 @@ Task tool + routing skills remain the fallback for simple/cost-sensitive tasks.
 ## Quick Reference
 
 ```bash
+# Project analysis
+/analysis
+
 # Show all commands
 /lists
 

--- a/templates/CLAUDE.md.ko
+++ b/templates/CLAUDE.md.ko
@@ -145,6 +145,7 @@ oh-my-customcode로 구동됩니다.
 
 | 커맨드 | 설명 |
 |--------|------|
+| `/analysis` | 프로젝트 분석 및 자동 커스터마이징 |
 | `/create-agent` | 새 에이전트 생성 |
 | `/update-docs` | 프로젝트 구조와 문서 동기화 |
 | `/update-external` | 외부 소스에서 에이전트 업데이트 |
@@ -174,7 +175,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (41 파일)
-|   +-- skills/                  # 스킬 (55 디렉토리)
+|   +-- skills/                  # 스킬 (56 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R018)
 |   +-- hooks/                   # 훅 스크립트 (메모리, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)
@@ -238,6 +239,9 @@ Claude Code의 Agent Teams 기능이 활성화되어 있으면 (`CLAUDE_CODE_EXP
 ## 빠른 참조
 
 ```bash
+# 프로젝트 분석
+/analysis
+
 # 모든 커맨드 표시
 /lists
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -18,7 +18,7 @@
       "name": "skills",
       "path": ".claude/skills",
       "description": "Reusable skill modules (includes slash commands)",
-      "files": 55
+      "files": 56
     },
     {
       "name": "guides",

--- a/tests/unit/core/template-validation.test.ts
+++ b/tests/unit/core/template-validation.test.ts
@@ -465,7 +465,7 @@ describe('Template Validation', () => {
       const readmePath = resolve(import.meta.dir, '../../../README.md');
       const readmeContent = await readFile(readmePath, 'utf-8');
 
-      // Match "### Skills (55)" pattern
+      // Match "### Skills (56)" pattern
       const skillsHeaderMatch = readmeContent.match(/###\s+Skills\s+\((\d+)\)/);
       expect(skillsHeaderMatch).not.toBeNull();
 


### PR DESCRIPTION
## Summary
- `/analysis` 슬래시 명령어 추가 — 프로젝트 자동 분석 및 커스터마이징
- 24+ 기술 스택 감지 및 에이전트/스킬 자동 매핑
- Gap 분석, 자동 구성, 리포트 출력 지원
- `--dry-run`, `--verbose` 옵션

## Changes
- New: `.claude/skills/analysis/SKILL.md` + template mirror
- Updated: CLAUDE.md, templates, README.md, manifest.json, package.json (v0.19.1), CHANGELOG.md, tests

## Test plan
- [x] 1010 tests pass, 100% coverage
- [x] Skill count updated (55 → 56) across all references

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)