### PR TITLE
Release v0.35.2

### DIFF
--- a/.claude/agent-memory/mgr-sauron/MEMORY.md
+++ b/.claude/agent-memory/mgr-sauron/MEMORY.md
@@ -101,6 +101,18 @@ The bash script in R017 that checks skill refs (`grep "^skills:" -A 10`) picks u
 - This is a KNOWN pre-existing issue — ontology is advisory/RAG-only, NOT blocking functionality
 - DO NOT treat ontology stale state as a verification failure; treat as issue for future ontology update PR
 
+### v0.35.0 Release Verification (2026-03-14)
+- Full R017 sauron:watch passed (1 non-blocking issue) for release/v0.35.0 pre-push gate
+- All 44 agents, 71 skills, 25 guides, 19 rules, 1 hook, 4 contexts: counts verified and match manifest
+- v0.35.0 changes: cost-cap-advisor.sh (new PostToolUse hook), stuck-detector.sh + task-outcome-recorder.sh updates, dev-review/dev-refactor/research SKILL.md updates (pre-flight guards + Anthropic workflow patterns)
+- All template files in sync: hooks.json, statusline.sh, cost-cap-advisor.sh, stuck-detector.sh, task-outcome-recorder.sh, dev-review/dev-refactor/research SKILL.md
+- Hook scripts: 10 referenced in hooks.json (all exist on disk), 1 orphaned (session-compliance-report.sh)
+- session-compliance-report.sh: ORPHANED SCRIPT — exists in .claude/hooks/scripts/ but NOT in hooks.json (removed in commit 5e483f0 as part of omcustom: namespace cleanup) and NOT in templates. Non-blocking, pre-existing since v0.34.0.
+- stage-blocker.sh uses exit 2 (hard block for structured-dev-cycle Write/Edit guard) — INTENTIONAL, same as stuck-detector exit 1
+- context:fork count: 9/10 cap (unchanged)
+- scope distribution: core 57, harness 10, package 4 (71 total)
+- hooks.json has 7 PreToolUse, 1 SessionStart, 1 SubagentStart, 1 SubagentStop, 11 PostToolUse, 2 Stop entries
+
 ### deer-flow P0 Soul System (added 2026-03-12, feature/deer-flow-p0)
 - Soul files: `.claude/agents/souls/{name}.soul.md` with frontmatter `agent:` + `version:`
 - Activation: agent frontmatter `soul: true` + routing skill Step 5 reads soul file

--- a/.claude/rules/MUST-agent-design.md
+++ b/.claude/rules/MUST-agent-design.md
@@ -165,10 +165,10 @@ Use `context: fork` for skills that orchestrate multi-agent workflows. Cap at **
 | Multi-agent coordination patterns | Single-agent reference skills |
 | Task decomposition/planning | External tool integrations |
 
-Current skills with `context: fork` (9/10 cap):
+Current skills with `context: fork` (8/10 cap):
 - secretary-routing, dev-lead-routing, de-lead-routing, qa-lead-routing
 - dag-orchestration, task-decomposition, worker-reviewer-pipeline
-- pipeline-guards, deep-plan
+- pipeline-guards
 
 ## Naming
 

--- a/.claude/rules/MUST-orchestrator-coordination.md
+++ b/.claude/rules/MUST-orchestrator-coordination.md
@@ -6,6 +6,8 @@
 
 The main conversation is the **sole orchestrator**. It uses routing skills to delegate tasks to subagents via the Agent tool (formerly Task tool). Subagents CANNOT spawn other subagents.
 
+**Agent Teams Exception**: Agent Teams members are peers, not hierarchical subagents. Teams members CAN spawn sub-agents via the Agent tool to execute complex workflows (e.g., research teams, verification teams). This enables Teams-compatible skills like `/research` and `/deep-plan` to run inside Team members. The Teams member acts as a local orchestrator for its own sub-tasks.
+
 **The orchestrator MUST NEVER directly write, edit, or create files. ALL file modifications MUST be delegated to appropriate subagents.**
 
 ## Self-Check (Before File Modification)

--- a/.claude/skills/deep-plan/SKILL.md
+++ b/.claude/skills/deep-plan/SKILL.md
@@ -5,14 +5,14 @@ scope: core
 version: 1.0.0
 user-invocable: true
 argument-hint: "<topic-or-issue>"
-context: fork
+teams-compatible: true
 ---
 
 # Deep Plan Skill
 
 Research-validated planning that eliminates the gap between research assumptions and actual code. Orchestrates a 3-phase cycle: Discovery Research → Reality-Check Planning → Plan Verification.
 
