### PR TITLE
feat: add Pair Pipeline, PR Auto-Improve, and Pipeline Guards skills (Phase 3)

### DIFF
--- a/.claude/TODO.md
+++ b/.claude/TODO.md
@@ -1,0 +1,34 @@
+# TODO — oh-my-customcode
+
+> Last updated: 2026-03-08
+
+## Pending
+
+### #213 Phase 3: Pair Pipeline + PR Auto-Improvement
+- [ ] Commit, push, PR → merge to develop
+
+## Completed (2026-03-08)
+
+- [x] #213 Phase 3 skills & templates
+  - Pair Pipeline skill (`skills/worker-reviewer-pipeline/SKILL.md`)
+  - PR Auto-Improvement skill (opt-in, `skills/pr-auto-improve/SKILL.md`)
+  - Pipeline Guards (`skills/pipeline-guards/SKILL.md`)
+  - Templates sync
+
+## Completed (2026-03-07)
+
+- [x] npm publish v0.19.4
+- [x] npm publish v0.20.0
+- [x] npm publish v0.21.0
+- [x] #212 Prevention measures → v0.19.4
+  - R018 Spawn Completeness Check
+  - R009 partial spawn violation examples
+  - Git workflow reminder in session-env-check.sh
+- [x] #213 Phase 1: Model Escalation + Stuck Detection → v0.20.0 (PR #214)
+  - model-escalation skill + 2 hooks
+  - stuck-recovery skill + 1 hook
+  - hooks.json + R006 updated
+- [x] #213 Phase 2: DAG Orchestration + Task Decomposition → v0.21.0 (PR #215)
+  - dag-orchestration skill
+  - task-decomposition skill
+  - README/manifest count updated (58→60)

--- a/.claude/skills/pipeline-guards/SKILL.md
+++ b/.claude/skills/pipeline-guards/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: pipeline-guards
+description: Safety constraints and quality gates for pipeline and workflow execution
+---
+
+# Pipeline Guards Skill
+
+Defines mandatory safety constraints for all pipeline, workflow, and iterative execution within the oh-my-customcode system. Prevents infinite loops, enforces timeouts, and establishes quality gates.
+
+**System-wide** — these guards apply to dag-orchestration, worker-reviewer-pipeline, and any iterative process.
+
+## Guard Limits
+
+| Guard | Default | Hard Cap | Applies To |
+|-------|---------|----------|------------|
+| Max iterations | 3 | 5 | worker-reviewer-pipeline |
+| Max DAG nodes | 20 | 30 | dag-orchestration |
+| Max parallel agents | 4 | 4 | R009 (all pipelines) |
+| Timeout per node | 300s | 600s | dag-orchestration nodes |
+| Timeout per pipeline | 900s | 1800s | worker-reviewer-pipeline |
+| Max retry count | 2 | 3 | Failure retry strategies |
+| Max PR improvement items | 20 | 50 | pr-auto-improve |
+
+## Enforcement
+
+Guards are enforced at two levels:
+
+### Level 1: Skill-Level (Soft)
+Each skill checks guard limits before execution:
+
+```
+Before starting pipeline:
+  1. Check max_iterations ≤ hard cap
+  2. Check timeout ≤ hard cap
+  3. Check node count ≤ hard cap
+  If any exceeded → warn user, use hard cap value
+```
+
+### Level 2: Hook-Level (Hard)
+The stuck-detector hook monitors for guard violations:
+
+```
+PostToolUse → check:
+  - Iteration count > max_iterations?
+  - Elapsed time > timeout?
+  - Same error repeated > max_retry?
+  If any → emit advisory to stderr
+```
+
+## Quality Gates
+
+### Pipeline Quality Gate
+```
+[Quality Gate Check]
+├── Critical issues: {count} (must be 0)
+├── Major issues: {count} (must be ≤ threshold)
+├── Minor issues: {count} (informational)
+└── Gate: PASS | FAIL
+```
+
+### DAG Completion Gate
+```
+[DAG Completion Gate]
+├── Nodes completed: {n}/{total}
+├── Nodes failed: {count}
+├── Nodes skipped: {count}
+└── Gate: PASS | PARTIAL | FAIL
+```
+
+## Escalation Integration
+
+When guards are triggered, they integrate with existing advisory systems:
+
+| Event | Action |
+|-------|--------|
+| Max iterations reached | → stuck-recovery advisory |
+| Repeated failures | → model-escalation advisory |
+| Timeout approaching (80%) | → warn user, suggest early termination |
+| Hard cap hit | → force stop, report to user |
+
+## Guard Configuration
+
+Pipelines can override defaults (within hard caps):
+
+```yaml
+# In pipeline/workflow spec
+guards:
+  max_iterations: 4          # Override default 3, cannot exceed 5
+  timeout_per_node: 120      # Override default 300s
+  timeout_pipeline: 600      # Override default 900s
+  quality_gate: all_pass     # all_pass | majority_pass
+```
+
+## Kill Switch
+
+When a pipeline or workflow must be terminated:
+
+```
+[Kill Switch] Activated
+├── Reason: {max_iterations | timeout | user_request | stuck_detected}
+├── Pipeline: {name}
+├── Progress: {completed}/{total} steps
+├── Preserved state: /tmp/.claude-pipeline-$PPID.json
+└── Action: Stopped gracefully, state saved for resume
+```
+
+The kill switch:
+1. Signals all running agents to complete current operation
+2. Does NOT terminate mid-write (waits for current tool call)
+3. Saves pipeline state for potential resume
+4. Reports final status to user
+
+## State Preservation
+
+On guard-triggered termination:
+
+```json
+{
+  "pipeline": "feature-review",
+  "terminated_at": "2026-03-07T10:15:00Z",
+  "reason": "max_iterations_reached",
+  "completed_iterations": 3,
+  "last_verdict": "FAIL",
+  "remaining_issues": [
+    {"severity": "major", "file": "src/auth.ts", "line": 42, "description": "..."}
+  ],
+  "worker_last_output": "...",
+  "resumable": true
+}
+```
+
+## Display Format
+
+Guard warnings appear inline:
+
+```
+[Guard] ⚠ Iteration 3/3 — final attempt
+[Guard] ⚠ Timeout 80% (240s/300s) — consider early termination
+[Guard] 🛑 Max iterations reached — pipeline stopped
+[Guard] 🛑 Hard timeout (600s) — force stop
+```
+
+## Integration
+
+| Rule/Skill | Integration |
+|------------|-------------|
+| R009 | Max parallel agents enforced (hard cap: 4) |
+| R010 | Guards run in orchestrator only |
+| R015 | Guard warnings displayed transparently |
+| dag-orchestration | Node count and timeout limits |
+| worker-reviewer-pipeline | Iteration and pipeline timeout limits |
+| pr-auto-improve | Improvement item count limits |
+| stuck-recovery | Guard triggers feed into stuck detection |
+| model-escalation | Repeated failures trigger escalation advisory |
+
+## Override Policy
+
+- Defaults can be overridden in pipeline spec (within hard caps)
+- Hard caps can ONLY be changed by modifying this skill file
+- User cannot bypass hard caps at runtime
+- All overrides are logged and displayed (R015)
+
+## Limitations
+
+- Guards are advisory at skill level, hard at hook level
+- Cannot prevent infinite loops in agent reasoning (only tool call patterns)
+- State preservation is best-effort (process crash = state loss)
+- Resume from saved state requires user confirmation

