### PR TITLE
chore(release): v0.30.7 — documentation sync fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ All commands are invoked inside the Claude Code conversation.
 | `/sauron-watch` | Full R017 sync verification |
 | `/monitoring-setup` | OTel console monitoring enable/disable |
 | `/codex-exec` | Execute Codex CLI prompt |
+| `/structured-dev-cycle` | 6-phase structured development cycle |
 | `/lists` | Show all available commands |
 | `/status` | System status and health checks |
 | `/help` | Help information |
@@ -272,9 +273,6 @@ After `omcustom init`:
 your-project/
 ├── CLAUDE.md              # Entry point for Claude
 ├── .claude/
-│   ├── rules/             # Behavior rules (18 total)
-│   ├── hooks/             # Event hooks (2 total)
-│   ├── contexts/          # Context files (4 total)
 │   ├── agents/            # Agent definitions (43 flat .md files)
 │   │   ├── lang-golang-expert.md
 │   │   ├── be-fastapi-expert.md
@@ -285,12 +283,15 @@ your-project/
 │   │   ├── react-best-practices/
 │   │   ├── secretary-routing/
 │   │   └── ...
-│   └── ontology/          # Ontology knowledge graph for RAG context
-│       ├── schema.yaml
-│       ├── agents.yaml
-│       ├── skills.yaml
-│       ├── rules.yaml
-│       └── graphs/
+│   ├── ontology/          # Ontology knowledge graph for RAG context
+│   │   ├── schema.yaml
+│   │   ├── agents.yaml
+│   │   ├── skills.yaml
+│   │   ├── rules.yaml
+│   │   └── graphs/
+│   ├── rules/             # Behavior rules (18 total)
+│   ├── hooks/             # Event hooks (2 total)
+│   └── contexts/          # Context files (4 total)
 └── guides/                # Reference docs (23 total)
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-customcode",
-  "version": "0.30.6",
+  "version": "0.30.7",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.30.6",
+  "version": "0.30.7",
   "lastUpdated": "2026-03-09T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- Fixed missing `/structured-dev-cycle` slash command in English README (Korean README already had it)
- Unified project structure directory ordering between README.md and README_ko.md
- Bumped version to 0.30.7

Closes #262

## Changes
- `README.md`: Added `/structured-dev-cycle` to Verification & System table, reordered project structure to match Korean README
- `package.json`: Version bump 0.30.6 → 0.30.7
- `templates/manifest.json`: Version bump 0.30.6 → 0.30.7