### PR TITLE
fix(serve): replace truncate with line-clamp-2 (#475)

### DIFF
--- a/packages/serve/src/routes/agents/+page.svelte
+++ b/packages/serve/src/routes/agents/+page.svelte
@@ -196,7 +196,7 @@
 								{agent.name}
 							</a>
 						</td>
-						<td class="px-4 py-3 text-zinc-400 max-w-xs truncate">{agent.description}</td>
+						<td class="px-4 py-3 text-zinc-400 max-w-xs" title={agent.description}><span class="line-clamp-2">{agent.description}</span></td>
 						<td class="px-4 py-3">
 							<span class="px-2 py-0.5 rounded text-xs font-medium border {modelColor[agent.model] ?? 'bg-zinc-800 text-zinc-400 border-zinc-700'}">
 								{agent.model}

--- a/packages/serve/src/routes/rules/+page.svelte
+++ b/packages/serve/src/routes/rules/+page.svelte
@@ -125,7 +125,7 @@
 								{rule.name}
 							</a>
 						</td>
-						<td class="px-4 py-3 text-zinc-500 max-w-md truncate">{rule.description}</td>
+						<td class="px-4 py-3 text-zinc-500 max-w-md" title={rule.description}><span class="line-clamp-2">{rule.description}</span></td>
 					</tr>
 				{:else}
 					<tr>

--- a/packages/serve/src/routes/skills/+page.svelte
+++ b/packages/serve/src/routes/skills/+page.svelte
@@ -170,7 +170,7 @@
 								{skill.name}
 							</a>
 						</td>
-						<td class="px-4 py-3 text-zinc-400 max-w-md truncate">{skill.description}</td>
+						<td class="px-4 py-3 text-zinc-400 max-w-md" title={skill.description}><span class="line-clamp-2">{skill.description}</span></td>
 						<td class="px-4 py-3">
 							<span class="px-2 py-0.5 rounded text-xs font-medium border {scopeColor[skill.scope] ?? 'bg-zinc-800 text-zinc-400 border-zinc-700'}">
 								{skill.scope}


### PR DESCRIPTION
## Summary
- Replace `truncate` (single-line cutoff) with `line-clamp-2` (two-line ellipsis)
- Add `title` hover attribute for full description text
- Applied to agents, skills, rules list pages

Closes #475

## Test plan
- [ ] Description shows up to 2 lines in list views
- [ ] Hover shows full text
- [ ] SvelteKit build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)