### PR TITLE
fix: parallel spawn [N] prefix and session-end self-check (#236, #237)

### DIFF
--- a/.claude/rules/MUST-parallel-execution.md
+++ b/.claude/rules/MUST-parallel-execution.md
@@ -112,12 +112,14 @@ Before writing/editing multiple files:
 ## Display Format
 
 ```
-[Instance 1] mgr-creator:sonnet → Create Go agent
-[Instance 2] lang-python-expert:sonnet → Review Python code
-[Instance 3] Explore:haiku → Search codebase
+[1] mgr-creator:sonnet → Create Go agent
+[2] lang-python-expert:sonnet → Review Python code
+[3] Explore:haiku → Search codebase
 ```
 
-Must use `{subagent_type}:{model}` format. Custom names not allowed.
+Must use `[N] {subagent_type}:{model}` format. `[N]` is 1-indexed and MUST match the `description` parameter prefix of the Agent tool call for Running display correlation.
+
+Single agent spawns do NOT use the `[N]` prefix.
 
 ## Result Aggregation
 

--- a/.claude/rules/MUST-tool-identification.md
+++ b/.claude/rules/MUST-tool-identification.md
@@ -1,0 +1,113 @@
+# [MUST] Tool Usage Identification Rules
+
+> **Priority**: MUST - ENFORCED | **ID**: R008
+
+## Core Rule
+
+Every tool call MUST be prefixed with agent and model identification:
+
+```
+[agent-name][model] → Tool: <tool-name>
+[agent-name][model] → Target: <file/path/url>
+```
+
+For parallel calls: list ALL identifications BEFORE the tool calls.
+
+### Common Violations to Avoid
+
+```
+❌ WRONG: Calling tools without identification
+   "먼저 JD 내용을 확인하겠습니다."
+   <tool_call>WebFetch(...)</tool_call>
+
+❌ WRONG: Missing model in identification
+   [secretary] → Tool: WebFetch
+   [secretary] → Fetching: https://example.com/jd.md
+
+✓ CORRECT: Always identify with agent AND model
+   "먼저 JD 내용을 확인하겠습니다."
+   [secretary][opus] → Tool: WebFetch
+   [secretary][opus] → Fetching: https://example.com/jd.md
+   <tool_call>WebFetch(...)</tool_call>
+
+❌ WRONG: Parallel calls without listing all identifications
+   <tool_call>WebFetch(url1)</tool_call>
+   <tool_call>WebFetch(url2)</tool_call>
+   <tool_call>Bash(cmd)</tool_call>
+
+✓ CORRECT: List all identifications with models, then call
+   [secretary][opus] → Tool: WebFetch
+   [secretary][opus] → Fetching: url1
+   [secretary][opus] → Tool: WebFetch
+   [secretary][opus] → Fetching: url2
+   [secretary][opus] → Tool: Bash
+   [secretary][opus] → Running: cmd
+   <tool_call>WebFetch(url1)</tool_call>
+   <tool_call>WebFetch(url2)</tool_call>
+   <tool_call>Bash(cmd)</tool_call>
+```
+
+## Models
+
+| Model | Use |
+|-------|-----|
+| `opus` | Complex reasoning, architecture |
+| `sonnet` | General tasks, code generation (default) |
+| `haiku` | Fast simple tasks, file search |
+
+## Tool Categories
+
+| Category | Tools | Verb |
+|----------|-------|------|
+| File Read | Read, Glob, Grep | Reading / Searching |
+| File Write | Write, Edit | Writing / Editing |
+| Network | WebFetch | Fetching |
+| Execution | Bash, Agent | Running / Spawning |
+
+## Agent Tool Format
+
+```
+subagent_type:model → description
+```
+
+`subagent_type` MUST match actual Agent tool parameter. Custom names not allowed.
+
+## Parallel Spawn Prefix Rule
+
+When spawning 2+ agents in parallel, each agent's `description` parameter MUST include a `[N]` prefix (1-indexed) to enable correlation with the Running display:
+
+```
+Agent(description: "[1] Go code review", subagent_type: "lang-golang-expert")
+Agent(description: "[2] Python code review", subagent_type: "lang-python-expert")
+```
+
+Single agent spawns do NOT use the `[N]` prefix.
+
+This ensures the Running display:
+```
+⏺ Running 2 agents… (ctrl+o to expand)
+   ├─ [1] Go code review · ...
+   └─ [2] Python code review · ...
+```
+
+matches the spawn announcement:
+```
+[secretary][opus] → Spawning:
+  [1] lang-golang-expert:sonnet → Go code review
+  [2] lang-python-expert:sonnet → Python code review
+```
+
+## Example
+
+```
+[mgr-creator][sonnet] → Write: .claude/agents/new-agent.md
+[secretary][opus] → Spawning:
+  [1] lang-golang-expert:sonnet → Go code review
+  [2] lang-python-expert:sonnet → Python code review
+```
+
+Parallel spawn description parameter:
+```
+Agent(description: "[1] Go code review", subagent_type: "lang-golang-expert", ...)
+Agent(description: "[2] Python code review", subagent_type: "lang-python-expert", ...)
+```

--- a/.claude/rules/SHOULD-memory-integration.md
+++ b/.claude/rules/SHOULD-memory-integration.md
@@ -78,6 +78,31 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 | claude-mem | Orchestrator | `mcp__plugin_claude-mem_mcp-search__save_memory` | Save session summary with project, tasks, decisions | No (best-effort) |
 | episodic-memory | Orchestrator | `mcp__plugin_episodic-memory_episodic-memory__search` | Verify session is indexed for future retrieval | No (best-effort) |
 
+### Session-End Self-Check (MANDATORY)
+
+```
+╔══════════════════════════════════════════════════════════════════╗
+║  BEFORE CONFIRMING SESSION-END TO USER:                          ║
+║                                                                   ║
+║  1. Did sys-memory-keeper update MEMORY.md?                      ║
+║     YES → Continue                                               ║
+║     NO  → Delegate to sys-memory-keeper first                    ║
+║                                                                   ║
+║  2. Did I attempt claude-mem save?                               ║
+║     YES → Continue (even if it failed)                           ║
+║     NO  → ToolSearch + save now                                  ║
+║                                                                   ║
+║  3. Did I attempt episodic-memory verification?                  ║
+║     YES → Continue (even if it failed)                           ║
+║     NO  → ToolSearch + verify now  ← THIS IS THE COMMONLY       ║
+║           SKIPPED STEP. DO NOT SKIP IT.                          ║
+║                                                                   ║
+║  ALL THREE must be attempted before confirming to user.          ║
+║  "Attempted" means called the tool — failure is OK, skipping     ║
+║  is NOT.                                                          ║
+╚══════════════════════════════════════════════════════════════════╝
+```
+
 ### Failure Policy
 
 - MCP saves are **non-blocking**: memory failure MUST NOT prevent session from ending


### PR DESCRIPTION
## Summary
- **#236**: R008/R009에 병렬 spawn 시 `[N]` 접두사 규칙 추가. Agent의 `description` 파라미터에 `[N]` prefix를 포함하여 Running 표시와 spawn 공지의 1:1 대응을 가능하게 함
- **#237**: R011에 세션 종료 self-check 추가. episodic-memory 검증 단계가 반복 누락되는 버그 방지를 위해 mandatory 체크리스트 추가

## Changes
- `.claude/rules/MUST-tool-identification.md` (R008): Parallel Spawn Prefix Rule 섹션 추가
- `.claude/rules/MUST-parallel-execution.md` (R009): Display Format을 `[N]` prefix 형식으로 업데이트
- `.claude/rules/SHOULD-memory-integration.md` (R011): Session-End Self-Check (MANDATORY) 섹션 추가

## Test plan
- [x] `bun test` — 1013 tests passed
- [x] `bun run lint` — no errors
- [ ] CI pipeline passes (Lint, Test, Rust Tests, Version Sync, Dependency Security Audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)