### PR TITLE
feat: session compliance report — #265 Phase 1

### DIFF
--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -238,6 +238,16 @@
         "matcher": "*",
         "hooks": [
           {
+            "type": "command",
+            "command": "bash .claude/hooks/scripts/session-compliance-report.sh"
+          }
+        ],
+        "description": "Session compliance report — summarize rule violations detected during session (advisory, non-blocking)"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
             "type": "prompt",
             "prompt": "Session-end memory checkpoint (R011 enforcement). Check conversation history for these 3 steps: 1) sys-memory-keeper was delegated to update MEMORY.md 2) claude-mem save was attempted via ToolSearch + mcp__plugin_claude-mem_mcp-search__save_memory 3) episodic-memory verification was attempted via ToolSearch + mcp__plugin_episodic-memory_episodic-memory__search. Decision rules: If ALL 3 were attempted (success or failure both count): approve. If MCP tools are unavailable after ToolSearch attempt: approve with note. If session had no explicit session-end signal from user (quick question, no memory work): approve. If any step was NOT attempted despite user signaling session end: block with systemMessage listing the missing steps."
           }

--- a/.claude/hooks/scripts/agent-teams-advisor.sh
+++ b/.claude/hooks/scripts/agent-teams-advisor.sh
@@ -26,6 +26,10 @@ echo "$COUNT" > "$COUNTER_FILE"
 
 # Warn from 2nd Task call onward -- Agent Teams may be more appropriate
 if [ "$COUNT" -ge 2 ]; then
+  # Log R018 violation when threshold reached
+  if [ "$COUNT" -eq 3 ]; then
+    echo "{\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"rule\":\"R018\",\"type\":\"agent-teams-threshold\",\"detail\":\"3+ Agent/Task calls without Agent Teams\"}" >> "/tmp/.claude-violations-${PPID}"
+  fi
   echo "" >&2
   echo "--- [R018 Advisor] Agent/Task tool call #${COUNT} in this session ---" >&2
   echo "  WARNING: Multiple Task calls detected. Consider Agent Teams if:" >&2

--- a/.claude/hooks/scripts/git-delegation-guard.sh
+++ b/.claude/hooks/scripts/git-delegation-guard.sh
@@ -27,6 +27,7 @@ if [ "$agent_type" != "mgr-gitnerd" ]; then
     if echo "$prompt" | grep -qi "$keyword"; then
       echo "[Hook] WARNING: R010 violation detected - git operation ('$keyword') delegated to '$agent_type' instead of 'mgr-gitnerd'" >&2
       echo "[Hook] Per R010, all git operations (commit/push/branch/merge/etc.) MUST be delegated to mgr-gitnerd" >&2
+      echo "{\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"rule\":\"R010\",\"type\":\"git-delegation\",\"detail\":\"'$keyword' delegated to '$agent_type' instead of mgr-gitnerd\"}" >> "/tmp/.claude-violations-${PPID}"
       break
     fi
   done

--- a/.claude/hooks/scripts/session-compliance-report.sh
+++ b/.claude/hooks/scripts/session-compliance-report.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Stop hook: Session compliance report (R265 Phase 1)
+# Reads violation logs collected by PreToolUse hooks during the session
+# Advisory only — never blocks session termination
+# Ref: https://github.com/baekenough/oh-my-customcode/issues/265
+
+set -euo pipefail
+
+input=$(cat)
+
+VIOLATIONS_FILE="/tmp/.claude-violations-${PPID}"
+TASK_COUNT_FILE="/tmp/.claude-task-count-${PPID}"
+
+echo "" >&2
+echo "╔══════════════════════════════════════════════╗" >&2
+echo "║        Session Compliance Report             ║" >&2
+echo "╚══════════════════════════════════════════════╝" >&2
+
+# Count total Agent/Task calls
+if [ -f "$TASK_COUNT_FILE" ]; then
+  TOTAL_TASKS=$(cat "$TASK_COUNT_FILE")
+  echo "[Compliance] Agent/Task calls this session: ${TOTAL_TASKS}" >&2
+else
+  TOTAL_TASKS=0
+  echo "[Compliance] Agent/Task calls this session: 0" >&2
+fi
+
+# Check violations
+if [ -f "$VIOLATIONS_FILE" ] && [ -s "$VIOLATIONS_FILE" ]; then
+  VIOLATION_COUNT=$(wc -l < "$VIOLATIONS_FILE" | tr -d ' ')
+  echo "[Compliance] Violations detected: ${VIOLATION_COUNT}" >&2
+  echo "" >&2
+
+  # Group by rule
+  R010_COUNT=$(grep -c '"rule":"R010"' "$VIOLATIONS_FILE" 2>/dev/null || echo "0")
+  R018_COUNT=$(grep -c '"rule":"R018"' "$VIOLATIONS_FILE" 2>/dev/null || echo "0")
+
+  if [ "$R010_COUNT" -gt 0 ]; then
+    echo "  R010 (Git Delegation): ${R010_COUNT} violation(s)" >&2
+    grep '"rule":"R010"' "$VIOLATIONS_FILE" | jq -r '.detail' 2>/dev/null | while read -r detail; do
+      echo "    - ${detail}" >&2
+    done
+  fi
+
+  if [ "$R018_COUNT" -gt 0 ]; then
+    echo "  R018 (Agent Teams): ${R018_COUNT} violation(s)" >&2
+    grep '"rule":"R018"' "$VIOLATIONS_FILE" | jq -r '.detail' 2>/dev/null | while read -r detail; do
+      echo "    - ${detail}" >&2
+    done
+  fi
+
+  echo "" >&2
+  echo "[Compliance] Review violations above and consider rule updates per R016." >&2
+else
+  echo "[Compliance] No violations detected. All clear!" >&2
+fi
+
+echo "────────────────────────────────────────────────" >&2
+
+# Cleanup temp files (best effort)
+rm -f "$VIOLATIONS_FILE" 2>/dev/null || true
+
+# CRITICAL: Always pass through input and exit 0
+echo "$input"
+exit 0


### PR DESCRIPTION
## Summary
- Added session-end rule compliance reporting (advisory, non-blocking)
- `git-delegation-guard.sh` now logs R010 violations to `/tmp/.claude-violations-$PPID`
- `agent-teams-advisor.sh` now logs R018 violations at 3+ agent threshold
- New `session-compliance-report.sh` Stop hook reads violations and outputs summary report
- Version bumped to 0.30.7

Closes #265 (Phase 1)

## Changes
- `.claude/hooks/scripts/git-delegation-guard.sh`: Violation logging added
- `.claude/hooks/scripts/agent-teams-advisor.sh`: R018 threshold logging added
- `.claude/hooks/scripts/session-compliance-report.sh`: New stop hook script
- `.claude/hooks/hooks.json`: Registered new Stop hook
- `README.md`: Added `/structured-dev-cycle`, unified project structure ordering (from PR #263)
- `package.json` + `templates/manifest.json`: Version bump 0.30.6 → 0.30.7