### PR TITLE
fix: resolve update command bugs (#220, #221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.1] - 2026-03-08
+
+### Fixed
+- **dry-run modifies files** (Issue #220): `omcustom update --dry-run` no longer modifies CLAUDE.md or config — entry doc update and config save are now guarded by dry-run check
+- **Content loss on update** (Issue #221): `omcustom update` now preserves existing project-specific CLAUDE.md content when no omcustom markers exist, instead of overwriting it entirely
+
 ## [0.23.0] - 2026-03-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-customcode",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/src/core/entry-merger.ts
+++ b/src/core/entry-merger.ts
@@ -144,11 +144,17 @@ export function mergeEntryDoc(existingContent: string, templateContent: string):
 
   if (!hasManagedSections) {
     const wrapped = wrapInManagedMarkers(templateContent);
+    const existingTrimmed = existingContent.trim();
+    const content = existingTrimmed ? `${wrapped}\n\n${existingTrimmed}` : wrapped;
     return {
-      content: wrapped,
+      content,
       managedSections: 1,
-      customSections: 0,
-      warnings: ['No managed sections found in existing content, wrapping template entirely'],
+      customSections: existingTrimmed ? 1 : 0,
+      warnings: existingTrimmed
+        ? [
+            'No managed sections found in existing content. Template inserted as managed section, existing content preserved below.',
+          ]
+        : ['No managed sections found in existing content, wrapping template entirely'],
     };
   }
 

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -406,6 +406,46 @@ async function updateEntryDoc(
 }
 
 /**
+ * Handle full-update-only post-processing steps and log success
+ */
+async function runFullUpdatePostProcessing(
+  options: UpdateOptions,
+  result: UpdateResult,
+  config: OmccConfig
+): Promise<void> {
+  const isFullUpdate = !options.components || options.components.length === 0;
+
+  if (isFullUpdate) {
+    const synced = await syncRootLevelFiles(options.targetDir, options);
+    result.syncedRootFiles = synced;
+
+    const removed = await removeDeprecatedFiles(options.targetDir, options);
+    result.removedDeprecatedFiles = removed;
+
+    if (!options.dryRun) {
+      await updateEntryDoc(options.targetDir, config, options);
+    }
+  }
+
+  if (!options.dryRun) {
+    config.version = result.newVersion;
+    config.lastUpdated = new Date().toISOString();
+    await saveConfig(options.targetDir, config);
+  }
+
+  result.success = true;
+
+  if (result.previousVersion !== result.newVersion) {
+    success('update.success', { from: result.previousVersion, to: result.newVersion });
+  } else if (result.updatedComponents.length > 0) {
+    success('update.components_synced', {
+      version: result.newVersion,
+      components: result.updatedComponents.join(', '),
+    });
+  }
+}
+
+/**
  * Update oh-my-customcode installation
  */
 export async function update(options: UpdateOptions): Promise<UpdateResult> {
@@ -450,40 +490,7 @@ export async function update(options: UpdateOptions): Promise<UpdateResult> {
       config
     );
 
-    // Sync root-level files (statusline.sh, etc.)
-    if (!options.components || options.components.length === 0) {
-      const synced = await syncRootLevelFiles(options.targetDir, options);
-      result.syncedRootFiles = synced;
-    }
-
-    // Remove deprecated files (only on full update)
-    if (!options.components || options.components.length === 0) {
-      const removed = await removeDeprecatedFiles(options.targetDir, options);
-      result.removedDeprecatedFiles = removed;
-    }
-
-    // Update entry doc with merge (only on full update)
-    if (!options.components || options.components.length === 0) {
-      await updateEntryDoc(options.targetDir, config, options);
-    }
-
-    config.version = result.newVersion;
-    config.lastUpdated = new Date().toISOString();
-    await saveConfig(options.targetDir, config);
-
-    result.success = true;
-
-    if (result.previousVersion !== result.newVersion) {
-      // Case 1: Version upgrade
-      success('update.success', { from: result.previousVersion, to: result.newVersion });
-    } else if (result.updatedComponents.length > 0) {
-      // Case 2: Component sync within same version
-      success('update.components_synced', {
-        version: result.newVersion,
-        components: result.updatedComponents.join(', '),
-      });
-    }
-    // Case 3: No changes - already handled by early return at line 434-439
+    await runFullUpdatePostProcessing(options, result, config);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     result.error = message;

--- a/tests/unit/core/entry-doc-update.test.ts
+++ b/tests/unit/core/entry-doc-update.test.ts
@@ -31,7 +31,7 @@ describe('updateEntryDoc via update()', () => {
   // Test 1: merge mode - existing file with markers
   it('should merge entry doc preserving custom sections', async () => {
     await createConfig();
-    const layout = getProviderLayout('claude');
+    const layout = getProviderLayout();
 
     // Set up directory structure
     await mkdir(join(tempDir, layout.rootDir), { recursive: true });
@@ -56,7 +56,6 @@ describe('updateEntryDoc via update()', () => {
     // Run update without specifying components (triggers updateEntryDoc)
     const result = await update({
       targetDir: tempDir,
-      provider: 'claude',
       force: false,
     });
 
@@ -77,7 +76,7 @@ describe('updateEntryDoc via update()', () => {
   // Test 2: force mode - overwrite with backup
   it('should force overwrite entry doc with backup', async () => {
     await createConfig();
-    const layout = getProviderLayout('claude');
+    const layout = getProviderLayout();
     await mkdir(join(tempDir, layout.rootDir), { recursive: true });
 
     const templateName = `${layout.entryFile.replace('.md', '')}.md.en`;
@@ -91,7 +90,6 @@ describe('updateEntryDoc via update()', () => {
 
     const result = await update({
       targetDir: tempDir,
-      provider: 'claude',
       force: true,
     });
 
@@ -105,7 +103,7 @@ describe('updateEntryDoc via update()', () => {
   // Test 3: new file creation - wrap in markers
   it('should create entry doc with markers when it does not exist', async () => {
     await createConfig();
-    const layout = getProviderLayout('claude');
+    const layout = getProviderLayout();
     await mkdir(join(tempDir, layout.rootDir), { recursive: true });
 
     const templateName = `${layout.entryFile.replace('.md', '')}.md.en`;
@@ -119,7 +117,6 @@ describe('updateEntryDoc via update()', () => {
 
     const result = await update({
       targetDir: tempDir,
-      provider: 'claude',
       force: false,
     });
 
@@ -132,10 +129,65 @@ describe('updateEntryDoc via update()', () => {
     expect(content).toContain('<!-- omcustom:end -->');
   });
 
-  // Test 4: updateEntryDoc not called when specific components requested
+  // Test 4: dry-run must not modify entry doc
+  it('should NOT modify entry doc during dry-run', async () => {
+    await createConfig();
+    const layout = getProviderLayout();
+    await mkdir(join(tempDir, layout.rootDir), { recursive: true });
+
+    const templateName = `${layout.entryFile.replace('.md', '')}.md.en`;
+    const templatePath = resolveTemplatePath(templateName);
+    if (!(await fileExists(templatePath))) {
+      return;
+    }
+
+    const entryPath = join(tempDir, layout.entryFile);
+    const originalContent = 'This content must NOT be modified during dry-run';
+    await writeFile(entryPath, originalContent);
+
+    const result = await update({
+      targetDir: tempDir,
+      force: true,
+      dryRun: true,
+    });
+
+    expect(result.success).toBe(true);
+
+    // Entry doc must remain unchanged during dry-run
+    const content = await readFile(entryPath, 'utf-8');
+    expect(content).toBe(originalContent);
+  });
+
+  // Test 5: dry-run must not update config version
+  it('should NOT update config during dry-run', async () => {
+    await createConfig({ version: '0.1.0' });
+    const layout = getProviderLayout();
+    await mkdir(join(tempDir, layout.rootDir), { recursive: true });
+
+    // Capture config content before dry-run
+    const configPath = join(tempDir, '.omcustomrc.json');
+    const contentBefore = await readFile(configPath, 'utf-8');
+    const configBefore = JSON.parse(contentBefore);
+
+    const result = await update({
+      targetDir: tempDir,
+      force: true,
+      dryRun: true,
+    });
+
+    expect(result.success).toBe(true);
+
+    // Config version must remain unchanged during dry-run
+    const contentAfter = await readFile(configPath, 'utf-8');
+    const configAfter = JSON.parse(contentAfter);
+    expect(configAfter.version).toBe(configBefore.version);
+    expect(configAfter.version).toBe('0.1.0');
+  });
+
+  // Test 6: updateEntryDoc not called when specific components requested
   it('should not update entry doc when specific components are requested', async () => {
     await createConfig();
-    const layout = getProviderLayout('claude');
+    const layout = getProviderLayout();
     await mkdir(join(tempDir, layout.rootDir), { recursive: true });
 
     const entryPath = join(tempDir, layout.entryFile);
@@ -144,7 +196,6 @@ describe('updateEntryDoc via update()', () => {
 
     const result = await update({
       targetDir: tempDir,
-      provider: 'claude',
       components: ['rules'],
     });
 

--- a/tests/unit/core/entry-merger.test.ts
+++ b/tests/unit/core/entry-merger.test.ts
@@ -250,11 +250,58 @@ Real managed section
 
       expect(result.content).toBe(`<!-- omcustom:start -->
 Template content
+<!-- omcustom:end -->
+
+Custom user content`);
+      expect(result.managedSections).toBe(1);
+      expect(result.customSections).toBe(1);
+      expect(result.warnings.length).toBe(1);
+      expect(result.warnings[0]).toContain('No managed sections found');
+      expect(result.warnings[0]).toContain('preserved below');
+    });
+
+    it('should only wrap template when existing content is empty', () => {
+      const existingContent = '';
+      const templateContent = 'Template content';
+
+      const result = mergeEntryDoc(existingContent, templateContent);
+
+      expect(result.content).toBe(`<!-- omcustom:start -->
+Template content
 <!-- omcustom:end -->`);
       expect(result.managedSections).toBe(1);
       expect(result.customSections).toBe(0);
       expect(result.warnings.length).toBe(1);
-      expect(result.warnings[0]).toContain('No managed sections found');
+      expect(result.warnings[0]).toContain('wrapping template entirely');
+    });
+
+    it('should preserve multiline project content when no markers exist', () => {
+      const existingContent = `# My Project
+
+This is a project-specific README.
+It has multiple lines of important content.
+
+## Setup
+Run \`npm install\` to get started.`;
+      const templateContent = 'Template content';
+
+      const result = mergeEntryDoc(existingContent, templateContent);
+
+      expect(result.content).toBe(`<!-- omcustom:start -->
+Template content
+<!-- omcustom:end -->
+
+# My Project
+
+This is a project-specific README.
+It has multiple lines of important content.
+
+## Setup
+Run \`npm install\` to get started.`);
+      expect(result.managedSections).toBe(1);
+      expect(result.customSections).toBe(1);
+      expect(result.warnings.length).toBe(1);
+      expect(result.warnings[0]).toContain('preserved below');
     });
 
     it('should replace managed section with new template', () => {
@@ -335,20 +382,6 @@ Custom content`);
       expect(result.customSections).toBe(1);
       expect(result.warnings.length).toBe(1);
       expect(result.warnings[0]).toContain('Multiple managed sections found');
-    });
-
-    it('should handle empty existing content', () => {
-      const existingContent = '';
-      const templateContent = 'Template content';
-
-      const result = mergeEntryDoc(existingContent, templateContent);
-
-      expect(result.content).toBe(`<!-- omcustom:start -->
-Template content
-<!-- omcustom:end -->`);
-      expect(result.managedSections).toBe(1);
-      expect(result.customSections).toBe(0);
-      expect(result.warnings.length).toBe(1);
     });
 
     it('should handle empty template content', () => {


### PR DESCRIPTION
## Summary
- **#220**: `omcustom update --dry-run` was modifying CLAUDE.md and config. Added dry-run guards to `updateEntryDoc()` and `saveConfig()` calls.
- **#221**: `omcustom update` was discarding existing CLAUDE.md content when no omcustom markers existed. Now preserves existing content below the managed section.

## Changes
- `src/core/updater.ts`: Wrap entry doc update and config save in `!options.dryRun` guard
- `src/core/entry-merger.ts`: Preserve existing content in `mergeEntryDoc()` when no markers found
- Tests: 4 new test cases covering both bugs (34 total, all passing)

## Test plan
- [x] `bun test` — 34/34 pass
- [x] `bun run typecheck` — clean
- [ ] CI validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)