### PR TITLE
Release v0.44.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-customcode",
   "workspaces": ["packages/*"],
-  "version": "0.44.2",
+  "version": "0.44.3",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.44.2",
+  "version": "0.44.3",
   "lastUpdated": "2026-03-16T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- fix(ci): make GitHub Packages verification non-blocking in verify-release job

GitHub Packages has eventual consistency delays exceeding 5 minutes, causing the verification step to fail every release despite successful publish. Changed from error+exit1 to warning+exit0.

## Test plan
- [ ] Verify Release job completes with green status (no more red X on GHP verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)