-**Orchestrator-only** — only the main conversation uses this skill (R010). All phases execute as subagents.
+**Teams-compatible** — works both from the main conversation (R010) and inside Agent Teams members. When used in Teams, the member directly executes the 3-phase workflow without Skill tool invocation.
 
 ## Usage
 
@@ -50,7 +50,11 @@ Phase 1: Discovery Research
 └── Output: research report (artifact)
 ```
 
-**Execution**: Delegates to `/research` skill via `Skill(research, args="<topic>")`. The orchestrator waits for completion before proceeding to Phase 2.
+**Execution**:
+- **Orchestrator mode**: Delegates to `/research` skill via `Skill(research, args="<topic>")`.
+- **Teams mode**: Executes the research workflow inline (see Teams Mode section). The member spawns research teams directly as sub-agents.
+
+The executor waits for completion before proceeding to Phase 2.
 
 **Output**: Full research report with ADOPT/ADAPT/AVOID taxonomy.
 
@@ -251,7 +255,7 @@ Phase 1 delegation to `/research` means Agent Teams decisions are handled by the
 
 | Component | Integration |
 |-----------|-------------|
-| `/research` | Phase 1 full invocation + Phase 3 reduced invocation pattern |
+| `/research` | Phase 1 full invocation (via Skill tool or inline in Teams mode) + Phase 3 reduced invocation pattern |
 | EnterPlanMode/ExitPlanMode | Phase 2 plan creation and user approval |
 | Explore agents | Phase 2 codebase verification (up to 3 parallel) |
 | R009 | Phase 1 (10 teams batched), Phase 2 (3 Explore), Phase 3 (3 teams) |
@@ -270,6 +274,53 @@ Phase 1 delegation to `/research` means Agent Teams decisions are handled by the
 | Phase 3 REVISE ≥ 2 times | Escalate to user for manual judgment |
 | Explore agent failure | Reduce parallel count, retry with remaining |
 | Partial team failure | Synthesize from available results, note gaps |
+
+## Teams Mode
+
+When running inside an Agent Teams member (not via Skill tool), the deep-plan workflow operates identically but with these adaptations:
+
+### How It Works
+
+The orchestrator reads this SKILL.md and includes the deep-plan instructions directly in the Teams member's prompt. The member then:
+
+1. Phase 1: Executes research workflow inline (not via `Skill(research)`) — spawns 10 research teams as sub-agents
+2. Phase 2: Uses EnterPlanMode/ExitPlanMode and Explore agents normally
+3. Phase 3: Spawns 3 verification teams as sub-agents
+4. Delivers final verified plan via `SendMessage` to team lead
+
+### Prompt Embedding Pattern
+
+```
+# When spawning a Teams member for deep-plan:
+Agent(
+  name: "planner-1",
+  team_name: "my-team",
+  prompt: """
+  You are a deep-plan agent. Follow the deep-plan skill workflow below:
+  {contents of deep-plan/SKILL.md}
+
+  Also follow this research workflow for Phase 1:
+  {contents of research/SKILL.md}
+
+  Topic: {user's planning topic}
+  Deliver verified plan via SendMessage to team lead when complete.
+  """
+)
+```
+
+### Differences from Orchestrator Mode
+
+| Aspect | Orchestrator Mode | Teams Mode |
+|--------|------------------|------------|
+| Invocation | `Skill(deep-plan)` | Prompt embedding |
+| Phase 1 research | `Skill(research)` | Inline execution |
+| Result delivery | Return to main conversation | `SendMessage` to team lead |
+| Plan approval | User via ExitPlanMode | Team lead via SendMessage |
+| Context isolation | Previously used `context: fork` | Standard context (no fork) |
+
+### Why No context: fork
+
+`context: fork` was removed to enable Teams compatibility. Fork blocks sub-agent spawning, which is essential for Phase 1 (10 research teams) and Phase 3 (3 verification teams). Without fork, deep-plan operates in the standard context, which is required for both orchestrator and Teams usage.
 
 ## Artifact Persistence
 

--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -3,13 +3,14 @@ name: research
 description: 10-team parallel deep analysis with cross-verification for any topic, repository, or technology. Use when user invokes /research or asks for comprehensive research.
 scope: core
 user-invocable: true
+teams-compatible: true
 ---
 
 # Research Skill
 
 Orchestrates 10 parallel research teams for comprehensive deep analysis of any topic, GitHub repository, or technology. Produces a structured report with ADOPT/ADAPT/AVOID taxonomy.
 
-**Orchestrator-only** — only the main conversation uses this skill (R010). Teams execute as subagents.
+**Teams-compatible** — works both from the main conversation (R010) and inside Agent Teams members. When used in Teams, the member directly executes the research workflow without Skill tool invocation.
 
 ## Usage
 
@@ -384,6 +385,52 @@ Progress:
 ├── T5-T8: → Running
 └── T9-T10: ○ Pending
 ```
