### PR TITLE
chore(release): v0.31.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.1] - 2026-03-12
+
+### Fixed
+- **Guide count sync**: Corrected guide count from 24 to 25 across README_ko.md and template CLAUDE.md files (PR #308)
+
 ## [0.31.0] - 2026-03-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-customcode",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.31.0",
+  "version": "0.31.1",
   "lastUpdated": "2026-03-09T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- fix: sync guide count across README_ko.md and template CLAUDE.md files (24→25)
- feat: deer-flow P0 — SOUL.md identity, behavioral memory, artifact output (#275)

Closes #275 (if not already closed)