### PR TITLE
feat(eval): add evaluations table and Web UI pages (#467)

### DIFF
--- a/packages/eval-core/src/db/migrate.ts
+++ b/packages/eval-core/src/db/migrate.ts
@@ -53,10 +53,23 @@ export function runMigrations(dbPath: string): void {
       error_summary TEXT,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     )`,
+    `CREATE TABLE IF NOT EXISTS evaluations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      turn_id TEXT REFERENCES turns(turn_id),
+      session_id TEXT REFERENCES sessions(session_id),
+      score INTEGER,
+      verdict TEXT,
+      tags TEXT,
+      comment TEXT,
+      evaluated_at TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
     'CREATE INDEX IF NOT EXISTS idx_sessions_session_id ON sessions(session_id)',
     'CREATE INDEX IF NOT EXISTS idx_turns_session_id ON turns(session_id)',
     'CREATE INDEX IF NOT EXISTS idx_invocations_ppid ON agent_invocations(session_ppid)',
     'CREATE INDEX IF NOT EXISTS idx_invocations_agent_type ON agent_invocations(agent_type)',
+    'CREATE INDEX IF NOT EXISTS idx_evaluations_session_id ON evaluations(session_id)',
+    'CREATE INDEX IF NOT EXISTS idx_evaluations_turn_id ON evaluations(turn_id)',
   ];
 
   for (const sql of statements) {

--- a/packages/eval-core/src/db/schema.ts
+++ b/packages/eval-core/src/db/schema.ts
@@ -53,3 +53,17 @@ export const agentInvocations = sqliteTable('agent_invocations', {
     .notNull()
     .$defaultFn(() => new Date().toISOString()),
 });
+
+export const evaluations = sqliteTable('evaluations', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  turnId: text('turn_id').references(() => turns.turnId),
+  sessionId: text('session_id').references(() => sessions.sessionId),
+  score: integer('score'),              // 1-5
+  verdict: text('verdict'),             // pass | fail | needs_refinement
+  tags: text('tags'),                   // JSON array string: ["good_prompt", "wrong_routing"]
+  comment: text('comment'),
+  evaluatedAt: text('evaluated_at').notNull(),
+  createdAt: text('created_at')
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
+});

--- a/packages/eval-core/src/index.ts
+++ b/packages/eval-core/src/index.ts
@@ -1,5 +1,5 @@
 export * from './types/index.js';
 export { createDb, type EvalDb } from './db/client.js';
-export { agentInvocations, sessions, turns } from './db/schema.js';
+export { agentInvocations, evaluations, sessions, turns } from './db/schema.js';
 export { collect, type CollectOptions, type CollectResult } from './collect/index.js';
 export { runMigrations } from './db/migrate.js';

