### PR TITLE
fix: remove leaked claude-mem session file (Closes #284)

### DIFF
--- a/templates/.claude/skills/go-best-practices/CLAUDE.md
+++ b/templates/.claude/skills/go-best-practices/CLAUDE.md
@@ -1,9 +1,0 @@
-<claude-mem-context>
-# Recent Activity
-
-### Feb 5, 2026
-
-| ID | Time | T | Title | Read |
-|----|------|---|-------|------|
-| #8 | 8:07 PM | 🔵 | Skill Definition Structure | ~626 |
-</claude-mem-context>


### PR DESCRIPTION
## Summary

- Removes `templates/.claude/skills/go-best-practices/CLAUDE.md` — a 204-byte file containing only leaked claude-mem session context data from 2026-02-05
- The file had no actual skill content; it was a stray artifact from a past session that was accidentally committed into the template directory
- Because `.claude/` directories are auto-loaded by Claude Code, this file was being injected into every new Claude Code session that used the go-best-practices skill template, silently consuming context window tokens

## Root Cause

The `templates/.claude/skills/go-best-practices/` directory contained a `CLAUDE.md` that held raw claude-mem session output instead of real skill documentation. Claude Code auto-loads any `CLAUDE.md` found under `.claude/`, so the leak propagated to all downstream sessions.

## Impact

- Fixes context window pollution for all users who have the go-best-practices skill installed
- No skill functionality is affected — the file contained zero skill content

## Test plan

- [x] Pre-commit checks pass (1035 tests, 100% function coverage, 99.37% line coverage)
- [x] Confirm `templates/.claude/skills/go-best-practices/CLAUDE.md` is removed from the repository
- [x] Verify no other stray claude-mem files remain in the templates tree

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)