### PR TITLE
Release v0.43.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,24 @@
         "bun": ">=1.0.0",
       },
     },
+    "packages/serve": {
+      "name": "@omcustom/serve",
+      "version": "0.1.0",
+      "dependencies": {
+        "marked": "^15.0.0",
+        "yaml": "^2.0.0",
+      },
+      "devDependencies": {
+        "@sveltejs/adapter-node": "^5.0.0",
+        "@sveltejs/kit": "^2.0.0",
+        "@tailwindcss/vite": "^4.0.0",
+        "svelte": "^5.0.0",
+        "svelte-check": "^4.0.0",
+        "tailwindcss": "^4.0.0",
+        "typescript": "^5.0.0",
+        "vite": "^6.0.0",
+      },
+    },
   },
   "overrides": {
     "esbuild": "^0.25.0",
@@ -185,9 +203,19 @@
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
     "@omcustom/eval-core": ["@omcustom/eval-core@workspace:packages/eval-core"],
+
+    "@omcustom/serve": ["@omcustom/serve@workspace:packages/serve"],
 
     "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.10", "", { "os": "darwin", "cpu": "arm64" }, "sha512-PXgg5gqcS/rHwa1hF0JdM1y5TiyejVrMHoBmWY/DjtfYZoFTXie1RCFOkoG0b5diOOmUcuYarMpH7CSNTqwj+w=="],
 
@@ -214,6 +242,16 @@
     "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.10", "", { "os": "win32", "cpu": "x64" }, "sha512-gh3UAHbUdDUG6fhLc1Csa4IGdtghue6U8oAIXWnUqawp6lwb3gOCRvp25IUnLF5vUHtgfMxuEUYV7YA2WxVutw=="],
 
     "@petamoriken/float16": ["@petamoriken/float16@3.9.3", "", {}, "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g=="],
