### PR TITLE
fix: Sprint 3 code quality — java21 refs, rule dedup, guides sync

### DIFF
--- a/.claude/agents/lang-java21-expert.md
+++ b/.claude/agents/lang-java21-expert.md
@@ -1,0 +1,48 @@
+---
+name: lang-java21-expert
+description: Expert Java 21 developer for modern Java with Virtual Threads, Pattern Matching, Record Patterns, and Sequenced Collections. Use for Java files (*.java, pom.xml, build.gradle), Java-related keywords, high-concurrency systems, data-centric APIs with Records, and migrating from older Java versions.
+model: sonnet
+memory: project
+effort: high
+skills:
+  - java21-best-practices
+tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+---
+
+You are an expert Java 21 developer for modern Java features including Virtual Threads, Pattern Matching, Record Patterns, and Sequenced Collections.
+
+## Capabilities
+
+- Modern Java 21 leveraging latest features
+- Virtual Threads (JEP 444) for scalable concurrency
+- Pattern Matching for switch and instanceof
+- Record Patterns (JEP 440), Sequenced Collections (JEP 431)
+- Google Java Style Guide compliance
+- Legacy Java migration to Java 21
+
+## Reference Documentation
+
+- https://docs.oracle.com/en/java/javase/21/
+- https://google.github.io/styleguide/javaguide.html
+
+## Skills
+
+Apply the **java21-best-practices** skill for core Java 21 development guidelines.
+
+## Reference Guides
+
+Consult the **java21** guide at `guides/java21/` for reference documentation from official Oracle and OpenJDK docs.
+
+## Workflow
+
+1. Understand requirements
+2. Apply java21-best-practices skill
+3. Reference java21 guide for specific patterns
+4. Write/review code with modern Java 21 features
+5. Ensure idiomatic use of Records, Sealed Classes, and Pattern Matching

--- a/.claude/rules/MUST-orchestrator-coordination.md
+++ b/.claude/rules/MUST-orchestrator-coordination.md
@@ -241,29 +241,11 @@ The skill's WORKFLOW is followed, but git EXECUTION is delegated to mgr-gitnerd 
 
 ## Agent Teams (MUST when enabled)
 
-When `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`: Agent Teams is **MANDATORY** for qualifying tasks per R018 (MUST-agent-teams.md).
+When `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`: Agent Teams is **MANDATORY** for qualifying tasks.
 
-### Architecture (Agent Teams enabled)
+See **R018 (MUST-agent-teams.md)** for the complete decision matrix, self-check, team patterns, and lifecycle.
 
-```
-Main Conversation (orchestrator)
-  ├─ Simple/independent tasks → Agent tool (R009)
-  └─ Collaborative/iterative tasks → Agent Teams (R018)
-      ├─ TeamCreate
-      ├─ TaskCreate (shared tasks)
-      ├─ Agent(spawn members)
-      └─ SendMessage(coordinate)
-```
-
-### When to Use Agent Teams vs Agent Tool
-
-| Criteria | Agent Tool | Agent Teams (MUST) |
-|----------|-----------|-------------------|
-| Agent count | 1-2 | 3+ |
-| Coordination needed | No | Yes |
-| Review/fix cycles | No | Yes |
-| Shared state | No | Yes |
-
+**Quick rule**: 3+ agents OR review cycle OR 2+ issues in same batch → Agent Teams (MUST).
 Using Agent tool when Agent Teams criteria are met is a **VIOLATION** of R018.
 
 ## Announcement Format

--- a/.claude/rules/MUST-parallel-execution.md
+++ b/.claude/rules/MUST-parallel-execution.md
@@ -20,22 +20,9 @@ Examples: creating multiple agents, reviewing multiple files, batch operations o
 > **WARNING**: Before spawning 2+ parallel agents, you MUST evaluate Agent Teams eligibility.
 > Skipping this check is a VIOLATION of both R009 and R018.
 >
+> **See R018 (MUST-agent-teams.md) for the complete self-check and decision matrix.**
+>
 > Quick rule: **3+ agents OR review cycle OR 2+ issues in same batch → Agent Teams (MUST)**
-
-Before spawning parallel Agent instances, evaluate Agent Teams eligibility:
-
-```
-2+ independent tasks detected
-  ↓
-Is Agent Teams available? (env or tools check)
-  ├─ NO → Proceed with Agent tool (standard R009)
-  └─ YES → Check eligibility:
-       ├─ 3+ agents needed? → Agent Teams (MUST)
-       ├─ Review → fix cycle? → Agent Teams (MUST)
-       └─ Neither → Agent tool (standard R009)
-```
-
-This gate is MANDATORY when Agent Teams is enabled. Skipping it is a violation of both R009 and R018.
 
 ## Self-Check
 
@@ -43,8 +30,7 @@ Before writing/editing multiple files:
 1. Are files independent? → YES: spawn parallel agents
 2. Using Write/Edit sequentially for 2+ files? → STOP, parallelize
 3. Specialized agent available? → Use it (not general-purpose)
-4. Agent Teams available + 3+ agents or review cycle? → YES: use Agent Teams instead of Agent tool
-5. Agent Teams members? → ALL members MUST spawn in a single message (no partial spawning)
+4. Agent Teams available? → **Check R018 criteria before spawning 2+ agents**
 
 ### Common Violations to Avoid
 
@@ -85,19 +71,9 @@ Before writing/editing multiple files:
    Agent(lang-kotlin-expert → usecase queries)     ├─ All spawned together
    Agent(be-springboot-expert → persistence)       │
    Agent(be-springboot-expert → security)          ┘
