### PR TITLE
feat: context fork expansion and routing context visibility

### DIFF
--- a/.claude/rules/MUST-agent-design.md
+++ b/.claude/rules/MUST-agent-design.md
@@ -74,6 +74,42 @@ When enabled: first 200 lines of MEMORY.md loaded into system prompt.
 
 Agent body: purpose, capabilities overview, workflow. NOT detailed instructions or reference docs.
 
+## Skill Frontmatter
+
+Location: `.claude/skills/{name}/SKILL.md`
+
+### Required Fields
+
+```yaml
+name: skill-name           # Unique identifier (kebab-case)
+description: Brief desc    # One-line summary
+```
+
+### Optional Fields
+
+```yaml
+context: fork              # Forked context for isolated execution
+version: 1.0.0             # Semantic version
+user-invocable: false      # Whether user can invoke directly
+disable-model-invocation: true  # Prevent model from auto-invoking
+```
+
+### Context Fork Criteria
+
+Use `context: fork` for skills that orchestrate multi-agent workflows. Cap at **10 total** across the project.
+
+| Use `context: fork` | Do NOT use `context: fork` |
+|---------------------|---------------------------|
+| Routing skills (secretary, dev-lead, etc.) | Best-practices skills |
+| Workflow orchestration (DAG, pipelines) | Hook/command skills |
+| Multi-agent coordination patterns | Single-agent reference skills |
+| Task decomposition/planning | External tool integrations |
+
+Current skills with `context: fork` (9/10 cap):
+- secretary-routing, dev-lead-routing, de-lead-routing, qa-lead-routing
+- dag-orchestration, task-decomposition, worker-reviewer-pipeline
+- structured-dev-cycle, pipeline-guards
+
 ## Naming
 
 | Type | Pattern | Example |

--- a/.claude/rules/MUST-agent-identification.md
+++ b/.claude/rules/MUST-agent-identification.md
@@ -1,0 +1,48 @@
+# [MUST] Agent Identification Rules
+
+> **Priority**: MUST - ENFORCED | **ID**: R007
+
+## Core Rule
+
+Every response MUST start with agent identification:
+
+```
+┌─ Agent: {agent-name} ({agent-type})
+├─ Skill: {skill-name} (if applicable)
+└─ Task: {brief-task-description}
+```
+
+Default (no specific agent): `┌─ Agent: claude (default)`
+
+## Simplified Format
+
+For brief responses: `[mgr-creator] Creating agent structure...`
+With skill: `[fe-vercel-agent → react-best-practices] Analyzing...`
+
+## Routing Context
+
+When the orchestrator uses a routing skill, identification should reflect the active context:
+
+```
+┌─ Agent: claude (secretary-routing)
+├─ Skill: secretary-routing
+└─ Task: route agent management request
+```
+
+| Context | Identification |
+|---------|---------------|
+| No routing active | `claude (default)` |
+| secretary-routing | `claude (secretary-routing)` |
+| dev-lead-routing | `claude (dev-lead-routing)` |
+| de-lead-routing | `claude (de-lead-routing)` |
+| qa-lead-routing | `claude (qa-lead-routing)` |
+| Skill invocation | `claude → {skill-name}` |
+
+## When to Display
+
+| Situation | Display |
+|-----------|---------|
+| Agent-specific task | Full header |
+| Using skill | Include skill name |
+| General conversation | "claude (default)" |
+| Long tasks | Show progress with agent context |

--- a/.claude/skills/pipeline-guards/SKILL.md
+++ b/.claude/skills/pipeline-guards/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pipeline-guards
 description: Safety constraints and quality gates for pipeline and workflow execution
+context: fork
 ---
 
 # Pipeline Guards Skill

--- a/.claude/skills/task-decomposition/SKILL.md
+++ b/.claude/skills/task-decomposition/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: task-decomposition
 description: Auto-decompose large tasks into DAG-compatible parallel subtasks
+context: fork
 ---
 
 # Task Decomposition Skill

--- a/.claude/skills/worker-reviewer-pipeline/SKILL.md
+++ b/.claude/skills/worker-reviewer-pipeline/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: worker-reviewer-pipeline
 description: Worker-Reviewer iterative pipeline for quality-critical code with review cycles
+context: fork
 ---
 
 # Worker-Reviewer Pipeline Skill


### PR DESCRIPTION
## Summary
- Added `context: fork` to orchestrator skill frontmatter (R006 documentation)
- Added routing context visibility to agent identification (R007)
- Updated task-decomposition, worker-reviewer-pipeline, structured-dev-cycle, pipeline-guards skills

Closes #224
Closes #229

## Test plan
- [ ] Verify context fork criteria documented in R006
- [ ] Verify routing context table in R007
- [ ] Verify orchestrator skills have `context: fork` in frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)