--- a/packages/serve/src/lib/server/eval-reader.ts
+++ b/packages/serve/src/lib/server/eval-reader.ts
@@ -1,0 +1,197 @@
+import { readFile, writeFile, readdir, mkdir } from 'fs/promises';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+import { readFileSync, readdirSync } from 'fs';
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+const HOME = process.env.HOME ?? process.env.USERPROFILE ?? '~';
+const EVAL_DIR = join(HOME, '.omcustom', 'evaluations');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface Evaluation {
+	id: string;
+	sessionId: string;
+	turnId?: string;
+	score: number; // 1-5
+	verdict: string; // pass | fail | needs_refinement
+	tags: string[];
+	comment: string;
+	evaluatedAt: string;
+}
+
+export interface SessionSummary {
+	sessionId: string;
+	startedAt: string;
+	agentCount: number;
+	evaluationCount: number;
+	avgScore: number | null;
+}
+
+export interface TaskOutcome {
+	agent_type?: string;
+	outcome?: string;
+	model?: string;
+	timestamp?: string;
+	session_id?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Evaluations — JSON file per evaluation in ~/.omcustom/evaluations/
+// ---------------------------------------------------------------------------
+
+async function ensureEvalDir(): Promise<void> {
+	try {
+		await mkdir(EVAL_DIR, { recursive: true });
+	} catch {
+		// already exists or unwritable — ignore
+	}
+}
+
+export async function getEvaluations(): Promise<Evaluation[]> {
+	await ensureEvalDir();
+
+	let files: string[];
+	try {
+		files = await readdir(EVAL_DIR);
+	} catch {
+		return [];
+	}
+
+	const evaluations: Evaluation[] = [];
+	for (const file of files) {
+		if (!file.endsWith('.json')) continue;
+		try {
+			const content = await readFile(join(EVAL_DIR, file), 'utf-8');
+			const parsed = JSON.parse(content) as Evaluation;
+			evaluations.push(parsed);
+		} catch {
+			// Skip malformed files
+		}
+	}
+
+	// Sort newest first
+	return evaluations.sort(
+		(a, b) => new Date(b.evaluatedAt).getTime() - new Date(a.evaluatedAt).getTime()
+	);
+}
+
+export async function getEvaluation(id: string): Promise<Evaluation | null> {
+	// Sanitize id — no path traversal
+	const safeId = id.replace(/[^a-zA-Z0-9-_]/g, '');
+	const filePath = join(EVAL_DIR, `${safeId}.json`);
+	try {
+		const content = await readFile(filePath, 'utf-8');
+		return JSON.parse(content) as Evaluation;
+	} catch {
+		return null;
+	}
+}
+
+export async function saveEvaluation(
+	data: Omit<Evaluation, 'id'>
+): Promise<Evaluation> {
+	await ensureEvalDir();
+	const id = randomUUID();
+	const evaluation: Evaluation = { id, ...data };
+	const filePath = join(EVAL_DIR, `${id}.json`);
+	await writeFile(filePath, JSON.stringify(evaluation, null, 2), 'utf-8');
+	return evaluation;
+}
+
+// ---------------------------------------------------------------------------
+// Session summaries — derived from /tmp/.claude-task-outcomes-* JSONL files
+// ---------------------------------------------------------------------------
+
+function readTaskOutcomesSync(): TaskOutcome[] {
+	const outcomes: TaskOutcome[] = [];
+	try {
+		// Find all JSONL files matching the pattern
+		const tmpDir = '/tmp';
+		let tmpFiles: string[];
+		try {
+			tmpFiles = readdirSync(tmpDir);
+		} catch {
+			return outcomes;
+		}
+
+		const matchingFiles = tmpFiles.filter((f) => f.startsWith('.claude-task-outcomes-'));
+
+		for (const file of matchingFiles) {
+			try {
+				const content = readFileSync(join(tmpDir, file), 'utf-8');
+				for (const line of content.split('\n')) {
+					const trimmed = line.trim();
+					if (!trimmed) continue;
+					try {
+						outcomes.push(JSON.parse(trimmed) as TaskOutcome);
+					} catch {
+						// Skip malformed lines
+					}
+				}
+			} catch {
+				// Skip unreadable files
+			}
+		}
+	} catch {
+		// Return empty on any error
+	}
+	return outcomes;
+}
+
+export async function getSessionSummaries(): Promise<SessionSummary[]> {
+	const outcomes = readTaskOutcomesSync();
+	const evaluations = await getEvaluations();
+
+	// Group outcomes by session_id
+	const sessionMap = new Map<string, TaskOutcome[]>();
+	for (const outcome of outcomes) {
+		const sid = outcome.session_id ?? 'unknown';
+		if (!sessionMap.has(sid)) sessionMap.set(sid, []);
+		sessionMap.get(sid)!.push(outcome);
+	}
+
+	// Build evaluation index by sessionId
+	const evalsBySession = new Map<string, Evaluation[]>();
+	for (const ev of evaluations) {
+		if (!evalsBySession.has(ev.sessionId)) evalsBySession.set(ev.sessionId, []);
+		evalsBySession.get(ev.sessionId)!.push(ev);
+	}
+
+	// Include sessions that have evaluations but no JSONL data
+	for (const ev of evaluations) {
+		if (!sessionMap.has(ev.sessionId)) {
+			sessionMap.set(ev.sessionId, []);
+		}
+	}
+
+	const summaries: SessionSummary[] = [];
+	for (const [sessionId, sessionOutcomes] of sessionMap) {
+		const timestamps = sessionOutcomes
+			.map((o) => o.timestamp)
+			.filter(Boolean)
+			.sort() as string[];
+		const startedAt = timestamps[0] ?? new Date().toISOString();
+		const sessionEvals = evalsBySession.get(sessionId) ?? [];
+		const scores = sessionEvals.map((e) => e.score).filter((s) => s >= 1 && s <= 5);
+		const avgScore = scores.length > 0 ? scores.reduce((a, b) => a + b, 0) / scores.length : null;
+
+		summaries.push({
+			sessionId,
+			startedAt,
+			agentCount: sessionOutcomes.length,
+			evaluationCount: sessionEvals.length,
+			avgScore
+		});
+	}
+
+	// Sort by startedAt descending (most recent first)
+	return summaries
+		.sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime())
+		.slice(0, 20); // Show latest 20 sessions
+}