-
-❌ WRONG: Agent Teams partial spawn (1 of N members)
-   TeamCreate("feature-team")
-   Message 1: Agent(member-1)  ← only 1/3 spawned, VIOLATION
-   Message 2: Agent(member-2)  ← sequential, VIOLATION
-   Message 3: Agent(member-3)  ← sequential, VIOLATION
-
-✓ CORRECT: All Agent Teams members in single message
-   TeamCreate("feature-team")
-   Agent(member-1)  ┐
-   Agent(member-2)  ├─ Single message, all at once
-   Agent(member-3)  ┘
 ```
+
+> **Agent Teams partial spawn violations** → See R018 (MUST-agent-teams.md) "Spawn Completeness Check".
 
 ## Execution Rules
 

--- a/.claude/skills/java21-best-practices/SKILL.md
+++ b/.claude/skills/java21-best-practices/SKILL.md
@@ -1,0 +1,304 @@
+---
+name: java21-best-practices
+description: Modern Java 21 patterns from Virtual Threads, Pattern Matching, Records, and Sealed Classes
+user-invocable: false
+---
+
+## Purpose
+
+Apply modern Java 21 patterns and best practices leveraging the latest language features for clean, performant, and maintainable Java code.
+
+## Core Principles
+
+```
+Embrace modern Java features over legacy patterns
+Prefer immutability and data-centric design
+Leverage Virtual Threads for scalable concurrency
+Use Pattern Matching for expressive type handling
+```
+
+## Rules
+
+### 1. Naming Conventions (Google Java Style)
+
+```yaml
+packages:
+  style: lowercase, no underscores
+  example: com.example.project
+
+classes:
+  style: UpperCamelCase
+  example: OrderProcessor, UserRecord
+
+methods_variables:
+  style: lowerCamelCase
+  example: processOrder(), itemCount
+
+constants:
+  style: UPPER_SNAKE_CASE
+  example: static final int MAX_RETRIES = 3
+
+records:
+  style: UpperCamelCase (same as class)
+  example: record Point(int x, int y) {}
+```
+
+### 2. Virtual Threads (JEP 444)
+
+```yaml
+principles:
+  - Use Virtual Threads for I/O-bound tasks
+  - Avoid pooling Virtual Threads (they are lightweight)
+  - Replace thread pools for blocking I/O with Virtual Thread executors
+
+patterns: |
+  // Preferred: Virtual Thread executor
+  try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+      Future<String> result = executor.submit(() -> fetchFromDB());
+      System.out.println(result.get());
+  }
+
+  // Direct creation
+  Thread vThread = Thread.ofVirtual().start(() -> {
+      // blocking I/O is fine here
+      String data = callExternalApi();
+      process(data);
+  });
+
+  // With structured concurrency (JEP 453, preview)
+  try (var scope = new StructuredTaskScope.ShutdownOnFailure()) {
+      Future<String> user = scope.fork(() -> fetchUser(id));
+      Future<List<Order>> orders = scope.fork(() -> fetchOrders(id));
+      scope.join().throwIfFailed();
+      return new UserProfile(user.get(), orders.get());
+  }
+
+antipatterns:
+  - "Executors.newFixedThreadPool() for I/O tasks — use Virtual Threads instead"
+  - "Thread.sleep() on platform threads for rate limiting — use Virtual Threads"
+  - "synchronized blocks in Virtual Thread code — use ReentrantLock instead"
+```
+
+### 3. Pattern Matching
+
+```yaml
+instanceof_patterns: |
+  // Old style (avoid)
+  if (obj instanceof String) {
+      String s = (String) obj;
+      System.out.println(s.length());
+  }
+
+  // New style (prefer)
+  if (obj instanceof String s) {
+      System.out.println(s.length());
+  }
+
+  // With guard
+  if (obj instanceof String s && s.length() > 5) {
+      System.out.println("Long string: " + s);
+  }
+
+switch_patterns: |
+  // Pattern matching for switch (JEP 441)
+  String result = switch (obj) {
+      case Integer i -> "int " + i;
+      case String s  -> "str " + s;
+      case null      -> "null";
+      default        -> "other " + obj;
+  };
+
+  // With guards (when clause)
+  String label = switch (shape) {
+      case Circle c when c.radius() > 10 -> "large circle";
+      case Circle c                       -> "small circle";
+      case Rectangle r                    -> "rectangle";
+      default                             -> "unknown";
+  };
+```
+
+### 4. Records (JEP 395)
+
+```yaml
+principles:
+  - Use Records for immutable data carriers
+  - Prefer Records over POJOs with getters/setters for pure data
+  - Compact constructors for validation
+
+patterns: |
+  // Basic record
+  record Point(int x, int y) {}
+
+  // With validation (compact constructor)
+  record Range(int min, int max) {
+      Range {
+          if (min > max) throw new IllegalArgumentException(
+              "min %d > max %d".formatted(min, max));
+      }
+  }
+
+  // With custom methods
+  record Circle(double radius) {
+      double area() {
+          return Math.PI * radius * radius;
+      }
+  }
+
+  // Implementing interface
+  interface Shape { double area(); }
+  record Square(double side) implements Shape {
+      public double area() { return side * side; }
+  }
+
+antipatterns:
+  - "Mutable state in records — records are inherently immutable"
+  - "Using records for entities with behavior — prefer classes"
+```
+
+### 5. Record Patterns (JEP 440)
+
+```yaml
+patterns: |
+  // Deconstruct record in instanceof
+  if (obj instanceof Point(int x, int y)) {
+      System.out.println("x=" + x + ", y=" + y);
+  }
+
+  // In switch
+  String describe = switch (shape) {
+      case Circle(double r)        -> "circle r=" + r;
+      case Rectangle(double w, double h) -> "rect " + w + "x" + h;
+      default -> "unknown";
+  };
+
+  // Nested record patterns
+  record ColoredPoint(Point point, Color color) {}
+  if (obj instanceof ColoredPoint(Point(int x, int y), Color c)) {
+      System.out.println("colored point at " + x + "," + y);
+  }
+```
+
+### 6. Sealed Classes (JEP 409)
+
+```yaml
+principles:
+  - Use Sealed Classes for closed type hierarchies
+  - Combine with Pattern Matching switch for exhaustive handling
+  - Prefer sealed interfaces for behavior-focused hierarchies
+
+patterns: |
+  // Sealed interface with records
+  sealed interface Shape permits Circle, Rectangle, Triangle {}
+  record Circle(double radius) implements Shape {}
+  record Rectangle(double width, double height) implements Shape {}
+  record Triangle(double base, double height) implements Shape {}
+
+  // Exhaustive switch (no default needed)
+  double area = switch (shape) {
+      case Circle(double r)             -> Math.PI * r * r;
+      case Rectangle(double w, double h) -> w * h;
+      case Triangle(double b, double h)  -> 0.5 * b * h;
+  };
+```
+
+### 7. Sequenced Collections (JEP 431)
+
+```yaml
+principles:
+  - Use SequencedCollection for ordered access
+  - getFirst()/getLast() replace get(0) and get(size-1)
+
+patterns: |
+  // SequencedCollection methods
+  List<String> list = new ArrayList<>(List.of("a", "b", "c"));
+  String first = list.getFirst(); // "a"
+  String last  = list.getLast();  // "c"
+  list.addFirst("z");             // ["z", "a", "b", "c"]
+  list.addLast("end");            // ["z", "a", "b", "c", "end"]
+
+  // Reversed view
+  List<String> reversed = list.reversed();
+
+  // SequencedMap
+  SequencedMap<String, Integer> map = new LinkedHashMap<>();
+  map.put("one", 1);
+  map.put("two", 2);
+  Map.Entry<String, Integer> firstEntry = map.firstEntry(); // "one"=1
+```
+
+### 8. Text Blocks and String Features
+
+```yaml
+patterns: |
+  // Text blocks (since Java 15)
+  String json = """
+      {
+          "name": "Alice",
+          "age": 30
+      }
+      """;
+
+  // String.formatted() (since Java 15)
+  String msg = "Hello, %s! You are %d years old.".formatted(name, age);
+
+  // String templates (JEP 430, preview in Java 21)
+  // Prefer String.formatted() or MessageFormat for now
+```
+
+### 9. Error Handling
+
+```yaml
+principles:
+  - Prefer checked exceptions for recoverable conditions
+  - Use unchecked exceptions for programming errors
+  - Never swallow exceptions silently
+  - Use specific exception types
+
+patterns: |
+  // Specific exception type
+  public User findUser(long id) {
+      return userRepository.findById(id)
+          .orElseThrow(() -> new UserNotFoundException("User not found: " + id));
+  }
+
+  // Multi-catch
+  try {
+      process();
+  } catch (IOException | SQLException e) {
+      log.error("Data access failed", e);
+      throw new ServiceException("Processing failed", e);
+  }
+```
+
+### 10. Documentation
+
+```yaml
+format: |
+  /**
+   * Processes the given {@link Order} and returns a {@link Receipt}.
+   *
+   * @param order the order to process (must not be null)
+   * @return the generated receipt
+   * @throws OrderException if the order cannot be fulfilled
+   */
+  public Receipt processOrder(Order order) { }
+
+best_practices:
+  - Use @param and @return for public API
+  - Link related types with {@link}
+  - Document checked exceptions with @throws
+  - Keep Javadoc focused on "what", not "how"
+```
+
+## Application
+
+When writing or reviewing Java 21 code:
+
+1. **Use** Records for pure data classes over verbose POJOs
+2. **Use** Sealed Classes + Pattern Matching for type hierarchies
+3. **Use** Virtual Threads for I/O-bound concurrency
+4. **Use** `instanceof` pattern matching over explicit casts
+5. **Prefer** switch expressions over switch statements
+6. **Use** `getFirst()`/`getLast()` for sequenced collections
+7. **Write** exhaustive switch for sealed types (no default)
+8. **Document** public APIs with proper Javadoc

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,426 @@
+# Architecture
+
+> oh-my-customcode v0.30.9
+
+## 1. System Overview
+
+oh-my-customcode is a batteries-included agent harness for Claude Code. It ships 44 pre-built subagents, 68 skills, 18 governing rules, and a hook system — all wired together so that any Claude Code session inherits a complete multi-agent operating model without additional configuration. The core philosophy is: **"No expert? CREATE one, connect knowledge, and USE it."** When a task arrives with no matching specialist, the system auto-creates one by discovering relevant skills and guides, then immediately executes the task.
+
+Current version: **0.30.9** — distributed as `oh-my-customcode` on npm, CLI: `omcustom`.
+
+---
+
+## 2. High-Level Architecture
+
+```mermaid
+flowchart TD
+    User([User]) --> Orchestrator["Main Conversation\n(Orchestrator)"]
+
+    Orchestrator --> SR[secretary-routing]
+    Orchestrator --> DR[dev-lead-routing]
+    Orchestrator --> DE[de-lead-routing]
+    Orchestrator --> QA[qa-lead-routing]
+
+    SR --> MgrAgents["Manager Agents\nmgr-creator · mgr-gitnerd\nmgr-sauron · mgr-updater\nmgr-supplier · mgr-claude-code-bible"]
+    DR --> DevAgents["Language / Backend / Frontend\nTooling / DB / Infra / Arch"]
+    DE --> DEAgents["Data Engineering\nde-airflow · de-dbt · de-spark\nde-kafka · de-snowflake · de-pipeline"]
+    QA --> QAAgents["QA Team\nqa-planner · qa-writer · qa-engineer"]
+
+    Hooks["Hook System\nPreToolUse · PostToolUse\nSessionStart · Stop\nSubagentStart · SubagentStop"] -.->|cross-cutting| Orchestrator
+
+    Memory["Memory Layer\nNative auto-memory\nMCP: claude-mem · episodic-memory"] -.->|persistence| Orchestrator
+
+    style Orchestrator fill:#2d6a4f,color:#fff
+    style Hooks fill:#6d4c41,color:#fff
+    style Memory fill:#1a237e,color:#fff
+```
+
+---
+
+## 3. Component Inventory
+
+### 3.1 Rule System (R000–R018, no R014)
+
+| ID | Priority | Name | Description |
+|----|----------|------|-------------|
+| R000 | MUST | Language Policy | Korean I/O, English files, delegation model |
+| R001 | MUST | Safety Rules | Prohibited actions, destructive-op gates |
+| R002 | MUST | Permissions | Tool tier policy, file access scope |
+| R003 | SHOULD | Interaction Rules | Response principles, status format |
+| R004 | SHOULD | Error Handling | Error levels, recovery strategies |
+| R005 | MAY | Optimization | Efficiency, token optimization |
+| R006 | MUST | Agent Design | Agent file format, separation of concerns |
+| R007 | MUST | Agent Identification | Every response starts with agent header |
+| R008 | MUST | Tool Identification | Every tool call includes agent+model prefix |
+| R009 | MUST | Parallel Execution | 2+ independent tasks MUST run in parallel |
+| R010 | MUST | Orchestrator Coordination | Orchestrator never writes files directly |
+| R011 | SHOULD | Memory Integration | Native auto-memory + MCP supplementary |
+| R012 | SHOULD | HUD Statusline | Real-time session status display |
+| R013 | SHOULD | Ecomode | Task-type-aware context budget thresholds |
+| R015 | MUST | Intent Transparency | Display routing reasoning before execution |
+| R016 | MUST | Continuous Improvement | Rule violation → update rule → continue |
+| R017 | MUST | Sync Verification | 5+3 round verification before push |
+| R018 | MUST (conditional) | Agent Teams | Mandatory when CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 |
+
+### 3.2 Agent Taxonomy (44 agents)
+
+| Category | Count | Agents |
+|----------|-------|--------|
+| SW Engineer / Language | 6 | lang-golang-expert, lang-python-expert, lang-rust-expert, lang-kotlin-expert, lang-typescript-expert, lang-java21-expert |
+| SW Engineer / Backend | 6 | be-fastapi-expert, be-springboot-expert, be-go-backend-expert, be-express-expert, be-nestjs-expert, be-django-expert |
+| SW Engineer / Frontend | 4 | fe-vercel-agent, fe-vuejs-agent, fe-svelte-agent, fe-flutter-agent |
+| SW Engineer / Tooling | 3 | tool-npm-expert, tool-optimizer, tool-bun-expert |
+| Data Engineering | 6 | de-airflow-expert, de-dbt-expert, de-spark-expert, de-kafka-expert, de-snowflake-expert, de-pipeline-expert |
+| Database | 3 | db-supabase-expert, db-postgres-expert, db-redis-expert |
+| Security | 1 | sec-codeql-expert |
+| Architecture | 2 | arch-documenter, arch-speckit-agent |
+| Infrastructure | 2 | infra-docker-expert, infra-aws-expert |
+| QA | 3 | qa-planner, qa-writer, qa-engineer |
+| Manager | 6 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
+| System | 2 | sys-memory-keeper, sys-naggy |
+| **Total** | **44** | |
+
+### 3.3 Skill Catalog (68 skills)
+
+**Routing skills (4, context: fork)**
+
+| Skill | Routes To |
+|-------|-----------|
+| secretary-routing | mgr-* and sys-* agents |
+| dev-lead-routing | lang-*, be-*, fe-*, tool-*, db-*, arch-*, infra-* agents |
+| de-lead-routing | de-* agents |
+| qa-lead-routing | qa-* agents |
+
+**Workflow/orchestration skills (5, context: fork)**
+
+dag-orchestration, task-decomposition, worker-reviewer-pipeline, pipeline-guards, structured-dev-cycle
+
+**Best-practices skills (~25)**
+
+go-best-practices, go-backend-best-practices, python-best-practices, rust-best-practices, kotlin-best-practices, typescript-best-practices, react-best-practices, web-design-guidelines, fastapi-best-practices, springboot-best-practices, django-best-practices, flutter-best-practices, docker-best-practices, aws-best-practices, postgres-best-practices, supabase-postgres-best-practices, redis-best-practices, kafka-best-practices, dbt-best-practices, spark-best-practices, snowflake-best-practices, airflow-best-practices, pipeline-architecture-patterns, vercel-deploy, writing-clearly-and-concisely
+
+**Slash command / user-invocable skills**
+
+analysis, create-agent, update-docs, update-external, audit-agents, fix-refs, dev-review, dev-refactor, memory-save, memory-recall, monitoring-setup, npm-publish, npm-version, npm-audit, codex-exec, optimize-analyze, optimize-bundle, optimize-report, research, sauron-watch, structured-dev-cycle, lists, status, help
+
+**System / internal skills**
+
+intent-detection, model-escalation, stuck-recovery, result-aggregation, multi-model-verification, pr-auto-improve, memory-management, claude-code-bible, cve-triage, jinja2-prompts, skills-sh-search
+
+### 3.4 Guide Library (24 topics)
+
+| Category | Guides |
+|----------|--------|
+| Internal | claude-code |
+| Language | golang, python, rust, kotlin, typescript |
+| Frontend | flutter, web-design |
+| Backend | fastapi, springboot, go-backend, django-best-practices |
+| Infrastructure | docker, aws |
+| Data Engineering | airflow, dbt, kafka, spark, snowflake, iceberg |
+| Database | supabase-postgres, postgres, redis |
+| Writing | elements-of-style |
+
+### 3.5 Hook System
+
+| Event | Scripts / Handlers | Purpose |
+|-------|--------------------|---------|
+| SessionStart | session-env-check.sh | Detect codex CLI + Agent Teams availability |
+| PreToolUse (Write/Edit) | stage-blocker.sh | Block writes outside implement stage |
+| PreToolUse (Bash dev server) | inline script | Force dev servers into tmux |
+| PreToolUse (Agent/Task) | HUD display, git-delegation-guard.sh, agent-teams-advisor.sh, model-escalation-advisor.sh | Spawn display, R010 enforcement, R018 advisory, escalation advisory |
+| PostToolUse (Edit TS/JS) | prettier, tsc, console.log detector | Auto-format + type-check JS/TS |
+| PostToolUse (Edit Go) | gofmt | Auto-format Go files |
+| PostToolUse (Edit Py) | ruff, ty | Auto-format + type-check Python |
+| PostToolUse (Bash) | PR URL logger | Log PR URL after `gh pr create` |
+| PostToolUse (Agent/Task) | task-outcome-recorder.sh | Record outcomes for model escalation |
+| PostToolUse (any tool) | context-budget-advisor.sh, stuck-detector.sh | Ecomode advisory, loop detection |
+| SubagentStart | HUD inline display | Log agent type:model when subagent starts |
+| SubagentStop | task-outcome-recorder.sh | Record final outcome |
+| Stop | stop-console-audit.sh, session-compliance-report.sh, R011 prompt | Final audit, compliance report, memory checkpoint |
+
+---
+
+## 4. Orchestration Pattern
+
+### 4.1 Singleton Orchestrator (R010)
+
+The main conversation is the **sole orchestrator**. It coordinates via routing skills and the Agent tool. It NEVER writes or edits files directly — all file mutations are delegated to subagents.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant O as Orchestrator
+    participant RS as Routing Skill
+    participant SA as Subagent
+
+    U->>O: Request
+    O->>RS: Detect intent (R015)
+    RS-->>O: Selected agent + confidence
+    O->>SA: Spawn via Agent tool (R009)
+    SA->>SA: Execute (Read/Write/Edit/Bash)
+    SA-->>O: Result
+    O-->>U: Response
+```
+
+### 4.2 Routing Architecture
+
+```mermaid
+flowchart LR
+    O[Orchestrator] --> SR[secretary-routing]
+    O --> DR[dev-lead-routing]
+    O --> DE[de-lead-routing]
+    O --> QA[qa-lead-routing]
+
+    SR --> mgr-creator
+    SR --> mgr-updater
+    SR --> mgr-supplier
+    SR --> mgr-gitnerd
+    SR --> mgr-sauron
+    SR --> mgr-claude-code-bible
+    SR --> sys-memory-keeper
+    SR --> sys-naggy
+
+    DR --> lang["lang-golang-expert\nlang-python-expert\nlang-rust-expert\nlang-kotlin-expert\nlang-typescript-expert\nlang-java21-expert"]
+    DR --> be["be-fastapi-expert\nbe-springboot-expert\nbe-go-backend-expert\nbe-express-expert\nbe-nestjs-expert\nbe-django-expert"]
+    DR --> fe["fe-vercel-agent\nfe-vuejs-agent\nfe-svelte-agent\nfe-flutter-agent"]
+    DR --> infra["infra-docker-expert\ninfra-aws-expert\ndb-supabase-expert\ndb-postgres-expert\ndb-redis-expert"]
+
+    DE --> de["de-airflow-expert\nde-dbt-expert\nde-spark-expert\nde-kafka-expert\nde-snowflake-expert\nde-pipeline-expert"]
+
+    QA --> qa["qa-planner\nqa-writer\nqa-engineer"]
+```
+
+### 4.3 Dynamic Agent Creation
+
+When routing detects no matching specialist:
+
+```mermaid
+flowchart TD
+    A[Routing detects no match] --> B{Specialized task?}
+    B -- Yes --> C[Delegate to mgr-creator]
+    B -- No --> D[Use general-purpose]
+    C --> E[Auto-discover .claude/skills/ + guides/]
+    E --> F[Create .claude/agents/name.md]
+    F --> G[Orchestrator uses new agent for original task]
+    G --> H[Agent persisted for future reuse]
+```
+
+### 4.4 Intent Detection
+
+Intent is scored before routing is executed (R015):
+
+| Factor | Weight |
+|--------|--------|
+| Keywords | 40% |
+| File patterns | 30% |
+| Action verbs | 20% |
+| Context (prior agent, cwd) | 10% |
+
+| Confidence | Action |
+|------------|--------|
+| >= 90% | Auto-execute, display intent block |
+| 70–89% | Request confirmation, show alternatives |
+| < 70% | List options for user to choose |
+
+---
+
+## 5. Execution Patterns
+
+### 5.1 Parallel Execution (R009)
+
+Two or more independent tasks MUST run in parallel (max 4 concurrent). Sequential execution of parallelizable tasks is a rule violation.
+
+```
+Agent(task-1):sonnet   ┐
+Agent(task-2):sonnet   ├─ Single message — all spawned together
+Agent(task-3):haiku    │
+Agent(task-4):haiku    ┘
+```
+
+Large tasks exceeding 3 minutes MUST be split into parallel sub-tasks. Before spawning 2+ agents, Agent Teams eligibility must be evaluated (see 5.2).
+
+### 5.2 Agent Teams (R018, conditional)
+
+Active when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`. When enabled and criteria are met, use is MANDATORY.
+
+| Criteria | Agent Tool | Agent Teams (MUST) |
+|----------|-----------|-------------------|
+| 1–2 agents, independent | Yes | |
+| 3+ agents | | Yes |
+| Review → fix → re-review cycle | | Yes |
+| Shared state / coordination needed | | Yes |
+| Cost-sensitive batch ops | Yes | |
+
+Lifecycle: `TeamCreate → TaskCreate → Agent(spawn all members in one message) → SendMessage → TaskUpdate → TeamDelete`
+
+### 5.3 Research Pattern (/research)
+
+10 research teams across 5 domains, executed in 3 batches per R009:
+
+```
+Batch 1: T1(Arch·breadth), T2(Arch·depth), T3(Sec·breadth), T4(Sec·depth)
+Batch 2: T5(Intg·breadth), T6(Intg·depth), T7(Comp·breadth), T8(Comp·depth)
+Batch 3: T9(Innov·breadth), T10(Innov·depth)
+
+Phase 2: Cross-verification (2–5 rounds, opus + codex-exec)
+Phase 3: Synthesis (opus) → ADOPT / ADAPT / AVOID taxonomy
+Phase 4: Structured report + GitHub issue
+```
+
+---
+
+## 6. Memory Architecture
+
+### 6.1 Native Auto-Memory
+
+Enabled by `memory:` field in agent frontmatter. The system creates a memory directory and injects the first 200 lines of `MEMORY.md` into the agent's system prompt.
+
+| Scope | Location | Git Tracked |
+|-------|----------|-------------|
+| `user` | `~/.claude/agent-memory/<name>/` | No |
+| `project` | `.claude/agent-memory/<name>/` | Yes |
+| `local` | `.claude/agent-memory-local/<name>/` | No |
+
+Memory entries carry confidence annotations (`[confidence: low/medium/high]`). New discoveries start at `low`; user confirmation or cross-session verification promotes them.
+
+### 6.2 MCP Memory (Supplementary)
+
+MCP tools are orchestrator-scoped — subagents cannot access them.
+
+| System | Tool | Use Case |
+|--------|------|----------|
+| claude-mem | `mcp__plugin_claude-mem_mcp-search__save_memory` | Cross-session search, temporal queries |
+| episodic-memory | `mcp__plugin_episodic-memory_episodic-memory__search` | Session indexing for future retrieval |
+
+Use native auto-memory first. Fall back to MCP only for cross-session search or temporal queries.
+
+### 6.3 Session-End Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant O as Orchestrator
+    participant SMK as sys-memory-keeper
+    participant MCP as MCP (claude-mem / episodic)
+
+    U->>O: Session end signal
+    O->>SMK: Delegate: update MEMORY.md
+    SMK-->>O: Native memory updated
+    O->>MCP: Save session summary (best-effort)
+    O->>MCP: Verify episodic index (best-effort)
+    O-->>U: Session saved confirmation
+```
+
+MCP saves are non-blocking — failure does not prevent session end.
+
+---
+
+## 7. CI/CD Pipeline
+
+```mermaid
+flowchart LR
+    develop --> PR[Pull Request]
+    PR --> ci["ci.yml\nbuild · test · lint\ntypecheck · coverage"]
+    ci --> develop
+
+    develop --> rel["release/* branch"]
+    rel --> tag["git tag v*"]
+    tag --> release["release.yml\nnpm publish\nGitHub Packages"]
+
+    subgraph Side Workflows
+        docs-validator
+        docs-sync
+        security-audit
+        notify-teammates
+        release-notes
+    end
+```
+
+### 7.1 Quality Gates
+
+| Gate | Tool / Script | Threshold |
+|------|---------------|-----------|
+| Code coverage | bun test --coverage | 97% |
+| Version sync | manifest.json ↔ package.json | Exact match |
+| Docs validation | validate-docs.ts | README count consistency |
+| Sauron verification | mgr-sauron (R017) | All 5+3 rounds pass |
+| TypeScript | tsc --noEmit | Zero errors |
+| Lint | biome check | Zero errors |
+
+---
+
+## 8. Distribution Model
+
+### 8.1 npm Package
+
+```
+Package: oh-my-customcode
+CLI:     omcustom
+Registry: registry.npmjs.org (public)
+
+Exports:
+  dist/         — compiled CLI + library
+  templates/    — .claude/ directory structure for target projects
+```
+
+Runtime deps: commander, i18next, yaml. Build/runtime: bun. Node >=18 required.
+
+npm publish is triggered only by the CI/CD pipeline on `release/*` branches — never run locally.
+
+### 8.2 Template System
+
+`templates/` mirrors `.claude/` so that `omcustom` can scaffold agent systems into any project. `manifest.json` declares counts of agents, skills, hooks, contexts, and guides; CI enforces these counts match the filesystem.
+
+---
+
+## 9. Claude Code Compatibility
+
+| Feature | < v2.1.63 | >= v2.1.63 | oh-my-customcode |
+|---------|-----------|-----------|------------------|
+| Subagent tool name | Task | Agent | Dual support (Agent/Task) |
+| subagent_type field | Yes | Yes (unchanged) | Yes |
+| Hook matcher | `tool == "Task"` | `tool == "Agent"` | `tool == "Task" \|\| tool == "Agent"` |
+| SubagentStart event | No | Yes | Yes (v0.23.0+) |
+| SubagentStop event | No | Yes | Yes (v0.23.0+) |
+| Agent Teams | No | Yes (experimental) | Yes, enforced by R018 when enabled |
+
+---
+
+## 10. Context Budget
+
+| Item | Approximate Size |
+|------|-----------------|
+| CLAUDE.md | ~5K tokens |
+| Rules (18 files) | ~25K tokens |
+| Total mandatory load | ~30K tokens / session |
+
+Skills and guides are loaded on-demand when invoked — not pre-loaded.
+
+**Ecomode (R013)** auto-activates based on task type and context usage:
+
+| Task Type | Context Trigger |
+|-----------|----------------|
+| Research (/research, 10-team) | 40% |
+| Implementation (code generation) | 50% |
+| Review (code review, audit) | 60% |
+| Management (git, deploy, CI) | 70% |
+| General (default) | 80% |
+
+The `context-budget-advisor.sh` PostToolUse hook monitors usage and emits advisory warnings as thresholds are approached.
+
+---
+
+## 11. Glossary
+
+| Term | Definition |
+|------|-----------|
+| Orchestrator | The main Claude Code conversation; the sole coordinator. Never writes files. |
+| Subagent | An isolated agent instance spawned by the orchestrator via the Agent tool. |
+| Routing skill | A `context: fork` skill that maps user intent to the correct specialist agent. |
+| Agent Teams | Claude Code experimental feature (R018) enabling peer-to-peer agent messaging via TeamCreate/SendMessage. |
+| Hook | A script bound to a Claude Code lifecycle event (PreToolUse, PostToolUse, etc.) in hooks.json. |
+| Native auto-memory | The `memory:` frontmatter field that injects MEMORY.md into an agent's context each session. |
+| Dynamic creation | The fallback pattern where mgr-creator auto-builds a new specialist when no existing agent matches. |
+| Ecomode | Compact output mode that activates automatically when context usage exceeds task-type thresholds. |
+| context: fork | A SKILL.md frontmatter flag that runs the skill in an isolated context — used for routing and orchestration skills. |
+| R017 (Sauron) | The 5-round manager + 3-round deep-review verification cycle required before any structural push. |

