### PR TITLE
hotfix: v0.42.1 — fix README skill count

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-customcode",
   "workspaces": ["packages/*"],
-  "version": "0.42.0",
+  "version": "0.42.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.42.0",
+  "version": "0.42.1",
   "lastUpdated": "2026-03-16T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
Fix README skill count validation failure that blocked v0.41.0 and v0.42.0 npm publish.

- README.md: 74 → 75 (already fixed in develop at 9f13d19)
- Version bump: 0.42.0 → 0.42.1

## Context
The adversarial-review skill was added in v0.41.0 but README counts weren't updated,
causing `validate-docs.ts` to fail in the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)