### PR TITLE
release: v0.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.1] - 2026-03-13
+
+### Added
+- **`/deep-plan` skill**: Research-validated planning with 3-phase cycle (Discovery Research → Reality-Check Planning → Plan Verification). Eliminates gap between research assumptions and actual codebase state (#325)
+
+### Fixed
+- **validate-docs hook counting**: Fixed false positive where `scripts/` directory was counted as a hook file. Now counts only `.json` files as hooks (#325)
+
 ## [0.32.0] - 2026-03-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-customcode",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.33.0",
+  "version": "0.33.1",
   "lastUpdated": "2026-03-13T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- Added `/deep-plan` skill: Research-validated planning with 3-phase cycle
- Fixed validate-docs hook counting false positive

## Changes
- Version bump: 0.33.0 → 0.33.1
- CHANGELOG.md updated

## Release Checklist
- [ ] CI passes
- [ ] Merge to develop
- [ ] Create GitHub Release tag v0.33.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)