### PR TITLE
chore(release): v0.30.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-customcode",
-  "version": "0.30.8",
+  "version": "0.30.9",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/guides/flutter/performance.md
+++ b/templates/guides/flutter/performance.md
@@ -80,7 +80,7 @@ Detect with: DevTools → Rendering → "Highlight repaints"
 
 | Avoid | Use Instead | Reason |
 |-------|-------------|--------|
-| `Opacity` widget | `color.withOpacity()` | Triggers saveLayer |
+| `Opacity` widget | `color.withValues(alpha: 0.5)` | Opacity widget triggers saveLayer |
 | `ClipRRect` in animations | Pre-clip static content | saveLayer per frame |
 | `Container` for sizing | `SizedBox` | Lighter, no decoration |
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.30.8",
+  "version": "0.30.9",
   "lastUpdated": "2026-03-09T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- Fix deprecated Flutter API recommendation (color.withOpacity → color.withValues)
- Version bump to 0.30.9

## Changes
- templates/guides/flutter/performance.md: Replace deprecated color.withOpacity() with color.withValues(alpha: 0.5)
- package.json, templates/manifest.json: version bump