### PR TITLE
feat: interactive init wizard (#398)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "oh-my-customcode",
       "dependencies": {
+        "@clack/prompts": "^1.1.0",
         "commander": "^14.0.2",
         "i18next": "^25.8.0",
         "yaml": "^2.8.2",
@@ -18,7 +19,7 @@
         "js-yaml": "^4.1.0",
         "nodemailer": "^8.0.1",
         "typescript": "^5.7.3",
-        "vitepress": "^1.6.3",
+        "vitepress": "^1.6.4",
       },
     },
   },
@@ -92,6 +93,10 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.3.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-Re4I7UnOoyE4kHMqpgtG6UvSBGBbbtvsOvBROgCCoH7EgANN6plSQhvo2W7OCITvTp7gD6oZOyZy72lUdXjqZg=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.12", "", { "os": "win32", "cpu": "x64" }, "sha512-qqGVWqNNek0KikwPZlOIoxtXgsNGsX+rgdEzgw82Re8nF02W+E2WokaQhpF5TdBh/D/RQ3TLppH+otp6ztN0lw=="],
+
+    "@clack/core": ["@clack/core@1.1.0", "", { "dependencies": { "sisteransi": "^1.0.5" } }, "sha512-SVcm4Dqm2ukn64/8Gub2wnlA5nS2iWJyCkdNHcvNHPIeBTGojpdJ+9cZKwLfmqy7irD4N5qLteSilJlE0WLAtA=="],
+
+    "@clack/prompts": ["@clack/prompts@1.1.0", "", { "dependencies": { "@clack/core": "1.1.0", "sisteransi": "^1.0.5" } }, "sha512-pkqbPGtohJAvm4Dphs2M8xE29ggupihHdy1x84HNojZuMtFsHiUlRvqD24tM2+XmI+61LlfNceM3Wr7U5QES5g=="],
 
     "@docsearch/css": ["@docsearch/css@3.8.2", "", {}, "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ=="],
 
