### PR TITLE
fix: restore ontology-rag MCP server configuration

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "ontology-rag": {
+      "type": "stdio",
+      "command": ".venv/bin/python",
+      "args": [
+        "-m",
+        "ontology_rag.mcp_server"
+      ],
+      "env": {
+        "ONTOLOGY_DIR": ".claude/ontology"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,7 @@ Claude Code의 Agent Teams 기능이 활성화되어 있으면 (`CLAUDE_CODE_EXP
 | 서버 | 용도 |
 |------|------|
 | claude-mem | 세션 메모리 영속성 (Chroma 기반) |
+| ontology-rag | 에이전트/스킬/규칙 온톨로지 기반 컨텍스트 및 라우팅 |
 
 ### 설치 명령어
 


### PR DESCRIPTION
## Summary

- Restores `.mcp.json` with the `ontology-rag` MCP server configuration (file existed locally but was never tracked by git due to `.gitignore`)
- Adds `ontology-rag` to the recommended MCP servers table in `CLAUDE.md`

## Problem

Issue #294 reported zero usage of `ontology-rag`. Root cause: `.mcp.json` was listed in `.gitignore` and was never committed to the repository, so consumers of oh-my-customcode had no way to discover or use the server configuration.

## Changes

### Phase 1: Restore server configuration
- **`.mcp.json`** — added to git tracking via `git add -f` (gitignore bypass). Contains `ontology-rag` stdio server config pointing to `.claude/ontology/` directory.
- **`CLAUDE.md`** — added `ontology-rag` row to the "권장 MCP 서버" table with description of its purpose (ontology-based context and routing for agents/skills/rules).

## Test plan

- [ ] Verify `.mcp.json` is present after `git clone` / fresh install
- [ ] Confirm `ontology-rag` entry appears in `CLAUDE.md` recommended MCP servers table
- [ ] Validate `.mcp.json` JSON is well-formed

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)