--- a/packages/serve/src/routes/+layout.svelte
+++ b/packages/serve/src/routes/+layout.svelte
@@ -7,7 +7,8 @@
 		{ href: '/agents', label: 'Agents', icon: '◈' },
 		{ href: '/skills', label: 'Skills', icon: '◆' },
 		{ href: '/guides', label: 'Guides', icon: '◉' },
-		{ href: '/rules', label: 'Rules', icon: '◇' }
+		{ href: '/rules', label: 'Rules', icon: '◇' },
+		{ href: '/evaluations', label: 'Evaluations', icon: '★' }
 	];
 
 	function isActive(href: string, pathname: string): boolean {

--- a/packages/serve/src/routes/evaluations/+page.server.ts
+++ b/packages/serve/src/routes/evaluations/+page.server.ts
@@ -1,0 +1,7 @@
+import type { PageServerLoad } from './$types';
+import { getEvaluations, getSessionSummaries } from '$lib/server/eval-reader';
+
+export const load: PageServerLoad = async () => {
+	const [evaluations, sessions] = await Promise.all([getEvaluations(), getSessionSummaries()]);
+	return { evaluations, sessions };
+};

--- a/packages/serve/src/routes/evaluations/+page.svelte
+++ b/packages/serve/src/routes/evaluations/+page.svelte
@@ -1,0 +1,273 @@
+<script lang="ts">
+	import type { PageData } from './$types';
+
+	export let data: PageData;
+
+	let search = '';
+	let selectedVerdict = '';
+
+	$: filtered = data.evaluations.filter((e) => {
+		const matchVerdict = !selectedVerdict || e.verdict === selectedVerdict;
+		const q = search.toLowerCase();
+		const matchSearch =
+			!q ||
+			e.sessionId.toLowerCase().includes(q) ||
+			e.comment.toLowerCase().includes(q) ||
+			e.tags.some((t) => t.toLowerCase().includes(q));
+		return matchVerdict && matchSearch;
+	});
+
+	function clearFilters() {
+		search = '';
+		selectedVerdict = '';
+	}
+
+	$: hasFilters = search || selectedVerdict;
+
+	function scoreColor(score: number): string {
+		if (score >= 5) return 'text-emerald-400';
+		if (score >= 4) return 'text-green-400';
+		if (score >= 3) return 'text-amber-400';
+		if (score >= 2) return 'text-orange-400';
+		return 'text-red-400';
+	}
+
+	function scoreBg(score: number): string {
+		if (score >= 5) return 'bg-emerald-900/50 border-emerald-700';
+		if (score >= 4) return 'bg-green-900/50 border-green-700';
+		if (score >= 3) return 'bg-amber-900/50 border-amber-700';
+		if (score >= 2) return 'bg-orange-900/50 border-orange-700';
+		return 'bg-red-900/50 border-red-700';
+	}
+
+	const verdictColor: Record<string, string> = {
+		pass: 'bg-emerald-900/50 text-emerald-300 border-emerald-700',
+		fail: 'bg-red-900/50 text-red-300 border-red-700',
+		needs_refinement: 'bg-amber-900/50 text-amber-300 border-amber-700'
+	};
+
+	function formatDate(iso: string): string {
+		try {
+			return new Date(iso).toLocaleString(undefined, {
+				month: 'short',
+				day: 'numeric',
+				hour: '2-digit',
+				minute: '2-digit'
+			});
+		} catch {
+			return iso;
+		}
+	}
+
+	function truncateSession(id: string): string {
+		return id.length > 16 ? id.slice(0, 8) + '…' + id.slice(-4) : id;
+	}
+
+	function avgScoreColor(avg: number | null): string {
+		if (avg === null) return 'text-zinc-500';
+		if (avg >= 4.5) return 'text-emerald-400';
+		if (avg >= 3.5) return 'text-green-400';
+		if (avg >= 2.5) return 'text-amber-400';
+		return 'text-red-400';
+	}
+</script>
+
+<div class="p-8">
+	<!-- Header -->
+	<div class="mb-6 flex items-center justify-between">
+		<div>
+			<h1 class="text-2xl font-bold text-zinc-50">Evaluations</h1>
+			<p class="mt-1 text-sm text-zinc-500">
+				{#if hasFilters}
+					<span class="font-medium text-emerald-400">{filtered.length}</span> / {data.evaluations
+						.length} evaluations
+				{:else}
+					{data.evaluations.length} evaluations total
+				{/if}
+			</p>
+		</div>
+		<a
+			href="/evaluations/create"
+			class="flex items-center gap-2 rounded border border-emerald-700 bg-emerald-800/60 px-3 py-2 text-sm font-medium text-emerald-300 transition-colors hover:border-emerald-500 hover:bg-emerald-800"
+		>
+			<span class="text-base leading-none">+</span> New Evaluation
+		</a>
+	</div>
+
+	<!-- Session summaries -->
+	{#if data.sessions.length > 0}
+		<div class="mb-8">
+			<div class="mb-3 text-xs font-medium uppercase tracking-wide text-zinc-500">
+				Recent Sessions
+			</div>
+			<div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+				{#each data.sessions.slice(0, 8) as session}
+					<div class="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4">
+						<div class="mb-2 flex items-start justify-between gap-2">
+							<span
+								class="truncate font-mono text-xs text-zinc-400"
+								title={session.sessionId}
+							>
+								{truncateSession(session.sessionId)}
+							</span>
+							{#if session.avgScore !== null}
+								<span
+									class="shrink-0 text-sm font-bold {avgScoreColor(session.avgScore)}"
+								>
+									{session.avgScore.toFixed(1)}
+								</span>
+							{/if}
+						</div>
+						<div class="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-zinc-600">
+							<span>{session.agentCount} invocations</span>
+							<span
+								class={session.evaluationCount > 0 ? 'text-zinc-400' : ''}
+							>
+								{session.evaluationCount} eval{session.evaluationCount !== 1 ? 's' : ''}
+							</span>
+						</div>
+						<div class="mt-2 text-xs text-zinc-700">
+							{formatDate(session.startedAt)}
+						</div>
+					</div>
+				{/each}
+			</div>
+		</div>
+	{/if}
+
+	<!-- Filters -->
+	<div class="mb-4 flex flex-wrap items-center gap-3">
+		<input
+			type="text"
+			placeholder="Search by session, comment, tags..."
+			bind:value={search}
+			class="w-72 rounded border border-zinc-700 bg-zinc-900 px-3 py-1.5 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
+		/>
+
+		<div class="flex gap-2">
+			{#each ['pass', 'fail', 'needs_refinement'] as v}
+				<button
+					onclick={() => (selectedVerdict = selectedVerdict === v ? '' : v)}
+					class="rounded border px-2.5 py-1 text-xs font-medium transition-colors {selectedVerdict === v
+						? (verdictColor[v] ?? 'bg-zinc-700 text-zinc-200 border-zinc-500')
+						: 'border-zinc-700 text-zinc-500 hover:border-zinc-600 hover:text-zinc-300'}"
+				>
+					{v === 'needs_refinement' ? 'needs refinement' : v}
+				</button>
+			{/each}
+		</div>
+
+		{#if hasFilters}
+			<button
+				onclick={clearFilters}
+				class="rounded border border-zinc-700 px-2 py-1 text-xs text-zinc-500 transition-colors hover:text-zinc-300"
+			>
+				Clear
+			</button>
+		{/if}
+	</div>
+
+	<!-- Evaluation table -->
+	{#if filtered.length === 0}
+		<div class="rounded-lg border border-zinc-800 py-16 text-center text-zinc-600">
+			{#if data.evaluations.length === 0}
+				<p class="text-base">No evaluations yet.</p>
+				<p class="mt-2 text-sm">
+					<a
+						href="/evaluations/create"
+						class="text-emerald-500 hover:text-emerald-400"
+					>Create your first evaluation →</a
+					>
+				</p>
+			{:else}
+				No evaluations match the current filters.
+			{/if}
+		</div>
+	{:else}
+		<div class="overflow-hidden rounded-lg border border-zinc-800">
+			<table class="w-full text-sm">
+				<thead>
+					<tr class="border-b border-zinc-800 bg-zinc-900">
+						<th class="px-4 py-3 text-left font-medium text-zinc-400">Score</th>
+						<th class="px-4 py-3 text-left font-medium text-zinc-400">Verdict</th>
+						<th class="px-4 py-3 text-left font-medium text-zinc-400">Session</th>
+						<th class="px-4 py-3 text-left font-medium text-zinc-400">Tags</th>
+						<th class="px-4 py-3 text-left font-medium text-zinc-400">Comment</th>
+						<th class="px-4 py-3 text-left font-medium text-zinc-400">Date</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each filtered as ev, i}
+						<tr
+							class="border-t border-zinc-800 transition-colors hover:bg-zinc-900/60 {i % 2 === 1
+								? 'bg-zinc-900/30'
+								: ''}"
+						>
+							<!-- Score -->
+							<td class="px-4 py-3">
+								<span
+									class="inline-flex h-7 w-7 items-center justify-center rounded border text-xs font-bold {scoreBg(ev.score)} {scoreColor(ev.score)}"
+								>
+									{ev.score}
+								</span>
+							</td>
+
+							<!-- Verdict -->
+							<td class="px-4 py-3">
+								<span
+									class="rounded border px-2 py-0.5 text-xs font-medium {verdictColor[ev.verdict] ??
+										'bg-zinc-800 text-zinc-400 border-zinc-700'}"
+								>
+									{ev.verdict === 'needs_refinement' ? 'needs refinement' : ev.verdict}
+								</span>
+							</td>
+
+							<!-- Session ID -->
+							<td class="px-4 py-3">
+								<span class="font-mono text-xs text-zinc-400" title={ev.sessionId}>
+									{truncateSession(ev.sessionId)}
+								</span>
+								{#if ev.turnId}
+									<div class="font-mono text-xs text-zinc-600" title={ev.turnId}>
+										turn: {truncateSession(ev.turnId)}
+									</div>
+								{/if}
+							</td>
+
+							<!-- Tags -->
+							<td class="px-4 py-3">
+								{#if ev.tags.length > 0}
+									<div class="flex flex-wrap gap-1">
+										{#each ev.tags as tag}
+											<span
+												class="rounded bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-400"
+											>
+												{tag}
+											</span>
+										{/each}
+									</div>
+								{:else}
+									<span class="text-zinc-700">—</span>
+								{/if}
+							</td>
+
+							<!-- Comment -->
+							<td class="max-w-xs px-4 py-3 text-zinc-400">
+								{#if ev.comment}
+									<span class="line-clamp-2 text-xs">{ev.comment}</span>
+								{:else}
+									<span class="text-zinc-700">—</span>
+								{/if}
+							</td>
+
+							<!-- Date -->
+							<td class="px-4 py-3 text-xs text-zinc-600 whitespace-nowrap">
+								{formatDate(ev.evaluatedAt)}
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+	{/if}
+</div>

--- a/packages/serve/src/routes/evaluations/create/+page.server.ts
+++ b/packages/serve/src/routes/evaluations/create/+page.server.ts
@@ -1,0 +1,49 @@
+import { redirect, fail } from '@sveltejs/kit';
+import type { Actions, PageServerLoad } from './$types';
+import { saveEvaluation } from '$lib/server/eval-reader';
+import { getSessionSummaries } from '$lib/server/eval-reader';
+
+export const load: PageServerLoad = async () => {
+	const sessions = await getSessionSummaries();
+	return { sessions };
+};
+
+export const actions: Actions = {
+	default: async ({ request }) => {
+		const data = await request.formData();
+
+		const sessionId = String(data.get('sessionId') ?? '').trim();
+		const turnId = String(data.get('turnId') ?? '').trim() || undefined;
+		const scoreRaw = Number(data.get('score') ?? 3);
+		const verdict = String(data.get('verdict') ?? 'pass');
+		const tagsRaw = String(data.get('tags') ?? '');
+		const comment = String(data.get('comment') ?? '').trim();
+
+		if (!sessionId) {
+			return fail(400, { error: 'Session ID is required' });
+		}
+
+		const score = Math.min(5, Math.max(1, Math.round(scoreRaw)));
+
+		if (!['pass', 'fail', 'needs_refinement'].includes(verdict)) {
+			return fail(400, { error: 'Invalid verdict value' });
+		}
+
+		const tags = tagsRaw
+			.split(',')
+			.map((t) => t.trim())
+			.filter(Boolean);
+
+		await saveEvaluation({
+			sessionId,
+			turnId,
+			score,
+			verdict,
+			tags,
+			comment,
+			evaluatedAt: new Date().toISOString()
+		});
+
+		throw redirect(303, '/evaluations');
+	}
+};

--- a/packages/serve/src/routes/evaluations/create/+page.svelte
+++ b/packages/serve/src/routes/evaluations/create/+page.svelte
@@ -1,0 +1,222 @@
+<script lang="ts">
+	import type { PageData, ActionData } from './$types';
+
+	export let data: PageData;
+	export let form: ActionData;
+
+	let score = 3;
+	let verdict = 'pass';
+	let sessionIdMode: 'manual' | 'select' = data.sessions.length > 0 ? 'select' : 'manual';
+
+	const verdictOptions = [
+		{ value: 'pass', label: 'Pass', color: 'emerald' },
+		{ value: 'fail', label: 'Fail', color: 'red' },
+		{ value: 'needs_refinement', label: 'Needs Refinement', color: 'amber' }
+	] as const;
+
+	const scoreLabels: Record<number, string> = {
+		1: 'Poor',
+		2: 'Below Average',
+		3: 'Average',
+		4: 'Good',
+		5: 'Excellent'
+	};
+
+	function scoreButtonClass(s: number, selected: number): string {
+		const isSelected = s === selected;
+		if (!isSelected) {
+			return 'border-zinc-700 text-zinc-500 hover:border-zinc-500 hover:text-zinc-300';
+		}
+		if (s >= 5) return 'border-emerald-600 bg-emerald-900/60 text-emerald-300';
+		if (s >= 4) return 'border-green-600 bg-green-900/60 text-green-300';
+		if (s >= 3) return 'border-amber-600 bg-amber-900/60 text-amber-300';
+		if (s >= 2) return 'border-orange-600 bg-orange-900/60 text-orange-300';
+		return 'border-red-600 bg-red-900/60 text-red-300';
+	}
+
+	function verdictClass(value: string, selected: string): string {
+		if (value !== selected) {
+			return 'border-zinc-700 text-zinc-500 hover:border-zinc-500 hover:text-zinc-300';
+		}
+		if (value === 'pass') return 'border-emerald-600 bg-emerald-900/60 text-emerald-300';
+		if (value === 'fail') return 'border-red-600 bg-red-900/60 text-red-300';
+		return 'border-amber-600 bg-amber-900/60 text-amber-300';
+	}
+
+	function truncateSession(id: string): string {
+		return id.length > 20 ? id.slice(0, 8) + '…' + id.slice(-6) : id;
+	}
+</script>
+
+<div class="p-8">
+	<div class="mb-6">
+		<a href="/evaluations" class="text-sm text-zinc-500 hover:text-zinc-300 transition-colors">
+			← Evaluations
+		</a>
+		<h1 class="mt-3 text-2xl font-bold text-zinc-50">New Evaluation</h1>
+	</div>
+
+	{#if form?.error}
+		<div class="mb-4 rounded border border-red-800 bg-red-900/30 px-4 py-3 text-sm text-red-300">
+			{form.error}
+		</div>
+	{/if}
+
+	<form method="POST" class="max-w-xl space-y-6">
+		<!-- Session ID -->
+		<div>
+			<label for="sessionId" class="mb-2 block text-sm font-medium text-zinc-300">
+				Session ID <span class="text-red-400">*</span>
+			</label>
+
+			{#if data.sessions.length > 0}
+				<div class="mb-2 flex gap-2 text-xs">
+					<button
+						type="button"
+						onclick={() => (sessionIdMode = 'select')}
+						class="rounded px-2 py-0.5 transition-colors {sessionIdMode === 'select'
+							? 'bg-zinc-700 text-zinc-200'
+							: 'text-zinc-500 hover:text-zinc-300'}"
+					>
+						Select recent
+					</button>
+					<button
+						type="button"
+						onclick={() => (sessionIdMode = 'manual')}
+						class="rounded px-2 py-0.5 transition-colors {sessionIdMode === 'manual'
+							? 'bg-zinc-700 text-zinc-200'
+							: 'text-zinc-500 hover:text-zinc-300'}"
+					>
+						Enter manually
+					</button>
+				</div>
+			{/if}
+
+			{#if sessionIdMode === 'select' && data.sessions.length > 0}
+				<select
+					id="sessionId"
+					name="sessionId"
+					required
+					class="w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-200 focus:border-zinc-500 focus:outline-none"
+				>
+					<option value="">— Select a session —</option>
+					{#each data.sessions as session}
+						<option value={session.sessionId}>
+							{truncateSession(session.sessionId)}
+							({session.agentCount} invocations,
+							{session.evaluationCount} eval{session.evaluationCount !== 1 ? 's' : ''})
+						</option>
+					{/each}
+				</select>
+			{:else}
+				<input
+					id="sessionId"
+					type="text"
+					name="sessionId"
+					placeholder="e.g. abc12345-..."
+					required
+					class="w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
+				/>
+			{/if}
+		</div>
+
+		<!-- Turn ID (optional) -->
+		<div>
+			<label for="turnId" class="mb-2 block text-sm font-medium text-zinc-300">
+				Turn ID <span class="text-zinc-600">(optional)</span>
+			</label>
+			<input
+				id="turnId"
+				type="text"
+				name="turnId"
+				placeholder="Leave blank to evaluate the full session"
+				class="w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
+			/>
+		</div>
+
+		<!-- Score -->
+		<div>
+			<div class="mb-2 text-sm font-medium text-zinc-300">Score</div>
+			<div class="flex items-center gap-2">
+				{#each [1, 2, 3, 4, 5] as s}
+					<button
+						type="button"
+						onclick={() => (score = s)}
+						class="flex h-10 w-10 items-center justify-center rounded border text-sm font-bold transition-colors {scoreButtonClass(
+							s,
+							score
+						)}"
+					>
+						{s}
+					</button>
+				{/each}
+				<span class="ml-2 text-sm text-zinc-500">
+					{scoreLabels[score] ?? ''}
+				</span>
+			</div>
+			<input type="hidden" name="score" value={score} />
+		</div>
+
+		<!-- Verdict -->
+		<div>
+			<div class="mb-2 text-sm font-medium text-zinc-300">Verdict</div>
+			<div class="flex flex-wrap gap-2">
+				{#each verdictOptions as opt}
+					<button
+						type="button"
+						onclick={() => (verdict = opt.value)}
+						class="rounded border px-4 py-2 text-sm font-medium transition-colors {verdictClass(
+							opt.value,
+							verdict
+						)}"
+					>
+						{opt.label}
+					</button>
+				{/each}
+			</div>
+			<input type="hidden" name="verdict" value={verdict} />
+		</div>
+
+		<!-- Tags -->
+		<div>
+			<label for="tags" class="mb-2 block text-sm font-medium text-zinc-300">
+				Tags <span class="text-zinc-600">(comma-separated)</span>
+			</label>
+			<input
+				id="tags"
+				type="text"
+				name="tags"
+				placeholder="e.g. routing, context-handling, tool-use"
+				class="w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none"
+			/>
+		</div>
+
+		<!-- Comment -->
+		<div>
+			<label for="comment" class="mb-2 block text-sm font-medium text-zinc-300">Comment</label>
+			<textarea
+				id="comment"
+				name="comment"
+				rows="4"
+				placeholder="Describe what worked well, what failed, or what needs improvement..."
+				class="w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none resize-none"
+			></textarea>
+		</div>
+
+		<!-- Actions -->
+		<div class="flex gap-3 pt-2">
+			<button
+				type="submit"
+				class="rounded border border-emerald-700 bg-emerald-800/60 px-5 py-2 text-sm font-medium text-emerald-300 transition-colors hover:border-emerald-500 hover:bg-emerald-800"
+			>
+				Save Evaluation
+			</button>
+			<a
+				href="/evaluations"
+				class="rounded border border-zinc-700 px-5 py-2 text-sm font-medium text-zinc-400 transition-colors hover:border-zinc-600 hover:text-zinc-200"
+			>
+				Cancel
+			</a>
+		</div>
+	</form>
+</div>


### PR DESCRIPTION
## Summary
- Add `evaluations` table to eval-core schema (score 1-5, verdict, tags, comment)
- Add `/evaluations` list page with session summaries and evaluation table
- Add `/evaluations/create` form for new evaluations
- JSON-file storage at `~/.omcustom/evaluations/` (node-compatible, no bun:sqlite dependency)
- Sidebar "Evaluations" nav item

Closes #467

## Test plan
- [ ] eval-core typecheck passes
- [ ] SvelteKit build succeeds
- [ ] /evaluations page loads (empty state)
- [ ] /evaluations/create form submits
- [ ] Evaluation saved as JSON file

🤖 Generated with [Claude Code](https://claude.com/claude-code)