### PR TITLE
Release v0.43.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-customcode",
   "workspaces": ["packages/*"],
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.43.0",
+  "version": "0.43.1",
   "lastUpdated": "2026-03-16T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- feat(serve): skill/guide creation pages with natural language input (#469)
- feat(serve): SessionStart auto-serve hook
- fix(serve): CSRF, path containment, SvelteKit envPrefix compatibility
- perf(ci): all CI jobs on macos-latest, remove nuc13 dependency (#472)

## Changes since v0.43.0
- `/skills/create` and `/guides/create` pages (Claude CLI + keyword fallback)
- `serve-autostart.sh` SessionStart hook for automatic Web UI startup
- `validateWithClaude()` foundation for post-save advisory validation
- CI pipeline fully on GitHub-hosted macOS runners (6 jobs parallel)
- Path containment checks in all save actions
- Template sync for new hook scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)