### PR TITLE
fix: memory hybrid approach and display format simplification

### DIFF
--- a/.claude/agents/sys-memory-keeper.md
+++ b/.claude/agents/sys-memory-keeper.md
@@ -1,6 +1,6 @@
 ---
 name: sys-memory-keeper
-description: Use when you need to manage session memory persistence using claude-mem, save context before compaction, restore context on session start, query past memories, or perform session-end dual-system auto-save
+description: Use when you need to manage session memory persistence via native auto-memory, save context before compaction, restore context on session start, collect session summaries, or perform session-end memory operations
 model: sonnet
 memory: project
 effort: medium
@@ -47,12 +47,12 @@ Provider: claude-mem | Collection: claude_memories | Archive: ~/.claude-mem/arch
 When triggered by session-end signal from orchestrator:
 
 1. **Collect** session summary: completed tasks, key decisions, open items
-2. **Save to claude-mem** (if available): `mcp__plugin_claude-mem_mcp-search__save_memory` with project name, session date, and summary
-3. **Verify episodic-memory** (if available): `mcp__plugin_episodic-memory_episodic-memory__search` to confirm session is indexed
-4. **Report** results to orchestrator: saved/skipped/failed per system
+2. **Update native auto-memory** (MEMORY.md) with session learnings
+3. **Return formatted summary** to orchestrator for MCP persistence (claude-mem, episodic-memory)
+
+> **Note**: MCP tools (claude-mem, episodic-memory) are orchestrator-scoped and cannot be called from subagents. The orchestrator handles MCP saves directly after receiving the formatted summary.
 
 ### Failure Handling
 
-- claude-mem unavailable → skip, report warning
-- episodic-memory unavailable → skip, report warning
-- Both unavailable → warn orchestrator, do not block session end
+- MEMORY.md update failure → report error to orchestrator
+- MCP persistence is orchestrator's responsibility — not handled here

--- a/.claude/rules/MUST-parallel-execution.md
+++ b/.claude/rules/MUST-parallel-execution.md
@@ -112,12 +112,12 @@ Before writing/editing multiple files:
 ## Display Format
 
 ```
-[Instance 1] Agent(mgr-creator):sonnet → Create Go agent
-[Instance 2] Agent(lang-python-expert):sonnet → Review Python code
-[Instance 3] Agent(Explore):haiku → Search codebase
+[Instance 1] mgr-creator:sonnet → Create Go agent
+[Instance 2] lang-python-expert:sonnet → Review Python code
+[Instance 3] Explore:haiku → Search codebase
 ```
 
-Must use `Agent({subagent_type}):{model}` format. Custom names not allowed.
+Must use `{subagent_type}:{model}` format. Custom names not allowed.
 
 ## Result Aggregation
 

--- a/.claude/rules/SHOULD-hud-statusline.md
+++ b/.claude/rules/SHOULD-hud-statusline.md
@@ -32,8 +32,8 @@ Implemented in `.claude/hooks/hooks.json` (PreToolUse → Agent/Task matcher).
 
 ```
 ─── [Agent] secretary | [Parallel] 4 ───
-  [1] Agent(mgr-creator):sonnet → Create agent
-  [2] Agent(lang-golang-expert):haiku → Code review
+  [1] mgr-creator:sonnet → Create agent
+  [2] lang-golang-expert:haiku → Code review
 ```
 
 ## Statusline API (Command-based)

--- a/.claude/rules/SHOULD-memory-integration.md
+++ b/.claude/rules/SHOULD-memory-integration.md
@@ -49,23 +49,38 @@ Session-end detected when user says: "끝", "종료", "마무리", "done", "wrap
 ```
 User signals session end
   → Orchestrator delegates to sys-memory-keeper
-    → sys-memory-keeper performs dual-system save:
-       1. claude-mem save (if available)
-       2. episodic-memory verification (if available)
-    → Reports result to orchestrator
+    → sys-memory-keeper performs:
+       1. Collect session summary (tasks, decisions, open items)
+       2. Update native auto-memory (MEMORY.md)
+       3. Return formatted summary to orchestrator
+  → Orchestrator performs MCP saves directly:
+       1. claude-mem save (if available via ToolSearch)
+       2. episodic-memory verification (if available via ToolSearch)
   → Orchestrator confirms to user
 ```
 
+### Responsibility Split
+
+MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inherited by subagents. Therefore:
+
+| Responsibility | Owner | Reason |
+|----------------|-------|--------|
+| Session summary collection | sys-memory-keeper | Domain expertise in memory formatting |
+| Native auto-memory (MEMORY.md) | sys-memory-keeper | Has Write access to memory directory |
+| claude-mem MCP save | Orchestrator | MCP tools only available at orchestrator level |
+| episodic-memory MCP verification | Orchestrator | MCP tools only available at orchestrator level |
+
 ### Dual-System Save
 
-| System | Tool | Action | Required |
-|--------|------|--------|----------|
-| claude-mem | `mcp__plugin_claude-mem_mcp-search__save_memory` | Save session summary with project, tasks, decisions | No (best-effort) |
-| episodic-memory | `mcp__plugin_episodic-memory_episodic-memory__search` | Verify session is indexed for future retrieval | No (best-effort) |
+| System | Owner | Tool | Action | Required |
+|--------|-------|------|--------|----------|
+| Native auto-memory | sys-memory-keeper | Write | Update MEMORY.md with session learnings | Yes |
+| claude-mem | Orchestrator | `mcp__plugin_claude-mem_mcp-search__save_memory` | Save session summary with project, tasks, decisions | No (best-effort) |
+| episodic-memory | Orchestrator | `mcp__plugin_episodic-memory_episodic-memory__search` | Verify session is indexed for future retrieval | No (best-effort) |
 
 ### Failure Policy
 
-- Both saves are **non-blocking**: memory failure MUST NOT prevent session from ending
+- MCP saves are **non-blocking**: memory failure MUST NOT prevent session from ending
 - If claude-mem unavailable: skip, log warning
 - If episodic-memory unavailable: skip, log warning
 - If both unavailable: warn user, proceed with session end


### PR DESCRIPTION
## Summary
- Fixed memory hybrid approach: sys-memory-keeper handles native memory, orchestrator handles MCP saves (R011 update)
- Simplified agent spawn display format: removed redundant `Agent()` wrapper (R008, R009, R012 updates)

Closes #228
Closes #232

## Test plan
- [ ] Verify R011 session-end flow delegates correctly
- [ ] Verify display format shows `subagent_type:model` without `Agent()` wrapper
- [ ] Verify R008, R009, R012 rules are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)