--- a/ARCHITECTURE_ko.md
+++ b/ARCHITECTURE_ko.md
@@ -1,0 +1,426 @@
+# 아키텍처
+
+> oh-my-customcode v0.30.9
+
+## 1. 시스템 개요
+
+oh-my-customcode는 Claude Code를 위한 배터리 포함형 에이전트 하네스입니다. 44개의 사전 구축된 서브에이전트, 68개의 스킬, 18개의 거버넌스 규칙, 훅 시스템이 모두 연결되어 있어 추가 설정 없이 Claude Code 세션에 완전한 멀티 에이전트 운영 모델이 적용됩니다. 핵심 철학: **"전문가가 없으면? 만들고, 지식을 연결하고, 사용한다."** 매칭되는 전문가가 없는 작업이 들어오면 시스템이 자동으로 관련 스킬과 가이드를 탐색하여 새 에이전트를 생성한 뒤 즉시 작업을 실행합니다.
+
+현재 버전: **0.30.9** — npm 패키지명 `oh-my-customcode`, CLI: `omcustom`
+
+---
+
+## 2. 고수준 아키텍처
+
+```mermaid
+flowchart TD
+    User([사용자]) --> Orchestrator["메인 대화\n(오케스트레이터)"]
+
+    Orchestrator --> SR[secretary-routing]
+    Orchestrator --> DR[dev-lead-routing]
+    Orchestrator --> DE[de-lead-routing]
+    Orchestrator --> QA[qa-lead-routing]
+
+    SR --> MgrAgents["매니저 에이전트\nmgr-creator · mgr-gitnerd\nmgr-sauron · mgr-updater\nmgr-supplier · mgr-claude-code-bible"]
+    DR --> DevAgents["언어 / 백엔드 / 프론트엔드\n툴링 / DB / 인프라 / 아키텍처"]
+    DE --> DEAgents["데이터 엔지니어링\nde-airflow · de-dbt · de-spark\nde-kafka · de-snowflake · de-pipeline"]
+    QA --> QAAgents["QA 팀\nqa-planner · qa-writer · qa-engineer"]
+
+    Hooks["훅 시스템\nPreToolUse · PostToolUse\nSessionStart · Stop\nSubagentStart · SubagentStop"] -.->|횡단 관심사| Orchestrator
+
+    Memory["메모리 레이어\n네이티브 자동 메모리\nMCP: claude-mem · episodic-memory"] -.->|영속성| Orchestrator
+
+    style Orchestrator fill:#2d6a4f,color:#fff
+    style Hooks fill:#6d4c41,color:#fff
+    style Memory fill:#1a237e,color:#fff
+```
+
+---
+
+## 3. 컴포넌트 인벤토리
+
+### 3.1 규칙 시스템 (R000–R018, R014 없음)
+
+| ID | 우선순위 | 이름 | 설명 |
+|----|----------|------|------|
+| R000 | MUST | 언어 정책 | 한국어 I/O, 영어 파일, 위임 모델 |
+| R001 | MUST | 안전 규칙 | 금지 행위, 파괴적 작업 승인 게이트 |
+| R002 | MUST | 권한 규칙 | 도구 티어 정책, 파일 접근 범위 |
+| R003 | SHOULD | 상호작용 규칙 | 응답 원칙, 상태 포맷 |
+| R004 | SHOULD | 오류 처리 | 오류 등급, 복구 전략 |
+| R005 | MAY | 최적화 | 효율성, 토큰 최적화 |
+| R006 | MUST | 에이전트 설계 | 에이전트 파일 포맷, 관심사 분리 |
+| R007 | MUST | 에이전트 식별 | 모든 응답은 에이전트 헤더로 시작 |
+| R008 | MUST | 도구 식별 | 모든 도구 호출에 에이전트+모델 접두사 포함 |
+| R009 | MUST | 병렬 실행 | 독립 작업 2개 이상은 반드시 병렬 실행 |
+| R010 | MUST | 오케스트레이터 조율 | 오케스트레이터는 절대 파일을 직접 작성하지 않음 |
+| R011 | SHOULD | 메모리 통합 | 네이티브 자동 메모리 + MCP 보조 |
+| R012 | SHOULD | HUD 상태줄 | 실시간 세션 상태 표시 |
+| R013 | SHOULD | Ecomode | 작업 유형별 컨텍스트 예산 임계값 |
+| R015 | MUST | 의도 투명성 | 라우팅 실행 전 reasoning 표시 |
+| R016 | MUST | 지속적 개선 | 규칙 위반 시 → 규칙 업데이트 → 계속 |
+| R017 | MUST | 동기화 검증 | 푸시 전 5+3 라운드 검증 |
+| R018 | MUST (조건부) | Agent Teams | CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 시 필수 |
+
+### 3.2 에이전트 분류 (44개)
+
+| 카테고리 | 수량 | 에이전트 |
+|----------|------|----------|
+| SW Engineer / 언어 | 6 | lang-golang-expert, lang-python-expert, lang-rust-expert, lang-kotlin-expert, lang-typescript-expert, lang-java21-expert |
+| SW Engineer / 백엔드 | 6 | be-fastapi-expert, be-springboot-expert, be-go-backend-expert, be-express-expert, be-nestjs-expert, be-django-expert |
+| SW Engineer / 프론트엔드 | 4 | fe-vercel-agent, fe-vuejs-agent, fe-svelte-agent, fe-flutter-agent |
+| SW Engineer / 툴링 | 3 | tool-npm-expert, tool-optimizer, tool-bun-expert |
+| 데이터 엔지니어링 | 6 | de-airflow-expert, de-dbt-expert, de-spark-expert, de-kafka-expert, de-snowflake-expert, de-pipeline-expert |
+| 데이터베이스 | 3 | db-supabase-expert, db-postgres-expert, db-redis-expert |
+| 보안 | 1 | sec-codeql-expert |
+| 아키텍처 | 2 | arch-documenter, arch-speckit-agent |
+| 인프라 | 2 | infra-docker-expert, infra-aws-expert |
+| QA | 3 | qa-planner, qa-writer, qa-engineer |
+| 매니저 | 6 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
+| 시스템 | 2 | sys-memory-keeper, sys-naggy |
+| **합계** | **44** | |
+
+### 3.3 스킬 카탈로그 (68개)
+
+**라우팅 스킬 (4개, context: fork)**
+
+| 스킬 | 라우팅 대상 |
+|------|------------|
+| secretary-routing | mgr-* 및 sys-* 에이전트 |
+| dev-lead-routing | lang-*, be-*, fe-*, tool-*, db-*, arch-*, infra-* 에이전트 |
+| de-lead-routing | de-* 에이전트 |
+| qa-lead-routing | qa-* 에이전트 |
+
+**워크플로우/오케스트레이션 스킬 (5개, context: fork)**
+
+dag-orchestration, task-decomposition, worker-reviewer-pipeline, pipeline-guards, structured-dev-cycle
+
+**베스트 프랙티스 스킬 (~25개)**
+
+go-best-practices, go-backend-best-practices, python-best-practices, rust-best-practices, kotlin-best-practices, typescript-best-practices, react-best-practices, web-design-guidelines, fastapi-best-practices, springboot-best-practices, django-best-practices, flutter-best-practices, docker-best-practices, aws-best-practices, postgres-best-practices, supabase-postgres-best-practices, redis-best-practices, kafka-best-practices, dbt-best-practices, spark-best-practices, snowflake-best-practices, airflow-best-practices, pipeline-architecture-patterns, vercel-deploy, writing-clearly-and-concisely
+
+**슬래시 커맨드 / 사용자 직접 호출 스킬**
+
+analysis, create-agent, update-docs, update-external, audit-agents, fix-refs, dev-review, dev-refactor, memory-save, memory-recall, monitoring-setup, npm-publish, npm-version, npm-audit, codex-exec, optimize-analyze, optimize-bundle, optimize-report, research, sauron-watch, structured-dev-cycle, lists, status, help
+
+**시스템 / 내부 스킬**
+
+intent-detection, model-escalation, stuck-recovery, result-aggregation, multi-model-verification, pr-auto-improve, memory-management, claude-code-bible, cve-triage, jinja2-prompts, skills-sh-search
+
+### 3.4 가이드 라이브러리 (24개 토픽)
+
+| 카테고리 | 가이드 |
+|----------|--------|
+| 내부 | claude-code |
+| 언어 | golang, python, rust, kotlin, typescript |
+| 프론트엔드 | flutter, web-design |
+| 백엔드 | fastapi, springboot, go-backend, django-best-practices |
+| 인프라 | docker, aws |
+| 데이터 엔지니어링 | airflow, dbt, kafka, spark, snowflake, iceberg |
+| 데이터베이스 | supabase-postgres, postgres, redis |
+| 글쓰기 | elements-of-style |
+
+### 3.5 훅 시스템
+
+| 이벤트 | 스크립트 / 핸들러 | 목적 |
+|--------|------------------|------|
+| SessionStart | session-env-check.sh | codex CLI + Agent Teams 가용성 감지 |
+| PreToolUse (Write/Edit) | stage-blocker.sh | implement 단계 외 쓰기 차단 |
+| PreToolUse (Bash dev server) | 인라인 스크립트 | dev 서버를 tmux로 강제 |
+| PreToolUse (Agent/Task) | HUD 표시, git-delegation-guard.sh, agent-teams-advisor.sh, model-escalation-advisor.sh | 스폰 표시, R010 강제, R018 어드바이저리, 에스컬레이션 어드바이저리 |
+| PostToolUse (Edit TS/JS) | prettier, tsc, console.log 탐지 | JS/TS 자동 포맷 + 타입 체크 |
+| PostToolUse (Edit Go) | gofmt | Go 파일 자동 포맷 |
+| PostToolUse (Edit Py) | ruff, ty | Python 자동 포맷 + 타입 체크 |
+| PostToolUse (Bash) | PR URL 로거 | `gh pr create` 후 PR URL 기록 |
+| PostToolUse (Agent/Task) | task-outcome-recorder.sh | 모델 에스컬레이션 결과 기록 |
+| PostToolUse (모든 도구) | context-budget-advisor.sh, stuck-detector.sh | Ecomode 어드바이저리, 반복 루프 감지 |
+| SubagentStart | HUD 인라인 표시 | 서브에이전트 시작 시 agent type:model 로그 |
+| SubagentStop | task-outcome-recorder.sh | 최종 결과 기록 |
+| Stop | stop-console-audit.sh, session-compliance-report.sh, R011 프롬프트 | 최종 감사, 컴플라이언스 리포트, 메모리 체크포인트 |
+
+---
+
+## 4. 오케스트레이션 패턴
+
+### 4.1 싱글톤 오케스트레이터 (R010)
+
+메인 대화가 **유일한 오케스트레이터**입니다. 라우팅 스킬과 Agent 도구를 통해 조율하며, **절대 직접 파일을 작성하거나 편집하지 않습니다** — 모든 파일 변경은 서브에이전트에 위임됩니다.
+
+```mermaid
+sequenceDiagram
+    participant U as 사용자
+    participant O as 오케스트레이터
+    participant RS as 라우팅 스킬
+    participant SA as 서브에이전트
+
+    U->>O: 요청
+    O->>RS: 의도 감지 (R015)
+    RS-->>O: 선택된 에이전트 + 신뢰도
+    O->>SA: Agent 도구로 스폰 (R009)
+    SA->>SA: 실행 (Read/Write/Edit/Bash)
+    SA-->>O: 결과
+    O-->>U: 응답
+```
+
+### 4.2 라우팅 아키텍처
+
+```mermaid
+flowchart LR
+    O[오케스트레이터] --> SR[secretary-routing]
+    O --> DR[dev-lead-routing]
+    O --> DE[de-lead-routing]
+    O --> QA[qa-lead-routing]
+
+    SR --> mgr-creator
+    SR --> mgr-updater
+    SR --> mgr-supplier
+    SR --> mgr-gitnerd
+    SR --> mgr-sauron
+    SR --> mgr-claude-code-bible
+    SR --> sys-memory-keeper
+    SR --> sys-naggy
+
+    DR --> lang["lang-golang-expert\nlang-python-expert\nlang-rust-expert\nlang-kotlin-expert\nlang-typescript-expert\nlang-java21-expert"]
+    DR --> be["be-fastapi-expert\nbe-springboot-expert\nbe-go-backend-expert\nbe-express-expert\nbe-nestjs-expert\nbe-django-expert"]
+    DR --> fe["fe-vercel-agent\nfe-vuejs-agent\nfe-svelte-agent\nfe-flutter-agent"]
+    DR --> infra["infra-docker-expert\ninfra-aws-expert\ndb-supabase-expert\ndb-postgres-expert\ndb-redis-expert"]
+
+    DE --> de["de-airflow-expert\nde-dbt-expert\nde-spark-expert\nde-kafka-expert\nde-snowflake-expert\nde-pipeline-expert"]
+
+    QA --> qa["qa-planner\nqa-writer\nqa-engineer"]
+```
+
+### 4.3 동적 에이전트 생성
+
+라우팅에서 매칭되는 전문가를 찾지 못할 경우:
+
+```mermaid
+flowchart TD
+    A[라우팅: 매치 없음] --> B{전문화된 작업?}
+    B -- 예 --> C[mgr-creator에 위임]
+    B -- 아니오 --> D[general-purpose 사용]
+    C --> E[.claude/skills/ + guides/ 자동 탐색]
+    E --> F[.claude/agents/name.md 생성]
+    F --> G[오케스트레이터가 새 에이전트로 원래 작업 실행]
+    G --> H[에이전트 영속 저장 — 이후 재사용 가능]
+```
+
+### 4.4 의도 감지
+
+라우팅 실행 전 의도 점수가 산출됩니다 (R015):
+
+| 요소 | 가중치 |
+|------|--------|
+| 키워드 | 40% |
+| 파일 패턴 | 30% |
+| 동작 동사 | 20% |
+| 컨텍스트 (이전 에이전트, 작업 디렉토리) | 10% |
+
+| 신뢰도 | 동작 |
+|--------|------|
+| >= 90% | 자동 실행, 의도 블록 표시 |
+| 70–89% | 확인 요청, 대안 표시 |
+| < 70% | 사용자가 선택할 수 있는 옵션 목록 표시 |
+
+---
+
+## 5. 실행 패턴
+
+### 5.1 병렬 실행 (R009)
+
+독립적인 작업이 2개 이상이면 반드시 병렬 실행합니다 (최대 4개 동시). 병렬 가능한 작업을 순차 실행하는 것은 규칙 위반입니다.
+
+```
+Agent(task-1):sonnet   ┐
+Agent(task-2):sonnet   ├─ 단일 메시지 — 모두 동시에 스폰
+Agent(task-3):haiku    │
+Agent(task-4):haiku    ┘
+```
+
+3분을 초과하는 대형 작업은 반드시 병렬 서브 태스크로 분할합니다. 에이전트 2개 이상 스폰 전에 Agent Teams 적격성을 평가해야 합니다 (5.2 참조).
+
+### 5.2 Agent Teams (R018, 조건부)
+
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` 설정 시 활성화됩니다. 활성화 상태에서 기준을 충족하면 사용이 **의무**입니다.
+
+| 기준 | Agent 도구 | Agent Teams (MUST) |
+|------|-----------|-------------------|
+| 1–2개 에이전트, 독립적 | 예 | |
+| 3개 이상 에이전트 | | 예 |
+| 리뷰 → 수정 → 재리뷰 사이클 | | 예 |
+| 공유 상태 / 에이전트 간 조율 필요 | | 예 |
+| 비용 민감 배치 작업 | 예 | |
+
+라이프사이클: `TeamCreate → TaskCreate → Agent(모든 멤버를 한 메시지에 스폰) → SendMessage → TaskUpdate → TeamDelete`
+
+### 5.3 리서치 패턴 (/research)
+
+5개 도메인에 걸친 10개 리서치 팀, R009에 따라 3개 배치로 실행:
+
+```
+배치 1: T1(아키텍처·광역), T2(아키텍처·심층), T3(보안·광역), T4(보안·심층)
+배치 2: T5(통합·광역), T6(통합·심층), T7(비교·광역), T8(비교·심층)
+배치 3: T9(혁신·광역), T10(혁신·심층)
+
+Phase 2: 교차 검증 (2–5 라운드, opus + codex-exec)
+Phase 3: 종합 (opus) → ADOPT / ADAPT / AVOID 분류
+Phase 4: 구조화된 리포트 + GitHub 이슈 생성
+```
+
+---
+
+## 6. 메모리 아키텍처
+
+### 6.1 네이티브 자동 메모리
+
+에이전트 프론트매터의 `memory:` 필드로 활성화됩니다. 시스템이 메모리 디렉토리를 생성하고 `MEMORY.md`의 앞 200줄을 에이전트 시스템 프롬프트에 주입합니다.
+
+| 스코프 | 위치 | Git 추적 |
+|--------|------|----------|
+| `user` | `~/.claude/agent-memory/<name>/` | 아니오 |
+| `project` | `.claude/agent-memory/<name>/` | 예 |
+| `local` | `.claude/agent-memory-local/<name>/` | 아니오 |
+
+메모리 항목에는 신뢰도 어노테이션(`[confidence: low/medium/high]`)이 포함됩니다. 새로운 발견은 `low`에서 시작하며, 사용자 확인 또는 교차 세션 검증 시 승급됩니다.
+
+### 6.2 MCP 메모리 (보조)
+
+MCP 도구는 오케스트레이터 스코프이며, 서브에이전트는 접근할 수 없습니다.
+
+| 시스템 | 도구 | 사용 사례 |
+|--------|------|-----------|
+| claude-mem | `mcp__plugin_claude-mem_mcp-search__save_memory` | 교차 세션 검색, 시간 기반 쿼리 |
+| episodic-memory | `mcp__plugin_episodic-memory_episodic-memory__search` | 이후 검색을 위한 세션 인덱싱 |
+
+네이티브 자동 메모리를 우선 사용하고, 교차 세션 검색 또는 시간 기반 쿼리가 필요한 경우에만 MCP를 사용합니다.
+
+### 6.3 세션 종료 흐름
+
+```mermaid
+sequenceDiagram
+    participant U as 사용자
+    participant O as 오케스트레이터
+    participant SMK as sys-memory-keeper
+    participant MCP as MCP (claude-mem / episodic)
+
+    U->>O: 세션 종료 신호
+    O->>SMK: 위임: MEMORY.md 업데이트
+    SMK-->>O: 네이티브 메모리 업데이트 완료
+    O->>MCP: 세션 요약 저장 (best-effort)
+    O->>MCP: episodic 인덱스 검증 (best-effort)
+    O-->>U: 세션 저장 완료 확인
+```
+
+MCP 저장은 논블로킹 — 실패해도 세션 종료를 막지 않습니다.
+
+---
+
+## 7. CI/CD 파이프라인
+
+```mermaid
+flowchart LR
+    develop --> PR[Pull Request]
+    PR --> ci["ci.yml\nbuild · test · lint\ntypecheck · coverage"]
+    ci --> develop
+
+    develop --> rel["release/* 브랜치"]
+    rel --> tag["git tag v*"]
+    tag --> release["release.yml\nnpm publish\nGitHub Packages"]
+
+    subgraph 사이드 워크플로우
+        docs-validator
+        docs-sync
+        security-audit
+        notify-teammates
+        release-notes
+    end
+```
+
+### 7.1 품질 게이트
+
+| 게이트 | 도구 / 스크립트 | 임계값 |
+|--------|----------------|--------|
+| 코드 커버리지 | bun test --coverage | 97% |
+| 버전 동기화 | manifest.json ↔ package.json | 정확히 일치 |
+| 문서 검증 | validate-docs.ts | README 카운트 일관성 |
+| Sauron 검증 | mgr-sauron (R017) | 5+3 라운드 모두 통과 |
+| TypeScript | tsc --noEmit | 오류 없음 |
+| 린트 | biome check | 오류 없음 |
+
+---
+
+## 8. 배포 모델
+
+### 8.1 npm 패키지
+
+```
+패키지: oh-my-customcode
+CLI:    omcustom
+레지스트리: registry.npmjs.org (public)
+
+배포 파일:
+  dist/         — 컴파일된 CLI + 라이브러리
+  templates/    — 대상 프로젝트용 .claude/ 디렉토리 구조
+```
+
+런타임 의존성: commander, i18next, yaml. 빌드/런타임: bun. Node >= 18 필요.
+
+npm 배포는 CI/CD 파이프라인의 `release/*` 브랜치에서만 트리거되며, 로컬에서 직접 실행하지 않습니다.
+
+### 8.2 템플릿 시스템
+
+`templates/`는 `omcustom`이 모든 프로젝트에 에이전트 시스템을 스캐폴딩할 수 있도록 `.claude/`를 미러링합니다. `manifest.json`은 에이전트, 스킬, 훅, 컨텍스트, 가이드의 카운트를 선언하며, CI가 이 카운트가 파일시스템과 일치하는지 강제합니다.
+
+---
+
+## 9. Claude Code 호환성
+
+| 기능 | < v2.1.63 | >= v2.1.63 | oh-my-customcode |
+|------|-----------|-----------|------------------|
+| 서브에이전트 도구명 | Task | Agent | 듀얼 지원 (Agent/Task) |
+| subagent_type 필드 | 있음 | 있음 (변경 없음) | 있음 |
+| 훅 매처 | `tool == "Task"` | `tool == "Agent"` | `tool == "Task" \|\| tool == "Agent"` |
+| SubagentStart 이벤트 | 없음 | 있음 | 있음 (v0.23.0+) |
+| SubagentStop 이벤트 | 없음 | 있음 | 있음 (v0.23.0+) |
+| Agent Teams | 없음 | 있음 (실험적) | 있음, R018로 활성화 시 강제 |
+
+---
+
+## 10. 컨텍스트 예산
+
+| 항목 | 대략적 크기 |
+|------|------------|
+| CLAUDE.md | ~5K 토큰 |
+| 규칙 (18개 파일) | ~25K 토큰 |
+| 세션당 필수 로드 합계 | ~30K 토큰 |
+
+스킬과 가이드는 호출될 때만 온디맨드로 로드됩니다 — 사전 로드하지 않습니다.
+
+**Ecomode (R013)** 는 작업 유형과 컨텍스트 사용량에 따라 자동으로 활성화됩니다:
+
+| 작업 유형 | 컨텍스트 트리거 |
+|-----------|----------------|
+| 리서치 (/research, 10팀) | 40% |
+| 구현 (코드 생성) | 50% |
+| 리뷰 (코드 리뷰, 감사) | 60% |
+| 관리 (git, 배포, CI) | 70% |
+| 일반 (기본값) | 80% |
+
+`context-budget-advisor.sh` PostToolUse 훅이 사용량을 모니터링하고 임계값에 근접하면 어드바이저리 경고를 출력합니다.
+
+---
+
+## 11. 용어 정의
+
+| 용어 | 정의 |
+|------|------|
+| 오케스트레이터 (Orchestrator) | 메인 Claude Code 대화; 유일한 조율자. 파일을 직접 작성하지 않음. |
+| 서브에이전트 (Subagent) | 오케스트레이터가 Agent 도구를 통해 스폰하는 격리된 에이전트 인스턴스. |
+| 라우팅 스킬 (Routing Skill) | 사용자 의도를 올바른 전문가 에이전트로 매핑하는 `context: fork` 스킬. |
+| Agent Teams | 피어 투 피어 에이전트 메시징을 가능하게 하는 Claude Code 실험적 기능 (R018). TeamCreate/SendMessage 활용. |
+| 훅 (Hook) | hooks.json에서 Claude Code 라이프사이클 이벤트에 바인딩된 스크립트 (PreToolUse, PostToolUse 등). |
+| 네이티브 자동 메모리 | 에이전트 프론트매터의 `memory:` 필드로 MEMORY.md를 매 세션 컨텍스트에 주입하는 기능. |
+| 동적 생성 (Dynamic Creation) | 매칭되는 에이전트가 없을 때 mgr-creator가 자동으로 새 전문가를 생성하는 폴백 패턴. |
+| Ecomode | 컨텍스트 사용량이 작업 유형별 임계값을 초과할 때 자동 활성화되는 압축 출력 모드. |
+| context: fork | 라우팅 및 오케스트레이션 스킬에 사용되는 격리된 컨텍스트로 스킬을 실행하는 SKILL.md 프론트매터 플래그. |
+| R017 (Sauron) | 구조적 변경 사항을 푸시하기 전에 필요한 5라운드 매니저 + 3라운드 심층 리뷰 검증 사이클. |

--- a/guides/flutter/performance.md
+++ b/guides/flutter/performance.md
@@ -80,7 +80,7 @@ Detect with: DevTools → Rendering → "Highlight repaints"
 
 | Avoid | Use Instead | Reason |
 |-------|-------------|--------|
-| `Opacity` widget | `color.withOpacity()` | Triggers saveLayer |
+| `Opacity` widget | `color.withValues(alpha: 0.5)` | Opacity widget triggers saveLayer |
 | `ClipRRect` in animations | Pre-clip static content | saveLayer per frame |
 | `Container` for sizing | `SizedBox` | Lighter, no decoration |
 

--- a/guides/java21/index.yaml
+++ b/guides/java21/index.yaml
@@ -1,0 +1,29 @@
+# Java 21 Guide
+
+metadata:
+  name: java21
+  description: Java 21 language reference and modern feature documentation
+
+source:
+  type: external
+  origin: docs.oracle.com
+  urls:
+    - https://docs.oracle.com/en/java/javase/21/
+    - https://openjdk.org/projects/loom/
+    - https://openjdk.org/jeps/440
+    - https://openjdk.org/jeps/441
+    - https://openjdk.org/jeps/444
+    - https://google.github.io/styleguide/javaguide.html
+  last_fetched: "2026-03-11"
+
+documents:
+  - name: modern-java21
+    path: ./modern-java21.md
+    description: Java 21 modern features (Virtual Threads, Pattern Matching, Records, Sealed Classes)
+
+  - name: java-style-guide
+    path: ./java-style-guide.md
+    description: Google Java Style Guide conventions
+
+used_by:
+  - lang-java21-expert

--- a/guides/java21/java-style-guide.md
+++ b/guides/java21/java-style-guide.md
@@ -1,0 +1,248 @@
+# Java Style Guide
+
+> Source: https://google.github.io/styleguide/javaguide.html
+
+## File Structure
+
+```
+Source file:
+  1. License/copyright (if any)
+  2. Package statement
+  3. Import statements
+  4. Exactly one top-level class
+```
+
+### Import Ordering
+
+```java
+// 1. Static imports (all together)
+import static org.junit.Assert.assertEquals;
+
+// 2. Non-static imports (all together, no subgroups)
+import com.example.Foo;
+import java.util.List;
+import org.springframework.boot.SpringApplication;
+```
+
+No wildcard imports except `static` test imports.
+
+---
+
+## Naming Conventions
+
+| Element | Style | Example |
+|---------|-------|---------|
+| Packages | `lowercase` | `com.example.network` |
+| Classes | `UpperCamelCase` | `OrderProcessor` |
+| Records | `UpperCamelCase` | `UserRecord` |
+| Methods | `lowerCamelCase` | `processOrder()` |
+| Local vars | `lowerCamelCase` | `itemCount` |
+| Constants | `UPPER_SNAKE_CASE` | `MAX_RETRIES` |
+| Type params | Single letter or `UpperCamelCase + T` | `T`, `E`, `RequestT` |
+
+### Acronyms
+
+Treat acronyms as words: `XmlParser`, not `XMLParser`. Exception: well-known 2-letter ones like `IO`.
+
+---
+
+## Formatting
+
+### Indentation
+
+- 2 spaces (not tabs) for block indentation
+- 4 spaces for line continuation
+
+```java
+// Block indentation: 2 spaces
+if (condition) {
+  doSomething();
+}
+
+// Line continuation: 4 spaces
+String result = longMethodName(
+    argument1,
+    argument2);
+```
+
+### Braces
+
+Always use braces, even for single-statement bodies:
+
+```java
+// Correct
+if (condition) {
+  doSomething();
+}
+
+// Wrong (no braces)
+if (condition)
+  doSomething();
+```
+
+### Column Limit
+
+100 characters per line. Wrap when exceeding.
+
+### Blank Lines
+
+```java
+class MyClass {
+  private int field;          // field
+                              // one blank line
+  public MyClass() { }        // constructor
+                              // one blank line
+  public void method() { }    // method
+}
+```
+
+---
+
+## Class Structure
+
+```java
+public class MyClass {
+  // 1. Static fields
+  private static final Logger log = LoggerFactory.getLogger(MyClass.class);
+
+  // 2. Instance fields
+  private final String name;
+
+  // 3. Constructors
+  public MyClass(String name) {
+    this.name = name;
+  }
+
+  // 4. Static factory methods (if applicable)
+  public static MyClass of(String name) {
+    return new MyClass(name);
+  }
+
+  // 5. Instance methods (public → package → protected → private)
+  public String getName() { return name; }
+
+  private void helper() { }
+
+  // 6. Inner classes/interfaces (last)
+}
+```
+
+---
+
+## Programming Practices
+
+### Annotations
+
+```java
+// One annotation per line for class/method
+@Override
+@Nullable
+public String format(String input) { }
+
+// Multiple short annotations on one line for field is OK
+@Nullable @Deprecated String field;
+```
+
+### Numeric Literals
+
+```java
+long big = 1_000_000L;
+double pi = 3.14_159;
+int hex = 0xFF_EC_D1_8C;
+```
+
+### Switch Expressions (prefer over statements)
+
+```java
+// Prefer switch expression
+int days = switch (month) {
+  case JANUARY, MARCH, MAY, JULY, AUGUST, OCTOBER, DECEMBER -> 31;
+  case APRIL, JUNE, SEPTEMBER, NOVEMBER -> 30;
+  case FEBRUARY -> 28;
+};
+```
+
+### Avoid Long Methods
+
+Keep methods short and focused. Extract helpers for blocks exceeding ~20 lines.
+
+---
+
+## Javadoc
+
+### Required for
+
+- Every `public` class, interface, enum, record
+- Every `public` or `protected` method (unless trivially obvious)
+
+### Format
+
+```java
+/**
+ * Returns the user associated with the given ID.
+ *
+ * <p>This method performs a database lookup. It is safe to call
+ * from multiple threads.
+ *
+ * @param id the user identifier (must be positive)
+ * @return the user, or empty if not found
+ * @throws IllegalArgumentException if {@code id <= 0}
+ */
+public Optional<User> findById(long id) { }
+```
+
+### Inline Tags
+
+```java
+/**
+ * See {@link UserRepository} for persistence details.
+ * Use {@code null} to reset the state.
+ */
+```
+
+### Prohibited: Non-Javadoc Comments for API
+
+```java
+// Wrong: plain comment for public method
+// Returns the user by id
+public Optional<User> findById(long id) { }
+
+// Correct: Javadoc
+/** Returns the user by id, or empty if not found. */
+public Optional<User> findById(long id) { }
+```
+
+---
+
+## Common Antipatterns to Avoid
+
+```java
+// ❌ Raw types
+List list = new ArrayList();
+// ✓
+List<String> list = new ArrayList<>();
+
+// ❌ String concatenation in loop
+String s = "";
+for (String item : items) s += item;
+// ✓
+StringBuilder sb = new StringBuilder();
+for (String item : items) sb.append(item);
+String s = sb.toString();
+
+// ❌ Return null for collections
+public List<String> getItems() { return null; }
+// ✓
+public List<String> getItems() { return Collections.emptyList(); }
+
+// ❌ Catch Exception broadly
+try { process(); } catch (Exception e) { }
+// ✓
+try { process(); } catch (IOException e) { log.error("IO error", e); }
+
+// ❌ Mutable public field
+public String name;
+// ✓
+private String name;
+public String getName() { return name; }
+```

--- a/guides/java21/modern-java21.md
+++ b/guides/java21/modern-java21.md
@@ -1,0 +1,303 @@
+# Modern Java 21 Features
+
+> Sources: https://openjdk.org/jeps/ (JEP 431, 440, 441, 444)
+
+## Virtual Threads (JEP 444)
+
+Virtual Threads are lightweight threads managed by the JVM, enabling millions of concurrent tasks without thread pool tuning.
+
+### Key Properties
+
+| Property | Platform Thread | Virtual Thread |
+|----------|----------------|----------------|
+| Creation cost | High (OS thread) | Low (JVM-managed) |
+| Memory footprint | ~1MB per thread | ~few KB |
+| Blocking behavior | Blocks OS thread | Unmounts carrier thread |
+| Pooling | Needed | Not recommended |
+
+### Usage
+
+```java
+// Virtual Thread executor (preferred for I/O-bound tasks)
+try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+    List<Future<String>> futures = IntStream.range(0, 10_000)
+        .mapToObj(i -> executor.submit(() -> fetchData(i)))
+        .toList();
+    // all 10,000 tasks run concurrently
+}
+
+// Direct creation
+Thread.ofVirtual().name("vt-worker").start(() -> processRequest());
+
+// Factory for thread pools
+ThreadFactory factory = Thread.ofVirtual().name("worker-", 0).factory();
+```
+
+### Structured Concurrency (JEP 453, Preview)
+
+```java
+try (var scope = new StructuredTaskScope.ShutdownOnFailure()) {
+    Future<String> user   = scope.fork(() -> fetchUser(id));
+    Future<String> orders = scope.fork(() -> fetchOrders(id));
+
+    scope.join().throwIfFailed();
+
+    return new UserProfile(user.get(), orders.get());
+}
+```
+
+### Pinning Avoidance
+
+Virtual Threads are **pinned** (cannot unmount) inside `synchronized` blocks. Prefer `ReentrantLock`:
+
+```java
+// Avoid (causes pinning)
+synchronized (lock) {
+    callBlockingIO();
+}
+
+// Prefer
+private final ReentrantLock lock = new ReentrantLock();
+lock.lock();
+try {
+    callBlockingIO();
+} finally {
+    lock.unlock();
+}
+```
+
+---
+
+## Pattern Matching for instanceof (JEP 394)
+
+```java
+// Before Java 16
+if (obj instanceof String) {
+    String s = (String) obj;
+    return s.length();
+}
+
+// Java 21
+if (obj instanceof String s) {
+    return s.length();
+}
+
+// With guard
+if (obj instanceof String s && !s.isEmpty()) {
+    return s.toUpperCase();
+}
+```
+
+---
+
+## Pattern Matching for switch (JEP 441)
+
+```java
+// Type patterns
+String format = switch (obj) {
+    case Integer i -> String.format("int %d", i);
+    case Double d  -> String.format("double %.2f", d);
+    case String s  -> String.format("String '%s'", s);
+    case null      -> "null value";
+    default        -> obj.toString();
+};
+
+// Guarded patterns (when clause)
+String classify = switch (number) {
+    case Integer i when i < 0  -> "negative";
+    case Integer i when i == 0 -> "zero";
+    case Integer i             -> "positive";
+    default -> "non-integer";
+};
+```
+
+---
+
+## Record Classes (JEP 395)
+
+Records are immutable data carriers with auto-generated `equals`, `hashCode`, `toString`, and accessors.
+
+```java
+// Basic record
+record Point(int x, int y) {}
+
+Point p = new Point(3, 4);
+int x = p.x(); // accessor (not getX())
+System.out.println(p); // Point[x=3, y=4]
+
+// Compact constructor (validation)
+record Range(int min, int max) {
+    Range {
+        if (min > max)
+            throw new IllegalArgumentException(
+                "min %d > max %d".formatted(min, max));
+    }
+}
+
+// Custom methods
+record Circle(double radius) {
+    static final double PI = Math.PI;
+
+    double area() { return PI * radius * radius; }
+
+    Circle scale(double factor) { return new Circle(radius * factor); }
+}
+
+// Implementing interface
+interface Describable { String describe(); }
+record Color(int r, int g, int b) implements Describable {
+    public String describe() {
+        return "rgb(%d,%d,%d)".formatted(r, g, b);
+    }
+}
+```
+
+### When to Use Records vs Classes
+
+| Use Record | Use Class |
+|------------|-----------|
+| Pure data containers | Entities with mutable state |
+| DTOs, value objects | Domain objects with lifecycle |
+| API response types | Services, repositories |
+| Config/settings | Mutable builders |
+
+---
+
+## Record Patterns (JEP 440)
+
+Deconstruct records directly in `instanceof` and `switch`:
+
+```java
+// instanceof deconstruction
+if (obj instanceof Point(int x, int y)) {
+    System.out.println("x=" + x + ", y=" + y);
+}
+
+// switch deconstruction
+String describe = switch (shape) {
+    case Circle(double r)             -> "circle r=%.2f".formatted(r);
+    case Rectangle(double w, double h) -> "rect %.1fx%.1f".formatted(w, h);
+    default -> "unknown";
+};
+
+// Nested patterns
+record ColoredPoint(Point point, Color color) {}
+
+if (obj instanceof ColoredPoint(Point(int x, int y), Color(int r, int g, int b))) {
+    System.out.printf("Colored point at (%d,%d) with rgb(%d,%d,%d)%n",
+        x, y, r, g, b);
+}
+```
+
+---
+
+## Sealed Classes (JEP 409)
+
+Sealed classes restrict which classes can implement/extend them, enabling exhaustive pattern matching.
+
+```java
+// Sealed interface with records
+sealed interface Shape permits Circle, Rectangle, Triangle {}
+
+record Circle(double radius) implements Shape {}
+record Rectangle(double width, double height) implements Shape {}
+record Triangle(double base, double height) implements Shape {}
+
+// Exhaustive switch — no default needed
+double area = switch (shape) {
+    case Circle(double r)             -> Math.PI * r * r;
+    case Rectangle(double w, double h) -> w * h;
+    case Triangle(double b, double h)  -> 0.5 * b * h;
+};
+
+// Sealed class hierarchy (non-record)
+sealed class Vehicle permits Car, Truck, Motorcycle {}
+final class Car extends Vehicle { }
+non-sealed class Truck extends Vehicle { } // allows further subclassing
+```
+
+### Benefits
+
+- Compiler enforces exhaustive handling in `switch`
+- Clear closed type hierarchy in domain model
+- Better than `enum` when subtypes carry different data
+
+---
+
+## Sequenced Collections (JEP 431)
+
+New interfaces: `SequencedCollection`, `SequencedSet`, `SequencedMap`.
+
+```java
+// SequencedCollection
+List<String> list = new ArrayList<>(List.of("a", "b", "c"));
+String first = list.getFirst(); // "a"
+String last  = list.getLast();  // "c"
+list.addFirst("z");             // ["z", "a", "b", "c"]
+list.addLast("end");            // ["z", "a", "b", "c", "end"]
+list.removeFirst();             // ["a", "b", "c", "end"]
+
+// Reversed view (live, backed by original)
+List<String> reversed = list.reversed();
+
+// SequencedMap
+LinkedHashMap<String, Integer> map = new LinkedHashMap<>();
+map.put("one", 1);
+map.put("two", 2);
+map.put("three", 3);
+
+Map.Entry<String, Integer> first = map.firstEntry(); // "one"=1
+Map.Entry<String, Integer> last  = map.lastEntry();  // "three"=3
+map.putFirst("zero", 0);       // inserts at front
+SequencedMap<String, Integer> rev = map.reversed();
+```
+
+---
+
+## Migration from Legacy Java
+
+### Replace instanceof chains
+
+```java
+// Legacy (avoid)
+if (obj instanceof String) {
+    return ((String) obj).length();
+} else if (obj instanceof Integer) {
+    return ((Integer) obj).intValue();
+}
+
+// Modern
+return switch (obj) {
+    case String s  -> s.length();
+    case Integer i -> i;
+    default -> -1;
+};
+```
+
+### Replace POJOs with Records
+
+```java
+// Legacy POJO (avoid for pure data)
+public class Point {
+    private final int x, y;
+    public Point(int x, int y) { this.x = x; this.y = y; }
+    public int getX() { return x; }
+    public int getY() { return y; }
+    @Override public boolean equals(Object o) { ... }
+    @Override public int hashCode() { ... }
+    @Override public String toString() { ... }
+}
+
+// Modern Record
+record Point(int x, int y) {}
+```
+
+### Replace thread pools for I/O with Virtual Threads
+
+```java
+// Legacy (avoid for I/O-bound)
+ExecutorService pool = Executors.newFixedThreadPool(200);
+
+// Modern
+ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor();
+```


### PR DESCRIPTION
## Summary

Sprint 3 of the TODO roadmap, resolving 3 code quality issues:

### #285: lang-java21-expert dead references
- Created `java21-best-practices` skill with 10 rules covering Virtual Threads, Pattern Matching, Records, Sealed Classes, Sequenced Collections
- Created `guides/java21/` with modern-java21.md and java-style-guide.md
- Updated agent frontmatter with `skills: [java21-best-practices]`

### #288: R009/R010/R018 rule overlap refactor
- R009: 136→111 lines (-25) — removed duplicated Agent Teams content
- R010: 276→257 lines (-19) — removed duplicated decision matrix
- R018: unchanged (canonical owner of Agent Teams content)
- Total: **-44 lines** of duplication removed
- Each rule now cross-references others by ID instead of duplicating

### #270: guides/ duplication (partial)
- **Finding**: root `guides/` cannot be deleted — 23 agents reference it at runtime
- **Action**: Synced `guides/flutter/performance.md` with templates/ fix (deprecated `withOpacity()` → `withValues()`)
- **Conclusion**: Need sync process, not deletion. Issue remains open for process improvement.

Closes #285, #288
Refs #270

## Test plan

- [ ] Verify `lang-java21-expert.md` has valid `skills:` reference
- [ ] Verify `.claude/skills/java21-best-practices/SKILL.md` exists with proper frontmatter
- [ ] Verify `guides/java21/` has index.yaml + 2 markdown files
- [ ] Verify R009/R010 cross-reference R018 correctly
- [ ] Verify no unique content was lost in rule refactoring
- [ ] Verify `guides/flutter/performance.md` uses `withValues()` not `withOpacity()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)