### PR TITLE
release: v0.30.5

### DIFF
--- a/.github/scripts/analyze-issue.ts
+++ b/.github/scripts/analyze-issue.ts
@@ -49,7 +49,7 @@ const CONFIG = {
   anthropicApiKey: process.env.ANTHROPIC_API_KEY,
   githubToken: process.env.GITHUB_TOKEN,
   githubRepo: process.env.GITHUB_REPOSITORY,
-  model: process.env.CLAUDE_MODEL || 'claude-sonnet-4-20250514',
+  model: process.env.CLAUDE_MODEL || 'claude-sonnet-4-6',
   maxTokens: 8000,
 };
 

--- a/.github/scripts/generate-release-notes.ts
+++ b/.github/scripts/generate-release-notes.ts
@@ -196,7 +196,7 @@ async function generateReleaseNotes(version?: string): Promise<string> {
   });
 
   const message = await client.messages.create({
-    model: process.env.CLAUDE_MODEL || 'claude-sonnet-4-20250514',
+    model: process.env.CLAUDE_MODEL || 'claude-sonnet-4-6',
     max_tokens: 2048,
     messages: [
       {

--- a/.github/scripts/validate-docs.ts
+++ b/.github/scripts/validate-docs.ts
@@ -267,7 +267,7 @@ async function validateDocs(): Promise<string> {
   const client = new Anthropic();
 
   const message = await client.messages.create({
-    model: process.env.CLAUDE_MODEL || 'claude-sonnet-4-20250514',
+    model: process.env.CLAUDE_MODEL || 'claude-sonnet-4-6',
     max_tokens: 2048,
     messages: [
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-customcode",
-  "version": "0.30.4",
+  "version": "0.30.5",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.30.4",
+  "version": "0.30.5",
   "lastUpdated": "2026-03-09T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- fix: update outdated Claude model IDs in CI scripts (claude-sonnet-4-20250514 → claude-sonnet-4-6)
- chore: bump version to 0.30.5

## Changes
- Updated 3 CI scripts with correct model ID: `validate-docs.ts`, `generate-release-notes.ts`, `analyze-issue.ts`
- Version bump: 0.30.4 → 0.30.5