### PR TITLE
fix: resolve README docs validation mismatches and enhance validator

### DIFF
--- a/.github/scripts/validate-docs.ts
+++ b/.github/scripts/validate-docs.ts
@@ -116,6 +116,50 @@ function extractNamesFromReadme(readme: string): { agents: string[]; skills: str
   return { agents, skills };
 }
 
+interface SkillTableResult {
+  skillNames: string[];
+  categoryCountSum: number;
+}
+
+/**
+ * Parses the Skills table from README.md between "### Skills" and "### Guides" headers.
+ * Each row format: | **Category Name** | N | skill-1, skill-2, skill-3 |
+ * Returns all individual skill names and the sum of all category counts.
+ */
+function extractSkillNamesFromTable(readme: string): SkillTableResult {
+  // Extract the Skills section: between "### Skills" and "### Guides"
+  const sectionMatch = readme.match(/###\s+Skills[^\n]*\n([\s\S]*?)(?=###\s+Guides)/);
+  if (!sectionMatch) {
+    return { skillNames: [], categoryCountSum: 0 };
+  }
+
+  const skillsSection = sectionMatch[1];
+  const skillNames: string[] = [];
+  let categoryCountSum = 0;
+
+  // Match table data rows: | **Category** | N | skill-1, skill-2, ... |
+  // Skip header row (contains "Category", "Count", "Skills") and separator row (contains dashes)
+  const tableRowRegex = /^\|\s*\*\*[^|]+\*\*\s*\|\s*(\d+)\s*\|\s*([^|]+)\s*\|/gm;
+  let rowMatch: RegExpExecArray | null;
+
+  while ((rowMatch = tableRowRegex.exec(skillsSection)) !== null) {
+    const count = parseInt(rowMatch[1], 10);
+    const skillsCell = rowMatch[2];
+
+    categoryCountSum += count;
+
+    // Parse comma-separated skill names, trimming whitespace
+    const names = skillsCell
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean);
+
+    skillNames.push(...names);
+  }
+
+  return { skillNames, categoryCountSum };
+}
+
 function programmaticValidation(stats: ImplementationStats, readmeEn: string): ValidationResult {
   const readme = extractNamesFromReadme(readmeEn);
 
@@ -153,6 +197,39 @@ function programmaticValidation(stats: ImplementationStats, readmeEn: string): V
     const readmeCount = parseInt(skillCountMatch[1] || skillCountMatch[2]);
     if (readmeCount !== stats.skill_count) {
       countMismatches.push({ field: 'skills', readme: readmeCount, actual: stats.skill_count });
+    }
+  }
+
+  // Second pass: skill-name-level comparison against README Skills table
+  const skillTable = extractSkillNamesFromTable(readmeEn);
+  if (skillTable.skillNames.length > 0) {
+    const templateSkillNames = stats.skill_names.map((s) => s.toLowerCase());
+    const tableSkillNamesSet = new Set(skillTable.skillNames);
+    const templateSkillNamesSet = new Set(templateSkillNames);
+
+    // Skills in templates but missing from README table rows
+    const missingTableSkills = templateSkillNames.filter((s) => !tableSkillNamesSet.has(s));
+    if (missingTableSkills.length > 0) {
+      missingFromReadme.skills.push(
+        ...missingTableSkills.filter((s) => !missingFromReadme.skills.includes(s)),
+      );
+    }
+
+    // Skills in README table but not in templates (phantom entries)
+    const phantomTableSkills = skillTable.skillNames.filter((s) => !templateSkillNamesSet.has(s));
+    if (phantomTableSkills.length > 0) {
+      extraInReadme.skills.push(
+        ...phantomTableSkills.filter((s) => !extraInReadme.skills.includes(s)),
+      );
+    }
+
+    // Check if category count sum matches actual skill count
+    if (skillTable.categoryCountSum !== stats.skill_count) {
+      countMismatches.push({
+        field: 'skills (table category sum)',
+        readme: skillTable.categoryCountSum,
+        actual: stats.skill_count,
+      });
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ Each sub-agent runs on an optimized model for its task type:
 Claude Code selects the appropriate model and parallelizes independent tasks (up to 4 concurrent sub-agents):
 
 ```
-/create-agent
+secretary-routing (routing skill)
   ├── mgr-creator:sonnet       — agent scaffolding
   └── mgr-supplier:haiku       — dependency check
 
-/code-review
+dev-lead-routing (routing skill)
   ├── lang-golang-expert:sonnet — Go implementation
   ├── lang-python-expert:sonnet — Python implementation
   └── qa-engineer:sonnet        — test generation
@@ -183,7 +183,7 @@ All commands are invoked inside the Claude Code conversation.
 | Category | Count | Skills |
 |----------|-------|--------|
 | **Routing** | 4 | secretary-routing, dev-lead-routing, de-lead-routing, qa-lead-routing |
-| **Best Practices** | 18 | go-best-practices, python-best-practices, typescript-best-practices, kotlin-best-practices, rust-best-practices, react-best-practices, fastapi-best-practices, springboot-best-practices, go-backend-best-practices, docker-best-practices, aws-best-practices, postgres-best-practices, supabase-postgres-best-practices, redis-best-practices, airflow-best-practices, dbt-best-practices, kafka-best-practices, snowflake-best-practices |
+| **Best Practices** | 19 | go-best-practices, python-best-practices, typescript-best-practices, kotlin-best-practices, rust-best-practices, react-best-practices, fastapi-best-practices, springboot-best-practices, go-backend-best-practices, docker-best-practices, aws-best-practices, postgres-best-practices, supabase-postgres-best-practices, redis-best-practices, airflow-best-practices, dbt-best-practices, kafka-best-practices, snowflake-best-practices, django-best-practices |
 | **Development** | 6 | dev-review, dev-refactor, create-agent, intent-detection, web-design-guidelines, analysis |
 | **Data Engineering** | 2 | spark-best-practices, pipeline-architecture-patterns |
 | **Optimization** | 3 | optimize-analyze, optimize-bundle, optimize-report |
@@ -203,8 +203,8 @@ Comprehensive reference documentation covering:
 - Agent creation and management
 - Skill development
 - Pipeline workflows
+- Multi-agent orchestration
 - Best practices and patterns
-- Sub-agent orchestration
 - Data engineering workflows
 - Database optimization
 
@@ -294,6 +294,8 @@ your-project/
 │   └── contexts/          # Context files (4 total)
 └── guides/                # Reference docs (23 total)
 ```
+
+> **Note**: In the official Claude Code format, there is no command registry — slash commands and natural language agent references are used instead.
 
 ---
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -183,7 +183,7 @@ dev-lead-routing (라우팅 스킬)
 | 카테고리 | 수 | 스킬 |
 |----------|-----|------|
 | **라우팅** | 4 | secretary-routing, dev-lead-routing, de-lead-routing, qa-lead-routing |
-| **베스트 프랙티스** | 18 | go-best-practices, python-best-practices, typescript-best-practices, kotlin-best-practices, rust-best-practices, react-best-practices, fastapi-best-practices, springboot-best-practices, go-backend-best-practices, docker-best-practices, aws-best-practices, postgres-best-practices, supabase-postgres-best-practices, redis-best-practices, airflow-best-practices, dbt-best-practices, kafka-best-practices, snowflake-best-practices |
+| **베스트 프랙티스** | 19 | go-best-practices, python-best-practices, typescript-best-practices, kotlin-best-practices, rust-best-practices, react-best-practices, fastapi-best-practices, springboot-best-practices, go-backend-best-practices, docker-best-practices, aws-best-practices, postgres-best-practices, supabase-postgres-best-practices, redis-best-practices, airflow-best-practices, dbt-best-practices, kafka-best-practices, snowflake-best-practices, django-best-practices |
 | **개발** | 6 | dev-review, dev-refactor, create-agent, intent-detection, web-design-guidelines, analysis |
 | **데이터 엔지니어링** | 2 | spark-best-practices, pipeline-architecture-patterns |
 | **최적화** | 3 | optimize-analyze, optimize-bundle, optimize-report |
@@ -274,7 +274,15 @@ your-project/
 ├── CLAUDE.md              # Claude 진입점
 ├── .claude/
 │   ├── agents/            # 에이전트 정의 (43개 플랫 .md 파일)
-│   ├── skills/            # 스킬 모듈 (67개 디렉토리)
+│   │   ├── lang-golang-expert.md
+│   │   ├── be-fastapi-expert.md
+│   │   ├── mgr-creator.md
+│   │   └── ...
+│   ├── skills/            # 스킬 모듈 (67개 디렉토리, 각 SKILL.md 포함)
+│   │   ├── go-best-practices/
+│   │   ├── react-best-practices/
+│   │   ├── secretary-routing/
+│   │   └── ...
 │   ├── ontology/          # RAG 컨텍스트용 온톨로지 지식 그래프
 │   │   ├── schema.yaml
 │   │   ├── agents.yaml


### PR DESCRIPTION
## Summary

- Add `django-best-practices` to the Best Practices row in both `README.md` and `README_ko.md` (18 → 19 skills listed)
- Align EN Sub-Agent example to the routing-skill pattern (remove phantom `/code-review` reference)
- Sync Guides table ordering and Project Structure detail between EN and KO READMEs
- Add `extractSkillNamesFromTable()` helper to `.github/scripts/validate-docs.ts` for skill-name-level validation in README tables

Closes #266

## Test plan

- [ ] Pre-commit hooks pass (TypeScript, Biome lint, Bun tests) — confirmed locally
- [ ] CI validate-docs job passes with the new `extractSkillNamesFromTable()` logic
- [ ] README Best Practices row shows 19 entries in both EN and KO
- [ ] No phantom skill references remain in Sub-Agent examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)