### PR TITLE
Release v0.37.1

### DIFF
--- a/.claude/skills/de-lead-routing/SKILL.md
+++ b/.claude/skills/de-lead-routing/SKILL.md
@@ -65,8 +65,11 @@ Check if Agent Teams is available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or T
 For **new pipeline code**, **DAG scaffolding**, or **SQL model generation**:
 
 1. Check `/tmp/.claude-env-status-*` for codex availability
-2. If codex available → suggest hybrid workflow for code generation
-3. If codex unavailable → use DE expert directly
+2. If codex available AND task involves new file creation → automatically delegate to `/codex-exec` for scaffolding:
+   - Display: `[Codex Hybrid] Delegating to codex-exec...`
+   - codex-exec generates initial code (strength: fast generation)
+   - Selected DE expert reviews and refines codex output (strength: reasoning, quality)
+3. If codex unavailable → display `[Codex] Unavailable — proceeding with {expert} directly` and use DE expert directly
 
 **Suitable**: New DAG files, dbt model scaffolding, SQL template generation
 **Unsuitable**: Existing pipeline modification, architecture decisions, data quality analysis

--- a/.claude/skills/dev-lead-routing/SKILL.md
+++ b/.claude/skills/dev-lead-routing/SKILL.md
@@ -99,10 +99,11 @@ Check if Agent Teams is available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or T
 For **new file creation**, **boilerplate**, or **test code generation**:
 
 1. Check `/tmp/.claude-env-status-*` for codex availability
-2. If codex available → suggest hybrid workflow:
+2. If codex available AND task involves new file creation → automatically delegate to `/codex-exec` for scaffolding:
+   - Display: `[Codex Hybrid] Delegating to codex-exec...`
    - codex-exec generates initial code (strength: fast generation)
-   - Claude expert reviews and refines (strength: reasoning, quality)
-3. If codex unavailable → use Claude expert directly
+   - Selected Claude expert reviews and refines codex output (strength: reasoning, quality)
+3. If codex unavailable → display `[Codex] Unavailable — proceeding with {expert} directly` and use Claude expert directly
 
 **Suitable**: New file creation, boilerplate, scaffolding, test code
 **Unsuitable**: Existing code modification, architecture decisions, bug fixes

--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -163,8 +163,21 @@ Batch 3: T9, T10            (Innovation)
 
 ### Phase 2: Cross-Verification Loop (min 2, max 30 rounds)
 
+#### Codex Availability Check
+
+Before starting verification rounds, check codex availability:
+
+```bash
+# Run this check once before Phase 2 begins
+which codex &>/dev/null && [ -n "$OPENAI_API_KEY" ]
+# Exit 0 → codex available: enable dual-model verification (opus + codex)
+# Exit 1 → codex unavailable: display notice and proceed with opus-only
 ```
-Team findings ──→ opus 4.6 verification ──→ codex-exec xhigh verification
+
+If unavailable, display: `[Phase 2] Codex unavailable — opus-only verification`
+
+```
+Team findings ──→ opus 4.6 verification ──→ codex-exec xhigh verification (if available)
        │                                              │
        └── Contradiction detected? ── YES ──→ Round N+1
                                       NO  ──→ Consensus reached → Phase 3
@@ -172,7 +185,8 @@ Team findings ──→ opus 4.6 verification ──→ codex-exec xhigh verific
 
 Each round:
 1. **opus 4.6**: Deep reasoning verification — checks logical consistency, identifies gaps, challenges assumptions
-2. **codex-exec xhigh** (if available): Independent code-level verification — validates technical claims, tests feasibility
+2. **codex-exec xhigh** (when available): Independent code-level verification — validates technical claims, tests feasibility
+   - If unavailable: display `[Phase 2] Round {N}: Codex unavailable, proceeding with opus verification only`
 3. **Contradiction resolution**: Reconcile divergent findings between teams and verifiers
 4. **Convergence check**: All major claims verified with no outstanding contradictions → proceed
 
@@ -272,10 +286,16 @@ Round N:
           - Internal consistency (breadth ↔ depth alignment)
           - Cross-domain consistency (security ↔ architecture)
           - Evidence quality (claims without backing)
-  Step 2: codex-exec validates technical claims:
-          - Code patterns actually exist
-          - Benchmarks are reproducible
-          - Dependencies resolve correctly
+  Step 2: codex-exec validates technical claims (when available):
+          a. Invoke: /codex-exec with findings from all teams
+          b. Prompt:  "Validate technical claims: {findings}.
+                       Check code patterns, benchmark reproducibility,
+                       dependency resolution."
+          c. Effort:  --effort xhigh
+          d. Parse:   contradictions → merge with opus findings
+          e. On timeout/error: log "[Phase 2] Round {N}: codex-exec error — {reason},
+                                continuing with opus results only"
+     If unavailable: log "[Phase 2] Round {N}: Codex unavailable, proceeding with opus verification only"
   Step 3: Compile contradiction list
           - 0 contradictions → CONVERGED
           - >0 contradictions → feedback to relevant teams → Round N+1

--- a/.claude/skills/structured-dev-cycle/SKILL.md
+++ b/.claude/skills/structured-dev-cycle/SKILL.md
@@ -95,9 +95,11 @@ A PreToolUse hook in `.claude/hooks/hooks.json` checks this marker and blocks Wr
 
 **Codex-Exec Hybrid Option**: When entering Stage 3:
 1. Check `/tmp/.claude-env-status-*` for codex CLI availability
-2. If available AND task involves new file creation:
-   - Suggest: `[Codex Hybrid Available] New file generation can use codex-exec for faster scaffolding. Orchestrator may delegate initial code generation to codex-exec, then have Claude expert review.`
-3. If unavailable → proceed with standard implementation via Claude experts
+2. If available AND task involves new file creation → automatically delegate scaffolding to `/codex-exec`:
+   - Display: `[Codex Hybrid] Delegating scaffolding to codex-exec...`
+   - codex-exec generates initial code (strength: fast generation)
+   - Claude expert reviews and refines codex output (strength: reasoning, quality)
+3. If unavailable → display `[Codex] Unavailable — proceeding with Claude experts directly` and proceed with standard implementation via Claude experts
 
 Suitable for codex hybrid: new files, boilerplate, test stubs, scaffolding
 Not suitable: modifying existing code, architecture-dependent changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oh-my-customcode",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.37.0",
+  "version": "0.37.1",
   "lastUpdated": "2026-03-14T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary

- **codex-exec auto-delegation** (#385): Research Phase 2, dev-lead/de-lead routing, structured-dev-cycle에서 codex-exec "suggest" → "auto-delegate" 전환
- **phuryn/pm-skills research** (#384): ADOPT/ADAPT/AVOID 분석 완료, Epic 닫기

### Changes
- research/SKILL.md: Phase 2 codex 실행 메커니즘 + availability check + visible fallback
- dev-lead-routing/SKILL.md: codex auto-delegate
- de-lead-routing/SKILL.md: codex auto-delegate
- structured-dev-cycle/SKILL.md: codex auto-delegate

## Test plan
- [ ] CI passes (lint, test, template sync)
- [ ] codex available 환경에서 `/research` 실행 시 Phase 2 codex 호출 확인
- [ ] codex unavailable 환경에서 visible fallback 메시지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)