### PR TITLE
feat: add docs validator as release gate

### DIFF
--- a/.github/scripts/validate-docs.ts
+++ b/.github/scripts/validate-docs.ts
@@ -274,19 +274,90 @@ _이 검증은 Claude API에 의해 자동 수행되었습니다._
 `;
 }
 
+function printProgrammaticResults(
+  stats: ImplementationStats,
+  validation: ValidationResult,
+  slashCommandValidation: SlashCommandValidation,
+): boolean {
+  console.log('📋 Programmatic Validation Results');
+
+  const hasProgrammaticIssues =
+    validation.missingFromReadme.agents.length > 0 ||
+    validation.missingFromReadme.skills.length > 0 ||
+    validation.extraInReadme.agents.length > 0 ||
+    validation.extraInReadme.skills.length > 0 ||
+    validation.countMismatches.length > 0 ||
+    slashCommandValidation.phantom.length > 0;
+
+  // Agent count line
+  const agentMismatch = validation.countMismatches.find((m) => m.field === 'agents');
+  if (agentMismatch) {
+    console.log(`❌ Agent count: README=${agentMismatch.readme}, actual=${agentMismatch.actual}`);
+  } else {
+    console.log(`✅ Agent count: ${stats.agent_count} (matched)`);
+  }
+
+  // Skill count line
+  const skillMismatch = validation.countMismatches.find((m) => m.field === 'skills');
+  if (skillMismatch) {
+    console.log(`❌ Skill count: README=${skillMismatch.readme}, actual=${skillMismatch.actual}`);
+  } else {
+    console.log(`✅ Skill count: ${stats.skill_count} (matched)`);
+  }
+
+  // Missing/extra agents
+  if (validation.missingFromReadme.agents.length > 0) {
+    console.log(`❌ Agents missing from README: ${validation.missingFromReadme.agents.join(', ')}`);
+  }
+  if (validation.extraInReadme.agents.length > 0) {
+    console.log(`❌ Phantom agents in README: ${validation.extraInReadme.agents.join(', ')}`);
+  }
+
+  // Missing/extra skills
+  if (validation.missingFromReadme.skills.length > 0) {
+    console.log(`❌ Skills missing from README: ${validation.missingFromReadme.skills.join(', ')}`);
+  }
+  if (validation.extraInReadme.skills.length > 0) {
+    console.log(`❌ Phantom skills in README: ${validation.extraInReadme.skills.join(', ')}`);
+  }
+
+  // Slash commands
+  if (slashCommandValidation.phantom.length > 0) {
+    console.log(`❌ Phantom slash commands: ${slashCommandValidation.phantom.map((c) => `/${c}`).join(', ')}`);
+    console.log(`✅ Slash commands: ${slashCommandValidation.valid.length} valid, ${slashCommandValidation.phantom.length} phantom`);
+  } else {
+    console.log(`✅ Slash commands: ${slashCommandValidation.valid.length} valid, 0 phantom`);
+  }
+
+  return !hasProgrammaticIssues;
+}
+
 async function main() {
+  const programmaticOnly = process.argv.includes('--programmatic-only');
+
   try {
     const stats = await collectImplementationStats();
     const readmeEn = await extractReadmeClaims('README.md');
-    const readmeKo = await extractReadmeClaims('README_ko.md');
 
     if (!readmeEn) {
       console.log('⚠️ README.md를 찾을 수 없습니다.');
       console.log('\n<!-- VALIDATION_STATUS: FAIL -->');
-      return;
+      process.exit(1);
     }
 
     const validation = programmaticValidation(stats, readmeEn);
+
+    if (programmaticOnly) {
+      const passed = printProgrammaticResults(stats, validation, slashCommandValidation);
+      const status = passed ? 'PASS' : 'FAIL';
+      console.log(`\n<!-- VALIDATION_STATUS: ${status} -->`);
+      if (!passed) {
+        process.exit(1);
+      }
+      return;
+    }
+
+    const readmeKo = await extractReadmeClaims('README_ko.md');
 
     const client = new Anthropic();
     const message = await client.messages.create({

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,27 @@ jobs:
       - name: Build
         run: bun run build
 
+  docs-validate:
+    name: Validate Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run documentation validation
+        run: bun run .github/scripts/validate-docs.ts --programmatic-only
+
   publish:
     name: Publish
-    needs: [test]
+    needs: [test, docs-validate]
     runs-on: macos-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- Closes #282
- Adds `--programmatic-only` mode to `validate-docs.ts` that skips Claude API calls and performs fast structural checks only (agent/skill counts, phantom entries in README, slash command validation)
- Adds `docs-validate` job to `release.yml` as a prerequisite (`needs`) for the `publish` job — documentation must pass validation before every npm release

## Changes

### `.github/scripts/validate-docs.ts`
- New `printProgrammaticResults()` function: outputs structured pass/fail lines for agent count, skill count, missing/phantom agents, missing/phantom skills, and phantom slash commands
- `--programmatic-only` flag: skips Anthropic API call entirely; exits with code `1` on any structural mismatch
- Moves `readmeKo` extraction after the programmatic gate so the API is never called in CI release checks

### `.github/workflows/release.yml`
- New `docs-validate` job: checkout → setup Bun → `bun install --frozen-lockfile` → `bun run .github/scripts/validate-docs.ts --programmatic-only`
- `publish` job now declares `needs: [test, docs-validate]` — a release cannot proceed if docs are out of sync

## Test plan

- [ ] Verify `docs-validate` job appears in the release workflow run on GitHub Actions
- [ ] Confirm `publish` job is blocked when `docs-validate` fails (e.g., temporarily add a phantom agent to README)
- [ ] Confirm `publish` job proceeds normally when docs are in sync
- [ ] Verify `--programmatic-only` flag produces no Anthropic API calls (check workflow logs for API key usage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)