### PR TITLE
fix: add Stop hook to enforce session-end memory saves (#241)

### DIFF
--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -223,6 +223,16 @@
           }
         ],
         "description": "Final console.log audit and session diagnostics before session ends"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Session-end memory checkpoint (R011 enforcement). Check conversation history for these 3 steps: 1) sys-memory-keeper was delegated to update MEMORY.md 2) claude-mem save was attempted via ToolSearch + mcp__plugin_claude-mem_mcp-search__save_memory 3) episodic-memory verification was attempted via ToolSearch + mcp__plugin_episodic-memory_episodic-memory__search. Decision rules: If ALL 3 were attempted (success or failure both count): approve. If MCP tools are unavailable after ToolSearch attempt: approve with note. If session had no explicit session-end signal from user (quick question, no memory work): approve. If any step was NOT attempted despite user signaling session end: block with systemMessage listing the missing steps."
+          }
+        ],
+        "description": "Enforce R011 session-end memory saves — block stop if claude-mem or episodic-memory saves were skipped"
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-customcode",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/hooks/hooks.json
+++ b/templates/.claude/hooks/hooks.json
@@ -223,6 +223,16 @@
           }
         ],
         "description": "Final console.log audit and session diagnostics before session ends"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Session-end memory checkpoint (R011 enforcement). Check conversation history for these 3 steps: 1) sys-memory-keeper was delegated to update MEMORY.md 2) claude-mem save was attempted via ToolSearch + mcp__plugin_claude-mem_mcp-search__save_memory 3) episodic-memory verification was attempted via ToolSearch + mcp__plugin_episodic-memory_episodic-memory__search. Decision rules: If ALL 3 were attempted (success or failure both count): approve. If MCP tools are unavailable after ToolSearch attempt: approve with note. If session had no explicit session-end signal from user (quick question, no memory work): approve. If any step was NOT attempted despite user signaling session end: block with systemMessage listing the missing steps."