@@ -386,6 +391,8 @@
     "search-insights": ["search-insights@2.17.3", "", {}, "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ=="],
 
     "shiki": ["shiki@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/langs": "2.5.0", "@shikijs/themes": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "prepublishOnly": "bun run build && bun run test"
   },
   "dependencies": {
+    "@clack/prompts": "^1.1.0",
     "commander": "^14.0.2",
     "i18next": "^25.8.0",
     "yaml": "^2.8.2"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -31,15 +31,16 @@ export function createProgram(): Command {
     .version(packageJson.version, '-v, --version', i18n.t('cli.versionOption'))
     .option('--skip-version-check', 'Skip CLI version pre-flight check');
 
-  // omcustom init [--lang en|ko] [--domain <domain>]
+  // omcustom init [--lang en|ko] [--domain <domain>] [--yes]
   program
     .command('init')
     .description(i18n.t('cli.init.description'))
-    .option('-l, --lang <language>', i18n.t('cli.init.langOption'), 'en')
+    .option('-l, --lang <language>', i18n.t('cli.init.langOption'))
     .option(
       '--domain <domain>',
       'Install only agents/skills for specific domain (backend, frontend, data-engineering, devops)'
     )
+    .option('--yes', 'Skip interactive wizard, use defaults')
     .action(async (options) => {
       await initCommand(options);
     });

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -9,13 +9,14 @@ import { getProviderLayout } from '../core/layout.js';
 import { checkUvAvailable, generateMCPConfig } from '../core/mcp-config.js';
 import { i18n } from '../i18n/index.js';
 import { fileExists } from '../utils/fs.js';
+import { getDefaultWizardResult, isInteractiveMode, runInitWizard } from './wizard.js';
 
 /**
  * Options for the init command
  */
 export interface InitOptions {
   /** Language for templates and messages (en|ko) */
-  lang: 'en' | 'ko';
+  lang?: 'en' | 'ko';
   /** Whether to overwrite existing files */
   force?: boolean;
   /**
@@ -24,6 +25,8 @@ export interface InitOptions {
    * When omitted, all agents are installed (backward compatible).
    */
   domain?: string;
+  /** Skip interactive wizard, use defaults */
+  yes?: boolean;
 }
 
 /**
@@ -121,6 +124,51 @@ function logInstallResultInfo(result: InstallerResult): void {
   logItems(result.warnings, (warning) => console.warn(`Warning: ${warning}`));
 }
 
+interface ResolvedOptions {
+  lang: 'en' | 'ko' | undefined;
+  domain: string | undefined;
+}
+
+/**
+ * Resolve lang/domain via wizard or defaults.
+ * Returns null if the wizard was cancelled.
+ */
+async function resolveOptions(options: InitOptions): Promise<ResolvedOptions | null> {
+  if (isInteractiveMode(options.yes)) {
+    const result = await runInitWizard({
+      yes: options.yes,
+      lang: options.lang,
+      domain: options.domain,
+    });
+    if (result.cancelled) return null;
+    return { lang: result.lang, domain: result.domain };
+  }
+  const defaults = getDefaultWizardResult({
+    yes: options.yes,
+    lang: options.lang,
+    domain: options.domain,
+  });
+  return { lang: defaults.lang, domain: defaults.domain };
+}
+
+/**
+ * Setup MCP config if uv is available.
+ */
+async function setupMcpConfig(targetDir: string): Promise<void> {
+  const uvAvailable = await checkUvAvailable();
+  if (uvAvailable) {
+    try {
+      await generateMCPConfig(targetDir);
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      console.warn(`Warning: Failed to setup MCP environment: ${msg}`);
+    }
+  } else {
+    console.warn('Warning: uv not found. Skipping MCP server configuration.');
+    console.warn('Install uv (https://docs.astral.sh/uv/) to enable MCP integration.');
+  }
+}
+
 /**
  * Execute the init command
  * @param options - Init command options
@@ -128,6 +176,12 @@ function logInstallResultInfo(result: InstallerResult): void {
  */
 export async function initCommand(options: InitOptions): Promise<InitResult> {
   const targetDir = process.cwd();
+
+  const resolved = await resolveOptions(options);
+  if (!resolved) {
+    return { success: false, message: i18n.t('cli.init.wizard.cancelled') };
+  }
+
   console.log(i18n.t('cli.init.start'));
 
   try {
@@ -142,10 +196,10 @@ export async function initCommand(options: InitOptions): Promise<InitResult> {
     console.log(i18n.t('cli.init.copying'));
     const installResult = await install({
       targetDir,
-      language: options.lang,
+      language: resolved.lang,
       force: options.force ?? false,
       backup: exists,
-      domain: options.domain,
+      domain: resolved.domain,
     });
 
     if (!installResult.success) {
@@ -156,19 +210,7 @@ export async function initCommand(options: InitOptions): Promise<InitResult> {
     logInstallResultInfo(installResult);
     logSuccessDetails(installedPaths, installResult.skippedComponents);
 
-    // Generate MCP config for ontology-rag if uv is available
-    const uvAvailable = await checkUvAvailable();
-    if (uvAvailable) {
-      try {
-        await generateMCPConfig(targetDir);
-      } catch (error) {
-        const msg = error instanceof Error ? error.message : String(error);
-        console.warn(`Warning: Failed to setup MCP environment: ${msg}`);
-      }
-    } else {
-      console.warn('Warning: uv not found. Skipping MCP server configuration.');
-      console.warn('Install uv (https://docs.astral.sh/uv/) to enable MCP integration.');
-    }
+    await setupMcpConfig(targetDir);
 
     return {
       success: true,

--- a/src/cli/wizard.ts
+++ b/src/cli/wizard.ts
@@ -1,0 +1,123 @@
+/**
+ * Interactive setup wizard for omcustom init command
+ */
+
+import * as p from '@clack/prompts';
+import i18next from 'i18next';
+
+export interface WizardResult {
+  lang: 'en' | 'ko';
+  domain: string | undefined;
+  teamMode: boolean;
+  cancelled: boolean;
+}
+
+export interface WizardOptions {
+  yes?: boolean;
+  lang?: string;
+  domain?: string;
+}
+
+/**
+ * Determine if the wizard should run interactively.
+ * Returns false when: --yes flag, non-TTY stdout, CI environment.
+ */
+export function isInteractiveMode(yes?: boolean): boolean {
+  if (yes) return false;
+  if (!process.stdout.isTTY) return false;
+  if (process.env.CI) return false;
+  if (process.env.GITHUB_ACTIONS) return false;
+  return true;
+}
+
+/**
+ * Build a non-interactive default result from CLI options.
+ */
+export function getDefaultWizardResult(options: WizardOptions): WizardResult {
+  return {
+    lang: (options.lang as 'en' | 'ko') || 'en',
+    domain: options.domain,
+    teamMode: false,
+    cancelled: false,
+  };
+}
+
+/** Cancelled sentinel result */
+function cancelResult(lang: 'en' | 'ko' = 'en', domain?: string): WizardResult {
+  p.outro(i18next.t('cli.init.wizard.cancelled'));
+  return { lang, domain: domain ?? undefined, teamMode: false, cancelled: true };
+}
+
+/** Step 1: Prompt for language selection */
+async function promptLang(options: WizardOptions): Promise<{ lang: 'en' | 'ko' } | null> {
+  if (options.lang === 'en' || options.lang === 'ko') {
+    return { lang: options.lang };
+  }
+  const result = await p.select({
+    message: i18next.t('cli.init.wizard.langPrompt'),
+    options: [
+      { value: 'ko', label: '한국어' },
+      { value: 'en', label: 'English' },
+    ],
+  });
+  if (p.isCancel(result)) return null;
+  return { lang: result as 'en' | 'ko' };
+}
+
+/** Step 2: Prompt for domain selection */
+async function promptDomain(
+  options: WizardOptions
+): Promise<{ domain: string | undefined } | null> {
+  if (options.domain) {
+    return { domain: options.domain === 'all' ? undefined : options.domain };
+  }
+  const result = await p.select({
+    message: i18next.t('cli.init.wizard.domainPrompt'),
+    options: [
+      { value: 'all', label: i18next.t('cli.init.wizard.domainAll') },
+      { value: 'backend', label: i18next.t('cli.init.wizard.domainBackend') },
+      { value: 'frontend', label: i18next.t('cli.init.wizard.domainFrontend') },
+      { value: 'data-engineering', label: i18next.t('cli.init.wizard.domainDataEngineering') },
+      { value: 'devops', label: i18next.t('cli.init.wizard.domainDevops') },
+    ],
+  });
+  if (p.isCancel(result)) return null;
+  return { domain: result === 'all' ? undefined : (result as string) };
+}
+
+/** Step 3: Prompt for team mode */
+async function promptTeamMode(): Promise<{ teamMode: boolean } | null> {
+  const result = await p.confirm({
+    message: i18next.t('cli.init.wizard.teamModePrompt'),
+    initialValue: false,
+  });
+  if (p.isCancel(result)) return null;
+  return { teamMode: result as boolean };
+}
+
+/**
+ * Run the interactive setup wizard.
+ * Falls back to defaults when running non-interactively.
+ */
+export async function runInitWizard(options: WizardOptions): Promise<WizardResult> {
+  if (!isInteractiveMode(options.yes)) {
+    return getDefaultWizardResult(options);
+  }
+
+  p.intro(i18next.t('cli.init.wizard.welcome'));
+
+  const langStep = await promptLang(options);
+  if (!langStep) return cancelResult();
+  const { lang } = langStep;
+
+  const domainStep = await promptDomain(options);
+  if (!domainStep) return cancelResult(lang);
+  const { domain } = domainStep;
+
+  const teamModeStep = await promptTeamMode();
+  if (!teamModeStep) return cancelResult(lang, domain);
+  const { teamMode } = teamModeStep;
+
+  p.outro(i18next.t('cli.init.wizard.confirm'));
+  return { lang, domain, teamMode, cancelled: false };
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -42,6 +42,10 @@ export interface OmccConfig {
   preserveFiles?: string[];
   /** Custom components not managed by omcustom */
   customComponents?: CustomComponentConfig[];
+  /** Domain filter used during installation */
+  domain?: string;
+  /** Team mode enabled */
+  teamMode?: boolean;
 }
 
 /**
@@ -140,6 +144,8 @@ export function getDefaultConfig(): OmccConfig {
       '.claude/agent-memory-local/',
     ],
     customComponents: [],
+    domain: undefined,
+    teamMode: false,
   };
 }
 

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -361,6 +361,7 @@ async function updateInstallConfig(
 ): Promise<void> {
   const config = await loadConfig(targetDir);
   config.language = options.language ?? DEFAULT_LANGUAGE;
+  config.domain = options.domain;
   config.installedAt = new Date().toISOString();
   config.installedComponents = installedComponents;
   await saveConfig(targetDir, config);

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -76,7 +76,21 @@
       "templateNotFound": "Template '{{name}}' not found",
       "initializingTemplate": "Initializing with template: {{name}}",
       "promptOverwrite": "Configuration already exists. Overwrite?",
-      "aborted": "Initialization aborted"
+      "aborted": "Initialization aborted",
+      "wizard": {
+        "welcome": "Welcome to oh-my-customcode setup!",
+        "langPrompt": "Select your preferred language",
+        "domainPrompt": "Select your team's primary domain",
+        "domainAll": "All domains (full install)",
+        "domainBackend": "Backend (Go, Python, Java, Spring, FastAPI, etc.)",
+        "domainFrontend": "Frontend (TypeScript, Vue, Svelte, Flutter, Vercel)",
+        "domainDataEngineering": "Data Engineering (Airflow, dbt, Spark, Kafka, etc.)",
+        "domainDevops": "DevOps / Infrastructure (Docker, AWS, CI/CD)",
+        "teamModePrompt": "Enable team mode?",
+        "teamModeHint": "Team mode enables shared evaluation server and authentication",
+        "confirm": "Ready to install with these settings:",
+        "cancelled": "Setup cancelled."
+      }
     },
     "update": {
       "description": "Update agents and configurations to latest version",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -76,7 +76,21 @@
       "templateNotFound": "'{{name}}' 템플릿을 찾을 수 없습니다",
       "initializingTemplate": "템플릿으로 초기화 중: {{name}}",
       "promptOverwrite": "설정 파일이 이미 존재합니다. 덮어쓰시겠습니까?",
-      "aborted": "초기화가 취소되었습니다"
+      "aborted": "초기화가 취소되었습니다",
+      "wizard": {
+        "welcome": "oh-my-customcode 설정을 시작합니다!",
+        "langPrompt": "사용할 언어를 선택하세요",
+        "domainPrompt": "팀의 주요 도메인을 선택하세요",
+        "domainAll": "전체 도메인 (전체 설치)",
+        "domainBackend": "백엔드 (Go, Python, Java, Spring, FastAPI 등)",
+        "domainFrontend": "프론트엔드 (TypeScript, Vue, Svelte, Flutter, Vercel)",
+        "domainDataEngineering": "데이터 엔지니어링 (Airflow, dbt, Spark, Kafka 등)",
+        "domainDevops": "DevOps / 인프라 (Docker, AWS, CI/CD)",
+        "teamModePrompt": "팀 모드를 활성화하시겠습니까?",
+        "teamModeHint": "팀 모드는 공유 평가 서버와 인증을 활성화합니다",
+        "confirm": "다음 설정으로 설치를 진행합니다:",
+        "cancelled": "설정이 취소되었습니다."
+      }
     },
     "update": {
       "description": "에이전트 및 설정을 최신 버전으로 업데이트",


### PR DESCRIPTION
## Summary

Adds an interactive setup wizard to \`omcustom init\` using @clack/prompts.

### Wizard Steps
1. **Language**: ko / en selection
2. **Domain**: all / backend / frontend / data-engineering / devops
3. **Team mode**: on/off toggle

### Non-interactive Support
- \`--yes\` flag skips wizard
- CI environments auto-detected (CI, GITHUB_ACTIONS env vars)
- Non-TTY terminals automatically use defaults

### Files Changed
- **New**: \`src/cli/wizard.ts\` (~120 LOC)
- **Modified**: \`src/cli/init.ts\`, \`src/cli/index.ts\`, \`src/core/config.ts\`, \`src/core/installer.ts\`
- **i18n**: \`en.json\`, \`ko.json\` — wizard translation keys

### Verification
- [x] \`bun run typecheck\` — 0 errors
- [x] \`bun test\` — 1221/1221 pass
- [x] \`bun run build\` — success

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)