### PR TITLE
feat(serve): sidebar Core category + dashboard analytics (#470)

### DIFF
--- a/packages/serve/src/lib/server/analytics.ts
+++ b/packages/serve/src/lib/server/analytics.ts
@@ -1,0 +1,333 @@
+import { readdir, readFile } from 'fs/promises';
+import { join } from 'path';
+
+// ---------------------------------------------------------------------------
+// Public interfaces
+// ---------------------------------------------------------------------------
+
+export interface SessionStats {
+	today: number;
+	thisWeek: number;
+	thisMonth: number;
+}
+
+export interface AgentInvocation {
+	agentType: string;
+	count: number;
+	successRate: number;
+	lastUsed: string;
+}
+
+export interface SkillInvocation {
+	skill: string;
+	count: number;
+}
+
+export interface AnalyticsData {
+	sessions: SessionStats;
+	agentInvocations: AgentInvocation[];
+	skillInvocations: SkillInvocation[];
+	totalInvocations: number;
+	successRate: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal types
+// ---------------------------------------------------------------------------
+
+interface TaskOutcomeRecord {
+	timestamp: string;
+	agent_type: string;
+	model: string;
+	outcome: string;
+	pattern_used: string;
+	skill: string;
+	description: string;
+	error_summary: string;
+}
+
+interface AgentAccumulator {
+	count: number;
+	successCount: number;
+	lastUsed: string;
+}
+
+// ---------------------------------------------------------------------------
+// JSONL file discovery — /tmp/.claude-task-outcomes-<PPID>
+// ---------------------------------------------------------------------------
+
+async function findOutcomeFiles(): Promise<string[]> {
+	try {
+		const entries = await readdir('/tmp');
+		return entries
+			.filter((e) => e.startsWith('.claude-task-outcomes-'))
+			.map((e) => join('/tmp', e));
+	} catch {
+		return [];
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JSONL parsing
+// ---------------------------------------------------------------------------
+
+function parseRecord(line: string): TaskOutcomeRecord | null {
+	const trimmed = line.trim();
+	if (!trimmed) return null;
+	try {
+		const parsed = JSON.parse(trimmed) as unknown;
+		if (!parsed || typeof parsed !== 'object') return null;
+		const r = parsed as Record<string, unknown>;
+		return {
+			timestamp: typeof r.timestamp === 'string' ? r.timestamp : '',
+			agent_type: typeof r.agent_type === 'string' ? r.agent_type : '',
+			model: typeof r.model === 'string' ? r.model : '',
+			outcome: typeof r.outcome === 'string' ? r.outcome : '',
+			pattern_used: typeof r.pattern_used === 'string' ? r.pattern_used : '',
+			skill: typeof r.skill === 'string' ? r.skill : '',
+			description: typeof r.description === 'string' ? r.description : '',
+			error_summary: typeof r.error_summary === 'string' ? r.error_summary : ''
+		};
+	} catch {
+		return null;
+	}
+}
+
+async function readOutcomeFile(filePath: string): Promise<TaskOutcomeRecord[]> {
+	try {
+		const content = await readFile(filePath, 'utf-8');
+		return content
+			.split('\n')
+			.map(parseRecord)
+			.filter((r): r is TaskOutcomeRecord => r !== null);
+	} catch {
+		return [];
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Date window helpers
+// ---------------------------------------------------------------------------
+
+interface DateWindows {
+	todayStart: Date;
+	weekStart: Date;
+	monthStart: Date;
+}
+
+function getDateWindows(): DateWindows {
+	const now = new Date();
+	const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+	const weekStart = new Date(todayStart);
+	weekStart.setDate(weekStart.getDate() - 7);
+	const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+	return { todayStart, weekStart, monthStart };
+}
+
+// ---------------------------------------------------------------------------
+// MEMORY.md Metrics table parsing
+// Format: | Agent Type | Tasks | Success Rate | Avg Model | Last Used |
+// ---------------------------------------------------------------------------
+
+interface MemoryMetricRow {
+	agentType: string;
+	count: number;
+	successRate: number;
+	lastUsed: string;
+}
+
+function parseMetricsTable(content: string): MemoryMetricRow[] {
+	const metricsMatch = content.match(/^## Metrics.*$([\s\S]*?)(?=^## |\s*$)/m);
+	if (!metricsMatch) return [];
+
+	const rows: MemoryMetricRow[] = [];
+	const tableLines = metricsMatch[1].split('\n');
+
+	for (const line of tableLines) {
+		// Match table data rows: | agent-type | 12 | 92% | sonnet | 2026-03-15 |
+		const cellMatch = line.match(/^\|\s*([^|]+?)\s*\|\s*(\d+)\s*\|\s*(\d+(?:\.\d+)?)%?\s*\|/);
+		if (!cellMatch) continue;
+
+		const agentType = cellMatch[1].trim();
+		// Skip header and separator rows
+		if (agentType === 'Agent Type' || agentType.startsWith('-') || agentType.startsWith('=')) continue;
+
+		const count = parseInt(cellMatch[2], 10);
+		const successRateRaw = parseFloat(cellMatch[3]);
+		// Handle both "92" (percent) and "0.92" (ratio)
+		const successRate = successRateRaw > 1 ? successRateRaw / 100 : successRateRaw;
+
+		// Extract last used date from last column if present
+		const lastUsedMatch = line.match(/\|\s*(\d{4}-\d{2}-\d{2})\s*\|?\s*$/);
+		const lastUsed = lastUsedMatch ? lastUsedMatch[1] : '';
+
+		if (agentType && !isNaN(count) && !isNaN(successRate)) {
+			rows.push({ agentType, count, successRate, lastUsed });
+		}
+	}
+
+	return rows;
+}
+
+async function readMemoryMetrics(root: string): Promise<MemoryMetricRow[]> {
+	const memoryBaseDir = join(root, '.claude', 'agent-memory');
+	let agentDirs: string[];
+	try {
+		agentDirs = await readdir(memoryBaseDir);
+	} catch {
+		return [];
+	}
+
+	const allRows: MemoryMetricRow[] = [];
+	for (const agentDir of agentDirs) {
+		const memoryPath = join(memoryBaseDir, agentDir, 'MEMORY.md');
+		try {
+			const content = await readFile(memoryPath, 'utf-8');
+			const rows = parseMetricsTable(content);
+			allRows.push(...rows);
+		} catch {
+			// No MEMORY.md or unreadable — skip
+		}
+	}
+
+	return allRows;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation from JSONL records
+// ---------------------------------------------------------------------------
+
+interface JsonlAggregation {
+	sessions: SessionStats;
+	agentMap: Map<string, AgentAccumulator>;
+	skillMap: Map<string, number>;
+	totalInvocations: number;
+	totalSuccess: number;
+}
+
+async function aggregateFromJsonl(): Promise<JsonlAggregation> {
+	const files = await findOutcomeFiles();
+	const { todayStart, weekStart, monthStart } = getDateWindows();
+
+	const sessions: SessionStats = { today: 0, thisWeek: 0, thisMonth: 0 };
+	const agentMap = new Map<string, AgentAccumulator>();
+	const skillMap = new Map<string, number>();
+	let totalInvocations = 0;
+	let totalSuccess = 0;
+
+	for (const file of files) {
+		const records = await readOutcomeFile(file);
+		if (records.length === 0) continue;
+
+		// Each file = one session; use earliest timestamp for date bucketing
+		const earliest = records.reduce(
+			(min, r) => (r.timestamp < min ? r.timestamp : min),
+			records[0].timestamp
+		);
+		const sessionDate = new Date(earliest);
+		if (!isNaN(sessionDate.getTime())) {
+			if (sessionDate >= todayStart) sessions.today++;
+			if (sessionDate >= weekStart) sessions.thisWeek++;
+			if (sessionDate >= monthStart) sessions.thisMonth++;
+		}
+
+		for (const record of records) {
+			totalInvocations++;
+			const isSuccess = record.outcome === 'success';
+			if (isSuccess) totalSuccess++;
+
+			// Agent accumulation
+			if (record.agent_type && record.agent_type !== 'unknown') {
+				const existing = agentMap.get(record.agent_type);
+				if (existing) {
+					existing.count++;
+					if (isSuccess) existing.successCount++;
+					if (record.timestamp > existing.lastUsed) existing.lastUsed = record.timestamp;
+				} else {
+					agentMap.set(record.agent_type, {
+						count: 1,
+						successCount: isSuccess ? 1 : 0,
+						lastUsed: record.timestamp
+					});
+				}
+			}
+
+			// Skill accumulation
+			if (record.skill) {
+				skillMap.set(record.skill, (skillMap.get(record.skill) ?? 0) + 1);
+			}
+		}
+	}
+
+	return { sessions, agentMap, skillMap, totalInvocations, totalSuccess };
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export async function getAnalytics(root: string): Promise<AnalyticsData> {
+	try {
+		const jsonl = await aggregateFromJsonl();
+
+		let agentInvocations: AgentInvocation[];
+		let skillInvocations: SkillInvocation[];
+		let totalInvocations: number;
+		let successRate: number;
+		const sessions = jsonl.sessions;
+
+		if (jsonl.totalInvocations > 0) {
+			// Live JSONL data available — use as primary source
+			agentInvocations = Array.from(jsonl.agentMap.entries())
+				.map(([agentType, acc]): AgentInvocation => ({
+					agentType,
+					count: acc.count,
+					successRate: acc.count > 0 ? acc.successCount / acc.count : 0,
+					lastUsed: acc.lastUsed
+				}))
+				.sort((a, b) => b.count - a.count);
+
+			skillInvocations = Array.from(jsonl.skillMap.entries())
+				.map(([skill, count]): SkillInvocation => ({ skill, count }))
+				.sort((a, b) => b.count - a.count);
+
+			totalInvocations = jsonl.totalInvocations;
+			successRate = jsonl.totalSuccess / jsonl.totalInvocations;
+		} else {
+			// Fallback to MEMORY.md metrics written by sys-memory-keeper
+			const memoryRows = await readMemoryMetrics(root);
+
+			agentInvocations = memoryRows
+				.map((row): AgentInvocation => ({
+					agentType: row.agentType,
+					count: row.count,
+					successRate: row.successRate,
+					lastUsed: row.lastUsed
+				}))
+				.sort((a, b) => b.count - a.count);
+
+			skillInvocations = [];
+
+			totalInvocations = memoryRows.reduce((sum, r) => sum + r.count, 0);
+			const totalSuccessFromMemory = memoryRows.reduce(
+				(sum, r) => sum + Math.round(r.count * r.successRate),
+				0
+			);
+			successRate = totalInvocations > 0 ? totalSuccessFromMemory / totalInvocations : 0;
+		}
+
+		return { sessions, agentInvocations, skillInvocations, totalInvocations, successRate };
+	} catch {
+		return emptyAnalytics();
+	}
+}
+
+function emptyAnalytics(): AnalyticsData {
+	return {
+		sessions: { today: 0, thisWeek: 0, thisMonth: 0 },
+		agentInvocations: [],
+		skillInvocations: [],
+		totalInvocations: 0,
+		successRate: 0
+	};
+}

--- a/packages/serve/src/routes/+layout.svelte
+++ b/packages/serve/src/routes/+layout.svelte
@@ -3,16 +3,25 @@
 	import { page } from '$app/stores';
 
 	const navItems = [
-		{ href: '/', label: 'Dashboard', icon: '▣' },
+		{ href: '/', label: 'Dashboard', icon: '▣' }
+	];
+
+	const coreItems = [
 		{ href: '/agents', label: 'Agents', icon: '◈' },
 		{ href: '/skills', label: 'Skills', icon: '◆' },
 		{ href: '/guides', label: 'Guides', icon: '◉' },
 		{ href: '/rules', label: 'Rules', icon: '◇' }
 	];
 
+	let coreOpen = true;
+
 	function isActive(href: string, pathname: string): boolean {
 		if (href === '/') return pathname === '/';
 		return pathname.startsWith(href);
+	}
+
+	$: if (coreItems.some(item => isActive(item.href, $page.url.pathname))) {
+		coreOpen = true;
 	}
 </script>
 
@@ -38,6 +47,31 @@
 					{item.label}
 				</a>
 			{/each}
+
+			<!-- Core category -->
+			<button
+				onclick={() => coreOpen = !coreOpen}
+				class="flex items-center gap-2 px-3 py-2 w-full text-left rounded text-xs font-semibold uppercase tracking-wider text-zinc-500 hover:text-zinc-300 transition-colors mt-3"
+			>
+				<span class="text-[10px]">{coreOpen ? '▾' : '▸'}</span>
+				Core
+			</button>
+
+			{#if coreOpen}
+				<div class="space-y-0.5">
+					{#each coreItems as item}
+						<a
+							href={item.href}
+							class="flex items-center gap-2.5 px-3 py-2 pl-6 rounded text-sm transition-colors {isActive(item.href, $page.url.pathname)
+								? 'bg-zinc-800 text-zinc-50'
+								: 'text-zinc-400 hover:text-zinc-200 hover:bg-zinc-900'}"
+						>
+							<span class="text-xs opacity-70">{item.icon}</span>
+							{item.label}
+						</a>
+					{/each}
+				</div>
+			{/if}
 		</nav>
 
 		<!-- Footer -->

--- a/packages/serve/src/routes/+page.server.ts
+++ b/packages/serve/src/routes/+page.server.ts
@@ -1,5 +1,6 @@
 import type { PageServerLoad } from './$types';
 import { getAgents, getSkills, getGuides, getRules, getProjectRoot } from '$lib/server/data';
+import { getAnalytics } from '$lib/server/analytics';
 
 const AGENT_TYPES: { label: string; pattern: RegExp }[] = [
 	{ label: 'SW Engineer / Language', pattern: /^lang-/ },
@@ -18,11 +19,12 @@ const AGENT_TYPES: { label: string; pattern: RegExp }[] = [
 
 export const load: PageServerLoad = async () => {
 	const root = await getProjectRoot();
-	const [agents, skills, guides, rules] = await Promise.all([
+	const [agents, skills, guides, rules, analytics] = await Promise.all([
 		getAgents(root),
 		getSkills(root),
 		getGuides(root),
-		getRules(root)
+		getRules(root),
+		getAnalytics(root)
 	]);
 
 	// Build type breakdown
@@ -61,6 +63,7 @@ export const load: PageServerLoad = async () => {
 		typeBreakdown,
 		scopeBreakdown,
 		priorityBreakdown,
-		root
+		root,
+		analytics
 	};
 };

--- a/packages/serve/src/routes/+page.svelte
+++ b/packages/serve/src/routes/+page.svelte
@@ -115,4 +115,122 @@
 			</div>
 		</div>
 	</div>
+
+	<!-- Analytics Section -->
+	{#if data.analytics}
+		<div class="mt-10 pt-8 border-t border-zinc-800">
+			<h2 class="text-lg font-bold text-zinc-200 mb-6">Analytics</h2>
+
+			<!-- Session stats + Overall -->
+			<div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+				<div class="border border-zinc-800 rounded-lg p-4">
+					<div class="text-zinc-500 text-xs uppercase tracking-wider">Today</div>
+					<div class="text-2xl font-bold text-zinc-100 mt-1">{data.analytics.sessions.today}</div>
+					<div class="text-zinc-600 text-xs">sessions</div>
+				</div>
+				<div class="border border-zinc-800 rounded-lg p-4">
+					<div class="text-zinc-500 text-xs uppercase tracking-wider">This Week</div>
+					<div class="text-2xl font-bold text-zinc-100 mt-1">{data.analytics.sessions.thisWeek}</div>
+					<div class="text-zinc-600 text-xs">sessions</div>
+				</div>
+				<div class="border border-zinc-800 rounded-lg p-4">
+					<div class="text-zinc-500 text-xs uppercase tracking-wider">This Month</div>
+					<div class="text-2xl font-bold text-zinc-100 mt-1">{data.analytics.sessions.thisMonth}</div>
+					<div class="text-zinc-600 text-xs">sessions</div>
+				</div>
+				<div class="border border-zinc-800 rounded-lg p-4">
+					<div class="text-zinc-500 text-xs uppercase tracking-wider">Success Rate</div>
+					<div
+						class="text-2xl font-bold mt-1 {data.analytics.successRate >= 0.9
+							? 'text-emerald-400'
+							: data.analytics.successRate >= 0.7
+								? 'text-amber-400'
+								: 'text-red-400'}"
+					>
+						{(data.analytics.successRate * 100).toFixed(1)}%
+					</div>
+					<div class="text-zinc-600 text-xs">{data.analytics.totalInvocations} invocations</div>
+				</div>
+			</div>
+
+			<!-- Top Agents + Top Skills -->
+			<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+				<!-- Top Agents -->
+				<div>
+					<h3 class="text-sm font-semibold text-zinc-400 uppercase tracking-wider mb-3">
+						Top Agents
+					</h3>
+					{#if data.analytics.agentInvocations.length > 0}
+						<div class="border border-zinc-800 rounded-lg overflow-hidden">
+							<table class="w-full text-sm">
+								<thead>
+									<tr class="bg-zinc-900">
+										<th class="px-4 py-2 text-left text-zinc-400 font-medium">Agent</th>
+										<th class="px-4 py-2 text-right text-zinc-400 font-medium">Count</th>
+										<th class="px-4 py-2 text-right text-zinc-400 font-medium">Success</th>
+									</tr>
+								</thead>
+								<tbody>
+									{#each data.analytics.agentInvocations.slice(0, 10) as row, i}
+										<tr class="border-t border-zinc-800 {i % 2 === 1 ? 'bg-zinc-900/50' : ''}">
+											<td class="px-4 py-2 text-zinc-300 font-mono text-xs">{row.agentType}</td>
+											<td class="px-4 py-2 text-right text-zinc-400">{row.count}</td>
+											<td
+												class="px-4 py-2 text-right {row.successRate >= 0.9
+													? 'text-emerald-400'
+													: row.successRate >= 0.7
+														? 'text-amber-400'
+														: 'text-red-400'}"
+											>
+												{(row.successRate * 100).toFixed(0)}%
+											</td>
+										</tr>
+									{/each}
+								</tbody>
+							</table>
+						</div>
+					{:else}
+						<div
+							class="border border-zinc-800 rounded-lg p-6 text-center text-zinc-600 text-sm"
+						>
+							No agent invocation data yet. Data appears after Claude Code sessions.
+						</div>
+					{/if}
+				</div>
+
+				<!-- Top Skills -->
+				<div>
+					<h3 class="text-sm font-semibold text-zinc-400 uppercase tracking-wider mb-3">
+						Top Skills
+					</h3>
+					{#if data.analytics.skillInvocations.length > 0}
+						<div class="border border-zinc-800 rounded-lg overflow-hidden">
+							<table class="w-full text-sm">
+								<thead>
+									<tr class="bg-zinc-900">
+										<th class="px-4 py-2 text-left text-zinc-400 font-medium">Skill</th>
+										<th class="px-4 py-2 text-right text-zinc-400 font-medium">Count</th>
+									</tr>
+								</thead>
+								<tbody>
+									{#each data.analytics.skillInvocations.slice(0, 10) as row, i}
+										<tr class="border-t border-zinc-800 {i % 2 === 1 ? 'bg-zinc-900/50' : ''}">
+											<td class="px-4 py-2 text-zinc-300 font-mono text-xs">{row.skill}</td>
+											<td class="px-4 py-2 text-right text-zinc-400">{row.count}</td>
+										</tr>
+									{/each}
+								</tbody>
+							</table>
+						</div>
+					{:else}
+						<div
+							class="border border-zinc-800 rounded-lg p-6 text-center text-zinc-600 text-sm"
+						>
+							No skill invocation data yet. Data appears after Claude Code sessions.
+						</div>
+					{/if}
+				</div>
+			</div>
+		</div>
+	{/if}
 </div>


### PR DESCRIPTION
## Summary
- Sidebar: group Agents/Skills/Guides/Rules under collapsible "Core" category
- Dashboard: add analytics section — session stats, top agents, top skills
- Data from `/tmp/.claude-task-outcomes-*` JSONL + `.claude/agent-memory/*/MEMORY.md` metrics
- Graceful empty state when no data available

Closes #470

## Test plan
- [ ] Sidebar shows collapsible Core category
- [ ] Core auto-expands when visiting sub-pages
- [ ] Dashboard shows analytics section
- [ ] Empty state renders when no JSONL data
- [ ] SvelteKit build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)