+          }
+        ],
+        "description": "Enforce R011 session-end memory saves — block stop if claude-mem or episodic-memory saves were skipped"
       }
     ]
   }

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.24.0",
+  "version": "0.24.1",
   "lastUpdated": "2026-03-09T00:00:00.000Z",
   "components": [
     {

--- a/tests/unit/core/hooks-validation.test.ts
+++ b/tests/unit/core/hooks-validation.test.ts
@@ -6,7 +6,8 @@ const HOOKS_FILE = resolve(import.meta.dir, '../../../templates/.claude/hooks/ho
 
 interface HookCommand {
   type: string;
-  command: string;
+  command?: string;
+  prompt?: string;
 }
 
 interface HookEntry {
@@ -189,59 +190,53 @@ describe('Hooks Validation', () => {
   });
 
   describe('Hook command format', () => {
-    it('should have type and command fields on every hook command', async () => {
-      const { parsed } = await loadHooksJson();
-      const data = parsed as HooksStructure;
-
+    function getAllHookCmds(data: HooksStructure): HookCommand[] {
       const allEntries: HookEntry[] = [
         ...(data.hooks.PreToolUse ?? []),
         ...(data.hooks.PostToolUse ?? []),
         ...(data.hooks.Stop ?? []),
       ];
+      return allEntries.flatMap((entry) => entry.hooks);
+    }
 
-      for (const entry of allEntries) {
-        for (const hookCmd of entry.hooks) {
-          expect(hookCmd).toHaveProperty('type');
-          expect(typeof hookCmd.type).toBe('string');
+    it('should have type and required payload fields on every hook command', async () => {
+      const { parsed } = await loadHooksJson();
+      const data = parsed as HooksStructure;
+
+      for (const hookCmd of getAllHookCmds(data)) {
+        expect(hookCmd).toHaveProperty('type');
+        expect(typeof hookCmd.type).toBe('string');
+        // 'command' type requires command field; 'prompt' type requires prompt field
+        if (hookCmd.type === 'command') {
           expect(hookCmd).toHaveProperty('command');
           expect(typeof hookCmd.command).toBe('string');
+        }
+        if (hookCmd.type === 'prompt') {
+          expect(hookCmd).toHaveProperty('prompt');
+          expect(typeof hookCmd.prompt).toBe('string');
         }
       }
     });
 
-    it('should have non-empty command strings on all hook commands', async () => {
+    it('should have non-empty payload strings on all hook commands', async () => {
       const { parsed } = await loadHooksJson();
       const data = parsed as HooksStructure;
 
-      const allEntries: HookEntry[] = [
-        ...(data.hooks.PreToolUse ?? []),
-        ...(data.hooks.PostToolUse ?? []),
-        ...(data.hooks.Stop ?? []),
-      ];
-
-      for (const entry of allEntries) {
-        for (const hookCmd of entry.hooks) {
-          expect(hookCmd.command.trim().length).toBeGreaterThan(0);
-        }
+      for (const hookCmd of getAllHookCmds(data)) {
+        if (hookCmd.type === 'command')
+          expect((hookCmd.command ?? '').trim().length).toBeGreaterThan(0);
+        if (hookCmd.type === 'prompt')
+          expect((hookCmd.prompt ?? '').trim().length).toBeGreaterThan(0);
       }
     });
 
     it('should have valid type values on all hook commands', async () => {
       const { parsed } = await loadHooksJson();
       const data = parsed as HooksStructure;
+      const validTypes = new Set(['command', 'prompt']);
 
-      const validTypes = new Set(['command']);
-
-      const allEntries: HookEntry[] = [
-        ...(data.hooks.PreToolUse ?? []),
-        ...(data.hooks.PostToolUse ?? []),
-        ...(data.hooks.Stop ?? []),
-      ];
-
-      for (const entry of allEntries) {
-        for (const hookCmd of entry.hooks) {
-          expect(validTypes.has(hookCmd.type)).toBe(true);
-        }
+      for (const hookCmd of getAllHookCmds(data)) {
+        expect(validTypes.has(hookCmd.type)).toBe(true);
       }
     });
   });

--- a/tests/unit/core/hooks-validation.test.ts
+++ b/tests/unit/core/hooks-validation.test.ts
@@ -4,11 +4,17 @@ import { resolve } from 'node:path';
 
 const HOOKS_FILE = resolve(import.meta.dir, '../../../templates/.claude/hooks/hooks.json');
 
-interface HookCommand {
-  type: string;
-  command?: string;
-  prompt?: string;
+interface CommandHook {
+  type: 'command';
+  command: string;
 }
+
+interface PromptHook {
+  type: 'prompt';
+  prompt: string;
+}
+
+type HookCommand = CommandHook | PromptHook;
 
 interface HookEntry {
   matcher: string;
@@ -223,10 +229,8 @@ describe('Hooks Validation', () => {
       const data = parsed as HooksStructure;
 
       for (const hookCmd of getAllHookCmds(data)) {
-        if (hookCmd.type === 'command')
-          expect((hookCmd.command ?? '').trim().length).toBeGreaterThan(0);
-        if (hookCmd.type === 'prompt')
-          expect((hookCmd.prompt ?? '').trim().length).toBeGreaterThan(0);
+        if (hookCmd.type === 'command') expect(hookCmd.command.trim().length).toBeGreaterThan(0);
+        if (hookCmd.type === 'prompt') expect(hookCmd.prompt.trim().length).toBeGreaterThan(0);
       }
     });
 
@@ -298,7 +302,8 @@ describe('Hooks Validation', () => {
       );
 
       expect(stageBlockingHook).toBeDefined();
-      const command = stageBlockingHook?.hooks[0].command ?? '';
+      const hookCmd = stageBlockingHook?.hooks[0];
+      const command = hookCmd?.type === 'command' ? hookCmd.command : '';
       expect(command).toContain('stage-blocker.sh');
 
       // Read the script file to verify it references /tmp/.claude-dev-stage
@@ -346,7 +351,8 @@ describe('Hooks Validation', () => {
 
       const stopHook = entries.find((entry) => entry.matcher === '*');
       expect(stopHook).toBeDefined();
-      const command = stopHook?.hooks[0].command ?? '';
+      const hookCmd = stopHook?.hooks[0];
+      const command = hookCmd?.type === 'command' ? hookCmd.command : '';
       expect(command).toContain('stop-console-audit.sh');
     });
 


### PR DESCRIPTION
## Summary
- Stop hook (prompt type) 추가: 세션 종료 시 3단계 메모리 저장 완료 여부 검증
- 미완료 시 block으로 세션 종료 차단, 누락된 단계 안내
- v0.24.1 버전 범프

## Problem
오케스트레이터가 세션 종료 시 claude-mem/episodic-memory MCP 저장을 반복적으로 스킵하는 버그.
R011 self-check 규칙만으로는 강제력이 부족했음.

## Solution
Stop hook에 prompt 타입 체크포인트 추가:
1. sys-memory-keeper MEMORY.md 업데이트 여부
2. claude-mem 저장 시도 여부
3. episodic-memory 검증 시도 여부

모두 시도된 경우 approve, 하나라도 빠지면 block.

## Test plan
- [ ] 세션 종료 시 Stop hook이 메모리 저장 검증하는지 확인
- [ ] 메모리 저장 완료 후 정상 approve 되는지 확인
- [ ] 메모리 저장 누락 시 block 되는지 확인
- [ ] MCP 도구 unavailable 시 approve 되는지 확인
- [ ] Quick question 세션 (세션 종료 신호 없음) 시 approve 되는지 확인

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)