--- a/.claude/skills/pr-auto-improve/SKILL.md
+++ b/.claude/skills/pr-auto-improve/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: pr-auto-improve
+description: Opt-in post-PR analysis and improvement suggestions for code quality enhancement
+---
+
+# PR Auto-Improvement Skill
+
+Analyzes pull requests after creation and suggests targeted improvements. **Strictly opt-in** — never runs automatically. User must explicitly request PR improvement.
+
+**Advisory-only** — suggests improvements, never force-pushes or modifies PRs without approval (R010).
+
+## Activation
+
+| Trigger | Behavior |
+|---------|----------|
+| User says "improve this PR" | Activate analysis |
+| User says "review PR #N" | Activate analysis |
+| PR created automatically | Do NOT activate (opt-in only) |
+| CI fails on PR | Suggest activation, do not auto-run |
+
+## Analysis Pipeline
+
+```
+1. Fetch PR diff (gh pr diff)
+2. Categorize changes by type:
+   - New code → check patterns, naming, structure
+   - Modified code → check consistency, regression risk
+   - Deleted code → check for orphaned references
+3. Run improvement checks (see checklist below)
+4. Generate improvement report
+5. User approves → create follow-up commit(s)
+```
+
+## Improvement Checklist
+
+| Category | Checks |
+|----------|--------|
+| **Code Quality** | Naming consistency, dead code, duplication, complexity |
+| **Type Safety** | Missing types, `any` usage, assertion safety |
+| **Error Handling** | Unhandled promises, missing try-catch, error propagation |
+| **Testing** | Missing test coverage for new functions, edge cases |
+| **Documentation** | Missing JSDoc for public APIs, outdated README refs |
+| **Security** | Hardcoded values, injection risks, permission checks |
+| **Performance** | Unnecessary re-renders, N+1 queries, missing indexes |
+
+## Report Format
+
+```
+[PR Auto-Improve] PR #{number} — {title}
+├── Files analyzed: {count}
+├── Improvements found: {count}
+│
+├── [Code Quality] ({count} items)
+│   ├── {file:line} — {description}
+│   └── {file:line} — {description}
+│
+├── [Testing] ({count} items)
+│   └── {file} — Missing test for {function}
+│
+├── [Documentation] ({count} items)
+│   └── {file:line} — {description}
+│
+└── Estimated effort: {low|medium|high}
+
+Apply improvements? [Y/n/select]
+```
+
+## Improvement Modes
+
+| Mode | Behavior |
+|------|----------|
+| `all` | Apply all suggested improvements |
+| `select` | User picks which improvements to apply |
+| `report` | Report only, no changes (default) |
+
+## Implementation Flow
+
+```
+User: "improve PR #215"
+  → Orchestrator activates pr-auto-improve
+  → Fetch PR diff via mgr-gitnerd
+  → Analyze with appropriate expert agent(s)
+  → Generate report
+  → User selects improvements
+  → Delegate fixes to specialist agents (R010)
+  → mgr-gitnerd creates follow-up commit
+```
+
+## Agent Selection for Fixes
+
+| File Type | Agent |
+|-----------|-------|
+| *.ts, *.tsx | lang-typescript-expert |
+| *.py | lang-python-expert |
+| *.go | lang-golang-expert |
+| *.kt | lang-kotlin-expert |
+| *.java | lang-java21-expert |
+| *.rs | lang-rust-expert |
+| Test files | qa-engineer |
+| Docs, README | arch-documenter |
+| Mixed | Multiple agents in parallel (R009) |
+
+## Integration
+
+| Rule | Integration |
+|------|-------------|
+| R009 | Multiple file fixes execute in parallel |
+| R010 | Orchestrator coordinates analysis and fix delegation |
+| R015 | Full transparency on what improvements are suggested and why |
+| R018 | 3+ fix agents → Agent Teams for coordination |
+| worker-reviewer-pipeline | Can chain: auto-improve → worker-reviewer for critical fixes |
+| pipeline-guards | Improvement count capped by guard limits |
+
+## Opt-In Safeguards
+
+- **NEVER** auto-activates on PR creation
+- **NEVER** pushes changes without user approval
+- **NEVER** modifies PR description or labels without approval
+- Report mode is default; changes require explicit "apply" command
+- All git operations go through mgr-gitnerd (R010)
+
+## Limitations
+
+- Analyzes only the PR diff, not the entire codebase
+- Cannot detect architectural issues (use dev-review for that)
+- Max 50 files per analysis (skip larger PRs with warning)
+- Does not run tests (delegates to qa-engineer if needed)

