### PR TITLE
fix: update Claude model ID and bump version to 0.24.0

### DIFF
--- a/.github/scripts/verify-claude-native.ts
+++ b/.github/scripts/verify-claude-native.ts
@@ -35,9 +35,7 @@ const KEY_DOC_PAGES = [
   '/en/hooks',
   '/en/features-overview',
   '/en/agent-teams',
-  '/en/model-configuration',
   '/en/settings',
-  '/en/mcp-servers',
 ];
 
 const PROJECT_ROOT = process.env.PROJECT_ROOT || process.cwd();
@@ -574,7 +572,7 @@ ${JSON.stringify(projectStructure.rules.filter((r) => r.is_unique), null, 2)}
 Respond with ONLY valid JSON, no markdown formatting.`;
 
   const response = await client.messages.create({
-    model: process.env.CLAUDE_MODEL || 'claude-sonnet-4-6-20250610',
+    model: process.env.CLAUDE_MODEL || 'claude-sonnet-4-6',
     max_tokens: 4096,
     messages: [{ role: 'user', content: prompt }],
   });

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Like oh-my-zsh transformed shell customization, oh-my-customcode makes personali
 
 | Feature | Description |
 |---------|-------------|
-| **Batteries Included** | 41 agents, 63 skills, 22 guides, 18 rules, 2 hooks, 4 contexts, ontology graph - ready to use out of the box |
+| **Batteries Included** | 42 agents, 66 skills, 22 guides, 18 rules, 2 hooks, 4 contexts, ontology graph - ready to use out of the box |
 | **Sub-Agent Model** | Supports hierarchical agent orchestration with specialized roles |
 | **Dead Simple Customization** | Create a folder + markdown file = new agent or skill |
 | **Mix and Match** | Use built-in components, create your own, or combine both |
@@ -107,7 +107,7 @@ Claude Code selects the appropriate model and parallelizes independent tasks (up
 
 ## What's Included
 
-### Agents (41)
+### Agents (42)
 
 | Category | Count | Agents |
 |----------|-------|--------|
@@ -122,9 +122,9 @@ Claude Code selects the appropriate model and parallelizes independent tasks (up
 | **Architecture** | 2 | arch-documenter, arch-speckit-agent |
 | **Infrastructure** | 2 | infra-docker-expert, infra-aws-expert |
 | **QA** | 3 | qa-planner, qa-writer, qa-engineer |
-| **Total** | **41** | |
+| **Total** | **42** | |
 
-### Skills (63)
+### Skills (66)
 
 | Category | Count | Skills |
 |----------|-------|--------|
@@ -225,7 +225,7 @@ your-project/
     │   ├── be-fastapi-expert.md
     │   ├── mgr-creator.md
     │   └── ...
-    ├── skills/            # Skill modules (63 directories, each with SKILL.md)
+    ├── skills/            # Skill modules (66 directories, each with SKILL.md)
     │   ├── go-best-practices/
     │   ├── react-best-practices/
     │   ├── secretary-routing/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-customcode",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/agents/sec-codeql-expert.md
+++ b/templates/.claude/agents/sec-codeql-expert.md
@@ -1,0 +1,51 @@
+---
+name: sec-codeql-expert
+description: Expert security code analyst using CodeQL for vulnerability detection, call graph analysis, and SARIF output. Use for security audits, CVE triage, code pattern analysis, and vulnerability validation.
+model: sonnet
+memory: project
+tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+---
+
+You are a security-focused code analyst specializing in CodeQL-based vulnerability detection and assessment.
+
+## Capabilities
+
+- Run CodeQL queries against codebases (C/C++, JavaScript, Python, Java, Go)
+- Analyze call graphs and data flow paths
+- Detect vulnerability patterns aligned with OWASP Top 10 and CWE classifications
+- Generate SARIF-formatted results for CI/CD integration
+- Triage CVE reports against the target codebase
+- Identify attack surface and risk areas
+- Produce remediation guidance with severity ratings
+
+## Workflow
+
+1. **Receive target** — file, directory, or repository path
+2. **Select query suite** — choose language-appropriate CodeQL pack
+3. **Execute analysis** — use CodeQL MCP server if available, fall back to CodeQL CLI
+4. **Process results** — parse SARIF output, deduplicate findings
+5. **Assess severity** — classify by CWE, assign CVSS-informed severity (Critical/High/Medium/Low)
+6. **Report** — structured findings with location, description, and remediation steps
+
+## Integration
+
+- Prefers CodeQL MCP server (`github/codeql-action` compatible) when available
+- Falls back to `codeql` CLI: `codeql database create` → `codeql database analyze`
+- All findings reference CWE IDs and include file:line locations
+- SARIF output compatible with GitHub Advanced Security and other SAST platforms
+
+## Report Format
+
+```
+[Finding] CWE-{id}: {title}
+Severity: Critical | High | Medium | Low
+Location: {file}:{line}
+Description: {what and why it's vulnerable}
+Remediation: {concrete fix guidance}
+```

--- a/templates/.claude/skills/cve-triage/SKILL.md
+++ b/templates/.claude/skills/cve-triage/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: cve-triage
+description: CVE triage workflow for vulnerability analysis, reproduction assessment, and patch verification
+user-invocable: false
+---
+
+# CVE Triage Skill
+
+A structured workflow for triaging CVE reports against a codebase. Coordinates security analysis, reproduction assessment, and patch verification.
+
+## Triage Phases
+
+### Phase 1: CVE Intake
+
+- Parse CVE identifier and advisory details
+- Identify affected component, version range, and CWE classification
+- Determine if codebase uses the affected component
+
+### Phase 2: Impact Assessment
+
+- Locate affected code paths via grep/CodeQL
+- Assess exploitability in the project's specific context
+- Determine severity (CRITICAL/HIGH/MEDIUM/LOW/NONE)
+- Check if existing mitigations reduce impact
+
+### Phase 3: Reproduction Analysis
+
+- Design minimal reproduction scenario
+- Identify prerequisites (configuration, network access, authentication)
+- Assess if reproduction is feasible in test environment
+
+### Phase 4: Remediation
+
+- Identify available patches or versions
+- Assess upgrade compatibility and breaking changes
+- Propose mitigation if patch unavailable
+- Generate remediation plan with effort estimate
+
+## Output Format
+
+```markdown
+## CVE Triage Report: {CVE-ID}
+
+### Summary
+| Field | Value |
+|-------|-------|
+| CVE | {CVE-ID} |
+| CWE | {CWE-ID}: {description} |
+| CVSS | {score} ({severity}) |
+| Affected | {component} {version range} |
+| Project Impact | {CRITICAL/HIGH/MEDIUM/LOW/NONE} |
+
+### Analysis
+{Detailed analysis of how CVE affects this codebase}
+
+### Remediation
+| Option | Effort | Risk |
+|--------|--------|------|
+| {option 1} | {effort} | {risk} |
+
+### Action Items
+- [ ] {item 1}
+- [ ] {item 2}
+```
+
+## Integration
+
+- Uses sec-codeql-expert for code analysis when available
+- Results feed into security documentation
+- Can be triggered as part of /research security analysis
+
+## Agent Selection
+
+| Phase | Agent | Model |
+|-------|-------|-------|
+| CVE Intake | Explore | haiku |
+| Impact Assessment | sec-codeql-expert | sonnet |
+| Reproduction | sec-codeql-expert | sonnet |
+| Remediation | appropriate-expert | sonnet |
+
+## Workflow
+
+```
+1. Receive CVE identifier or advisory
+2. Phase 1: Parse and classify the vulnerability
+3. Phase 2: Search codebase for affected components
+4. Phase 3: Evaluate reproduction feasibility
+5. Phase 4: Propose remediation with effort/risk tradeoffs
+6. Generate triage report in standard format
+```

--- a/templates/.claude/skills/jinja2-prompts/SKILL.md
+++ b/templates/.claude/skills/jinja2-prompts/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: jinja2-prompts
+description: Parameterized prompt templates using Jinja2 patterns for reusable, dynamic agent prompts
+user-invocable: false
+---
+
+# Jinja2 Prompt Templates
+
+## Purpose
+
+Define reusable, parameterized prompt templates for agent tasks. Templates enable consistent prompt formatting across workflows while allowing dynamic content injection.
+
+## Template Syntax
+
+Use Jinja2-style variable interpolation in prompt strings:
+
+```
+{{ variable }}                        — Variable substitution
+{% if condition %}...{% endif %}      — Conditional sections
+{% for item in list %}...{% endfor %} — Iteration
+{{ variable | default("fallback") }}  — Default values
+```
+
+## Security Rules
+
+- Templates MUST be author-written (stored in skill files), never user-supplied
+- Use `SandboxedEnvironment` (NOT `Environment` or `from_string()` directly)
+- No access to `env()`, `os`, `subprocess`, or any system functions
+- Variable allowlist: only explicitly provided context variables are accessible
+- NEVER render user-controlled strings as templates — treat them as plain data
+
+## Template Locations
+
+```
+.claude/skills/<skill-name>/templates/
+  ├── analysis.md.j2
+  ├── report.md.j2
+  └── triage.md.j2
+```
+
+## Usage Pattern
+
+```yaml
+# In skill or workflow definition
+template: analysis.md.j2
+variables:
+  target: "{{ repository_url }}"
+  scope: "security"
+  depth: "comprehensive"
+```
+
+Rendered by orchestrator before passing to agent as prompt.
+
+## Common Templates
+
+### Research Team Prompt
+
+```
+Role: {{ domain }} {{ role }} analyst
+Scope: {{ topic }}
+
+Tasks:
+{% for task in tasks %}
+{{ loop.index }}. {{ task }}
+{% endfor %}
+
+Output format:
+{{ output_format }}
+```
+
+### CVE Triage Prompt
+
+```
+Analyze {{ cve_id }} ({{ cwe_classification }})
+Affected component: {{ component }} {{ version_range }}
+{% if existing_mitigations %}
+Known mitigations: {{ existing_mitigations }}
+{% endif %}
+```
+
+## Integration
+
+- Used by `/research` skill for team prompt generation
+- Used by `cve-triage` skill for standardized analysis prompts
+- Compatible with DAG orchestration node prompts

--- a/templates/.claude/skills/research/SKILL.md
+++ b/templates/.claude/skills/research/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: research
+description: 10-team parallel deep analysis with cross-verification for any topic, repository, or technology. Use when user invokes /research or asks for comprehensive research.
+context: fork
+user-invocable: true
+---
+
+# Research Skill
+
+Orchestrates 10 parallel research teams for comprehensive deep analysis of any topic, GitHub repository, or technology. Produces a structured report with ADOPT/ADAPT/AVOID taxonomy.
+
+**Orchestrator-only** — only the main conversation uses this skill (R010). Teams execute as subagents.
+
+## Usage
+
+```
+/research <topic-or-url>
+/research https://github.com/user/repo
+/research "distributed consensus algorithms"
+/research Rust async runtime comparison
+```
+
+## Architecture — 4 Phases
+
+### Phase 1: Parallel Research (10 teams, batched per R009)
+
+Teams operate in breadth/depth pairs across 5 domains:
+
+| Pair | Domain | Team | Role | Focus |
+|------|--------|------|------|-------|
+| 1 | Architecture | T1 | Breadth | Survey, catalog, enumerate structure |
+| | | T2 | Depth | Deep-dive patterns, validate assumptions |
+| 2 | Security | T3 | Breadth | Vulnerability scan, attack surface enumeration |
+| | | T4 | Depth | Exploit validation, risk quantification |
+| 3 | Integration | T5 | Breadth | Compatibility mapping, dependency analysis |
+| | | T6 | Depth | Effort estimation, value assessment |
+| 4 | Comparative | T7 | Breadth | Alternative survey, market landscape |
+| | | T8 | Depth | Feature comparison, benchmark data |
+| 5 | Innovation | T9 | Breadth | Novel pattern identification, idea extraction |
+| | | T10 | Depth | Feasibility validation, adaptation design |
+
+**Batching order** (max 4 concurrent per R009):
+```
+Batch 1: T1, T2, T3, T4    (Architecture + Security)
+Batch 2: T5, T6, T7, T8    (Integration + Comparative)
+Batch 3: T9, T10            (Innovation)
+```
+
+### Phase 2: Cross-Verification Loop (min 2, max 5 rounds)
+
+```
+Team findings ──→ opus 4.6 verification ──→ codex-exec xhigh verification
+       │                                              │
+       └── Contradiction detected? ── YES ──→ Round N+1
+                                      NO  ──→ Consensus reached → Phase 3
+```
+
+Each round:
+1. **opus 4.6**: Deep reasoning verification — checks logical consistency, identifies gaps, challenges assumptions
+2. **codex-exec xhigh** (if available): Independent code-level verification — validates technical claims, tests feasibility
+3. **Contradiction resolution**: Reconcile divergent findings between teams and verifiers
+4. **Convergence check**: All major claims verified with no outstanding contradictions → proceed
+
+Convergence expected by round 3. Hard stop at round 5.
+
+### Phase 3: Synthesis
+
+1. Cross-team gap analysis — identify areas no team covered
+2. Unified priority ranking — weight findings by confidence and impact
+3. ADOPT / ADAPT / AVOID taxonomy generation
+
+### Phase 4: Output
+
+1. Structured markdown report (see Output Format below)
+2. GitHub issue auto-created with findings
+3. Action items with effort estimates
+
+## Execution Rules
+
+| Rule | Detail |
+|------|--------|
+| Max parallel teams | 4 concurrent (R009) |
+| Batching | T1-T4 → T5-T8 → T9-T10 |
+| Agent Teams gate | If enabled, use for cross-team coordination (R018) |
+| Orchestrator only | Main conversation manages all phases (R010) |
+| Ecomode | Auto-activate for team result aggregation (R013) |
+| Intent display | Show research plan before execution (R015) |
+
+## Model Selection
+
+| Phase | Model | Rationale |
+|-------|-------|-----------|
+| Phase 1 (Research teams) | sonnet | Balanced speed/quality for parallel research |
+| Phase 2 (opus verification) | opus | Deep reasoning for cross-verification |
+| Phase 2 (codex verification) | codex xhigh | Code-level validation of technical claims |
+| Phase 3 (Synthesis) | opus | Complex multi-source reasoning and taxonomy |
+
+## Team Prompt Templates
+
+### Breadth Teams (T1, T3, T5, T7, T9)
+
+```
+Role: {domain} breadth analyst
+Scope: {topic}
+
+Tasks:
+1. Survey the full landscape of {focus area}
+2. Catalog all {artifacts/components/alternatives} found
+3. Enumerate {structure/surface/compatibility/options/patterns}
+4. Produce structured inventory with confidence levels
+
+Output format:
+- Inventory table (item | description | confidence)
+- Coverage map (what was examined vs what remains)
+- Key observations (max 5)
+- Questions for depth team
+```
+
+### Depth Teams (T2, T4, T6, T8, T10)
+
+```
+Role: {domain} depth analyst
+Scope: {topic}
+
+Tasks:
+1. Deep-dive into {specific patterns/risks/efforts/benchmarks/feasibility}
+2. Validate assumptions from breadth analysis (if available)
+3. Quantify {quality/risk/effort/performance/value}
+4. Produce evidence-backed assessment
+
+Output format:
+- Detailed analysis (claim | evidence | confidence)
+- Validated/invalidated assumptions
+- Quantified metrics where possible
+- Risk/opportunity assessment
+```
+
+## Verification Loop Detail
+
+```
+Round N:
+  Input:  All 10 team findings + previous round feedback (if any)
+  Step 1: opus reviews each team pair for:
+          - Internal consistency (breadth ↔ depth alignment)
+          - Cross-domain consistency (security ↔ architecture)
+          - Evidence quality (claims without backing)
+  Step 2: codex-exec validates technical claims:
+          - Code patterns actually exist
+          - Benchmarks are reproducible
+          - Dependencies resolve correctly
+  Step 3: Compile contradiction list
+          - 0 contradictions → CONVERGED
+          - >0 contradictions → feedback to relevant teams → Round N+1
+```
+
+## Output Format
+
+```markdown
+# Research Report: {topic}
+
+## Executive Summary
+{2-3 paragraph overview of findings, key recommendation, confidence level}
+
+## Team Findings
+
+### Architecture (Teams 1-2)
+**Breadth**: {inventory summary}
+**Depth**: {analysis summary}
+**Confidence**: {High/Medium/Low}
+
+### Security (Teams 3-4)
+**Breadth**: {attack surface summary}
+**Depth**: {risk assessment summary}
+**Confidence**: {High/Medium/Low}
+
+### Integration (Teams 5-6)
+**Breadth**: {compatibility summary}
+**Depth**: {effort/value summary}
+**Confidence**: {High/Medium/Low}
+
+### Comparative (Teams 7-8)
+**Breadth**: {landscape summary}
+**Depth**: {benchmark summary}
+**Confidence**: {High/Medium/Low}
+
+### Innovation (Teams 9-10)
+**Breadth**: {pattern summary}
+**Depth**: {feasibility summary}
+**Confidence**: {High/Medium/Low}
+
+## Cross-Verification Results
+**Rounds completed**: {N}
+**Contradictions found**: {count}
+**Resolution**: {summary of how contradictions were resolved}
+
+## Taxonomy
+
+### ADOPT (Safe + High Value)
+| Item | Rationale | Confidence |
+|------|-----------|------------|
+
+### ADAPT (Valuable but needs modification)
+| Item | Required Changes | Effort |
+|------|-----------------|--------|
+
+### AVOID (Risk > Value)
+| Item | Risk | Alternatives |
+|------|------|-------------|
+
+## Action Items
+| # | Item | Effort | Priority | Owner |
+|---|------|--------|----------|-------|
+```
+
+## Fallback Behavior
+
+| Scenario | Fallback |
+|----------|----------|
+| codex-exec unavailable | opus-only verification (still min 2 rounds) |
+| Agent Teams unavailable | Standard Agent tool with R009 batching |
+| Partial team failure | Synthesize from available results, note gaps in report |
+| GitHub issue creation fails | Output report to conversation only |
+
+## Display Format
+
+Before execution:
+```
+[Research Plan] {topic}
+├── Phase 1: 10 teams (3 batches × 4/4/2)
+├── Phase 2: Cross-verification (2-5 rounds, opus + codex)
+├── Phase 3: Synthesis (opus)
+└── Phase 4: Report + GitHub issue
+
+Estimated: {time} | Teams: 10 | Models: sonnet → opus → codex
+Execute? [Y/n]
+```
+
+Progress:
+```
+[Research Progress] Phase 1 — Batch 2/3
+├── T1-T4: ✓ Complete
+├── T5-T8: → Running
+└── T9-T10: ○ Pending
+```
+
+## Integration
+
+| Rule | Integration |
+|------|-------------|
+| R009 | Max 4 parallel teams; batch in groups of 4/4/2 |
+| R010 | Orchestrator manages all phases; teams are subagents |
+| R013 | Ecomode auto-activates for 10-team aggregation |
+| R015 | Display research plan with team breakdown before execution |
+| R018 | Agent Teams for cross-team coordination if enabled |
+| dag-orchestration | Phase sequencing follows DAG pattern |
+| result-aggregation | Team results formatted per aggregation skill |
+| multi-model-verification | Phase 2 uses multi-model verification pattern |

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.23.2",
-  "lastUpdated": "2026-03-08T00:00:00.000Z",
+  "version": "0.24.0",
+  "lastUpdated": "2026-03-09T00:00:00.000Z",
   "components": [
     {
       "name": "rules",
@@ -12,13 +12,13 @@
       "name": "agents",
       "path": ".claude/agents",
       "description": "AI agent definitions (flat .md files with prefixes)",
-      "files": 41
+      "files": 42
     },
     {
       "name": "skills",
       "path": ".claude/skills",
       "description": "Reusable skill modules (includes slash commands)",
-      "files": 63
+      "files": 66
     },
     {
       "name": "guides",


### PR DESCRIPTION
## Summary

- Fix CI model ID: `claude-sonnet-4-6-20250610` → `claude-sonnet-4-6` in `.github/scripts/verify-claude-native.ts`
- Remove 2 document URLs returning 404 from the same CI script
- Bump version: `0.23.2` → `0.24.0` in `package.json` and `templates/manifest.json`
- Sync agent count 41 → 42, skill count 63 → 66 in `manifest.json` and `README.md`
- Add 3 missing skills to `templates/.claude/skills/`: `cve-triage`, `jinja2-prompts`, `research`
- Add missing agent to `templates/.claude/agents/`: `sec-codeql-expert`

## Test plan

- [x] All 1013 unit/integration tests pass (pre-commit hook verified)
- [x] `template-validation.test.ts` — agents count, skills count, README count sync all pass
- [x] TypeScript type check passes
- [x] Biome lint passes (schema version info is non-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)