### PR TITLE
release: v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-03-14
+
+### Added
+- `omcustom:` namespace prefix for 14 harness/package skills (Closes #264)
+- "When NOT to Use" guard sections for dev-review, dev-refactor, research skills
+- Stopping criteria display for worker-reviewer-pipeline and research skills
+- Cost estimate display for research skill
+- Pattern Selection guide (workflow-patterns.md)
+- Step 0 Pattern Selection in task-decomposition skill
+- `pattern_used` field in task-outcome-recorder hook
+- New evaluator-optimizer skill (general-purpose EO primitive)
+- Conditional hard-block (exit 1) in stuck-detector for 5+ consecutive repetitions
+
+### Changed
+- Reclassified 4 skills from core to harness scope (analysis, lists, status, help)
+- Skills count: 70 → 71
+- context:fork count documentation updated to 9/10
+
+### Fixed
+- Sauron verification findings (guide count, context:fork count, template sync)
+
+### Closed
+- #264: omcustom: namespace prefix convention
+- #328: CI validate-docs false positive
+- #329: Documentation informational findings
+
 ## [0.33.1] - 2026-03-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ All commands are invoked inside the Claude Code conversation.
 | `/memory-save` | Save session context to claude-mem |
 | `/memory-recall` | Search and recall memories |
 
-#### DevOps & Publishing
+#### DevOps & Package Management
 
 | Command | Description |
 |---------|-------------|

--- a/README_ko.md
+++ b/README_ko.md
@@ -128,7 +128,7 @@ dev-lead-routing (라우팅 스킬)
 | `/memory-save` | 세션 컨텍스트를 claude-mem에 저장 |
 | `/memory-recall` | 메모리 검색 및 리콜 |
 
-#### DevOps & 배포
+#### DevOps & 패키지 관리
 
 | 커맨드 | 설명 |
 |--------|------|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-customcode",
-  "version": "0.33.1",
+  "version": "0.34.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.33.1",
-  "lastUpdated": "2026-03-13T00:00:00.000Z",
+  "version": "0.34.0",
+  "lastUpdated": "2026-03-14T00:00:00.000Z",
   "components": [
     {
       "name": "rules",


### PR DESCRIPTION
## Summary

- Bump version from 0.33.1 to 0.34.0 in `package.json` and `templates/manifest.json`
- Update `CHANGELOG.md` with v0.34.0 release notes

## Changes in v0.34.0

### Added
- `omcustom:` namespace prefix for 14 harness/package skills (Closes #264)
- "When NOT to Use" guard sections for dev-review, dev-refactor, research skills
- Stopping criteria display for worker-reviewer-pipeline and research skills
- Cost estimate display for research skill
- Pattern Selection guide (workflow-patterns.md)
- Step 0 Pattern Selection in task-decomposition skill
- `pattern_used` field in task-outcome-recorder hook
- New evaluator-optimizer skill (general-purpose EO primitive)
- Conditional hard-block (exit 1) in stuck-detector for 5+ consecutive repetitions

### Changed
- Reclassified 4 skills from core to harness scope (analysis, lists, status, help)
- Skills count: 70 → 71
- context:fork count documentation updated to 9/10

### Fixed
- Sauron verification findings (guide count, context:fork count, template sync)

### Closed Issues
- #264: omcustom: namespace prefix convention
- #328: CI validate-docs false positive
- #329: Documentation informational findings

## Test plan
- [ ] CI passes on release branch
- [ ] Version sync check passes (package.json == templates/manifest.json)
- [ ] CHANGELOG.md format is valid
- [ ] After merge: fast-forward develop, create GitHub Release tag v0.34.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)