--- a/.claude/skills/worker-reviewer-pipeline/SKILL.md
+++ b/.claude/skills/worker-reviewer-pipeline/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: worker-reviewer-pipeline
+description: Worker-Reviewer iterative pipeline for quality-critical code with review cycles
+---
+
+# Worker-Reviewer Pipeline Skill
+
+Defines an iterative Worker→Reviewer pipeline where one agent implements changes and another reviews them. The cycle repeats until quality criteria are met or max iterations reached.
+
+**Orchestrator-only** — only the main conversation activates this pipeline (R010). Worker and Reviewer are subagents.
+
+## When to Activate
+
+| Condition | Activate? |
+|-----------|-----------|
+| Quality-critical code changes (auth, security, payments) | Yes |
+| Complex refactoring touching 5+ files | Yes |
+| User explicitly requests review cycle | Yes |
+| Simple file edits, config changes | No |
+| Documentation-only changes | No |
+
+## Pipeline Spec Format
+
+```yaml
+pipeline:
+  name: feature-review
+  description: Implement and review a feature
+
+worker:
+  agent: lang-typescript-expert    # or appropriate specialist
+  model: sonnet
+  prompt: "Implement the feature based on requirements"
+
+reviewer:
+  agent: lang-typescript-expert    # can be same or different specialist
+  model: opus                      # often higher model for review
+  prompt: "Review implementation for correctness, security, performance"
+
+config:
+  max_iterations: 3          # Max review cycles (default: 3)
+  quality_gate: all_pass     # all_pass | majority_pass | custom
+  auto_commit: false         # Auto-commit on quality pass (via mgr-gitnerd)
+```
+
+## Execution Flow
+
+```
+1. Orchestrator activates pipeline
+2. Worker agent implements changes
+3. Reviewer agent reviews Worker's output
+4. Reviewer produces verdict:
+   - PASS → Pipeline complete, proceed to next step
+   - FAIL(issues) → Worker receives feedback, re-implements
+5. Repeat 3-4 until PASS or max_iterations reached
+6. If max_iterations reached without PASS:
+   - Report partial results to user
+   - Recommend manual review
+```
+
+## Review Verdict Format
+
+Reviewer MUST output a structured verdict:
+
+```
+[Review Verdict]
+├── Status: PASS | FAIL
+├── Iteration: {n}/{max}
+├── Issues Found: {count}
+│   ├── [Critical] {description} — {file:line}
+│   ├── [Major] {description} — {file:line}
+│   └── [Minor] {description} — {file:line}
+└── Summary: {one-line}
+```
+
+## Quality Gates
+
+| Gate | Criteria |
+|------|----------|
+| `all_pass` | Zero Critical or Major issues (default) |
+| `majority_pass` | Zero Critical, ≤2 Minor issues allowed |
+| `custom` | User-defined in pipeline spec |
+
+## Integration with Agent Teams (R018)
+
+When Agent Teams is enabled, the pipeline SHOULD use Agent Teams:
+
+```
+TeamCreate("review-pipeline")
+  Worker (team member) ←→ Reviewer (team member)
+  SendMessage for feedback exchange
+  Shared TaskList for tracking issues
+```
+
+When Agent Teams is NOT available, falls back to sequential Task tool calls:
+```
+Task(worker) → result → Task(reviewer) → verdict → Task(worker) → ...
+```
+
+## Display Format
+
+```
+[Pipeline] feature-review — Worker: lang-typescript-expert, Reviewer: lang-typescript-expert
+[Iteration 1/3] Worker implementing...
+[Iteration 1/3] Reviewer reviewing...
+[Review] FAIL — 2 issues (1 Major, 1 Minor)
+[Iteration 2/3] Worker fixing issues...
+[Iteration 2/3] Reviewer re-reviewing...
+[Review] PASS — 0 issues
+[Pipeline Complete] 2 iterations, quality gate passed
+```
+
+## Common Pipeline Templates
+
+### Security-Critical Feature
+```yaml
+worker: {agent: lang-typescript-expert, model: sonnet}
+reviewer: {agent: lang-typescript-expert, model: opus}
+config: {max_iterations: 3, quality_gate: all_pass}
+```
+
+### Cross-Language Integration
+```yaml
+worker: {agent: lang-golang-expert, model: sonnet}
+reviewer: {agent: be-go-backend-expert, model: opus}
+config: {max_iterations: 2, quality_gate: all_pass}
+```
+
+### Quick Review
+```yaml
+worker: {agent: lang-python-expert, model: sonnet}
+reviewer: {agent: lang-python-expert, model: sonnet}
+config: {max_iterations: 1, quality_gate: majority_pass}
+```
+
+## Integration
+
+| Rule | Integration |
+|------|-------------|
+| R009 | Worker and Reviewer can run in parallel with other pipelines |
+| R010 | Pipeline orchestration runs only in main conversation |
+| R015 | Display pipeline plan and review verdicts transparently |
+| R018 | Agent Teams preferred when available for Worker↔Reviewer messaging |
+| pipeline-guards | Max iterations and timeout enforced by pipeline-guards |
+| model-escalation | Worker failures feed into escalation tracking |
+| stuck-recovery | Repeated FAIL verdicts trigger stuck detection advisory |
+
+## Limitations
+
+- Max 3 iterations by default (configurable, hard cap at 5 via pipeline-guards)
+- Worker and Reviewer must be different agent instances (same type allowed)
+- Nested pipelines not supported (use dag-orchestration for complex flows)
+- Pipeline does not auto-commit; orchestrator decides post-pipeline actions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,7 +175,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (41 파일)
-|   +-- skills/                  # 스킬 (56 디렉토리)
+|   +-- skills/                  # 스킬 (63 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R018)
 |   +-- hooks/                   # 훅 스크립트 (메모리, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Like oh-my-zsh transformed shell customization, oh-my-customcode makes personali
 
 | Feature | Description |
 |---------|-------------|
