### PR TITLE
feat: Sprint 4 — validator improvements (phantom detection + unit tests)

### DIFF
--- a/.github/scripts/validate-docs.test.ts
+++ b/.github/scripts/validate-docs.test.ts
@@ -1,0 +1,527 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  extractNamesFromReadme,
+  programmaticValidation,
+  buildPrompt,
+  collectImplementationStats,
+  extractSlashCommandsFromReadme,
+  type ImplementationStats,
+  type ValidationResult,
+  type SlashCommandValidation,
+} from './validate-docs';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STATS_ALL_MATCH: ImplementationStats = {
+  agent_count: 3,
+  agent_names: ['lang-go-expert', 'lang-python-expert', 'lang-typescript-expert'],
+  skill_count: 2,
+  skill_names: ['typescript-best-practices', 'react-best-practices'],
+  rule_count: 18,
+  guide_count: 24,
+  hook_count: 5,
+  context_count: 2,
+};
+
+const README_WITH_CANONICAL_BLOCKS = `
+# oh-my-customcode
+
+We have Agents (3) in the system.
+
+There are 2 skills available.
+
+## Canonical agent IDs
+
+\`\`\`text
+lang-go-expert
+lang-python-expert
+lang-typescript-expert
+\`\`\`
+
+## Canonical skill IDs
+
+\`\`\`text
+typescript-best-practices
+react-best-practices
+\`\`\`
+`;
+
+const README_MISSING_AGENT = `
+# oh-my-customcode
+
+We have Agents (3) in the system.
+
+There are 2 skills available.
+
+## Canonical agent IDs
+
+\`\`\`text
+lang-go-expert
+lang-python-expert
+\`\`\`
+
+## Canonical skill IDs
+
+\`\`\`text
+typescript-best-practices
+react-best-practices
+\`\`\`
+`;
+
+const README_EXTRA_AGENT = `
+# oh-my-customcode
+
+We have Agents (3) in the system.
+
+## Canonical agent IDs
+
+\`\`\`text
+lang-go-expert
+lang-python-expert
+lang-typescript-expert
+lang-rust-expert
+\`\`\`
+
+## Canonical skill IDs
+
+\`\`\`text
+typescript-best-practices
+react-best-practices
+\`\`\`
+`;
+
+const README_COUNT_MISMATCH = `
+# oh-my-customcode
+
+We have Agents (99) in the system.
+
+There are 99 skills available.
+`;
+
+const README_NO_CANONICAL_BLOCKS = `
+# oh-my-customcode
+
+| Agent | Type |
+|-------|------|
+| lang-go-expert | language |
+| lang-python-expert | language |
+`;
+
+const README_EMPTY = '';
+
+const VALIDATION_ALL_CLEAN: ValidationResult = {
+  missingFromReadme: { agents: [], skills: [] },
+  extraInReadme: { agents: [], skills: [] },
+  countMismatches: [],
+};
+
+const VALIDATION_WITH_ISSUES: ValidationResult = {
+  missingFromReadme: { agents: ['lang-typescript-expert'], skills: ['react-best-practices'] },
+  extraInReadme: { agents: ['phantom-agent'], skills: ['phantom-skill'] },
+  countMismatches: [
+    { field: 'agents', readme: 5, actual: 3 },
+    { field: 'skills', readme: 10, actual: 2 },
+  ],
+};
+
+const SLASH_COMMAND_VALIDATION_CLEAN: SlashCommandValidation = {
+  valid: ['analysis', 'dev-review'],
+  phantom: [],
+};
+
+const SLASH_COMMAND_VALIDATION_WITH_PHANTOM: SlashCommandValidation = {
+  valid: ['analysis'],
+  phantom: ['nonexistent-command'],
+};
+
+// ---------------------------------------------------------------------------
+// extractNamesFromReadme
+// ---------------------------------------------------------------------------
+
+describe('extractNamesFromReadme', () => {
+  test('extracts agents and skills from canonical blocks', () => {
+    const result = extractNamesFromReadme(README_WITH_CANONICAL_BLOCKS);
+
+    expect(result.agents).toEqual([
+      'lang-go-expert',
+      'lang-python-expert',
+      'lang-typescript-expert',
+    ]);
+    expect(result.skills).toEqual(['typescript-best-practices', 'react-best-practices']);
+  });
+
+  test('returns empty arrays for empty string input', () => {
+    const result = extractNamesFromReadme(README_EMPTY);
+
+    expect(result.agents).toEqual([]);
+    expect(result.skills).toEqual([]);
+  });
+
+  test('returns empty arrays when no canonical blocks exist', () => {
+    const result = extractNamesFromReadme(README_NO_CANONICAL_BLOCKS);
+
+    expect(result.agents).toEqual([]);
+    expect(result.skills).toEqual([]);
+  });
+
+  test('returns empty arrays for empty canonical blocks', () => {
+    const readme = `
+## Canonical agent IDs
+
+\`\`\`text
+\`\`\`
+
+## Canonical skill IDs
+
+\`\`\`text
+\`\`\`
+`;
+    const result = extractNamesFromReadme(readme);
+
+    expect(result.agents).toEqual([]);
+    expect(result.skills).toEqual([]);
+  });
+
+  test('trims whitespace from extracted names', () => {
+    const readme = `
+## Canonical agent IDs
+
+\`\`\`text
+  lang-go-expert
+  lang-python-expert
+\`\`\`
+`;
+    const result = extractNamesFromReadme(readme);
+
+    expect(result.agents).toEqual(['lang-go-expert', 'lang-python-expert']);
+  });
+
+  test('handles readme with only agent block (no skill block)', () => {
+    const readme = `
+## Canonical agent IDs
+
+\`\`\`text
+lang-go-expert
+\`\`\`
+`;
+    const result = extractNamesFromReadme(readme);
+
+    expect(result.agents).toEqual(['lang-go-expert']);
+    expect(result.skills).toEqual([]);
+  });
+
+  test('handles readme with only skill block (no agent block)', () => {
+    const readme = `
+## Canonical skill IDs
+
+\`\`\`text
+typescript-best-practices
+\`\`\`
+`;
+    const result = extractNamesFromReadme(readme);
+
+    expect(result.agents).toEqual([]);
+    expect(result.skills).toEqual(['typescript-best-practices']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractSlashCommandsFromReadme
+// ---------------------------------------------------------------------------
+
+describe('extractSlashCommandsFromReadme', () => {
+  test('extracts slash commands from table rows', () => {
+    const readme = `
+| Command | Description |
+|---------|-------------|
+| \`/analysis\` | Analyze project |
+| \`/dev-review\` | Code review |
+| \`/help\` | Show help |
+`;
+    const result = extractSlashCommandsFromReadme(readme);
+
+    expect(result).toEqual(['analysis', 'dev-review', 'help']);
+  });
+
+  test('returns empty array when no slash commands found', () => {
+    const result = extractSlashCommandsFromReadme(README_NO_CANONICAL_BLOCKS);
+
+    expect(result).toEqual([]);
+  });
+
+  test('returns empty array for empty string', () => {
+    const result = extractSlashCommandsFromReadme('');
+
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// programmaticValidation
+// ---------------------------------------------------------------------------
+
+describe('programmaticValidation', () => {
+  test('returns no issues when all names and counts match', () => {
+    const result = programmaticValidation(STATS_ALL_MATCH, README_WITH_CANONICAL_BLOCKS);
+
+    expect(result.missingFromReadme.agents).toEqual([]);
+    expect(result.missingFromReadme.skills).toEqual([]);
+    expect(result.extraInReadme.agents).toEqual([]);
+    expect(result.extraInReadme.skills).toEqual([]);
+    expect(result.countMismatches).toEqual([]);
+  });
+
+  test('detects agent missing from readme', () => {
+    const result = programmaticValidation(STATS_ALL_MATCH, README_MISSING_AGENT);
+
+    expect(result.missingFromReadme.agents).toContain('lang-typescript-expert');
+    expect(result.missingFromReadme.skills).toEqual([]);
+  });
+
+  test('detects extra agent in readme that does not exist in implementation', () => {
+    const result = programmaticValidation(STATS_ALL_MATCH, README_EXTRA_AGENT);
+
+    expect(result.extraInReadme.agents).toContain('lang-rust-expert');
+    expect(result.extraInReadme.skills).toEqual([]);
+  });
+
+  test('detects agent count mismatch', () => {
+    const result = programmaticValidation(STATS_ALL_MATCH, README_COUNT_MISMATCH);
+
+    const agentMismatch = result.countMismatches.find((m) => m.field === 'agents');
+    expect(agentMismatch).toBeDefined();
+    expect(agentMismatch?.readme).toBe(99);
+    expect(agentMismatch?.actual).toBe(3);
+  });
+
+  test('detects skill count mismatch', () => {
+    const result = programmaticValidation(STATS_ALL_MATCH, README_COUNT_MISMATCH);
+
+    const skillMismatch = result.countMismatches.find((m) => m.field === 'skills');
+    expect(skillMismatch).toBeDefined();
+    expect(skillMismatch?.readme).toBe(99);
+    expect(skillMismatch?.actual).toBe(2);
+  });
+
+  test('skips name comparison when no canonical blocks present', () => {
+    const result = programmaticValidation(STATS_ALL_MATCH, README_NO_CANONICAL_BLOCKS);
+
+    expect(result.missingFromReadme.agents).toEqual([]);
+    expect(result.missingFromReadme.skills).toEqual([]);
+    expect(result.extraInReadme.agents).toEqual([]);
+    expect(result.extraInReadme.skills).toEqual([]);
+  });
+
+  test('skips name comparison for empty readme', () => {
+    const result = programmaticValidation(STATS_ALL_MATCH, README_EMPTY);
+
+    expect(result.missingFromReadme.agents).toEqual([]);
+    expect(result.missingFromReadme.skills).toEqual([]);
+    expect(result.extraInReadme.agents).toEqual([]);
+    expect(result.extraInReadme.skills).toEqual([]);
+    expect(result.countMismatches).toEqual([]);
+  });
+
+  test('does not report count mismatch when counts match', () => {
+    const result = programmaticValidation(STATS_ALL_MATCH, README_WITH_CANONICAL_BLOCKS);
+
+    expect(result.countMismatches).toEqual([]);
+  });
+
+  test('detects missing skills in readme', () => {
+    const statsWithExtraSkill: ImplementationStats = {
+      ...STATS_ALL_MATCH,
+      skill_count: 3,
+      skill_names: ['typescript-best-practices', 'react-best-practices', 'golang-best-practices'],
+    };
+    const result = programmaticValidation(statsWithExtraSkill, README_WITH_CANONICAL_BLOCKS);
+
+    expect(result.missingFromReadme.skills).toContain('golang-best-practices');
+  });
+
+  test('detects extra skills in readme', () => {
+    const readme = `
+## Canonical agent IDs
+
+\`\`\`text
+lang-go-expert
+lang-python-expert
+lang-typescript-expert
+\`\`\`
+
+## Canonical skill IDs
+
+\`\`\`text
+typescript-best-practices
+react-best-practices
+phantom-skill
+\`\`\`
+`;
+    const result = programmaticValidation(STATS_ALL_MATCH, readme);
+
+    expect(result.extraInReadme.skills).toContain('phantom-skill');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPrompt
+// ---------------------------------------------------------------------------
+
+describe('buildPrompt', () => {
+  const readmeKo = '# 한국어 README';
+
+  test('includes stats JSON in the prompt', () => {
+    const prompt = buildPrompt(
+      STATS_ALL_MATCH,
+      README_WITH_CANONICAL_BLOCKS,
+      readmeKo,
+      VALIDATION_ALL_CLEAN,
+      SLASH_COMMAND_VALIDATION_CLEAN,
+    );
+
+    expect(prompt).toContain('"agent_count": 3');
+    expect(prompt).toContain('"skill_count": 2');
+    expect(prompt).toContain('"rule_count": 18');
+  });
+
+  test('includes success message when validation has no issues', () => {
+    const prompt = buildPrompt(
+      STATS_ALL_MATCH,
+      README_WITH_CANONICAL_BLOCKS,
+      readmeKo,
+      VALIDATION_ALL_CLEAN,
+      SLASH_COMMAND_VALIDATION_CLEAN,
+    );
+
+    expect(prompt).toContain('✅ 모든 agent/skill 이름과 개수가 README와 실제 구현에서 정확히 일치합니다.');
+  });
+
+  test('includes mismatch details when validation has issues', () => {
+    const prompt = buildPrompt(
+      STATS_ALL_MATCH,
+      README_WITH_CANONICAL_BLOCKS,
+      readmeKo,
+      VALIDATION_WITH_ISSUES,
+      SLASH_COMMAND_VALIDATION_CLEAN,
+    );
+
+    expect(prompt).toContain('불일치 발견');
+    expect(prompt).toContain('lang-typescript-expert');
+    expect(prompt).toContain('react-best-practices');
+    expect(prompt).toContain('phantom-agent');
+    expect(prompt).toContain('phantom-skill');
+    expect(prompt).toContain('agents 개수: README=5, 실제=3');
+    expect(prompt).toContain('skills 개수: README=10, 실제=2');
+  });
+
+  test('includes slash command success message when no phantom commands', () => {
+    const prompt = buildPrompt(
+      STATS_ALL_MATCH,
+      README_WITH_CANONICAL_BLOCKS,
+      readmeKo,
+      VALIDATION_ALL_CLEAN,
+      SLASH_COMMAND_VALIDATION_CLEAN,
+    );
+
+    expect(prompt).toContain('README의 모든 슬래시 커맨드');
+    expect(prompt).toContain('SKILL.md가 존재합니다');
+  });
+
+  test('includes phantom slash command details when present', () => {
+    const prompt = buildPrompt(
+      STATS_ALL_MATCH,
+      README_WITH_CANONICAL_BLOCKS,
+      readmeKo,
+      VALIDATION_ALL_CLEAN,
+      SLASH_COMMAND_VALIDATION_WITH_PHANTOM,
+    );
+
+    expect(prompt).toContain('Phantom 슬래시 커맨드 발견');
+    expect(prompt).toContain('/nonexistent-command');
+  });
+
+  test('includes readme content in the prompt', () => {
+    const prompt = buildPrompt(
+      STATS_ALL_MATCH,
+      README_WITH_CANONICAL_BLOCKS,
+      readmeKo,
+      VALIDATION_ALL_CLEAN,
+      SLASH_COMMAND_VALIDATION_CLEAN,
+    );
+
+    expect(prompt).toContain('oh-my-customcode');
+    expect(prompt).toContain('한국어 README');
+  });
+
+  test('does not include success message when issues are present', () => {
+    const prompt = buildPrompt(
+      STATS_ALL_MATCH,
+      README_WITH_CANONICAL_BLOCKS,
+      readmeKo,
+      VALIDATION_WITH_ISSUES,
+      SLASH_COMMAND_VALIDATION_CLEAN,
+    );
+
+    expect(prompt).not.toContain('✅ 모든 agent/skill 이름과 개수가 README와 실제 구현에서 정확히 일치합니다.');
+  });
+
+  test('returns a non-empty string', () => {
+    const prompt = buildPrompt(
+      STATS_ALL_MATCH,
+      README_WITH_CANONICAL_BLOCKS,
+      readmeKo,
+      VALIDATION_ALL_CLEAN,
+      SLASH_COMMAND_VALIDATION_CLEAN,
+    );
+
+    expect(typeof prompt).toBe('string');
+    expect(prompt.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectImplementationStats — smoke test (uses real templates/ directory)
+// ---------------------------------------------------------------------------
+
+describe('collectImplementationStats', () => {
+  test('returns an object with all required numeric fields', async () => {
+    const stats = await collectImplementationStats();
+
+    expect(typeof stats.agent_count).toBe('number');
+    expect(typeof stats.skill_count).toBe('number');
+    expect(typeof stats.rule_count).toBe('number');
+    expect(typeof stats.guide_count).toBe('number');
+    expect(typeof stats.hook_count).toBe('number');
+    expect(typeof stats.context_count).toBe('number');
+  });
+
+  test('returns agent_names array consistent with agent_count', async () => {
+    const stats = await collectImplementationStats();
+
+    expect(Array.isArray(stats.agent_names)).toBe(true);
+    expect(stats.agent_names.length).toBe(stats.agent_count);
+  });
+
+  test('returns skill_names array consistent with skill_count', async () => {
+    const stats = await collectImplementationStats();
+
+    expect(Array.isArray(stats.skill_names)).toBe(true);
+    expect(stats.skill_names.length).toBe(stats.skill_count);
+  });
+
+  test('agent_count is a non-negative integer', async () => {
+    const stats = await collectImplementationStats();
+
+    expect(stats.agent_count).toBeGreaterThanOrEqual(0);
+    expect(Number.isInteger(stats.agent_count)).toBe(true);
+  });
+
+  test('skill_count is a non-negative integer', async () => {
+    const stats = await collectImplementationStats();
+
+    expect(stats.skill_count).toBeGreaterThanOrEqual(0);
+    expect(Number.isInteger(stats.skill_count)).toBe(true);
+  });
+});

--- a/.github/scripts/validate-docs.ts
+++ b/.github/scripts/validate-docs.ts
@@ -9,7 +9,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import fs from 'node:fs';
 import path from 'node:path';
 
-interface ImplementationStats {
+export interface ImplementationStats {
   agent_count: number;
   agent_names: string[];
   skill_count: number;
@@ -20,13 +20,18 @@ interface ImplementationStats {
   context_count: number;
 }
 
-interface ValidationResult {
+export interface ValidationResult {
   missingFromReadme: { agents: string[]; skills: string[] };
   extraInReadme: { agents: string[]; skills: string[] };
   countMismatches: { field: string; readme: number; actual: number }[];
 }
 
-async function collectImplementationStats(): Promise<ImplementationStats> {
+export interface SlashCommandValidation {
+  valid: string[];    // Commands that have a matching SKILL.md
+  phantom: string[]; // Commands listed in README but missing SKILL.md
+}
+
+export async function collectImplementationStats(): Promise<ImplementationStats> {
   const stats: ImplementationStats = {
     agent_count: 0,
     agent_names: [],
@@ -97,7 +102,7 @@ async function extractReadmeClaims(path: string): Promise<string> {
   }
 }
 
-function extractNamesFromReadme(readme: string): { agents: string[]; skills: string[] } {
+export function extractNamesFromReadme(readme: string): { agents: string[]; skills: string[] } {
   const agents: string[] = [];
   const skills: string[] = [];
 
@@ -116,7 +121,43 @@ function extractNamesFromReadme(readme: string): { agents: string[]; skills: str
   return { agents, skills };
 }
 
-function programmaticValidation(stats: ImplementationStats, readmeEn: string): ValidationResult {
+/**
+ * Extracts slash command names from the README slash-commands table.
+ * Matches table rows of the form: | `/command-name` | Description |
+ */
+export function extractSlashCommandsFromReadme(readmeContent: string): string[] {
+  const commands: string[] = [];
+  const pattern = /^\|\s*`\/([a-z][a-z0-9-]*)`\s*\|/gm;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(readmeContent)) !== null) {
+    commands.push(match[1]);
+  }
+  return commands;
+}
+
+/**
+ * Validates that every slash command listed in the README has a corresponding
+ * SKILL.md file under templates/.claude/skills/<command-name>/SKILL.md.
+ */
+export function validateSlashCommands(readmeContent: string, skillsDir: string): SlashCommandValidation {
+  const commands = extractSlashCommandsFromReadme(readmeContent);
+
+  const valid: string[] = [];
+  const phantom: string[] = [];
+
+  for (const command of commands) {
+    const skillPath = path.join(skillsDir, command, 'SKILL.md');
+    if (fs.existsSync(skillPath)) {
+      valid.push(command);
+    } else {
+      phantom.push(command);
+    }
+  }
+
+  return { valid, phantom };
+}
+
+export function programmaticValidation(stats: ImplementationStats, readmeEn: string): ValidationResult {
   const readme = extractNamesFromReadme(readmeEn);
 
   // If canonical ID blocks are not found, skip name comparison
@@ -159,7 +200,13 @@ function programmaticValidation(stats: ImplementationStats, readmeEn: string): V
   return { missingFromReadme, extraInReadme, countMismatches };
 }
 
-function buildPrompt(stats: ImplementationStats, readmeEn: string, readmeKo: string, validation: ValidationResult): string {
+export function buildPrompt(
+  stats: ImplementationStats,
+  readmeEn: string,
+  readmeKo: string,
+  validation: ValidationResult,
+  slashCommandValidation: SlashCommandValidation,
+): string {
   const statsJson = JSON.stringify(stats, null, 2);
 
   return `당신은 oh-my-customcode 프로젝트의 문서 검증 전문가입니다.
@@ -187,6 +234,15 @@ ${validation.missingFromReadme.skills.length > 0 ? `- README에 누락된 skills
 ${validation.extraInReadme.agents.length > 0 ? `- README에만 있는 agents (실제 미존재): ${validation.extraInReadme.agents.join(', ')}` : ''}
 ${validation.extraInReadme.skills.length > 0 ? `- README에만 있는 skills (실제 미존재): ${validation.extraInReadme.skills.join(', ')}` : ''}
 ${validation.countMismatches.map((m) => `- ${m.field} 개수: README=${m.readme}, 실제=${m.actual}`).join('\n')}`
+}
+
+### 슬래시 커맨드 검증 (확정 - 변경 금지)
+
+${slashCommandValidation.phantom.length === 0
+  ? `✅ README의 모든 슬래시 커맨드(${slashCommandValidation.valid.length}개)에 대응하는 SKILL.md가 존재합니다.`
+  : `❌ Phantom 슬래시 커맨드 발견 (README에 있으나 SKILL.md 미존재):
+${slashCommandValidation.phantom.map((c) => `- /${c}`).join('\n')}
+유효한 커맨드(${slashCommandValidation.valid.length}개): ${slashCommandValidation.valid.map((c) => `/${c}`).join(', ')}`
 }
 
 ---
@@ -287,6 +343,8 @@ async function main() {
     }
 
     const validation = programmaticValidation(stats, readmeEn);
+    const skillsDir = path.join('templates', '.claude/skills');
+    const slashCommandValidation = validateSlashCommands(readmeEn, skillsDir);
 
     const client = new Anthropic();
     const message = await client.messages.create({
@@ -295,7 +353,7 @@ async function main() {
       messages: [
         {
           role: 'user',
-          content: buildPrompt(stats, readmeEn, readmeKo, validation),
+          content: buildPrompt(stats, readmeEn, readmeKo, validation, slashCommandValidation),
         },
       ],
     });
@@ -315,7 +373,8 @@ async function main() {
       validation.missingFromReadme.skills.length > 0 ||
       validation.extraInReadme.agents.length > 0 ||
       validation.extraInReadme.skills.length > 0 ||
-      validation.countMismatches.length > 0;
+      validation.countMismatches.length > 0 ||
+      slashCommandValidation.phantom.length > 0;
     // Check for explicit LLM verdict first, fall back to marker detection
     const hasExplicitFail = /최종 판정[\s\S]*?\*\*FAIL\*\*/i.test(result);
     const hasExplicitPass = /최종 판정[\s\S]*?\*\*PASS\*\*/i.test(result);


### PR DESCRIPTION
## Summary

- **#273 phantom slash command detection**: `validateSlashCommands()` 함수를 `validate-docs.ts`에 추가하여 README 슬래시 커맨드 테이블과 실제 `.claude/skills/` 디렉토리를 교차 검증. phantom 커맨드 발견 시 CI FAIL
- **#274 unit tests**: `validate-docs.test.ts` 신규 생성 (33개 테스트). `extractNamesFromReadme`, `programmaticValidation`, `buildPrompt`, `collectImplementationStats`, `extractSlashCommandsFromReadme` 함수 커버
- `validate-docs.ts`에 테스트에 필요한 함수 exports 추가

Closes #273
Closes #274

## Test plan

- [ ] CI passes: TypeScript type check, Biome lint, unit tests (1035 tests, 99.37% line coverage)
- [ ] `validateSlashCommands()` phantom 커맨드 감지 시 CI FAIL 확인
- [ ] 신규 33개 테스트 모두 pass 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)