+
+## Teams Mode
+
+When running inside an Agent Teams member (not via Skill tool), the research workflow operates identically but with these adaptations:
+
+### How It Works
+
+The orchestrator reads this SKILL.md and includes the research instructions directly in the Teams member's prompt. The member then:
+
+1. Executes Phase 1-4 autonomously using its own Agent tool access
+2. Spawns research teams as sub-agents (Teams members CAN spawn sub-agents)
+3. Delivers results via `SendMessage` to the team lead instead of returning to orchestrator
+
+### Prompt Embedding Pattern
+
+```
+# When spawning a Teams member for research:
+Agent(
+  name: "researcher-1",
+  team_name: "my-team",
+  prompt: """
+  You are a research agent. Follow the research skill workflow below:
+  {contents of research/SKILL.md}
+
+  Topic: {user's research topic}
+  Deliver results via SendMessage to team lead when complete.
+  """
+)
+```
+
+### Differences from Orchestrator Mode
+
+| Aspect | Orchestrator Mode | Teams Mode |
+|--------|------------------|------------|
+| Invocation | `Skill(research)` | Prompt embedding |
+| Result delivery | Return to main conversation | `SendMessage` to team lead |
+| Artifact persistence | Teams member writes artifact | Same |
+| GitHub issue creation | Orchestrator handles | Teams member handles directly |
+| Phase management | Orchestrator manages phases | Member manages phases autonomously |
+
+### Constraints
+
+- Each Teams member running research still respects R009 (max 4 concurrent sub-agents)
+- Batching order remains: T1-T4 → T5-T8 → T9-T10
+- Cost is identical to orchestrator mode (~$8-15 per research invocation)
+- Multiple Teams members running research simultaneously will multiply costs proportionally
 
 ## Integration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-customcode",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -165,10 +165,10 @@ Use `context: fork` for skills that orchestrate multi-agent workflows. Cap at **
 | Multi-agent coordination patterns | Single-agent reference skills |
 | Task decomposition/planning | External tool integrations |
 
-Current skills with `context: fork` (9/10 cap):
+Current skills with `context: fork` (8/10 cap):
 - secretary-routing, dev-lead-routing, de-lead-routing, qa-lead-routing
 - dag-orchestration, task-decomposition, worker-reviewer-pipeline
-- pipeline-guards, deep-plan
+- pipeline-guards
 
 ## Naming
 

--- a/templates/.claude/rules/MUST-orchestrator-coordination.md
+++ b/templates/.claude/rules/MUST-orchestrator-coordination.md
@@ -6,6 +6,8 @@
 
 The main conversation is the **sole orchestrator**. It uses routing skills to delegate tasks to subagents via the Agent tool (formerly Task tool). Subagents CANNOT spawn other subagents.
 
+**Agent Teams Exception**: Agent Teams members are peers, not hierarchical subagents. Teams members CAN spawn sub-agents via the Agent tool to execute complex workflows (e.g., research teams, verification teams). This enables Teams-compatible skills like `/research` and `/deep-plan` to run inside Team members. The Teams member acts as a local orchestrator for its own sub-tasks.
+
 **The orchestrator MUST NEVER directly write, edit, or create files. ALL file modifications MUST be delegated to appropriate subagents.**
 
 ## Self-Check (Before File Modification)

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.35.1",
+  "version": "0.35.2",
   "lastUpdated": "2026-03-14T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- feat: make research/deep-plan skills Agent Teams compatible
- Remove context:fork from deep-plan for Teams sub-agent spawning
- Add Agent Teams exception to R010 orchestrator rules
- Update R006 context:fork count (9→8)

## Changes
- `.claude/skills/research/SKILL.md` — Teams Mode section added
- `.claude/skills/deep-plan/SKILL.md` — context:fork removed, Teams Mode added
- `.claude/rules/MUST-orchestrator-coordination.md` — Agent Teams exception
- `.claude/rules/MUST-agent-design.md` — fork count 8/10
- `templates/` versions synced to 0.35.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)