+
+    "@polka/url": ["@polka/url@1.0.0-next.29", "", {}, "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww=="],
+
+    "@rollup/plugin-commonjs": ["@rollup/plugin-commonjs@29.0.2", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "commondir": "^1.0.1", "estree-walker": "^2.0.2", "fdir": "^6.2.0", "is-reference": "1.2.1", "magic-string": "^0.30.3", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^2.68.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-S/ggWH1LU7jTyi9DxZOKyxpVd4hF/OZ0JrEbeLjXk/DFXwRny0tjD2c992zOUYQobLrVkRVMDdmHP16HKP7GRg=="],
+
+    "@rollup/plugin-json": ["@rollup/plugin-json@6.1.0", "", { "dependencies": { "@rollup/pluginutils": "^5.1.0" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA=="],
+
+    "@rollup/plugin-node-resolve": ["@rollup/plugin-node-resolve@16.0.3", "", { "dependencies": { "@rollup/pluginutils": "^5.0.1", "@types/resolve": "1.20.2", "deepmerge": "^4.2.2", "is-module": "^1.0.0", "resolve": "^1.22.1" }, "peerDependencies": { "rollup": "^2.78.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg=="],
+
+    "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
 
@@ -281,7 +319,49 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.9", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-lVJX6qEgs/4DOcRTpo56tmKzVPtoWAaVbL4hfO7t7NVwl9AAXzQR6cihesW1BmNMPl+bK6dreu2sOKBP2Q9CIA=="],
+
+    "@sveltejs/adapter-node": ["@sveltejs/adapter-node@5.5.4", "", { "dependencies": { "@rollup/plugin-commonjs": "^29.0.0", "@rollup/plugin-json": "^6.1.0", "@rollup/plugin-node-resolve": "^16.0.0", "rollup": "^4.59.0" }, "peerDependencies": { "@sveltejs/kit": "^2.4.0" } }, "sha512-45X92CXW+2J8ZUzPv3eLlKWEzINKiiGeFWTjyER4ZN4sGgNoaoeSkCY/QYNxHpPXy71QPsctwccBo9jJs0ySPQ=="],
+
+    "@sveltejs/kit": ["@sveltejs/kit@2.55.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/cookie": "^0.6.0", "acorn": "^8.14.1", "cookie": "^0.6.0", "devalue": "^5.6.4", "esm-env": "^1.2.2", "kleur": "^4.1.5", "magic-string": "^0.30.5", "mrmime": "^2.0.0", "set-cookie-parser": "^3.0.0", "sirv": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0", "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0", "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.3.3", "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0" }, "optionalPeers": ["@opentelemetry/api", "typescript"], "bin": { "svelte-kit": "svelte-kit.js" } }, "sha512-MdFRjevVxmAknf2NbaUkDF16jSIzXMWd4Nfah0Qp8TtQVoSp3bV4jKt8mX7z7qTUTWvgSaxtR0EG5WJf53gcuA=="],
+
+    "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@7.0.0", "", { "dependencies": { "deepmerge": "^4.3.1", "magic-string": "^0.30.21", "obug": "^2.1.0", "vitefu": "^1.1.2" }, "peerDependencies": { "svelte": "^5.46.4", "vite": "^8.0.0-beta.7 || ^8.0.0" } }, "sha512-ILXmxC7HAsnkK2eslgPetrqqW1BKSL7LktsFgqzNj83MaivMGZzluWq32m25j2mDOjmSKX7GGWahePhuEs7P/g=="],
+
+    "@tailwindcss/node": ["@tailwindcss/node@4.2.1", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.31.1", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.1" } }, "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg=="],
+
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.1", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.1", "@tailwindcss/oxide-darwin-arm64": "4.2.1", "@tailwindcss/oxide-darwin-x64": "4.2.1", "@tailwindcss/oxide-freebsd-x64": "4.2.1", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.1", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.1", "@tailwindcss/oxide-linux-arm64-musl": "4.2.1", "@tailwindcss/oxide-linux-x64-gnu": "4.2.1", "@tailwindcss/oxide-linux-x64-musl": "4.2.1", "@tailwindcss/oxide-wasm32-wasi": "4.2.1", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.1", "@tailwindcss/oxide-win32-x64-msvc": "4.2.1" } }, "sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw=="],
+
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.2.1", "", { "os": "android", "cpu": "arm64" }, "sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg=="],
+
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.2.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw=="],
+
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.2.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw=="],
+
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.2.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA=="],
+
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1", "", { "os": "linux", "cpu": "arm" }, "sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw=="],
+
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ=="],
+
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.2.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ=="],
+
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g=="],
+
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.2.1", "", { "os": "linux", "cpu": "x64" }, "sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g=="],
+
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.2.1", "", { "dependencies": { "@emnapi/core": "^1.8.1", "@emnapi/runtime": "^1.8.1", "@emnapi/wasi-threads": "^1.1.0", "@napi-rs/wasm-runtime": "^1.1.1", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q=="],
+
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.2.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA=="],
+
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.1", "", { "os": "win32", "cpu": "x64" }, "sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ=="],
+
+    "@tailwindcss/vite": ["@tailwindcss/vite@4.2.1", "", { "dependencies": { "@tailwindcss/node": "4.2.1", "@tailwindcss/oxide": "4.2.1", "tailwindcss": "4.2.1" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7" } }, "sha512-TBf2sJjYeb28jD2U/OhwdW0bbOsxkWPwQ7SrqGf9sVcoYwZj7rkXljroBO9wKBut9XnmQLXanuDUeqQK0lGg/w=="],
+
     "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
+
+    "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -301,9 +381,15 @@
 
     "@types/nodemailer": ["@types/nodemailer@7.0.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-vI8oF1M+8JvQhsId0Pc38BdUP2evenIIys7c7p+9OZXSPOH5c1dyINP1jT8xQ2xPuBUXmIC87s+91IZMDjH8Ow=="],
 
+    "@types/resolve": ["@types/resolve@1.20.2", "", {}, "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/web-bluetooth": ["@types/web-bluetooth@0.0.21", "", {}, "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="],
+
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.57.1", "", {}, "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
@@ -341,9 +427,15 @@
 
     "@vueuse/shared": ["@vueuse/shared@12.8.2", "", { "dependencies": { "vue": "^3.5.13" } }, "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w=="],
 
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
     "algoliasearch": ["algoliasearch@5.47.0", "", { "dependencies": { "@algolia/abtesting": "1.13.0", "@algolia/client-abtesting": "5.47.0", "@algolia/client-analytics": "5.47.0", "@algolia/client-common": "5.47.0", "@algolia/client-insights": "5.47.0", "@algolia/client-personalization": "5.47.0", "@algolia/client-query-suggestions": "5.47.0", "@algolia/client-search": "5.47.0", "@algolia/ingestion": "1.47.0", "@algolia/monitoring": "1.47.0", "@algolia/recommend": "5.47.0", "@algolia/requester-browser-xhr": "5.47.0", "@algolia/requester-fetch": "5.47.0", "@algolia/requester-node-http": "5.47.0" } }, "sha512-AGtz2U7zOV4DlsuYV84tLp2tBbA7RPtLA44jbVH4TTpDcc1dIWmULjHSsunlhscbzDydnjuFlNhflR3nV4VJaQ=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
     "birpc": ["birpc@2.9.0", "", {}, "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw=="],
 
@@ -359,9 +451,17 @@
 
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
+
+    "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
 
     "copy-anything": ["copy-anything@4.0.5", "", { "dependencies": { "is-what": "^5.2.0" } }, "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA=="],
 
@@ -369,7 +469,13 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devalue": ["devalue@5.6.4", "", {}, "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
@@ -379,6 +485,8 @@
 
     "emoji-regex-xs": ["emoji-regex-xs@1.0.0", "", {}, "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="],
 
+    "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
+
     "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
@@ -387,15 +495,27 @@
 
     "esbuild-register": ["esbuild-register@3.6.0", "", { "dependencies": { "debug": "^4.3.4" }, "peerDependencies": { "esbuild": ">=0.12 <1" } }, "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg=="],
 
+    "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
+
+    "esrap": ["esrap@2.2.4", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15", "@typescript-eslint/types": "^8.2.0" } }, "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg=="],
+
     "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "focus-trap": ["focus-trap@7.8.0", "", { "dependencies": { "tabbable": "^6.4.0" } }, "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
     "gel": ["gel@2.2.0", "", { "dependencies": { "@petamoriken/float16": "^3.8.7", "debug": "^4.3.4", "env-paths": "^3.0.0", "semver": "^7.6.2", "shell-quote": "^1.8.1", "which": "^4.0.0" }, "bin": { "gel": "dist/cli.mjs" } }, "sha512-q0ma7z2swmoamHQusey8ayo8+ilVdzDt4WTxSPzq/yRqvucWRfymRVMvNgmSC0XK7eNjjEZEcplxpgaNojKdmQ=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
     "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
@@ -407,17 +527,55 @@
 
     "i18next": ["i18next@25.8.0", "", { "dependencies": { "@babel/runtime": "^7.28.4" }, "peerDependencies": { "typescript": "^5" }, "optionalPeers": ["typescript"] }, "sha512-urrg4HMFFMQZ2bbKRK7IZ8/CTE7D8H4JRlAwqA2ZwDRFfdd0K/4cdbNNLgfn9mo+I/h9wJu61qJzH7jCFAhUZQ=="],
 
+    "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
+
+    "is-module": ["is-module@1.0.0", "", {}, "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g=="],
+
+    "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
+
     "is-what": ["is-what@5.5.0", "", {}, "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw=="],
 
     "isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
+
+    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "lightningcss": ["lightningcss@1.31.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.31.1", "lightningcss-darwin-arm64": "1.31.1", "lightningcss-darwin-x64": "1.31.1", "lightningcss-freebsd-x64": "1.31.1", "lightningcss-linux-arm-gnueabihf": "1.31.1", "lightningcss-linux-arm64-gnu": "1.31.1", "lightningcss-linux-arm64-musl": "1.31.1", "lightningcss-linux-x64-gnu": "1.31.1", "lightningcss-linux-x64-musl": "1.31.1", "lightningcss-win32-arm64-msvc": "1.31.1", "lightningcss-win32-x64-msvc": "1.31.1" } }, "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.31.1", "", { "os": "android", "cpu": "arm64" }, "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.31.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.31.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.31.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.31.1", "", { "os": "linux", "cpu": "arm" }, "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.31.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.31.1", "", { "os": "linux", "cpu": "x64" }, "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.31.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.31.1", "", { "os": "win32", "cpu": "x64" }, "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw=="],
+
+    "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "mark.js": ["mark.js@8.11.1", "", {}, "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="],
+
+    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
 
     "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
 
@@ -435,17 +593,27 @@
 
     "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
 
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
+    "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "nodemailer": ["nodemailer@8.0.1", "", {}, "sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg=="],
 
+    "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
     "oniguruma-to-es": ["oniguruma-to-es@3.1.1", "", { "dependencies": { "emoji-regex-xs": "^1.0.0", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ=="],
+
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
@@ -453,11 +621,15 @@
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
@@ -465,13 +637,19 @@
 
     "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
+    "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
+
     "search-insights": ["search-insights@2.17.3", "", {}, "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "set-cookie-parser": ["set-cookie-parser@3.0.1", "", {}, "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q=="],
+
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
     "shiki": ["shiki@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/langs": "2.5.0", "@shikijs/themes": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ=="],
+
+    "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
@@ -489,7 +667,21 @@
 
     "superjson": ["superjson@2.2.6", "", { "dependencies": { "copy-anything": "^4" } }, "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA=="],
 
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "svelte": ["svelte@5.54.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.6.4", "esm-env": "^1.2.1", "esrap": "^2.2.2", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-TTDxwYnHkova6Wsyj1PGt9TByuWqvMoeY1bQiuAf2DM/JeDSMw7FjRKzk8K/5mJ99vGOKhbCqTDpyAKwjp4igg=="],
+
+    "svelte-check": ["svelte-check@4.4.5", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-1bSwIRCvvmSHrlK52fOlZmVtUZgil43jNL/2H18pRpa+eQjzGt6e3zayxhp1S7GajPFKNM/2PMCG+DZFHlG9fw=="],
+
     "tabbable": ["tabbable@6.4.0", "", {}, "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg=="],
+
+    "tailwindcss": ["tailwindcss@4.2.1", "", {}, "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw=="],
+
+    "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "totalist": ["totalist@3.0.1", "", {}, "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
@@ -513,7 +705,9 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+    "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
+
+    "vitefu": ["vitefu@1.1.2", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw=="],
 
     "vitepress": ["vitepress@1.6.4", "", { "dependencies": { "@docsearch/css": "3.8.2", "@docsearch/js": "3.8.2", "@iconify-json/simple-icons": "^1.2.21", "@shikijs/core": "^2.1.0", "@shikijs/transformers": "^2.1.0", "@shikijs/types": "^2.1.0", "@types/markdown-it": "^14.1.2", "@vitejs/plugin-vue": "^5.2.1", "@vue/devtools-api": "^7.7.0", "@vue/shared": "^3.5.13", "@vueuse/core": "^12.4.0", "@vueuse/integrations": "^12.4.0", "focus-trap": "^7.6.4", "mark.js": "8.11.1", "minisearch": "^7.1.1", "shiki": "^2.1.0", "vite": "^5.4.14", "vue": "^3.5.13" }, "peerDependencies": { "markdown-it-mathjax3": "^4", "postcss": "^8" }, "optionalPeers": ["markdown-it-mathjax3", "postcss"], "bin": { "vitepress": "bin/vitepress.js" } }, "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg=="],
 
@@ -523,6 +717,24 @@
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
+    "zimmerframe": ["zimmerframe@1.1.4", "", {}, "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ=="],
+
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@rollup/plugin-commonjs/is-reference": ["is-reference@1.2.1", "", { "dependencies": { "@types/estree": "*" } }, "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.9.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.1", "", { "dependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1", "@tybys/wasm-util": "^0.10.1" }, "bundled": true }, "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "vitepress/vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-customcode",
   "workspaces": ["packages/*"],
-  "version": "0.42.3",
+  "version": "0.43.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/packages/serve/.gitignore
+++ b/packages/serve/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+build/
+.svelte-kit/
+*.tsbuildinfo

--- a/packages/serve/package.json
+++ b/packages/serve/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@omcustom/serve",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
+  },
+  "dependencies": {
+    "yaml": "^2.0.0",
+    "marked": "^15.0.0"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-node": "^5.0.0",
+    "@sveltejs/kit": "^2.0.0",
+    "svelte": "^5.0.0",
+    "svelte-check": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^6.0.0",
+    "@tailwindcss/vite": "^4.0.0",
+    "tailwindcss": "^4.0.0"
+  }
+}

--- a/packages/serve/src/app.css
+++ b/packages/serve/src/app.css
@@ -1,0 +1,112 @@
+@import "tailwindcss";
+
+/* Prose styles for rendered markdown */
+.prose {
+  color: theme(colors.zinc.200);
+  max-width: none;
+}
+
+.prose h1,
+.prose h2,
+.prose h3,
+.prose h4 {
+  color: theme(colors.zinc.50);
+  font-weight: 600;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.prose h1 { font-size: 1.5rem; border-bottom: 1px solid theme(colors.zinc.700); padding-bottom: 0.5rem; }
+.prose h2 { font-size: 1.25rem; }
+.prose h3 { font-size: 1.1rem; }
+
+.prose p {
+  margin-bottom: 0.75rem;
+  line-height: 1.7;
+}
+
+.prose a {
+  color: theme(colors.emerald.400);
+  text-decoration: underline;
+}
+
+.prose a:hover {
+  color: theme(colors.emerald.300);
+}
+
+.prose code {
+  background: theme(colors.zinc.800);
+  color: theme(colors.emerald.300);
+  padding: 0.1em 0.3em;
+  border-radius: 3px;
+  font-size: 0.875em;
+}
+
+.prose pre {
+  background: theme(colors.zinc.900);
+  border: 1px solid theme(colors.zinc.700);
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+  margin-bottom: 1rem;
+}
+
+.prose pre code {
+  background: none;
+  padding: 0;
+  font-size: 0.85rem;
+  color: theme(colors.zinc.200);
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+}
+
+.prose th {
+  background: theme(colors.zinc.800);
+  color: theme(colors.zinc.200);
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border: 1px solid theme(colors.zinc.700);
+}
+
+.prose td {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid theme(colors.zinc.800);
+}
+
+.prose tr:nth-child(even) td {
+  background: theme(colors.zinc.900);
+}
+
+.prose ul {
+  list-style: disc;
+  padding-left: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.prose ol {
+  list-style: decimal;
+  padding-left: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.prose li {
+  margin-bottom: 0.25rem;
+}
+
+.prose blockquote {
+  border-left: 3px solid theme(colors.emerald.500);
+  padding-left: 1rem;
+  color: theme(colors.zinc.400);
+  margin-left: 0;
+  font-style: italic;
+}
+
+.prose hr {
+  border-color: theme(colors.zinc.700);
+  margin: 1.5rem 0;
+}

--- a/packages/serve/src/app.html
+++ b/packages/serve/src/app.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en" class="dark">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>omcustom</title>
+		%sveltekit.head%
+	</head>
+	<body class="bg-zinc-950 text-zinc-100 min-h-screen font-mono">
+		<div style="display: contents">%sveltekit.body%</div>
+	</body>
+</html>

--- a/packages/serve/src/lib/server/agent-generator.ts
+++ b/packages/serve/src/lib/server/agent-generator.ts
@@ -1,0 +1,338 @@
+// Keyword-based natural language parser for agent generation.
+// No external API dependencies — pure keyword inference.
+
+export interface GeneratedAgent {
+	name: string;
+	description: string;
+	model: string;
+	domain: string;
+	tools: string[];
+	skills: string[];
+	body: string;
+}
+
+// ---------------------------------------------------------------------------
+// Domain inference
+// ---------------------------------------------------------------------------
+
+interface DomainRule {
+	domain: string;
+	prefix: string;
+	keywords: string[];
+}
+
+const DOMAIN_RULES: DomainRule[] = [
+	{
+		domain: 'backend',
+		prefix: 'be',
+		keywords: [
+			'fastapi', 'django', 'flask', 'express', 'nestjs', 'spring', 'springboot',
+			'api', 'rest', 'graphql', 'grpc', 'server', '서버', '백엔드', 'backend',
+			'microservice', '마이크로서비스'
+		]
+	},
+	{
+		domain: 'frontend',
+		prefix: 'fe',
+		keywords: [
+			'react', 'vue', 'svelte', 'angular', 'next.js', 'nextjs', 'nuxt',
+			'flutter', 'ui', 'ux', 'frontend', '프론트', '프론트엔드',
+			'component', '컴포넌트', 'tailwind', 'css', 'html', 'web'
+		]
+	},
+	{
+		domain: 'devops',
+		prefix: 'infra',
+		keywords: [
+			'kubernetes', 'k8s', 'docker', 'helm', 'terraform', 'ansible',
+			'ci/cd', 'cicd', 'github actions', 'jenkins', 'aws', 'gcp', 'azure',
+			'devops', '인프라', 'infra', 'deployment', '배포', 'cloud', '클라우드',
+			'kubectl', 'pod', 'container', '컨테이너'
+		]
+	},
+	{
+		domain: 'database',
+		prefix: 'db',
+		keywords: [
+			'postgresql', 'postgres', 'mysql', 'sqlite', 'redis', 'mongodb',
+			'supabase', 'database', 'db', '데이터베이스', 'sql', 'nosql',
+			'orm', 'drizzle', 'prisma', 'migration', '마이그레이션'
+		]
+	},
+	{
+		domain: 'data-engineering',
+		prefix: 'de',
+		keywords: [
+			'airflow', 'spark', 'kafka', 'dbt', 'snowflake', 'hadoop',
+			'pipeline', '파이프라인', 'etl', 'elt', 'data engineering',
+			'데이터 엔지니어링', 'streaming', 'batch', 'warehouse', 'lakehouse',
+			'flink', 'beam', 'bigquery'
+		]
+	},
+	{
+		domain: 'security',
+		prefix: 'sec',
+		keywords: [
+			'security', '보안', 'cve', 'vulnerability', '취약점', 'codeql',
+			'sast', 'dast', 'pentest', 'auth', 'authentication', 'authorization',
+			'oauth', 'jwt', 'encryption', '암호화', 'firewall', 'waf'
+		]
+	},
+	{
+		domain: 'qa',
+		prefix: 'qa',
+		keywords: [
+			'test', 'testing', '테스트', 'qa', 'quality', '품질',
+			'unit test', 'e2e', 'integration test', 'playwright', 'cypress',
+			'jest', 'pytest', 'vitest', 'tdd', 'bdd', 'coverage'
+		]
+	},
+	{
+		domain: 'architecture',
+		prefix: 'arch',
+		keywords: [
+			'architecture', '아키텍처', 'design pattern', 'design', '설계',
+			'ddd', 'cqrs', 'event sourcing', 'microservices', 'system design',
+			'documentation', 'docs', '문서', 'spec', 'adr'
+		]
+	}
+];
+
+// Language-specific domain overrides
+const LANG_RULES: Array<{ keywords: string[]; prefix: string; domain: string }> = [
+	{ keywords: ['go', 'golang'], prefix: 'lang-go', domain: 'backend' },
+	{ keywords: ['python', 'py'], prefix: 'lang-python', domain: 'backend' },
+	{ keywords: ['rust'], prefix: 'lang-rust', domain: 'backend' },
+	{ keywords: ['kotlin'], prefix: 'lang-kotlin', domain: 'backend' },
+	{ keywords: ['typescript', 'ts'], prefix: 'lang-ts', domain: 'backend' },
+	{ keywords: ['java'], prefix: 'lang-java', domain: 'backend' }
+];
+
+// ---------------------------------------------------------------------------
+// Model inference
+// ---------------------------------------------------------------------------
+
+const MODEL_RULES: Array<{ model: string; keywords: string[] }> = [
+	{
+		model: 'opus',
+		keywords: ['opus', '복잡', 'complex', 'architecture', '아키텍처', 'design', '설계', 'reasoning', 'analysis']
+	},
+	{
+		model: 'haiku',
+		keywords: ['haiku', '빠른', 'fast', 'simple', 'search', '검색', '간단', 'lightweight', 'quick']
+	}
+];
+
+// ---------------------------------------------------------------------------
+// Tech keyword extraction for name generation
+// ---------------------------------------------------------------------------
+
+const TECH_KEYWORDS: Array<{ keyword: string; slug: string }> = [
+	// Infra
+	{ keyword: 'kubernetes', slug: 'k8s' },
+	{ keyword: 'k8s', slug: 'k8s' },
+	{ keyword: 'docker', slug: 'docker' },
+	{ keyword: 'helm', slug: 'helm' },
+	{ keyword: 'terraform', slug: 'terraform' },
+	{ keyword: 'aws', slug: 'aws' },
+	// DB
+	{ keyword: 'postgresql', slug: 'postgres' },
+	{ keyword: 'postgres', slug: 'postgres' },
+	{ keyword: 'redis', slug: 'redis' },
+	{ keyword: 'mongodb', slug: 'mongo' },
+	{ keyword: 'supabase', slug: 'supabase' },
+	// FE
+	{ keyword: 'react', slug: 'react' },
+	{ keyword: 'vue', slug: 'vue' },
+	{ keyword: 'svelte', slug: 'svelte' },
+	{ keyword: 'flutter', slug: 'flutter' },
+	{ keyword: 'next.js', slug: 'nextjs' },
+	{ keyword: 'nextjs', slug: 'nextjs' },
+	// BE
+	{ keyword: 'fastapi', slug: 'fastapi' },
+	{ keyword: 'django', slug: 'django' },
+	{ keyword: 'spring', slug: 'spring' },
+	{ keyword: 'nestjs', slug: 'nestjs' },
+	{ keyword: 'express', slug: 'express' },
+	// DE
+	{ keyword: 'airflow', slug: 'airflow' },
+	{ keyword: 'spark', slug: 'spark' },
+	{ keyword: 'kafka', slug: 'kafka' },
+	{ keyword: 'dbt', slug: 'dbt' },
+	{ keyword: 'snowflake', slug: 'snowflake' },
+	// Lang
+	{ keyword: 'golang', slug: 'go' },
+	{ keyword: ' go ', slug: 'go' },
+	{ keyword: 'python', slug: 'python' },
+	{ keyword: 'rust', slug: 'rust' },
+	{ keyword: 'kotlin', slug: 'kotlin' },
+	{ keyword: 'typescript', slug: 'ts' }
+];
+
+// ---------------------------------------------------------------------------
+// Core parser
+// ---------------------------------------------------------------------------
+
+export function parseNaturalLanguage(input: string): GeneratedAgent {
+	const lower = ` ${input.toLowerCase()} `;
+
+	// --- Model inference ---
+	let model = 'sonnet';
+	for (const rule of MODEL_RULES) {
+		if (rule.keywords.some((kw) => lower.includes(kw))) {
+			model = rule.model;
+			break;
+		}
+	}
+
+	// --- Domain inference ---
+	let domain = 'universal';
+	let prefix = 'agent';
+
+	// Check language-specific rules first (higher specificity)
+	for (const rule of LANG_RULES) {
+		if (rule.keywords.some((kw) => lower.includes(` ${kw} `) || lower.includes(`${kw}\n`))) {
+			domain = rule.domain;
+			prefix = rule.prefix;
+			break;
+		}
+	}
+
+	// Fall back to domain rules
+	if (domain === 'universal') {
+		for (const rule of DOMAIN_RULES) {
+			if (rule.keywords.some((kw) => lower.includes(kw))) {
+				domain = rule.domain;
+				prefix = rule.prefix;
+				break;
+			}
+		}
+	}
+
+	// --- Tech keyword slug for name ---
+	let techSlug = '';
+	for (const { keyword, slug } of TECH_KEYWORDS) {
+		if (lower.includes(keyword)) {
+			techSlug = slug;
+			break;
+		}
+	}
+
+	// --- Name generation ---
+	let name: string;
+	if (techSlug) {
+		name = `${prefix}-${techSlug}-expert`;
+	} else {
+		// Extract a meaningful word from input (first noun-like token ≥ 3 chars, non-Korean)
+		const words = input
+			.split(/\s+/)
+			.map((w) => w.toLowerCase().replace(/[^a-z0-9]/g, ''))
+			.filter((w) => w.length >= 3 && /^[a-z]/.test(w));
+		const candidate = words[0] ?? 'custom';
+		name = `${prefix}-${candidate}-expert`;
+	}
+
+	// Ensure kebab-case
+	name = name.replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+
+	// --- Description ---
+	// Use first sentence of input, capped at 80 chars
+	const firstSentence = input.split(/[.!?。\n]/)[0].trim();
+	const description =
+		firstSentence.length > 80 ? firstSentence.slice(0, 77) + '...' : firstSentence;
+
+	// --- Default tools ---
+	const tools = ['Read', 'Write', 'Edit', 'Grep', 'Glob', 'Bash'];
+
+	// --- Body generation ---
+	// Extract capability hints from input (lines starting with -, *, • or containing "가능", "can")
+	const capabilityLines = input
+		.split('\n')
+		.map((l) => l.trim())
+		.filter((l) => /^[-*•]/.test(l) || l.includes('가능') || l.includes(' can '))
+		.slice(0, 5)
+		.map((l) => `- ${l.replace(/^[-*•]\s*/, '')}`);
+
+	// If no explicit capability lines, extract tech terms
+	const capabilitiesSection =
+		capabilityLines.length > 0
+			? capabilityLines.join('\n')
+			: inferCapabilities(input, domain);
+
+	const body = `# ${description}
+
+## Role
+
+${input.trim()}
+
+## Capabilities
+
+${capabilitiesSection}
+
+## Workflow
+
+1. Analyze the task requirements
+2. Implement the solution following best practices
+3. Verify the results
+`;
+
+	return {
+		name,
+		description,
+		model,
+		domain,
+		tools,
+		skills: [],
+		body
+	};
+}
+
+function inferCapabilities(input: string, domain: string): string {
+	const domainDefaults: Record<string, string[]> = {
+		backend: ['- Design and implement RESTful APIs', '- Write server-side business logic', '- Handle database interactions'],
+		frontend: ['- Build responsive UI components', '- Implement client-side logic', '- Optimize rendering performance'],
+		devops: ['- Write infrastructure as code', '- Configure CI/CD pipelines', '- Manage container deployments'],
+		database: ['- Design database schemas', '- Write optimized queries', '- Manage migrations'],
+		'data-engineering': ['- Build data pipelines', '- Transform and validate data', '- Optimize batch processing'],
+		security: ['- Perform security audits', '- Identify vulnerabilities', '- Implement security controls'],
+		qa: ['- Write unit and integration tests', '- Set up test automation', '- Analyze test coverage'],
+		architecture: ['- Design system architecture', '- Document architectural decisions', '- Review code for patterns'],
+		universal: ['- Analyze task requirements', '- Implement solutions', '- Review and verify results']
+	};
+
+	const lines = domainDefaults[domain] ?? domainDefaults.universal;
+	return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter builder
+// ---------------------------------------------------------------------------
+
+export function buildAgentMarkdown(agent: GeneratedAgent): string {
+	const toolsList = agent.tools.map((t) => `  - ${t}`).join('\n');
+	const skillsList =
+		agent.skills.length > 0 ? `\nskills:\n${agent.skills.map((s) => `  - ${s}`).join('\n')}` : '';
+
+	return `---
+name: ${agent.name}
+description: ${agent.description}
+model: ${agent.model}
+domain: ${agent.domain}
+tools:
+${toolsList}${skillsList}
+---
+
+${agent.body}`;
+}
+
+// ---------------------------------------------------------------------------
+// Name sanitization (kebab-case only)
+// ---------------------------------------------------------------------------
+
+export function sanitizeName(name: string): string {
+	return name
+		.toLowerCase()
+		.replace(/[^a-z0-9-]/g, '-')
+		.replace(/-+/g, '-')
+		.replace(/^-|-$/g, '');
+}

--- a/packages/serve/src/lib/server/claude-cli.ts
+++ b/packages/serve/src/lib/server/claude-cli.ts
@@ -1,0 +1,87 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+export async function isClaudeAvailable(): Promise<boolean> {
+	try {
+		await execAsync('which claude');
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export async function generateAgentWithClaude(
+	naturalLanguageInput: string,
+	projectRoot: string
+): Promise<string> {
+	const prompt = buildPrompt(naturalLanguageInput);
+
+	const { stdout } = await execAsync(
+		`claude -p ${escapeShellArg(prompt)} --no-input`,
+		{
+			timeout: 60000,
+			maxBuffer: 1024 * 1024,
+			cwd: projectRoot
+		}
+	);
+
+	// Strip markdown code-block fences if Claude wrapped the output
+	const raw = stdout.trim();
+	return stripCodeBlock(raw);
+}
+
+function stripCodeBlock(raw: string): string {
+	// Remove leading ```markdown / ```yaml / ``` and trailing ```
+	const fenced = raw.match(/^```[a-z]*\n([\s\S]*?)\n```$/);
+	if (fenced) return fenced[1].trim();
+	return raw;
+}
+
+function escapeShellArg(arg: string): string {
+	return `'${arg.replace(/'/g, "'\\''")}'`;
+}
+
+function buildPrompt(input: string): string {
+	return `You are an agent file generator for oh-my-customcode.
+
+Generate a complete agent markdown file based on this description:
+"${input}"
+
+The file must follow this exact format:
+
+---
+name: {kebab-case-name}
+description: {one-line English description}
+model: {sonnet | opus | haiku}
+tools:
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+  - Bash
+---
+
+# {Agent Title}
+
+## Role
+{What this agent does}
+
+## Capabilities
+{Bullet list of capabilities}
+
+## Workflow
+{Numbered steps}
+
+Rules:
+- name must be kebab-case (e.g., lang-rust-expert, be-fastapi-expert)
+- Use existing naming conventions: lang-* for languages, be-* for backends, fe-* for frontends, de-* for data engineering, db-* for databases, infra-* for infrastructure, mgr-* for managers, sec-* for security, qa-* for QA, arch-* for architecture, tool-* for tooling
+- description must be in English, one line
+- model: use sonnet for general tasks, opus for complex reasoning/architecture, haiku for simple/fast tasks
+- tools: always include Read, Grep, Glob. Add Write, Edit for code modification. Add Bash for execution.
+- Body sections in English
+
+Output ONLY the markdown file content. No explanations, no code blocks, no surrounding text.`;
+}

--- a/packages/serve/src/lib/server/data.ts
+++ b/packages/serve/src/lib/server/data.ts
@@ -1,0 +1,337 @@
+import { readdir, readFile, stat } from 'fs/promises';
+import { join, basename } from 'path';
+import { parseFrontmatter } from './frontmatter.js';
+
+// ---------------------------------------------------------------------------
+// Project root resolution
+// ---------------------------------------------------------------------------
+
+async function findProjectRoot(startDir: string): Promise<string> {
+	// Honor explicit env var first
+	if (process.env.OMCUSTOM_PROJECT_ROOT) {
+		return process.env.OMCUSTOM_PROJECT_ROOT;
+	}
+
+	let dir = startDir;
+	for (let i = 0; i < 20; i++) {
+		try {
+			await stat(join(dir, 'CLAUDE.md'));
+			return dir;
+		} catch {
+			const parent = join(dir, '..');
+			if (parent === dir) break;
+			dir = parent;
+		}
+	}
+
+	// fallback — use cwd
+	return startDir;
+}
+
+let _root: string | null = null;
+
+export async function getProjectRoot(): Promise<string> {
+	if (_root) return _root;
+	_root = await findProjectRoot(process.cwd());
+	return _root;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AgentInfo {
+	name: string;
+	description: string;
+	model: string;
+	domain: string;
+	tools: string[];
+	skills: string[];
+	frontmatter: Record<string, unknown>;
+	body: string;
+}
+
+export interface SkillInfo {
+	name: string;
+	description: string;
+	scope: string;
+	contextFork: boolean;
+	frontmatter: Record<string, unknown>;
+	body: string;
+}
+
+export interface GuideInfo {
+	name: string;
+	exists: boolean;
+}
+
+export interface GuideDetail {
+	name: string;
+	body: string;
+	frontmatter: Record<string, unknown>;
+}
+
+export interface RuleInfo {
+	name: string;
+	id: string;
+	priority: string;
+	description: string;
+	frontmatter: Record<string, unknown>;
+	body: string;
+}
+
+// ---------------------------------------------------------------------------
+// Agents
+// ---------------------------------------------------------------------------
+
+export async function getAgents(root: string): Promise<AgentInfo[]> {
+	const dir = join(root, '.claude', 'agents');
+	let files: string[];
+	try {
+		files = await readdir(dir);
+	} catch {
+		return [];
+	}
+
+	const agents: AgentInfo[] = [];
+	for (const file of files) {
+		if (!file.endsWith('.md')) continue;
+		const name = basename(file, '.md');
+		const content = await readFile(join(dir, file), 'utf-8');
+		const { frontmatter, body } = parseFrontmatter(content);
+
+		agents.push({
+			name,
+			description: String(frontmatter.description ?? ''),
+			model: String(frontmatter.model ?? 'sonnet'),
+			domain: String(frontmatter.domain ?? ''),
+			tools: arrayField(frontmatter.tools),
+			skills: arrayField(frontmatter.skills),
+			frontmatter,
+			body
+		});
+	}
+
+	return agents.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getAgent(root: string, name: string): Promise<AgentInfo | null> {
+	const filePath = join(root, '.claude', 'agents', `${name}.md`);
+	let content: string;
+	try {
+		content = await readFile(filePath, 'utf-8');
+	} catch {
+		return null;
+	}
+	const { frontmatter, body } = parseFrontmatter(content);
+	return {
+		name,
+		description: String(frontmatter.description ?? ''),
+		model: String(frontmatter.model ?? 'sonnet'),
+		domain: String(frontmatter.domain ?? ''),
+		tools: arrayField(frontmatter.tools),
+		skills: arrayField(frontmatter.skills),
+		frontmatter,
+		body
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Skills
+// ---------------------------------------------------------------------------
+
+export async function getSkills(root: string): Promise<SkillInfo[]> {
+	const dir = join(root, '.claude', 'skills');
+	let entries: string[];
+	try {
+		entries = await readdir(dir);
+	} catch {
+		return [];
+	}
+
+	const skills: SkillInfo[] = [];
+	for (const entry of entries) {
+		const skillFile = join(dir, entry, 'SKILL.md');
+		let content: string;
+		try {
+			content = await readFile(skillFile, 'utf-8');
+		} catch {
+			continue;
+		}
+		const { frontmatter, body } = parseFrontmatter(content);
+		skills.push({
+			name: String(frontmatter.name ?? entry),
+			description: String(frontmatter.description ?? ''),
+			scope: String(frontmatter.scope ?? 'core'),
+			contextFork: frontmatter.context === 'fork',
+			frontmatter,
+			body
+		});
+	}
+
+	return skills.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getSkill(root: string, name: string): Promise<SkillInfo | null> {
+	const skillFile = join(root, '.claude', 'skills', name, 'SKILL.md');
+	let content: string;
+	try {
+		content = await readFile(skillFile, 'utf-8');
+	} catch {
+		return null;
+	}
+	const { frontmatter, body } = parseFrontmatter(content);
+	return {
+		name: String(frontmatter.name ?? name),
+		description: String(frontmatter.description ?? ''),
+		scope: String(frontmatter.scope ?? 'core'),
+		contextFork: frontmatter.context === 'fork',
+		frontmatter,
+		body
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Guides
+// ---------------------------------------------------------------------------
+
+export async function getGuides(root: string): Promise<GuideInfo[]> {
+	const dir = join(root, 'guides');
+	let entries: string[];
+	try {
+		entries = await readdir(dir);
+	} catch {
+		return [];
+	}
+
+	const guides: GuideInfo[] = [];
+	for (const entry of entries) {
+		try {
+			const s = await stat(join(dir, entry));
+			if (s.isDirectory()) {
+				guides.push({ name: entry, exists: true });
+			}
+		} catch {
+			// skip
+		}
+	}
+
+	return guides.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export async function getGuide(root: string, name: string): Promise<GuideDetail | null> {
+	const readmePath = join(root, 'guides', name, 'README.md');
+	let content: string;
+	try {
+		content = await readFile(readmePath, 'utf-8');
+	} catch {
+		// Try index.md fallback
+		try {
+			content = await readFile(join(root, 'guides', name, 'index.md'), 'utf-8');
+		} catch {
+			return null;
+		}
+	}
+	const { frontmatter, body } = parseFrontmatter(content);
+	return { name, body, frontmatter };
+}
+
+// ---------------------------------------------------------------------------
+// Rules
+// ---------------------------------------------------------------------------
+
+export async function getRules(root: string): Promise<RuleInfo[]> {
+	const dir = join(root, '.claude', 'rules');
+	let files: string[];
+	try {
+		files = await readdir(dir);
+	} catch {
+		return [];
+	}
+
+	const rules: RuleInfo[] = [];
+	for (const file of files) {
+		if (!file.endsWith('.md')) continue;
+		const content = await readFile(join(dir, file), 'utf-8');
+		const { frontmatter, body } = parseFrontmatter(content);
+
+		// Extract priority and ID from filename: MUST-agent-design.md or body H1
+		const filenameMatch = file.match(/^(MUST|SHOULD|MAY)-(.+)\.md$/i);
+		const priority = filenameMatch ? filenameMatch[1].toUpperCase() : 'UNKNOWN';
+		const ruleName = filenameMatch ? filenameMatch[2] : basename(file, '.md');
+
+		// Extract ID from body: "R007" pattern
+		const idMatch = body.match(/\bR\d{3}\b/);
+		const id = idMatch ? idMatch[0] : '';
+
+		rules.push({
+			name: ruleName,
+			id,
+			priority,
+			description: String(frontmatter.description ?? extractFirstHeading(body)),
+			frontmatter,
+			body
+		});
+	}
+
+	return rules.sort((a, b) => {
+		// Sort: MUST first, then SHOULD, then MAY; within group by ID
+		const order: Record<string, number> = { MUST: 0, SHOULD: 1, MAY: 2, UNKNOWN: 3 };
+		const po = (order[a.priority] ?? 3) - (order[b.priority] ?? 3);
+		if (po !== 0) return po;
+		return a.id.localeCompare(b.id);
+	});
+}
+
+export async function getRule(root: string, name: string): Promise<RuleInfo | null> {
+	// name is the slug — try to find the file by checking all files
+	const dir = join(root, '.claude', 'rules');
+	let files: string[];
+	try {
+		files = await readdir(dir);
+	} catch {
+		return null;
+	}
+
+	// Match by name portion of filename
+	const matched = files.find((f) => {
+		const base = basename(f, '.md');
+		// name could be "MUST-agent-design" or just "agent-design"
+		return base === name || base.toLowerCase().endsWith(`-${name}`) || base === `MUST-${name}` || base === `SHOULD-${name}` || base === `MAY-${name}`;
+	});
+
+	if (!matched) return null;
+
+	const content = await readFile(join(dir, matched), 'utf-8');
+	const { frontmatter, body } = parseFrontmatter(content);
+
+	const filenameMatch = matched.match(/^(MUST|SHOULD|MAY)-(.+)\.md$/i);
+	const priority = filenameMatch ? filenameMatch[1].toUpperCase() : 'UNKNOWN';
+	const ruleName = filenameMatch ? filenameMatch[2] : basename(matched, '.md');
+	const idMatch = body.match(/\bR\d{3}\b/);
+	const id = idMatch ? idMatch[0] : '';
+
+	return {
+		name: ruleName,
+		id,
+		priority,
+		description: String(frontmatter.description ?? extractFirstHeading(body)),
+		frontmatter,
+		body
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function arrayField(val: unknown): string[] {
+	if (Array.isArray(val)) return val.map(String);
+	if (typeof val === 'string') return [val];
+	return [];
+}
+
+function extractFirstHeading(body: string): string {
+	const match = body.match(/^#{1,3}\s+(.+)$/m);
+	return match ? match[1].replace(/\*\*/g, '').trim() : '';
+}

--- a/packages/serve/src/lib/server/frontmatter.ts
+++ b/packages/serve/src/lib/server/frontmatter.ts
@@ -1,0 +1,34 @@
+import { parse as parseYaml } from 'yaml';
+
+export interface ParsedFile {
+	frontmatter: Record<string, unknown>;
+	body: string;
+}
+
+export function parseFrontmatter(content: string): ParsedFile {
+	const trimmed = content.trimStart();
+
+	if (!trimmed.startsWith('---')) {
+		return { frontmatter: {}, body: content };
+	}
+
+	const end = trimmed.indexOf('\n---', 3);
+	if (end === -1) {
+		return { frontmatter: {}, body: content };
+	}
+
+	const yamlBlock = trimmed.slice(3, end).trim();
+	const body = trimmed.slice(end + 4).trimStart();
+
+	let frontmatter: Record<string, unknown> = {};
+	try {
+		const parsed = parseYaml(yamlBlock);
+		if (parsed && typeof parsed === 'object') {
+			frontmatter = parsed as Record<string, unknown>;
+		}
+	} catch {
+		// malformed YAML — return empty frontmatter, keep body
+	}
+
+	return { frontmatter, body };
+}

--- a/packages/serve/src/lib/server/markdown.ts
+++ b/packages/serve/src/lib/server/markdown.ts
@@ -1,0 +1,10 @@
+import { marked } from 'marked';
+
+marked.setOptions({
+	gfm: true,
+	breaks: false
+});
+
+export function renderMarkdown(content: string): string {
+	return marked.parse(content, { async: false }) as string;
+}

--- a/packages/serve/src/routes/+layout.svelte
+++ b/packages/serve/src/routes/+layout.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+	import '../app.css';
+	import { page } from '$app/stores';
+
+	const navItems = [
+		{ href: '/', label: 'Dashboard', icon: '▣' },
+		{ href: '/agents', label: 'Agents', icon: '◈' },
+		{ href: '/skills', label: 'Skills', icon: '◆' },
+		{ href: '/guides', label: 'Guides', icon: '◉' },
+		{ href: '/rules', label: 'Rules', icon: '◇' }
+	];
+
+	function isActive(href: string, pathname: string): boolean {
+		if (href === '/') return pathname === '/';
+		return pathname.startsWith(href);
+	}
+</script>
+
+<div class="flex min-h-screen">
+	<!-- Sidebar -->
+	<aside class="w-52 shrink-0 border-r border-zinc-800 bg-zinc-950 flex flex-col">
+		<!-- Logo -->
+		<div class="px-4 py-5 border-b border-zinc-800">
+			<span class="text-emerald-400 font-bold text-lg tracking-tight">omcustom</span>
+			<div class="text-zinc-600 text-xs mt-0.5">agent harness</div>
+		</div>
+
+		<!-- Nav -->
+		<nav class="flex-1 px-2 py-4 space-y-0.5">
+			{#each navItems as item}
+				<a
+					href={item.href}
+					class="flex items-center gap-2.5 px-3 py-2 rounded text-sm transition-colors {isActive(item.href, $page.url.pathname)
+						? 'bg-zinc-800 text-zinc-50'
+						: 'text-zinc-400 hover:text-zinc-200 hover:bg-zinc-900'}"
+				>
+					<span class="text-xs opacity-70">{item.icon}</span>
+					{item.label}
+				</a>
+			{/each}
+		</nav>
+
+		<!-- Footer -->
+		<div class="px-4 py-3 border-t border-zinc-800 text-zinc-600 text-xs">
+			oh-my-customcode
+		</div>
+	</aside>
+
+	<!-- Main content -->
+	<main class="flex-1 overflow-auto bg-zinc-950">
+		<slot />
+	</main>
+</div>

--- a/packages/serve/src/routes/+page.server.ts
+++ b/packages/serve/src/routes/+page.server.ts
@@ -1,0 +1,66 @@
+import type { PageServerLoad } from './$types';
+import { getAgents, getSkills, getGuides, getRules, getProjectRoot } from '$lib/server/data';
+
+const AGENT_TYPES: { label: string; pattern: RegExp }[] = [
+	{ label: 'SW Engineer / Language', pattern: /^lang-/ },
+	{ label: 'SW Engineer / Backend', pattern: /^be-/ },
+	{ label: 'SW Engineer / Frontend', pattern: /^fe-/ },
+	{ label: 'SW Engineer / Tooling', pattern: /^tool-/ },
+	{ label: 'Data Engineering', pattern: /^de-/ },
+	{ label: 'Database', pattern: /^db-/ },
+	{ label: 'Security', pattern: /^sec-/ },
+	{ label: 'Architecture', pattern: /^arch-/ },
+	{ label: 'Infrastructure', pattern: /^infra-/ },
+	{ label: 'QA', pattern: /^qa-/ },
+	{ label: 'Manager', pattern: /^mgr-/ },
+	{ label: 'System', pattern: /^sys-/ }
+];
+
+export const load: PageServerLoad = async () => {
+	const root = await getProjectRoot();
+	const [agents, skills, guides, rules] = await Promise.all([
+		getAgents(root),
+		getSkills(root),
+		getGuides(root),
+		getRules(root)
+	]);
+
+	// Build type breakdown
+	const typeBreakdown = AGENT_TYPES.map(({ label, pattern }) => ({
+		label,
+		count: agents.filter((a) => pattern.test(a.name)).length
+	})).filter((t) => t.count > 0);
+
+	const categorized = agents.filter((a) =>
+		AGENT_TYPES.some(({ pattern }) => pattern.test(a.name))
+	).length;
+	const uncategorized = agents.length - categorized;
+	if (uncategorized > 0) {
+		typeBreakdown.push({ label: 'Other', count: uncategorized });
+	}
+
+	// Skill scope breakdown
+	const scopeBreakdown = (['core', 'harness', 'package'] as const).map((scope) => ({
+		scope,
+		count: skills.filter((s) => s.scope === scope).length
+	}));
+
+	// Rule priority breakdown
+	const priorityBreakdown = (['MUST', 'SHOULD', 'MAY'] as const).map((p) => ({
+		priority: p,
+		count: rules.filter((r) => r.priority === p).length
+	}));
+
+	return {
+		counts: {
+			agents: agents.length,
+			skills: skills.length,
+			guides: guides.length,
+			rules: rules.length
+		},
+		typeBreakdown,
+		scopeBreakdown,
+		priorityBreakdown,
+		root
+	};
+};

--- a/packages/serve/src/routes/+page.svelte
+++ b/packages/serve/src/routes/+page.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+
+	const summaryCards = [
+		{ label: 'Agents', key: 'agents' as const, href: '/agents', icon: '◈', color: 'emerald' },
+		{ label: 'Skills', key: 'skills' as const, href: '/skills', icon: '◆', color: 'sky' },
+		{ label: 'Guides', key: 'guides' as const, href: '/guides', icon: '◉', color: 'violet' },
+		{ label: 'Rules', key: 'rules' as const, href: '/rules', icon: '◇', color: 'amber' }
+	];
+
+	const colorMap: Record<string, string> = {
+		emerald: 'border-emerald-800 bg-emerald-950/40 hover:bg-emerald-950/70 text-emerald-300',
+		sky: 'border-sky-800 bg-sky-950/40 hover:bg-sky-950/70 text-sky-300',
+		violet: 'border-violet-800 bg-violet-950/40 hover:bg-violet-950/70 text-violet-300',
+		amber: 'border-amber-800 bg-amber-950/40 hover:bg-amber-950/70 text-amber-300'
+	};
+
+	const priorityColor: Record<string, string> = {
+		MUST: 'text-red-400',
+		SHOULD: 'text-yellow-400',
+		MAY: 'text-green-400'
+	};
+</script>
+
+<div class="p-8">
+	<div class="mb-8">
+		<h1 class="text-2xl font-bold text-zinc-50">Dashboard</h1>
+		<p class="text-zinc-500 text-sm mt-1">Project root: <code class="text-zinc-400">{data.root}</code></p>
+	</div>
+
+	<!-- Summary cards -->
+	<div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-10">
+		{#each summaryCards as card}
+			<a
+				href={card.href}
+				class="border rounded-lg p-5 transition-colors cursor-pointer {colorMap[card.color]}"
+			>
+				<div class="text-2xl mb-2">{card.icon}</div>
+				<div class="text-3xl font-bold">{data.counts[card.key]}</div>
+				<div class="text-sm mt-1 opacity-80">{card.label}</div>
+			</a>
+		{/each}
+	</div>
+
+	<!-- Breakdown tables -->
+	<div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+		<!-- Agent type breakdown -->
+		<div class="col-span-1 lg:col-span-1">
+			<h2 class="text-sm font-semibold text-zinc-400 uppercase tracking-wider mb-3">Agent Types</h2>
+			<div class="border border-zinc-800 rounded-lg overflow-hidden">
+				<table class="w-full text-sm">
+					<thead>
+						<tr class="bg-zinc-900">
+							<th class="px-4 py-2 text-left text-zinc-400 font-medium">Type</th>
+							<th class="px-4 py-2 text-right text-zinc-400 font-medium">Count</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each data.typeBreakdown as row, i}
+							<tr class="border-t border-zinc-800 {i % 2 === 1 ? 'bg-zinc-900/50' : ''}">
+								<td class="px-4 py-2 text-zinc-300">{row.label}</td>
+								<td class="px-4 py-2 text-right text-zinc-400">{row.count}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		</div>
+
+		<!-- Skill scope breakdown -->
+		<div>
+			<h2 class="text-sm font-semibold text-zinc-400 uppercase tracking-wider mb-3">Skill Scopes</h2>
+			<div class="border border-zinc-800 rounded-lg overflow-hidden">
+				<table class="w-full text-sm">
+					<thead>
+						<tr class="bg-zinc-900">
+							<th class="px-4 py-2 text-left text-zinc-400 font-medium">Scope</th>
+							<th class="px-4 py-2 text-right text-zinc-400 font-medium">Count</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each data.scopeBreakdown as row, i}
+							<tr class="border-t border-zinc-800 {i % 2 === 1 ? 'bg-zinc-900/50' : ''}">
+								<td class="px-4 py-2 text-zinc-300">{row.scope}</td>
+								<td class="px-4 py-2 text-right text-zinc-400">{row.count}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		</div>
+
+		<!-- Rule priority breakdown -->
+		<div>
+			<h2 class="text-sm font-semibold text-zinc-400 uppercase tracking-wider mb-3">Rule Priorities</h2>
+			<div class="border border-zinc-800 rounded-lg overflow-hidden">
+				<table class="w-full text-sm">
+					<thead>
+						<tr class="bg-zinc-900">
+							<th class="px-4 py-2 text-left text-zinc-400 font-medium">Priority</th>
+							<th class="px-4 py-2 text-right text-zinc-400 font-medium">Count</th>
+						</tr>
+					</thead>
+					<tbody>
+						{#each data.priorityBreakdown as row, i}
+							<tr class="border-t border-zinc-800 {i % 2 === 1 ? 'bg-zinc-900/50' : ''}">
+								<td class="px-4 py-2 font-semibold {priorityColor[row.priority]}">{row.priority}</td>
+								<td class="px-4 py-2 text-right text-zinc-400">{row.count}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+</div>

--- a/packages/serve/src/routes/agents/+page.server.ts
+++ b/packages/serve/src/routes/agents/+page.server.ts
@@ -1,0 +1,12 @@
+import type { PageServerLoad } from './$types';
+import { getAgents, getProjectRoot } from '$lib/server/data';
+
+export const load: PageServerLoad = async () => {
+	const root = await getProjectRoot();
+	const agents = await getAgents(root);
+
+	// Collect unique domains
+	const domains = [...new Set(agents.map((a) => a.domain).filter(Boolean))].sort();
+
+	return { agents, domains };
+};

--- a/packages/serve/src/routes/agents/+page.svelte
+++ b/packages/serve/src/routes/agents/+page.svelte
@@ -1,0 +1,217 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+
+	let search = '';
+	let selectedDomains: Set<string> = new Set();
+	let selectedModels: Set<string> = new Set();
+	let sortKey = 'name';
+	let sortAsc = true;
+
+	$: filtered = data.agents.filter((a) => {
+		const matchDomain = selectedDomains.size === 0 || selectedDomains.has(a.domain);
+		const matchModel = selectedModels.size === 0 || selectedModels.has(a.model);
+		const q = search.toLowerCase();
+		const matchSearch =
+			!q ||
+			a.name.toLowerCase().includes(q) ||
+			a.description.toLowerCase().includes(q);
+		return matchDomain && matchModel && matchSearch;
+	});
+
+	$: sorted = [...filtered].sort((a, b) => {
+		const va = (a as unknown as Record<string, unknown>)[sortKey] ?? '';
+		const vb = (b as unknown as Record<string, unknown>)[sortKey] ?? '';
+		const cmp = String(va).localeCompare(String(vb));
+		return sortAsc ? cmp : -cmp;
+	});
+
+	function toggleSort(key: string) {
+		if (sortKey === key) {
+			sortAsc = !sortAsc;
+		} else {
+			sortKey = key;
+			sortAsc = true;
+		}
+	}
+
+	function toggleDomain(domain: string) {
+		const next = new Set(selectedDomains);
+		if (next.has(domain)) next.delete(domain);
+		else next.add(domain);
+		selectedDomains = next;
+	}
+
+	function toggleModel(model: string) {
+		const next = new Set(selectedModels);
+		if (next.has(model)) next.delete(model);
+		else next.add(model);
+		selectedModels = next;
+	}
+
+	function clearAll() {
+		search = '';
+		selectedDomains = new Set();
+		selectedModels = new Set();
+	}
+
+	$: hasFilters = search || selectedDomains.size > 0 || selectedModels.size > 0;
+
+	function sortIndicator(key: string): string {
+		if (sortKey !== key) return '';
+		return sortAsc ? ' ▲' : ' ▼';
+	}
+
+	const modelColor: Record<string, string> = {
+		sonnet: 'bg-emerald-900/50 text-emerald-300 border-emerald-700',
+		opus: 'bg-violet-900/50 text-violet-300 border-violet-700',
+		haiku: 'bg-sky-900/50 text-sky-300 border-sky-700'
+	};
+
+	const modelActiveColor: Record<string, string> = {
+		sonnet: 'bg-emerald-800 text-emerald-200 border-emerald-500',
+		opus: 'bg-violet-800 text-violet-200 border-violet-500',
+		haiku: 'bg-sky-800 text-sky-200 border-sky-500'
+	};
+
+	const domainColors: Record<string, string> = {
+		backend: 'bg-orange-900/40 text-orange-300',
+		frontend: 'bg-pink-900/40 text-pink-300',
+		'data-engineering': 'bg-cyan-900/40 text-cyan-300',
+		devops: 'bg-amber-900/40 text-amber-300',
+		database: 'bg-blue-900/40 text-blue-300',
+		management: 'bg-zinc-700 text-zinc-300',
+		security: 'bg-red-900/40 text-red-300',
+		qa: 'bg-green-900/40 text-green-300',
+		architecture: 'bg-indigo-900/40 text-indigo-300',
+		universal: 'bg-zinc-700 text-zinc-400'
+	};
+</script>
+
+<div class="p-8">
+	<div class="mb-6 flex items-center justify-between">
+		<div>
+			<h1 class="text-2xl font-bold text-zinc-50">Agents</h1>
+			<p class="text-zinc-500 text-sm mt-1">
+				{#if hasFilters}
+					<span class="text-emerald-400 font-medium">{filtered.length}</span> / {data.agents.length} agents
+				{:else}
+					{data.agents.length} agents total
+				{/if}
+			</p>
+		</div>
+		<a
+			href="/agents/create"
+			class="flex items-center gap-2 px-3 py-2 rounded bg-emerald-800/60 border border-emerald-700 text-emerald-300 text-sm hover:bg-emerald-800 hover:border-emerald-500 transition-colors font-medium"
+		>
+			<span class="text-base leading-none">+</span> New Agent
+		</a>
+	</div>
+
+	<!-- Search -->
+	<div class="mb-4">
+		<input
+			type="text"
+			placeholder="Search by name or description..."
+			bind:value={search}
+			class="bg-zinc-900 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500 w-72"
+		/>
+	</div>
+
+	<!-- Domain filter -->
+	<div class="mb-3">
+		<div class="text-xs text-zinc-600 mb-2 uppercase tracking-wide font-medium">Domain</div>
+		<div class="flex flex-wrap gap-2">
+			{#each data.domains as domain}
+				<button
+					onclick={() => toggleDomain(domain)}
+					class="px-2.5 py-1 rounded text-xs font-medium border transition-colors {selectedDomains.has(domain)
+						? (domainColors[domain] ?? 'bg-zinc-700 text-zinc-300') + ' border-zinc-500'
+						: 'border-zinc-700 text-zinc-500 hover:text-zinc-300 hover:border-zinc-600'}"
+				>
+					{domain}
+				</button>
+			{/each}
+		</div>
+	</div>
+
+	<!-- Model filter -->
+	<div class="mb-5">
+		<div class="text-xs text-zinc-600 mb-2 uppercase tracking-wide font-medium">Model</div>
+		<div class="flex gap-2">
+			{#each ['opus', 'sonnet', 'haiku'] as model}
+				<button
+					onclick={() => toggleModel(model)}
+					class="px-3 py-1 rounded text-xs font-semibold border transition-colors {selectedModels.has(model)
+						? (modelActiveColor[model] ?? 'bg-zinc-700 text-zinc-200 border-zinc-500')
+						: 'border-zinc-700 text-zinc-500 hover:text-zinc-300'}"
+				>
+					{model}
+				</button>
+			{/each}
+		</div>
+	</div>
+
+	{#if hasFilters}
+		<div class="mb-4">
+			<button
+				onclick={clearAll}
+				class="text-zinc-500 hover:text-zinc-300 text-xs px-2 py-1 border border-zinc-700 rounded transition-colors"
+			>
+				Clear filters
+			</button>
+		</div>
+	{/if}
+
+	<!-- Table -->
+	<div class="border border-zinc-800 rounded-lg overflow-hidden">
+		<table class="w-full text-sm">
+			<thead>
+				<tr class="bg-zinc-900 border-b border-zinc-800">
+					<th
+						class="px-4 py-3 text-left text-zinc-400 font-medium cursor-pointer select-none hover:text-zinc-200 {sortKey === 'name' ? 'text-zinc-200 font-bold' : ''}"
+						onclick={() => toggleSort('name')}
+					>Name{sortIndicator('name')}</th>
+					<th
+						class="px-4 py-3 text-left text-zinc-400 font-medium cursor-pointer select-none hover:text-zinc-200 {sortKey === 'description' ? 'text-zinc-200 font-bold' : ''}"
+						onclick={() => toggleSort('description')}
+					>Description{sortIndicator('description')}</th>
+					<th
+						class="px-4 py-3 text-left text-zinc-400 font-medium cursor-pointer select-none hover:text-zinc-200 {sortKey === 'model' ? 'text-zinc-200 font-bold' : ''}"
+						onclick={() => toggleSort('model')}
+					>Model{sortIndicator('model')}</th>
+					<th
+						class="px-4 py-3 text-left text-zinc-400 font-medium cursor-pointer select-none hover:text-zinc-200 {sortKey === 'domain' ? 'text-zinc-200 font-bold' : ''}"
+						onclick={() => toggleSort('domain')}
+					>Domain{sortIndicator('domain')}</th>
+					<th class="px-4 py-3 text-left text-zinc-400 font-medium">Skills</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each sorted as agent, i}
+					<tr class="border-t border-zinc-800 hover:bg-zinc-900/60 transition-colors {i % 2 === 1 ? 'bg-zinc-900/30' : ''}">
+						<td class="px-4 py-3">
+							<a href="/agents/{agent.name}" class="text-emerald-400 hover:text-emerald-300 font-medium">
+								{agent.name}
+							</a>
+						</td>
+						<td class="px-4 py-3 text-zinc-400 max-w-xs truncate">{agent.description}</td>
+						<td class="px-4 py-3">
+							<span class="px-2 py-0.5 rounded text-xs font-medium border {modelColor[agent.model] ?? 'bg-zinc-800 text-zinc-400 border-zinc-700'}">
+								{agent.model}
+							</span>
+						</td>
+						<td class="px-4 py-3 text-zinc-500 text-xs">{agent.domain || '—'}</td>
+						<td class="px-4 py-3 text-zinc-500 text-xs">{agent.skills.length > 0 ? agent.skills.length : '—'}</td>
+					</tr>
+				{:else}
+					<tr>
+						<td colspan="5" class="px-4 py-8 text-center text-zinc-600">No agents found</td>
+					</tr>
+				{/each}
+
+			</tbody>
+		</table>
+	</div>
+</div>

--- a/packages/serve/src/routes/agents/[name]/+page.server.ts
+++ b/packages/serve/src/routes/agents/[name]/+page.server.ts
@@ -1,0 +1,25 @@
+import type { PageServerLoad } from './$types';
+import { getAgent, getProjectRoot } from '$lib/server/data';
+import { renderMarkdown } from '$lib/server/markdown';
+import { error } from '@sveltejs/kit';
+
+export const load: PageServerLoad = async ({ params }) => {
+	const root = await getProjectRoot();
+	const agent = await getAgent(root, params.name);
+
+	if (!agent) {
+		error(404, `Agent "${params.name}" not found`);
+	}
+
+	const renderedBody = renderMarkdown(agent.body);
+
+	// Build clean frontmatter display (exclude body-level fields)
+	const displayMeta = Object.entries(agent.frontmatter)
+		.filter(([k]) => k !== 'name')
+		.map(([key, val]) => ({
+			key,
+			value: Array.isArray(val) ? val.join(', ') : String(val)
+		}));
+
+	return { agent, renderedBody, displayMeta };
+};

--- a/packages/serve/src/routes/agents/[name]/+page.svelte
+++ b/packages/serve/src/routes/agents/[name]/+page.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+
+	const modelColor: Record<string, string> = {
+		sonnet: 'bg-emerald-900/60 text-emerald-300 border-emerald-800',
+		opus: 'bg-violet-900/60 text-violet-300 border-violet-800',
+		haiku: 'bg-sky-900/60 text-sky-300 border-sky-800'
+	};
+</script>
+
+<div class="p-8 max-w-5xl">
+	<!-- Breadcrumb -->
+	<div class="text-sm text-zinc-600 mb-6">
+		<a href="/agents" class="hover:text-zinc-400">Agents</a>
+		<span class="mx-2">/</span>
+		<span class="text-zinc-300">{data.agent.name}</span>
+	</div>
+
+	<!-- Header -->
+	<div class="mb-8">
+		<div class="flex items-center gap-3 mb-2">
+			<h1 class="text-2xl font-bold text-zinc-50">{data.agent.name}</h1>
+			<span class="px-2 py-0.5 rounded border text-xs font-medium {modelColor[data.agent.model] ?? 'bg-zinc-800 text-zinc-400 border-zinc-700'}">
+				{data.agent.model}
+			</span>
+		</div>
+		{#if data.agent.description}
+			<p class="text-zinc-400">{data.agent.description}</p>
+		{/if}
+	</div>
+
+	<div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+		<!-- Metadata -->
+		<div class="lg:col-span-1 space-y-4">
+			<!-- Frontmatter table -->
+			<div class="border border-zinc-800 rounded-lg overflow-hidden">
+				<div class="bg-zinc-900 px-4 py-2 text-xs font-semibold text-zinc-400 uppercase tracking-wider">
+					Metadata
+				</div>
+				<table class="w-full text-sm">
+					<tbody>
+						{#each data.displayMeta as { key, value }}
+							<tr class="border-t border-zinc-800">
+								<td class="px-4 py-2 text-zinc-500 font-medium w-28 shrink-0">{key}</td>
+								<td class="px-4 py-2 text-zinc-300 break-all">{value || '—'}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+
+			<!-- Linked skills -->
+			{#if data.agent.skills.length > 0}
+				<div class="border border-zinc-800 rounded-lg overflow-hidden">
+					<div class="bg-zinc-900 px-4 py-2 text-xs font-semibold text-zinc-400 uppercase tracking-wider">
+						Skills ({data.agent.skills.length})
+					</div>
+					<ul class="divide-y divide-zinc-800">
+						{#each data.agent.skills as skill}
+							<li class="px-4 py-2">
+								<a href="/skills/{skill}" class="text-sky-400 hover:text-sky-300 text-sm">
+									{skill}
+								</a>
+							</li>
+						{/each}
+					</ul>
+				</div>
+			{/if}
+		</div>
+
+		<!-- Body -->
+		<div class="lg:col-span-2">
+			<div class="border border-zinc-800 rounded-lg p-6 prose">
+				{@html data.renderedBody}
+			</div>
+		</div>
+	</div>
+</div>

--- a/packages/serve/src/routes/agents/create/+page.server.ts
+++ b/packages/serve/src/routes/agents/create/+page.server.ts
@@ -1,0 +1,129 @@
+import { fail, redirect } from '@sveltejs/kit';
+import { writeFile, access } from 'fs/promises';
+import { join } from 'path';
+import type { Actions, PageServerLoad } from './$types';
+import { getProjectRoot, getSkills } from '$lib/server/data';
+import { parseNaturalLanguage, buildAgentMarkdown, sanitizeName } from '$lib/server/agent-generator';
+import { parseFrontmatter } from '$lib/server/frontmatter';
+import { isClaudeAvailable, generateAgentWithClaude } from '$lib/server/claude-cli';
+
+export const load: PageServerLoad = async () => {
+	const root = await getProjectRoot();
+	const skills = await getSkills(root);
+	const claudeAvailable = await isClaudeAvailable();
+	return {
+		skillNames: skills.map((s) => s.name),
+		claudeAvailable
+	};
+};
+
+export const actions: Actions = {
+	// Parse natural language and return structured data (no file write)
+	analyze: async ({ request }) => {
+		const data = await request.formData();
+		const input = String(data.get('input') ?? '').trim();
+
+		if (!input) {
+			return fail(400, { error: 'Input is required' });
+		}
+
+		const root = await getProjectRoot();
+		const claudeAvailable = await isClaudeAvailable();
+
+		if (claudeAvailable) {
+			try {
+				const rawOutput = await generateAgentWithClaude(input, root);
+				const { frontmatter, body } = parseFrontmatter(rawOutput);
+
+				return {
+					success: true,
+					mode: 'claude' as const,
+					name: String(frontmatter.name ?? ''),
+					description: String(frontmatter.description ?? ''),
+					model: String(frontmatter.model ?? 'sonnet'),
+					domain: String(frontmatter.domain ?? 'universal'),
+					tools: arrayField(frontmatter.tools),
+					skills: arrayField(frontmatter.skills),
+					body,
+					raw: rawOutput
+				};
+			} catch (err) {
+				// Claude CLI failed — fall back to keyword parser
+				console.warn('[claude-cli] Claude generation failed, falling back to keyword parser:', err);
+				const generated = parseNaturalLanguage(input);
+				const markdown = buildAgentMarkdown(generated);
+				return {
+					success: true,
+					mode: 'keyword-fallback' as const,
+					name: generated.name,
+					description: generated.description,
+					model: generated.model,
+					domain: generated.domain,
+					tools: generated.tools,
+					skills: generated.skills,
+					body: generated.body,
+					raw: markdown
+				};
+			}
+		} else {
+			const generated = parseNaturalLanguage(input);
+			const markdown = buildAgentMarkdown(generated);
+			return {
+				success: true,
+				mode: 'keyword' as const,
+				name: generated.name,
+				description: generated.description,
+				model: generated.model,
+				domain: generated.domain,
+				tools: generated.tools,
+				skills: generated.skills,
+				body: generated.body,
+				raw: markdown
+			};
+		}
+	},
+
+	// Save agent file
+	save: async ({ request }) => {
+		const data = await request.formData();
+		const rawName = String(data.get('name') ?? '').trim();
+		const content = String(data.get('content') ?? '').trim();
+
+		// Sanitize name — kebab-case only
+		const name = sanitizeName(rawName);
+
+		if (!name) {
+			return fail(400, { error: 'Agent name is required' });
+		}
+		if (!content) {
+			return fail(400, { error: 'Agent content is required' });
+		}
+
+		// Validate name format
+		if (!/^[a-z][a-z0-9-]*[a-z0-9]$/.test(name) && name.length > 1) {
+			return fail(400, { error: `Invalid agent name: "${name}". Use kebab-case (e.g., my-agent-expert)` });
+		}
+
+		const root = await getProjectRoot();
+		const agentPath = join(root, '.claude', 'agents', `${name}.md`);
+
+		// Check for existing file
+		try {
+			await access(agentPath);
+			// File exists
+			return fail(409, { error: `Agent "${name}" already exists. Choose a different name.` });
+		} catch {
+			// File does not exist — safe to write
+		}
+
+		await writeFile(agentPath, content + '\n', 'utf-8');
+
+		throw redirect(303, `/agents/${name}`);
+	}
+};
+
+function arrayField(val: unknown): string[] {
+	if (Array.isArray(val)) return val.map(String);
+	if (typeof val === 'string') return [val];
+	return [];
+}

--- a/packages/serve/src/routes/agents/create/+page.svelte
+++ b/packages/serve/src/routes/agents/create/+page.svelte
@@ -1,0 +1,346 @@
+<script lang="ts">
+	import type { PageData, ActionData } from './$types';
+	import { enhance } from '$app/forms';
+
+	export let data: PageData;
+	export let form: ActionData;
+
+	// Natural language input
+	let nlInput = '';
+	let analyzing = false;
+	let saving = false;
+
+	// Editable form fields (populated after analysis)
+	let agentName = '';
+	let agentDescription = '';
+	let agentModel = 'sonnet';
+	let agentDomain = 'universal';
+	let agentTools: string[] = ['Read', 'Write', 'Edit', 'Grep', 'Glob', 'Bash'];
+	let agentSkills: string[] = [];
+	let agentBody = '';
+	let analyzed = false;
+	let newSkill = '';
+	let analysisMode: 'claude' | 'keyword' | 'keyword-fallback' | null = null;
+
+	const ALL_TOOLS = ['Read', 'Write', 'Edit', 'Grep', 'Glob', 'Bash', 'WebFetch', 'WebSearch'];
+	const DOMAINS = [
+		'universal', 'backend', 'frontend', 'devops', 'database',
+		'data-engineering', 'security', 'qa', 'architecture', 'management'
+	];
+	const MODELS = ['sonnet', 'opus', 'haiku'];
+
+	// Populate fields when server returns analysis
+	$: if (form?.success) {
+		agentName = form.name ?? '';
+		agentDescription = form.description ?? '';
+		agentModel = form.model ?? 'sonnet';
+		agentDomain = form.domain ?? 'universal';
+		agentTools = form.tools ? [...(form.tools as string[])] : ['Read', 'Write', 'Edit', 'Grep', 'Glob', 'Bash'];
+		agentSkills = form.skills ? [...(form.skills as string[])] : [];
+		agentBody = form.body ?? '';
+		analysisMode = form.mode as typeof analysisMode ?? null;
+		analyzed = true;
+	}
+
+	// Live markdown preview
+	$: frontmatter = buildFrontmatter(agentName, agentDescription, agentModel, agentDomain, agentTools, agentSkills);
+	$: preview = frontmatter + '\n' + agentBody;
+
+	function buildFrontmatter(
+		name: string,
+		desc: string,
+		model: string,
+		domain: string,
+		tools: string[],
+		skills: string[]
+	): string {
+		const toolLines = tools.map((t) => `  - ${t}`).join('\n');
+		const skillsBlock =
+			skills.length > 0 ? `\nskills:\n${skills.map((s) => `  - ${s}`).join('\n')}` : '';
+		return `---\nname: ${name}\ndescription: ${desc}\nmodel: ${model}\ndomain: ${domain}\ntools:\n${toolLines}${skillsBlock}\n---`;
+	}
+
+	function toggleTool(tool: string) {
+		if (agentTools.includes(tool)) {
+			agentTools = agentTools.filter((t) => t !== tool);
+		} else {
+			agentTools = [...agentTools, tool];
+		}
+	}
+
+	function addSkill() {
+		const s = newSkill.trim();
+		if (s && !agentSkills.includes(s)) {
+			agentSkills = [...agentSkills, s];
+		}
+		newSkill = '';
+	}
+
+	function removeSkill(skill: string) {
+		agentSkills = agentSkills.filter((s) => s !== skill);
+	}
+
+	const domainColor: Record<string, string> = {
+		backend: 'text-orange-400',
+		frontend: 'text-pink-400',
+		'data-engineering': 'text-cyan-400',
+		devops: 'text-amber-400',
+		database: 'text-blue-400',
+		management: 'text-zinc-400',
+		security: 'text-red-400',
+		qa: 'text-green-400',
+		architecture: 'text-indigo-400',
+		universal: 'text-zinc-500'
+	};
+</script>
+
+<div class="p-8 max-w-5xl">
+	<div class="mb-6">
+		<a href="/agents" class="text-zinc-500 hover:text-zinc-300 text-sm mb-3 inline-block">← Agents</a>
+		<div class="flex items-center gap-3">
+			<h1 class="text-2xl font-bold text-zinc-50">New Agent</h1>
+			<!-- Claude availability badge -->
+			{#if data.claudeAvailable}
+				<span class="px-2 py-0.5 rounded-full text-xs font-medium bg-emerald-900/50 text-emerald-400 border border-emerald-700/50">
+					Claude Code ✓
+				</span>
+			{:else}
+				<span class="px-2 py-0.5 rounded-full text-xs font-medium bg-zinc-800 text-zinc-500 border border-zinc-700">
+					Keyword mode
+				</span>
+			{/if}
+		</div>
+		<p class="text-zinc-500 text-sm mt-1">Describe your agent in natural language, then refine the generated spec.</p>
+	</div>
+
+	<!-- Natural language input section -->
+	<div class="border border-zinc-800 rounded-lg p-5 mb-6 bg-zinc-900/30">
+		<label for="nl-input" class="block text-sm font-medium text-zinc-300 mb-2">Describe your agent</label>
+		<textarea
+			id="nl-input"
+			bind:value={nlInput}
+			rows="4"
+			placeholder="예: Kubernetes 배포 전문가. Helm 차트 작성, pod 디버깅 가능. opus 모델 사용.&#10;&#10;Or: A Go backend expert specializing in REST APIs and gRPC services."
+			class="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500 resize-none font-mono"
+		></textarea>
+
+		{#if form?.error && !analyzed}
+			<p class="text-red-400 text-xs mt-2">{form.error}</p>
+		{/if}
+
+		<form
+			method="POST"
+			action="?/analyze"
+			use:enhance={() => {
+				analyzing = true;
+				return async ({ update }) => {
+					analyzing = false;
+					await update();
+				};
+			}}
+		>
+			<input type="hidden" name="input" value={nlInput} />
+			<div class="mt-3 flex items-center gap-3">
+				<button
+					type="submit"
+					disabled={analyzing || !nlInput.trim()}
+					class="px-4 py-2 bg-zinc-700 hover:bg-zinc-600 disabled:opacity-40 disabled:cursor-not-allowed text-zinc-200 text-sm rounded transition-colors font-medium"
+				>
+					{#if analyzing}
+						<span class="flex items-center gap-2">
+							<span class="inline-block animate-spin">⟳</span>
+							{data.claudeAvailable ? 'Claude Code로 분석 중...' : 'Analyzing...'}
+						</span>
+					{:else}
+						Analyze
+					{/if}
+				</button>
+
+				<!-- Mode badge shown after analysis -->
+				{#if analysisMode === 'claude'}
+					<span class="text-xs text-emerald-400">🤖 Claude Code로 생성</span>
+				{:else if analysisMode === 'keyword-fallback'}
+					<span class="text-xs text-amber-400">⚠ Claude Code를 사용할 수 없습니다. 키워드 기반으로 전환합니다.</span>
+				{:else if analysisMode === 'keyword'}
+					<span class="text-xs text-zinc-500">📝 키워드 기반 생성</span>
+				{/if}
+			</div>
+		</form>
+	</div>
+
+	{#if analyzed}
+		<div class="grid grid-cols-2 gap-6">
+			<!-- Left: editable form -->
+			<div class="space-y-4">
+				<h2 class="text-sm font-semibold text-zinc-400 uppercase tracking-wide">Agent Spec</h2>
+
+				<!-- Name -->
+				<div>
+					<label for="agent-name" class="block text-xs text-zinc-500 mb-1">Name <span class="text-zinc-700">(kebab-case)</span></label>
+					<input
+						id="agent-name"
+						type="text"
+						bind:value={agentName}
+						placeholder="my-agent-expert"
+						class="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:border-zinc-500 font-mono"
+					/>
+				</div>
+
+				<!-- Description -->
+				<div>
+					<label for="agent-description" class="block text-xs text-zinc-500 mb-1">Description</label>
+					<input
+						id="agent-description"
+						type="text"
+						bind:value={agentDescription}
+						class="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:border-zinc-500"
+					/>
+				</div>
+
+				<!-- Model -->
+				<div>
+					<p class="text-xs text-zinc-500 mb-1">Model</p>
+					<div class="flex gap-2">
+						{#each MODELS as m}
+							<button
+								onclick={() => (agentModel = m)}
+								class="px-3 py-1 rounded text-xs font-semibold border transition-colors {agentModel === m
+									? m === 'opus' ? 'bg-violet-800 text-violet-200 border-violet-500'
+									: m === 'haiku' ? 'bg-sky-800 text-sky-200 border-sky-500'
+									: 'bg-emerald-800 text-emerald-200 border-emerald-500'
+									: 'border-zinc-700 text-zinc-500 hover:text-zinc-300'}"
+							>
+								{m}
+							</button>
+						{/each}
+					</div>
+				</div>
+
+				<!-- Domain -->
+				<div>
+					<label for="agent-domain" class="block text-xs text-zinc-500 mb-1">Domain</label>
+					<select
+						id="agent-domain"
+						bind:value={agentDomain}
+						class="bg-zinc-900 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-200 focus:outline-none focus:border-zinc-500 w-full"
+					>
+						{#each DOMAINS as d}
+							<option value={d} class={domainColor[d] ?? ''}>{d}</option>
+						{/each}
+					</select>
+				</div>
+
+				<!-- Tools -->
+				<div>
+					<p class="text-xs text-zinc-500 mb-2">Tools</p>
+					<div class="flex flex-wrap gap-2">
+						{#each ALL_TOOLS as tool}
+							<button
+								onclick={() => toggleTool(tool)}
+								class="px-2.5 py-1 rounded text-xs font-medium border transition-colors {agentTools.includes(tool)
+									? 'bg-emerald-900/50 text-emerald-300 border-emerald-700'
+									: 'border-zinc-700 text-zinc-600 hover:text-zinc-400'}"
+							>
+								{tool}
+							</button>
+						{/each}
+					</div>
+				</div>
+
+				<!-- Skills -->
+				<div>
+					<p class="text-xs text-zinc-500 mb-2">Skills</p>
+					{#if agentSkills.length > 0}
+						<div class="flex flex-wrap gap-1.5 mb-2">
+							{#each agentSkills as skill}
+								<span class="flex items-center gap-1 px-2 py-0.5 bg-zinc-800 border border-zinc-700 rounded text-xs text-zinc-300">
+									{skill}
+									<button
+										onclick={() => removeSkill(skill)}
+										class="text-zinc-600 hover:text-zinc-400 leading-none ml-1"
+									>×</button>
+								</span>
+							{/each}
+						</div>
+					{/if}
+					<div class="flex gap-2">
+						<input
+							type="text"
+							bind:value={newSkill}
+							list="skill-options"
+							placeholder="skill name..."
+							class="flex-1 bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-xs text-zinc-200 focus:outline-none focus:border-zinc-500"
+							onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addSkill(); } }}
+						/>
+						<datalist id="skill-options">
+							{#each data.skillNames as sn}
+								<option value={sn}></option>
+							{/each}
+						</datalist>
+						<button
+							onclick={addSkill}
+							class="px-2 py-1 text-xs bg-zinc-800 border border-zinc-700 rounded text-zinc-300 hover:bg-zinc-700 transition-colors"
+						>
+							Add
+						</button>
+					</div>
+				</div>
+
+				<!-- Body -->
+				<div>
+					<label for="agent-body" class="block text-xs text-zinc-500 mb-1">Body <span class="text-zinc-700">(markdown)</span></label>
+					<textarea
+						id="agent-body"
+						bind:value={agentBody}
+						rows="12"
+						class="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2 text-xs text-zinc-200 focus:outline-none focus:border-zinc-500 resize-y font-mono"
+					></textarea>
+				</div>
+			</div>
+
+			<!-- Right: live preview -->
+			<div>
+				<h2 class="text-sm font-semibold text-zinc-400 uppercase tracking-wide mb-3">Preview</h2>
+				<pre class="bg-zinc-900 border border-zinc-800 rounded-lg p-4 text-xs text-zinc-300 font-mono overflow-auto max-h-[600px] whitespace-pre-wrap break-words">{preview}</pre>
+			</div>
+		</div>
+
+		<!-- Save form -->
+		<div class="mt-6 pt-5 border-t border-zinc-800">
+			{#if form?.error}
+				<p class="text-red-400 text-sm mb-3">{form.error}</p>
+			{/if}
+
+			<form
+				method="POST"
+				action="?/save"
+				use:enhance={() => {
+					saving = true;
+					return async ({ update }) => {
+						saving = false;
+						await update({ reset: false });
+					};
+				}}
+			>
+				<input type="hidden" name="name" value={agentName} />
+				<input type="hidden" name="content" value={preview} />
+
+				<div class="flex gap-3">
+					<button
+						type="submit"
+						disabled={saving || !agentName.trim()}
+						class="px-5 py-2 bg-emerald-700 hover:bg-emerald-600 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm rounded font-medium transition-colors"
+					>
+						{saving ? 'Saving...' : 'Save Agent'}
+					</button>
+					<a
+						href="/agents"
+						class="px-4 py-2 border border-zinc-700 text-zinc-400 hover:text-zinc-200 text-sm rounded transition-colors"
+					>
+						Cancel
+					</a>
+				</div>
+			</form>
+		</div>
+	{/if}
+</div>

--- a/packages/serve/src/routes/rules/+page.server.ts
+++ b/packages/serve/src/routes/rules/+page.server.ts
@@ -1,0 +1,8 @@
+import type { PageServerLoad } from './$types';
+import { getRules, getProjectRoot } from '$lib/server/data';
+
+export const load: PageServerLoad = async () => {
+	const root = await getProjectRoot();
+	const rules = await getRules(root);
+	return { rules };
+};

--- a/packages/serve/src/routes/rules/+page.svelte
+++ b/packages/serve/src/routes/rules/+page.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+
+	let filterPriority = '';
+	let search = '';
+	let sortKey = 'id';
+	let sortAsc = true;
+
+	$: filtered = data.rules.filter((r) => {
+		const matchPriority = !filterPriority || r.priority === filterPriority;
+		const matchSearch =
+			!search ||
+			r.name.toLowerCase().includes(search.toLowerCase()) ||
+			r.id.toLowerCase().includes(search.toLowerCase()) ||
+			r.description.toLowerCase().includes(search.toLowerCase());
+		return matchPriority && matchSearch;
+	});
+
+	$: sorted = [...filtered].sort((a, b) => {
+		const va = (a as unknown as Record<string, unknown>)[sortKey] ?? '';
+		const vb = (b as unknown as Record<string, unknown>)[sortKey] ?? '';
+		const cmp = String(va).localeCompare(String(vb));
+		return sortAsc ? cmp : -cmp;
+	});
+
+	function toggleSort(key: string) {
+		if (sortKey === key) {
+			sortAsc = !sortAsc;
+		} else {
+			sortKey = key;
+			sortAsc = true;
+		}
+	}
+
+	function sortIndicator(key: string): string {
+		if (sortKey !== key) return '';
+		return sortAsc ? ' ▲' : ' ▼';
+	}
+
+	const priorityBadge: Record<string, string> = {
+		MUST: 'bg-red-900/50 text-red-300 border border-red-800',
+		SHOULD: 'bg-yellow-900/50 text-yellow-300 border border-yellow-800',
+		MAY: 'bg-green-900/50 text-green-300 border border-green-800'
+	};
+
+	const priorityText: Record<string, string> = {
+		MUST: 'text-red-400',
+		SHOULD: 'text-yellow-400',
+		MAY: 'text-green-400'
+	};
+</script>
+
+<div class="p-8">
+	<div class="mb-6">
+		<h1 class="text-2xl font-bold text-zinc-50">Rules</h1>
+		<p class="text-zinc-500 text-sm mt-1">
+			{#if filterPriority || search}
+				<span class="text-yellow-400 font-medium">{filtered.length}</span> / {data.rules.length} rules
+			{:else}
+				{data.rules.length} rules total
+			{/if}
+		</p>
+	</div>
+
+	<!-- Filters -->
+	<div class="flex gap-3 mb-5">
+		<input
+			type="text"
+			placeholder="Search rules..."
+			bind:value={search}
+			class="bg-zinc-900 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500 w-56"
+		/>
+		<div class="flex gap-2">
+			{#each ['MUST', 'SHOULD', 'MAY'] as p}
+				<button
+					onclick={() => { filterPriority = filterPriority === p ? '' : p; }}
+					class="px-3 py-1.5 rounded text-xs font-semibold border transition-colors {filterPriority === p ? priorityBadge[p] : 'border-zinc-700 text-zinc-500 hover:text-zinc-300'}"
+				>
+					{p}
+				</button>
+			{/each}
+		</div>
+		{#if filterPriority || search}
+			<button
+				onclick={() => { filterPriority = ''; search = ''; }}
+				class="text-zinc-500 hover:text-zinc-300 text-sm px-2"
+			>
+				Clear
+			</button>
+		{/if}
+	</div>
+
+	<div class="border border-zinc-800 rounded-lg overflow-hidden">
+		<table class="w-full text-sm">
+			<thead>
+				<tr class="bg-zinc-900 border-b border-zinc-800">
+					<th
+						class="px-4 py-3 text-left text-zinc-400 font-medium w-20 cursor-pointer select-none hover:text-zinc-200 {sortKey === 'id' ? 'text-zinc-200 font-bold' : ''}"
+						onclick={() => toggleSort('id')}
+					>ID{sortIndicator('id')}</th>
+					<th
+						class="px-4 py-3 text-left text-zinc-400 font-medium w-24 cursor-pointer select-none hover:text-zinc-200 {sortKey === 'priority' ? 'text-zinc-200 font-bold' : ''}"
+						onclick={() => toggleSort('priority')}
+					>Priority{sortIndicator('priority')}</th>
+					<th
+						class="px-4 py-3 text-left text-zinc-400 font-medium cursor-pointer select-none hover:text-zinc-200 {sortKey === 'name' ? 'text-zinc-200 font-bold' : ''}"
+						onclick={() => toggleSort('name')}
+					>Name{sortIndicator('name')}</th>
+					<th class="px-4 py-3 text-left text-zinc-400 font-medium">Description</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each sorted as rule, i}
+					<tr class="border-t border-zinc-800 hover:bg-zinc-900/60 transition-colors {i % 2 === 1 ? 'bg-zinc-900/30' : ''}">
+						<td class="px-4 py-3 font-mono text-zinc-500">{rule.id || '—'}</td>
+						<td class="px-4 py-3">
+							<span class="px-2 py-0.5 rounded text-xs font-bold {priorityBadge[rule.priority] ?? 'bg-zinc-800 text-zinc-400'}">
+								{rule.priority}
+							</span>
+						</td>
+						<td class="px-4 py-3">
+							<a href="/rules/{rule.name}" class="{priorityText[rule.priority] ?? 'text-zinc-300'} hover:opacity-80 font-medium">
+								{rule.name}
+							</a>
+						</td>
+						<td class="px-4 py-3 text-zinc-500 max-w-md truncate">{rule.description}</td>
+					</tr>
+				{:else}
+					<tr>
+						<td colspan="4" class="px-4 py-8 text-center text-zinc-600">No rules found</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
+</div>

--- a/packages/serve/src/routes/rules/[name]/+page.server.ts
+++ b/packages/serve/src/routes/rules/[name]/+page.server.ts
@@ -1,0 +1,16 @@
+import type { PageServerLoad } from './$types';
+import { getRule, getProjectRoot } from '$lib/server/data';
+import { renderMarkdown } from '$lib/server/markdown';
+import { error } from '@sveltejs/kit';
+
+export const load: PageServerLoad = async ({ params }) => {
+	const root = await getProjectRoot();
+	const rule = await getRule(root, params.name);
+
+	if (!rule) {
+		error(404, `Rule "${params.name}" not found`);
+	}
+
+	const renderedBody = renderMarkdown(rule.body);
+	return { rule, renderedBody };
+};

--- a/packages/serve/src/routes/rules/[name]/+page.svelte
+++ b/packages/serve/src/routes/rules/[name]/+page.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+
+	const priorityBadge: Record<string, string> = {
+		MUST: 'bg-red-900/60 text-red-300 border-red-800',
+		SHOULD: 'bg-yellow-900/60 text-yellow-300 border-yellow-800',
+		MAY: 'bg-green-900/60 text-green-300 border-green-800'
+	};
+</script>
+
+<div class="p-8 max-w-4xl">
+	<!-- Breadcrumb -->
+	<div class="text-sm text-zinc-600 mb-6">
+		<a href="/rules" class="hover:text-zinc-400">Rules</a>
+		<span class="mx-2">/</span>
+		<span class="text-zinc-300">{data.rule.name}</span>
+	</div>
+
+	<!-- Header -->
+	<div class="mb-8">
+		<div class="flex items-center gap-3 mb-2">
+			{#if data.rule.id}
+				<span class="text-zinc-500 font-mono text-sm">{data.rule.id}</span>
+			{/if}
+			<span class="px-2 py-0.5 rounded border text-xs font-bold {priorityBadge[data.rule.priority] ?? 'bg-zinc-800 text-zinc-400 border-zinc-700'}">
+				{data.rule.priority}
+			</span>
+			<h1 class="text-2xl font-bold text-zinc-50">{data.rule.name}</h1>
+		</div>
+		{#if data.rule.description}
+			<p class="text-zinc-400">{data.rule.description}</p>
+		{/if}
+	</div>
+
+	<!-- Body -->
+	<div class="border border-zinc-800 rounded-lg p-6 prose">
+		{@html data.renderedBody}
+	</div>
+</div>

--- a/packages/serve/src/routes/skills/+page.server.ts
+++ b/packages/serve/src/routes/skills/+page.server.ts
@@ -1,0 +1,9 @@
+import type { PageServerLoad } from './$types';
+import { getSkills, getProjectRoot } from '$lib/server/data';
+
+export const load: PageServerLoad = async () => {
+	const root = await getProjectRoot();
+	const skills = await getSkills(root);
+	const scopes = [...new Set(skills.map((s) => s.scope))].sort();
+	return { skills, scopes };
+};

--- a/packages/serve/src/routes/skills/+page.svelte
+++ b/packages/serve/src/routes/skills/+page.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+
+	let search = '';
+	let selectedScopes: Set<string> = new Set();
+	let forkOnly = false;
+	let sortKey = 'name';
+	let sortAsc = true;
+
+	$: filtered = data.skills.filter((s) => {
+		const matchScope = selectedScopes.size === 0 || selectedScopes.has(s.scope);
+		const matchFork = !forkOnly || s.contextFork;
+		const q = search.toLowerCase();
+		const matchSearch =
+			!q ||
+			s.name.toLowerCase().includes(q) ||
+			s.description.toLowerCase().includes(q);
+		return matchScope && matchFork && matchSearch;
+	});
+
+	$: sorted = [...filtered].sort((a, b) => {
+		const va = (a as unknown as Record<string, unknown>)[sortKey] ?? '';
+		const vb = (b as unknown as Record<string, unknown>)[sortKey] ?? '';
+		const cmp = String(va).localeCompare(String(vb));
+		return sortAsc ? cmp : -cmp;
+	});
+
+	function toggleSort(key: string) {
+		if (sortKey === key) {
+			sortAsc = !sortAsc;
+		} else {
+			sortKey = key;
+			sortAsc = true;
+		}
+	}
+
+	function toggleScope(scope: string) {
+		const next = new Set(selectedScopes);
+		if (next.has(scope)) next.delete(scope);
+		else next.add(scope);
+		selectedScopes = next;
+	}
+
+	function clearAll() {
+		search = '';
+		selectedScopes = new Set();
+		forkOnly = false;
+	}
+
+	$: hasFilters = search || selectedScopes.size > 0 || forkOnly;
+
+	function sortIndicator(key: string): string {
+		if (sortKey !== key) return '';
+		return sortAsc ? ' ▲' : ' ▼';
+	}
+
+	const scopeColor: Record<string, string> = {
+		core: 'bg-emerald-900/50 text-emerald-300 border-emerald-700',
+		harness: 'bg-amber-900/50 text-amber-300 border-amber-700',
+		package: 'bg-sky-900/50 text-sky-300 border-sky-700'
+	};
+
+	const scopeActiveColor: Record<string, string> = {
+		core: 'bg-emerald-800 text-emerald-200 border-emerald-500',
+		harness: 'bg-amber-800 text-amber-200 border-amber-500',
+		package: 'bg-sky-800 text-sky-200 border-sky-500'
+	};
+</script>
+
+<div class="p-8">
+	<div class="mb-6">
+		<h1 class="text-2xl font-bold text-zinc-50">Skills</h1>
+		<p class="text-zinc-500 text-sm mt-1">
+			{#if hasFilters}
+				<span class="text-sky-400 font-medium">{filtered.length}</span> / {data.skills.length} skills
+			{:else}
+				{data.skills.length} skills total
+			{/if}
+		</p>
+	</div>
+
+	<!-- Search -->
+	<div class="mb-4">
+		<input
+			type="text"
+			placeholder="Search skills..."
+			bind:value={search}
+			class="bg-zinc-900 border border-zinc-700 rounded px-3 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500 w-72"
+		/>
+	</div>
+
+	<!-- Scope filter -->
+	<div class="mb-3">
+		<div class="text-xs text-zinc-600 mb-2 uppercase tracking-wide font-medium">Scope</div>
+		<div class="flex gap-2">
+			{#each data.scopes as scope}
+				<button
+					onclick={() => toggleScope(scope)}
+					class="px-3 py-1 rounded text-xs font-semibold border transition-colors {selectedScopes.has(scope)
+						? (scopeActiveColor[scope] ?? 'bg-zinc-700 text-zinc-200 border-zinc-500')
+						: 'border-zinc-700 text-zinc-500 hover:text-zinc-300'}"
+				>
+					{scope}
+				</button>
+			{/each}
+		</div>
+	</div>
+
+	<!-- context:fork toggle -->
+	<div class="mb-5">
+		<div class="text-xs text-zinc-600 mb-2 uppercase tracking-wide font-medium">Context</div>
+		<button
+			onclick={() => (forkOnly = !forkOnly)}
+			class="px-3 py-1 rounded text-xs font-semibold border transition-colors {forkOnly
+				? 'bg-violet-800 text-violet-200 border-violet-500'
+				: 'border-zinc-700 text-zinc-500 hover:text-zinc-300'}"
+		>
+			context:fork only
+		</button>
+	</div>
+
+	{#if hasFilters}
+		<div class="mb-4">
+			<button
+				onclick={clearAll}
+				class="text-zinc-500 hover:text-zinc-300 text-xs px-2 py-1 border border-zinc-700 rounded transition-colors"
+			>
+				Clear filters
+			</button>
+		</div>
+	{/if}
+
+	<div class="border border-zinc-800 rounded-lg overflow-hidden">
+		<table class="w-full text-sm">
+			<thead>
+				<tr class="bg-zinc-900 border-b border-zinc-800">
+					<th
+						class="px-4 py-3 text-left text-zinc-400 font-medium cursor-pointer select-none hover:text-zinc-200 {sortKey === 'name' ? 'text-zinc-200 font-bold' : ''}"
+						onclick={() => toggleSort('name')}
+					>Name{sortIndicator('name')}</th>
+					<th
+						class="px-4 py-3 text-left text-zinc-400 font-medium cursor-pointer select-none hover:text-zinc-200 {sortKey === 'description' ? 'text-zinc-200 font-bold' : ''}"
+						onclick={() => toggleSort('description')}
+					>Description{sortIndicator('description')}</th>
+					<th
+						class="px-4 py-3 text-left text-zinc-400 font-medium cursor-pointer select-none hover:text-zinc-200 {sortKey === 'scope' ? 'text-zinc-200 font-bold' : ''}"
+						onclick={() => toggleSort('scope')}
+					>Scope{sortIndicator('scope')}</th>
+					<th
+						class="px-4 py-3 text-left text-zinc-400 font-medium cursor-pointer select-none hover:text-zinc-200 {sortKey === 'contextFork' ? 'text-zinc-200 font-bold' : ''}"
+						onclick={() => toggleSort('contextFork')}
+					>Context{sortIndicator('contextFork')}</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each sorted as skill, i}
+					<tr class="border-t border-zinc-800 hover:bg-zinc-900/60 transition-colors {i % 2 === 1 ? 'bg-zinc-900/30' : ''}">
+						<td class="px-4 py-3">
+							<a href="/skills/{skill.name}" class="text-sky-400 hover:text-sky-300 font-medium">
+								{skill.name}
+							</a>
+						</td>
+						<td class="px-4 py-3 text-zinc-400 max-w-md truncate">{skill.description}</td>
+						<td class="px-4 py-3">
+							<span class="px-2 py-0.5 rounded text-xs font-medium border {scopeColor[skill.scope] ?? 'bg-zinc-800 text-zinc-400 border-zinc-700'}">
+								{skill.scope}
+							</span>
+						</td>
+						<td class="px-4 py-3">
+							{#if skill.contextFork}
+								<span class="px-2 py-0.5 rounded text-xs font-medium bg-violet-900/40 text-violet-300 border border-violet-700">
+									fork
+								</span>
+							{:else}
+								<span class="text-zinc-700 text-xs">—</span>
+							{/if}
+						</td>
+					</tr>
+				{:else}
+					<tr>
+						<td colspan="4" class="px-4 py-8 text-center text-zinc-600">No skills found</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+	</div>
+</div>

--- a/packages/serve/src/routes/skills/[name]/+page.server.ts
+++ b/packages/serve/src/routes/skills/[name]/+page.server.ts
@@ -1,0 +1,24 @@
+import type { PageServerLoad } from './$types';
+import { getSkill, getProjectRoot } from '$lib/server/data';
+import { renderMarkdown } from '$lib/server/markdown';
+import { error } from '@sveltejs/kit';
+
+export const load: PageServerLoad = async ({ params }) => {
+	const root = await getProjectRoot();
+	const skill = await getSkill(root, params.name);
+
+	if (!skill) {
+		error(404, `Skill "${params.name}" not found`);
+	}
+
+	const renderedBody = renderMarkdown(skill.body);
+
+	const displayMeta = Object.entries(skill.frontmatter)
+		.filter(([k]) => k !== 'name')
+		.map(([key, val]) => ({
+			key,
+			value: Array.isArray(val) ? val.join(', ') : String(val)
+		}));
+
+	return { skill, renderedBody, displayMeta };
+};

--- a/packages/serve/src/routes/skills/[name]/+page.svelte
+++ b/packages/serve/src/routes/skills/[name]/+page.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+
+	const scopeColor: Record<string, string> = {
+		core: 'bg-emerald-900/60 text-emerald-300 border-emerald-800',
+		harness: 'bg-amber-900/60 text-amber-300 border-amber-800',
+		package: 'bg-sky-900/60 text-sky-300 border-sky-800'
+	};
+</script>
+
+<div class="p-8 max-w-5xl">
+	<!-- Breadcrumb -->
+	<div class="text-sm text-zinc-600 mb-6">
+		<a href="/skills" class="hover:text-zinc-400">Skills</a>
+		<span class="mx-2">/</span>
+		<span class="text-zinc-300">{data.skill.name}</span>
+	</div>
+
+	<!-- Header -->
+	<div class="mb-8">
+		<div class="flex items-center gap-3 mb-2">
+			<h1 class="text-2xl font-bold text-zinc-50">{data.skill.name}</h1>
+			<span class="px-2 py-0.5 rounded border text-xs font-medium {scopeColor[data.skill.scope] ?? 'bg-zinc-800 text-zinc-400 border-zinc-700'}">
+				{data.skill.scope}
+			</span>
+		</div>
+		{#if data.skill.description}
+			<p class="text-zinc-400">{data.skill.description}</p>
+		{/if}
+	</div>
+
+	<div class="grid grid-cols-1 lg:grid-cols-4 gap-6">
+		<!-- Metadata -->
+		<div class="lg:col-span-1">
+			<div class="border border-zinc-800 rounded-lg overflow-hidden">
+				<div class="bg-zinc-900 px-4 py-2 text-xs font-semibold text-zinc-400 uppercase tracking-wider">
+					Metadata
+				</div>
+				<table class="w-full text-sm">
+					<tbody>
+						{#each data.displayMeta as { key, value }}
+							<tr class="border-t border-zinc-800">
+								<td class="px-4 py-2 text-zinc-500 font-medium">{key}</td>
+								<td class="px-4 py-2 text-zinc-300 break-all">{value || '—'}</td>
+							</tr>
+						{/each}
+					</tbody>
+				</table>
+			</div>
+		</div>
+
+		<!-- Body -->
+		<div class="lg:col-span-3">
+			<div class="border border-zinc-800 rounded-lg p-6 prose">
+				{@html data.renderedBody}
+			</div>
+		</div>
+	</div>
+</div>

--- a/packages/serve/static/favicon.svg
+++ b/packages/serve/static/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#10b981"/>
+  <text x="5" y="23" font-size="20" font-family="monospace" fill="white">o</text>
+</svg>

--- a/packages/serve/svelte.config.js
+++ b/packages/serve/svelte.config.js
@@ -1,0 +1,13 @@
+import adapter from '@sveltejs/adapter-node';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	kit: {
+		adapter: adapter({
+			out: 'build',
+			envPrefix: 'OMCUSTOM_'
+		})
+	}
+};
+
+export default config;

--- a/packages/serve/tsconfig.json
+++ b/packages/serve/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "moduleResolution": "bundler"
+  }
+}

--- a/packages/serve/vite.config.ts
+++ b/packages/serve/vite.config.ts
@@ -1,0 +1,10 @@
+import { sveltekit } from '@sveltejs/kit/vite';
+import tailwindcss from '@tailwindcss/vite';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+	plugins: [tailwindcss(), sveltekit()],
+	server: {
+		port: 4321
+	}
+});

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,7 +4,9 @@
  * Main CLI application using Commander.js
  */
 
+import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
+import { join } from 'node:path';
 import { Command } from 'commander';
 import { formatPreflightWarnings, runPreflightCheck } from '../core/preflight.js';
 import { maybeHandleSelfUpdateForInit } from '../core/self-update.js';
@@ -13,6 +15,8 @@ import { doctorCommand } from './doctor.js';
 import { initCommand } from './init.js';
 import { listCommand } from './list.js';
 import { securityCommand } from './security.js';
+import { startServeBackground } from './serve.js';
+import { serveCommand, serveStopCommand } from './serve-commands.js';
 import { updateCommand } from './update.js';
 
 // Read version from package.json
@@ -97,6 +101,25 @@ export function createProgram(): Command {
       process.exitCode = result.success ? 0 : 1;
     });
 
+  // omcustom serve [--port 4321] [--open] [--foreground]
+  program
+    .command('serve')
+    .description('Start the web UI server')
+    .option('-p, --port <port>', 'Port number', '4321')
+    .option('--open', 'Open browser automatically')
+    .option('--foreground', 'Run in foreground (not detached)')
+    .action(async (options) => {
+      await serveCommand(options);
+    });
+
+  // omcustom serve-stop
+  program
+    .command('serve-stop')
+    .description('Stop the web UI server')
+    .action(async () => {
+      await serveStopCommand();
+    });
+
   // Pre-flight hook: run before any command
   program.hook('preAction', async (thisCommand, actionCommand) => {
     const opts = thisCommand.optsWithGlobals() as { skipVersionCheck?: boolean };
@@ -115,6 +138,17 @@ export function createProgram(): Command {
       const warnings = formatPreflightWarnings(result);
       console.warn(warnings);
       console.warn(''); // Empty line for spacing
+    }
+
+    // Auto-start serve in the background for any command that runs inside an
+    // initialized project (has .claude/ directory), except serve-stop itself.
+    const commandName = actionCommand.name();
+    if (commandName !== 'serve-stop' && commandName !== 'serve') {
+      const cwd = process.cwd();
+      if (existsSync(join(cwd, '.claude'))) {
+        // Fire-and-forget: must not block or throw — any failure is silently ignored
+        startServeBackground(cwd).catch(() => {});
+      }
     }
   });
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -9,6 +9,7 @@ import { getProviderLayout } from '../core/layout.js';
 import { checkUvAvailable, generateMCPConfig } from '../core/mcp-config.js';
 import { i18n } from '../i18n/index.js';
 import { fileExists } from '../utils/fs.js';
+import { DEFAULT_PORT, startServeBackground } from './serve.js';
 import { getDefaultWizardResult, isInteractiveMode, runInitWizard } from './wizard.js';
 
 /**
@@ -221,6 +222,11 @@ export async function initCommand(options: InitOptions): Promise<InitResult> {
     console.log('  /plugin install context7');
     console.log('');
     console.log('See CLAUDE.md "외부 의존성" section for details.');
+
+    // Auto-start web UI in background after successful init.
+    // Fire-and-forget: skip silently if build is missing.
+    await startServeBackground(targetDir).catch(() => {});
+    console.log(`Web UI: http://127.0.0.1:${DEFAULT_PORT}`);
 
     return {
       success: true,

--- a/src/cli/serve-commands.ts
+++ b/src/cli/serve-commands.ts
@@ -1,0 +1,111 @@
+/**
+ * CLI command handlers for `omcustom serve` and `omcustom serve-stop`
+ */
+
+import { execFile, spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import {
+  DEFAULT_PORT,
+  findServeBuildDir,
+  isServeRunning,
+  startServeBackground,
+  stopServe,
+} from './serve.js';
+
+export interface ServeCommandOptions {
+  port?: string;
+  open?: boolean;
+  foreground?: boolean;
+}
+
+/**
+ * Handler for `omcustom serve [--port 4321] [--open] [--foreground]`
+ */
+export async function serveCommand(options: ServeCommandOptions): Promise<void> {
+  const port = options.port !== undefined ? Number(options.port) : DEFAULT_PORT;
+
+  if (!Number.isFinite(port) || port < 1 || port > 65535) {
+    console.error(`Invalid port: ${options.port}`);
+    process.exit(1);
+  }
+
+  const cwd = process.cwd();
+
+  if (options.foreground === true) {
+    runForeground(cwd, port);
+    return;
+  }
+
+  await startServeBackground(cwd, port);
+
+  const running = await isServeRunning();
+  if (running) {
+    console.log(`Web UI started: http://127.0.0.1:${port}`);
+    if (options.open === true) {
+      openBrowser(port);
+    }
+  } else {
+    console.error('Failed to start Web UI server');
+    process.exit(1);
+  }
+}
+
+/**
+ * Handler for `omcustom serve-stop`
+ */
+export async function serveStopCommand(): Promise<void> {
+  const stopped = await stopServe();
+  if (stopped) {
+    console.log('Web UI server stopped');
+  } else {
+    console.log('Web UI server is not running');
+  }
+}
+
+/**
+ * Run the SvelteKit server in the foreground (blocking).
+ * Exits the current process with an error if the build is missing.
+ */
+function runForeground(projectRoot: string, port: number): void {
+  const buildDir = findServeBuildDir(projectRoot);
+  if (buildDir === null) {
+    console.error('Web UI build not found. Run: cd packages/serve && bun run build');
+    process.exit(1);
+  }
+
+  console.log(`Web UI: http://127.0.0.1:${port}`);
+
+  spawnSync('node', [join(buildDir, 'index.js')], {
+    env: {
+      ...process.env,
+      PORT: String(port),
+      HOST: '127.0.0.1',
+      OMCUSTOM_PROJECT_ROOT: projectRoot,
+    },
+    stdio: 'inherit',
+  });
+}
+
+/**
+ * Open a URL in the default browser using execFile (shell-injection safe).
+ * Uses platform-specific openers. Fires and forgets — failures are silently ignored.
+ */
+function openBrowser(port: number): void {
+  const url = `http://127.0.0.1:${port}`;
+  const platform = process.platform;
+
+  if (platform === 'darwin') {
+    execFile('open', [url], () => {
+      // intentionally empty — ignore open failures
+    });
+  } else if (platform === 'win32') {
+    // `start` is a cmd.exe built-in; pass via cmd /c
+    execFile('cmd', ['/c', 'start', url], () => {
+      // intentionally empty
+    });
+  } else {
+    execFile('xdg-open', [url], () => {
+      // intentionally empty
+    });
+  }
+}

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -1,0 +1,124 @@
+/**
+ * Background web server management for omcustom CLI
+ * Manages the lifecycle of the packages/serve SvelteKit server process
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { readFile, unlink, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export const DEFAULT_PORT = 4321;
+
+const PID_FILE = join(process.env.HOME ?? '~', '.omcustom-serve.pid');
+
+/**
+ * Find the built SvelteKit server directory.
+ * Checks two locations: the local monorepo packages/serve/build,
+ * and the npm-installed package path relative to this module.
+ */
+export function findServeBuildDir(projectRoot: string): string | null {
+  // 1. Monorepo: packages/serve/build (dev / local install)
+  const localBuild = join(projectRoot, 'packages', 'serve', 'build');
+  if (existsSync(join(localBuild, 'index.js'))) return localBuild;
+
+  // 2. npm global: installed next to dist/ inside the omcustom package
+  // __dirname is dist/cli/ when compiled, so go up two levels to package root
+  const npmBuild = join(import.meta.dirname, '..', '..', 'packages', 'serve', 'build');
+  if (existsSync(join(npmBuild, 'index.js'))) return npmBuild;
+
+  return null;
+}
+
+/**
+ * Check whether the serve process is currently running.
+ * Reads the PID file and sends signal 0 to verify the process exists.
+ * Cleans up a stale PID file if the process is gone.
+ */
+export async function isServeRunning(): Promise<boolean> {
+  try {
+    const raw = await readFile(PID_FILE, 'utf-8');
+    const pid = Number(raw.trim());
+    if (!Number.isFinite(pid) || pid <= 0) {
+      await cleanupPidFile();
+      return false;
+    }
+    process.kill(pid, 0); // signal 0 = existence check only
+    return true;
+  } catch {
+    await cleanupPidFile();
+    return false;
+  }
+}
+
+/**
+ * Start the SvelteKit web server as a detached background process.
+ * Silently skips if the server is already running or the build is missing.
+ *
+ * @param projectRoot - Absolute path to the project root (used to find build dir)
+ * @param port - TCP port to bind (default: 4321)
+ */
+export async function startServeBackground(
+  projectRoot: string,
+  port: number = DEFAULT_PORT
+): Promise<void> {
+  if (await isServeRunning()) {
+    return; // already running — no-op
+  }
+
+  const buildDir = findServeBuildDir(projectRoot);
+  if (buildDir === null) {
+    // Build not present (serve package not installed / not yet built) — silently skip
+    return;
+  }
+
+  const child = spawn('node', [join(buildDir, 'index.js')], {
+    env: {
+      ...process.env,
+      PORT: String(port),
+      HOST: '127.0.0.1',
+      OMCUSTOM_PROJECT_ROOT: projectRoot,
+    },
+    stdio: 'ignore',
+    detached: true,
+  });
+
+  child.unref();
+
+  if (child.pid !== undefined) {
+    await writeFile(PID_FILE, String(child.pid), 'utf-8');
+  }
+}
+
+/**
+ * Stop the background serve process.
+ *
+ * @returns `true` if a running process was stopped, `false` if nothing was running.
+ */
+export async function stopServe(): Promise<boolean> {
+  try {
+    const raw = await readFile(PID_FILE, 'utf-8');
+    const pid = Number(raw.trim());
+    if (!Number.isFinite(pid) || pid <= 0) {
+      await cleanupPidFile();
+      return false;
+    }
+    process.kill(pid, 'SIGTERM');
+    await cleanupPidFile();
+    return true;
+  } catch {
+    await cleanupPidFile();
+    return false;
+  }
+}
+
+/**
+ * Remove the PID file, ignoring errors if it does not exist.
+ */
+async function cleanupPidFile(): Promise<void> {
+  try {
+    await unlink(PID_FILE);
+  } catch {
+    // ignore — file may already be absent
+  }
+}

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.42.3",
+  "version": "0.43.0",
   "lastUpdated": "2026-03-16T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- feat(serve): Built-in Web UI — SvelteKit agent/skill/guide/rule explorer (#466)
- feat(cli): `omcustom serve` / `serve-stop` commands with auto-start (#466)
- chore: bump version to 0.43.0

## Changes

### Built-in Web UI (packages/serve)
- SvelteKit + adapter-node + Tailwind CSS v4
- Dashboard with summary cards (agents, skills, guides, rules counts)
- Agent/Skill/Guide/Rule list pages with filtering + sorting
- Detail pages with frontmatter metadata + markdown rendering
- Natural language agent creation (Claude Code CLI integration with keyword fallback)
- File-system based data source (zero-config, no database)

### CLI Integration
- `omcustom serve [--port] [--open] [--foreground]` — manual start
- `omcustom serve-stop` — stop background server
- Auto-start on any `omcustom` command when `.claude/` exists
- Auto-start after `omcustom init`
- PID-based process management (~/.omcustom-serve.pid)

## Issues
- Closes #466

## Test plan
- [ ] `omcustom serve --foreground` starts on port 4321
- [ ] Dashboard shows correct counts
- [ ] Agent list filtering by domain/model works
- [ ] Agent detail shows frontmatter + markdown body
- [ ] Agent creation with Claude Code CLI
- [ ] `omcustom serve-stop` stops the server
- [ ] CI passes (Lint, Test, Rust Tests, Template Sync, Version Sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)