-| **Batteries Included** | 41 agents, 60 skills, 22 guides, 18 rules, 2 hooks, 4 contexts, ontology graph - ready to use out of the box |
+| **Batteries Included** | 41 agents, 63 skills, 22 guides, 18 rules, 2 hooks, 4 contexts, ontology graph - ready to use out of the box |
 | **Sub-Agent Model** | Supports hierarchical agent orchestration with specialized roles |
 | **Dead Simple Customization** | Create a folder + markdown file = new agent or skill |
 | **Mix and Match** | Use built-in components, create your own, or combine both |
@@ -124,7 +124,7 @@ Claude Code selects the appropriate model and parallelizes independent tasks (up
 | **QA** | 3 | qa-planner, qa-writer, qa-engineer |
 | **Total** | **41** | |
 
-### Skills (60)
+### Skills (63)
 
 | Category | Count | Skills |
 |----------|-------|--------|
@@ -137,7 +137,7 @@ Claude Code selects the appropriate model and parallelizes independent tasks (up
 | **Package Management** | 3 | npm-publish, npm-version, npm-audit |
 | **Operations** | 7 | update-docs, update-external, audit-agents, fix-refs, sauron-watch, monitoring-setup, claude-code-bible |
 | **Utilities** | 5 | lists, help, status, result-aggregation, writing-clearly-and-concisely |
-| **Quality & Workflow** | 6 | multi-model-verification, structured-dev-cycle, model-escalation, stuck-recovery, dag-orchestration, task-decomposition |
+| **Quality & Workflow** | 9 | multi-model-verification, structured-dev-cycle, model-escalation, stuck-recovery, dag-orchestration, task-decomposition, worker-reviewer-pipeline, pr-auto-improve, pipeline-guards |
 | **Deploy** | 2 | vercel-deploy, codex-exec |
 | **External** | 1 | skills-sh-search |
 
@@ -225,7 +225,7 @@ your-project/
     │   ├── be-fastapi-expert.md
     │   ├── mgr-creator.md
     │   └── ...
-    ├── skills/            # Skill modules (60 directories, each with SKILL.md)
+    ├── skills/            # Skill modules (63 directories, each with SKILL.md)
     │   ├── go-best-practices/
     │   ├── react-best-practices/
     │   ├── secretary-routing/

--- a/templates/.claude/skills/pipeline-guards/SKILL.md
+++ b/templates/.claude/skills/pipeline-guards/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: pipeline-guards
+description: Safety constraints and quality gates for pipeline and workflow execution
+---
+
+# Pipeline Guards Skill
+
+Defines mandatory safety constraints for all pipeline, workflow, and iterative execution within the oh-my-customcode system. Prevents infinite loops, enforces timeouts, and establishes quality gates.
+
+**System-wide** — these guards apply to dag-orchestration, worker-reviewer-pipeline, and any iterative process.
+
+## Guard Limits
+
+| Guard | Default | Hard Cap | Applies To |
+|-------|---------|----------|------------|
+| Max iterations | 3 | 5 | worker-reviewer-pipeline |
+| Max DAG nodes | 20 | 30 | dag-orchestration |
+| Max parallel agents | 4 | 4 | R009 (all pipelines) |
+| Timeout per node | 300s | 600s | dag-orchestration nodes |
+| Timeout per pipeline | 900s | 1800s | worker-reviewer-pipeline |
+| Max retry count | 2 | 3 | Failure retry strategies |
+| Max PR improvement items | 20 | 50 | pr-auto-improve |
+
+## Enforcement
+
+Guards are enforced at two levels:
+
+### Level 1: Skill-Level (Soft)
+Each skill checks guard limits before execution:
+
+```
+Before starting pipeline:
+  1. Check max_iterations ≤ hard cap
+  2. Check timeout ≤ hard cap
+  3. Check node count ≤ hard cap
+  If any exceeded → warn user, use hard cap value
+```
+
+### Level 2: Hook-Level (Hard)
+The stuck-detector hook monitors for guard violations:
+
+```
+PostToolUse → check:
+  - Iteration count > max_iterations?
+  - Elapsed time > timeout?
+  - Same error repeated > max_retry?
+  If any → emit advisory to stderr
+```
+
+## Quality Gates
+
+### Pipeline Quality Gate
+```
+[Quality Gate Check]
+├── Critical issues: {count} (must be 0)
+├── Major issues: {count} (must be ≤ threshold)
+├── Minor issues: {count} (informational)
+└── Gate: PASS | FAIL
+```
+
+### DAG Completion Gate
+```
+[DAG Completion Gate]
+├── Nodes completed: {n}/{total}
+├── Nodes failed: {count}
+├── Nodes skipped: {count}
+└── Gate: PASS | PARTIAL | FAIL
+```
+
+## Escalation Integration
+
+When guards are triggered, they integrate with existing advisory systems:
+
+| Event | Action |
+|-------|--------|
+| Max iterations reached | → stuck-recovery advisory |
+| Repeated failures | → model-escalation advisory |
+| Timeout approaching (80%) | → warn user, suggest early termination |
+| Hard cap hit | → force stop, report to user |
+
+## Guard Configuration
+
+Pipelines can override defaults (within hard caps):
+
+```yaml
+# In pipeline/workflow spec
+guards:
+  max_iterations: 4          # Override default 3, cannot exceed 5
+  timeout_per_node: 120      # Override default 300s
+  timeout_pipeline: 600      # Override default 900s
+  quality_gate: all_pass     # all_pass | majority_pass
+```
+
+## Kill Switch
+
+When a pipeline or workflow must be terminated:
+
+```
+[Kill Switch] Activated
+├── Reason: {max_iterations | timeout | user_request | stuck_detected}
+├── Pipeline: {name}
+├── Progress: {completed}/{total} steps
+├── Preserved state: /tmp/.claude-pipeline-$PPID.json
+└── Action: Stopped gracefully, state saved for resume
+```
+
+The kill switch:
+1. Signals all running agents to complete current operation
+2. Does NOT terminate mid-write (waits for current tool call)
+3. Saves pipeline state for potential resume
+4. Reports final status to user
+
+## State Preservation
+
+On guard-triggered termination:
+
+```json
+{
+  "pipeline": "feature-review",
+  "terminated_at": "2026-03-07T10:15:00Z",
+  "reason": "max_iterations_reached",
+  "completed_iterations": 3,
+  "last_verdict": "FAIL",
+  "remaining_issues": [
+    {"severity": "major", "file": "src/auth.ts", "line": 42, "description": "..."}
+  ],
+  "worker_last_output": "...",
+  "resumable": true
+}
+```
+
+## Display Format
+
+Guard warnings appear inline:
+
+```
+[Guard] ⚠ Iteration 3/3 — final attempt
+[Guard] ⚠ Timeout 80% (240s/300s) — consider early termination
+[Guard] 🛑 Max iterations reached — pipeline stopped
+[Guard] 🛑 Hard timeout (600s) — force stop
+```
+
+## Integration
+
+| Rule/Skill | Integration |
+|------------|-------------|
+| R009 | Max parallel agents enforced (hard cap: 4) |
+| R010 | Guards run in orchestrator only |
+| R015 | Guard warnings displayed transparently |
+| dag-orchestration | Node count and timeout limits |
+| worker-reviewer-pipeline | Iteration and pipeline timeout limits |
+| pr-auto-improve | Improvement item count limits |
+| stuck-recovery | Guard triggers feed into stuck detection |
+| model-escalation | Repeated failures trigger escalation advisory |
+
+## Override Policy
+
+- Defaults can be overridden in pipeline spec (within hard caps)
+- Hard caps can ONLY be changed by modifying this skill file
+- User cannot bypass hard caps at runtime
+- All overrides are logged and displayed (R015)
+
+## Limitations
+
+- Guards are advisory at skill level, hard at hook level
+- Cannot prevent infinite loops in agent reasoning (only tool call patterns)
+- State preservation is best-effort (process crash = state loss)
+- Resume from saved state requires user confirmation

--- a/templates/.claude/skills/pr-auto-improve/SKILL.md
+++ b/templates/.claude/skills/pr-auto-improve/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: pr-auto-improve
+description: Opt-in post-PR analysis and improvement suggestions for code quality enhancement
+---
+
+# PR Auto-Improvement Skill
+
+Analyzes pull requests after creation and suggests targeted improvements. **Strictly opt-in** — never runs automatically. User must explicitly request PR improvement.
+
+**Advisory-only** — suggests improvements, never force-pushes or modifies PRs without approval (R010).
+
+## Activation
+
+| Trigger | Behavior |
+|---------|----------|
+| User says "improve this PR" | Activate analysis |
+| User says "review PR #N" | Activate analysis |
+| PR created automatically | Do NOT activate (opt-in only) |
+| CI fails on PR | Suggest activation, do not auto-run |
+
+## Analysis Pipeline
+
+```
+1. Fetch PR diff (gh pr diff)
+2. Categorize changes by type:
+   - New code → check patterns, naming, structure
+   - Modified code → check consistency, regression risk
+   - Deleted code → check for orphaned references
+3. Run improvement checks (see checklist below)
+4. Generate improvement report
+5. User approves → create follow-up commit(s)
+```
+
+## Improvement Checklist
+
+| Category | Checks |
+|----------|--------|
+| **Code Quality** | Naming consistency, dead code, duplication, complexity |
+| **Type Safety** | Missing types, `any` usage, assertion safety |
+| **Error Handling** | Unhandled promises, missing try-catch, error propagation |
+| **Testing** | Missing test coverage for new functions, edge cases |
+| **Documentation** | Missing JSDoc for public APIs, outdated README refs |
+| **Security** | Hardcoded values, injection risks, permission checks |
+| **Performance** | Unnecessary re-renders, N+1 queries, missing indexes |
+
+## Report Format
+
+```
+[PR Auto-Improve] PR #{number} — {title}
+├── Files analyzed: {count}
+├── Improvements found: {count}
+│
+├── [Code Quality] ({count} items)
+│   ├── {file:line} — {description}
+│   └── {file:line} — {description}
+│
+├── [Testing] ({count} items)
+│   └── {file} — Missing test for {function}
+│
+├── [Documentation] ({count} items)
+│   └── {file:line} — {description}
+│
+└── Estimated effort: {low|medium|high}
+
+Apply improvements? [Y/n/select]
+```
+
+## Improvement Modes
+
+| Mode | Behavior |
+|------|----------|
+| `all` | Apply all suggested improvements |
+| `select` | User picks which improvements to apply |
+| `report` | Report only, no changes (default) |
+
+## Implementation Flow
+
+```
+User: "improve PR #215"
+  → Orchestrator activates pr-auto-improve
+  → Fetch PR diff via mgr-gitnerd
+  → Analyze with appropriate expert agent(s)
+  → Generate report
+  → User selects improvements
+  → Delegate fixes to specialist agents (R010)
+  → mgr-gitnerd creates follow-up commit
+```
+
+## Agent Selection for Fixes
+
+| File Type | Agent |
+|-----------|-------|
+| *.ts, *.tsx | lang-typescript-expert |
+| *.py | lang-python-expert |
+| *.go | lang-golang-expert |
+| *.kt | lang-kotlin-expert |
+| *.java | lang-java21-expert |
+| *.rs | lang-rust-expert |
+| Test files | qa-engineer |
+| Docs, README | arch-documenter |
+| Mixed | Multiple agents in parallel (R009) |
+
+## Integration
+
+| Rule | Integration |
+|------|-------------|
+| R009 | Multiple file fixes execute in parallel |
+| R010 | Orchestrator coordinates analysis and fix delegation |
+| R015 | Full transparency on what improvements are suggested and why |
+| R018 | 3+ fix agents → Agent Teams for coordination |
+| worker-reviewer-pipeline | Can chain: auto-improve → worker-reviewer for critical fixes |
+| pipeline-guards | Improvement count capped by guard limits |
+
+## Opt-In Safeguards
+
+- **NEVER** auto-activates on PR creation
+- **NEVER** pushes changes without user approval
+- **NEVER** modifies PR description or labels without approval
+- Report mode is default; changes require explicit "apply" command
+- All git operations go through mgr-gitnerd (R010)
+
+## Limitations
+
+- Analyzes only the PR diff, not the entire codebase
+- Cannot detect architectural issues (use dev-review for that)
+- Max 50 files per analysis (skip larger PRs with warning)
+- Does not run tests (delegates to qa-engineer if needed)

--- a/templates/.claude/skills/worker-reviewer-pipeline/SKILL.md
+++ b/templates/.claude/skills/worker-reviewer-pipeline/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: worker-reviewer-pipeline
+description: Worker-Reviewer iterative pipeline for quality-critical code with review cycles
+---
+
+# Worker-Reviewer Pipeline Skill
+
+Defines an iterative Worker→Reviewer pipeline where one agent implements changes and another reviews them. The cycle repeats until quality criteria are met or max iterations reached.
+
+**Orchestrator-only** — only the main conversation activates this pipeline (R010). Worker and Reviewer are subagents.
+
+## When to Activate
+
+| Condition | Activate? |
+|-----------|-----------|
+| Quality-critical code changes (auth, security, payments) | Yes |
+| Complex refactoring touching 5+ files | Yes |
+| User explicitly requests review cycle | Yes |
+| Simple file edits, config changes | No |
+| Documentation-only changes | No |
+
+## Pipeline Spec Format
+
+```yaml
+pipeline:
+  name: feature-review
+  description: Implement and review a feature
+
+worker:
+  agent: lang-typescript-expert    # or appropriate specialist
+  model: sonnet
+  prompt: "Implement the feature based on requirements"
+
+reviewer:
+  agent: lang-typescript-expert    # can be same or different specialist
+  model: opus                      # often higher model for review
+  prompt: "Review implementation for correctness, security, performance"
+
+config:
+  max_iterations: 3          # Max review cycles (default: 3)
+  quality_gate: all_pass     # all_pass | majority_pass | custom
+  auto_commit: false         # Auto-commit on quality pass (via mgr-gitnerd)
+```
+
+## Execution Flow
+
+```
+1. Orchestrator activates pipeline
+2. Worker agent implements changes
+3. Reviewer agent reviews Worker's output
+4. Reviewer produces verdict:
+   - PASS → Pipeline complete, proceed to next step
+   - FAIL(issues) → Worker receives feedback, re-implements
+5. Repeat 3-4 until PASS or max_iterations reached
+6. If max_iterations reached without PASS:
+   - Report partial results to user
+   - Recommend manual review
+```
+
+## Review Verdict Format
+
+Reviewer MUST output a structured verdict:
+
+```
+[Review Verdict]
+├── Status: PASS | FAIL
+├── Iteration: {n}/{max}
+├── Issues Found: {count}
+│   ├── [Critical] {description} — {file:line}
+│   ├── [Major] {description} — {file:line}
+│   └── [Minor] {description} — {file:line}
+└── Summary: {one-line}
+```
+
+## Quality Gates
+
+| Gate | Criteria |
+|------|----------|
+| `all_pass` | Zero Critical or Major issues (default) |
+| `majority_pass` | Zero Critical, ≤2 Minor issues allowed |
+| `custom` | User-defined in pipeline spec |
+
+## Integration with Agent Teams (R018)
+
+When Agent Teams is enabled, the pipeline SHOULD use Agent Teams:
+
+```
+TeamCreate("review-pipeline")
+  Worker (team member) ←→ Reviewer (team member)
+  SendMessage for feedback exchange
+  Shared TaskList for tracking issues
+```
+
+When Agent Teams is NOT available, falls back to sequential Task tool calls:
+```
+Task(worker) → result → Task(reviewer) → verdict → Task(worker) → ...
+```
+
+## Display Format
+
+```
+[Pipeline] feature-review — Worker: lang-typescript-expert, Reviewer: lang-typescript-expert
+[Iteration 1/3] Worker implementing...
+[Iteration 1/3] Reviewer reviewing...
+[Review] FAIL — 2 issues (1 Major, 1 Minor)
+[Iteration 2/3] Worker fixing issues...
+[Iteration 2/3] Reviewer re-reviewing...
+[Review] PASS — 0 issues
+[Pipeline Complete] 2 iterations, quality gate passed
+```
+
+## Common Pipeline Templates
+
+### Security-Critical Feature
+```yaml
+worker: {agent: lang-typescript-expert, model: sonnet}
+reviewer: {agent: lang-typescript-expert, model: opus}
+config: {max_iterations: 3, quality_gate: all_pass}
+```
+
+### Cross-Language Integration
+```yaml
+worker: {agent: lang-golang-expert, model: sonnet}
+reviewer: {agent: be-go-backend-expert, model: opus}
+config: {max_iterations: 2, quality_gate: all_pass}
+```
+
+### Quick Review
+```yaml
+worker: {agent: lang-python-expert, model: sonnet}
+reviewer: {agent: lang-python-expert, model: sonnet}
+config: {max_iterations: 1, quality_gate: majority_pass}
+```
+
+## Integration
+
+| Rule | Integration |
+|------|-------------|
+| R009 | Worker and Reviewer can run in parallel with other pipelines |
+| R010 | Pipeline orchestration runs only in main conversation |
+| R015 | Display pipeline plan and review verdicts transparently |
+| R018 | Agent Teams preferred when available for Worker↔Reviewer messaging |
+| pipeline-guards | Max iterations and timeout enforced by pipeline-guards |
+| model-escalation | Worker failures feed into escalation tracking |
+| stuck-recovery | Repeated FAIL verdicts trigger stuck detection advisory |
+
+## Limitations
+
+- Max 3 iterations by default (configurable, hard cap at 5 via pipeline-guards)
+- Worker and Reviewer must be different agent instances (same type allowed)
+- Nested pipelines not supported (use dag-orchestration for complex flows)
+- Pipeline does not auto-commit; orchestrator decides post-pipeline actions

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -18,7 +18,7 @@
       "name": "skills",
       "path": ".claude/skills",
       "description": "Reusable skill modules (includes slash commands)",
-      "files": 60
+      "files": 63
     },
     {
       "name": "guides",


### PR DESCRIPTION
## Summary

- Implements Phase 3 of #213 (OpenSwarm selective adoption)
- 3 new skills: worker-reviewer-pipeline, pr-auto-improve, pipeline-guards
- Skill count updated: 60 → 63
- Templates synced
- npm publish for v0.19.4, v0.20.0, v0.21.0 confirmed complete

## New Skills

| Skill | Description |
|-------|-------------|
| worker-reviewer-pipeline | Iterative Worker→Reviewer quality pipeline with configurable quality gates |
| pr-auto-improve | Opt-in post-PR analysis with improvement suggestions (never auto-activates) |
| pipeline-guards | Safety constraints: max iterations, timeouts, quality gates, kill switch |

## Test Plan

- [ ] Verify skill count matches across README, CLAUDE.md, manifest.json (63)
- [ ] Verify SKILL.md content in both .claude/skills/ and templates/.claude/skills/
- [ ] Run full test suite (npm test)
- [ ] Validate pipeline-guards limits integrate with existing dag-orchestration/stuck-recovery

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)