### PR TITLE
release/v0.44.4

### DIFF
--- a/.github/workflows/issue-analyzer.yml
+++ b/.github/workflows/issue-analyzer.yml
@@ -9,16 +9,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Airflow DAG
-        uses: appleboy/ssh-action@v1
         env:
+          AIRFLOW_API_URL: ${{ secrets.AIRFLOW_API_URL }}
+          AIRFLOW_API_USER: ${{ secrets.AIRFLOW_API_USER }}
+          AIRFLOW_API_PASSWORD: ${{ secrets.AIRFLOW_API_PASSWORD }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-        with:
-          host: 49.142.111.166
-          port: 9416
-          username: baekenough
-          key: ${{ secrets.AIRFLOW_SSH_KEY }}
-          envs: ISSUE_NUMBER
-          script: |
-            docker exec customclaw-airflow-1 \
-              airflow dags trigger omc_issue_analyzer \
-              -c "{\"issue_number\": $ISSUE_NUMBER}"
+        run: |
+          set -euo pipefail
+
+          # Get auth token
+          TOKEN=$(curl -sf -X POST "${AIRFLOW_API_URL}/auth/token" \
+            -H "Content-Type: application/json" \
+            -d "{\"username\":\"${AIRFLOW_API_USER}\",\"password\":\"${AIRFLOW_API_PASSWORD}\"}" \
+            | jq -r '.access_token')
+
+          if [ -z "${TOKEN}" ] || [ "${TOKEN}" = "null" ]; then
+            echo "Failed to obtain Airflow auth token"
+            exit 1
+          fi
+
+          # Trigger DAG
+          RESPONSE=$(curl -sf -X POST "${AIRFLOW_API_URL}/dags/omc_issue_analyzer/dagRuns" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"dag_run_id\": \"opened_${ISSUE_NUMBER}_$(date +%s)\",
+              \"conf\": {\"issue_number\": ${ISSUE_NUMBER}},
+              \"note\": \"Triggered by issue #${ISSUE_NUMBER} opened event\"
+            }")
+
+          echo "Triggered analysis for issue #${ISSUE_NUMBER}"
+          echo "${RESPONSE}" | jq -r '.dag_run_id // "unknown"' | xargs -I{} echo "DAG run ID: {}"

--- a/.github/workflows/issue-comment-reeval.yml
+++ b/.github/workflows/issue-comment-reeval.yml
@@ -1,0 +1,66 @@
+# Triggers re-evaluation of an issue via the Airflow omc_issue_analyzer DAG
+# when a non-bot user comments on an open issue labeled 'needs-input'.
+# Required secrets: AIRFLOW_API_URL, AIRFLOW_API_USER, AIRFLOW_API_PASSWORD
+
+name: Re-evaluate issue on user comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  reeval:
+    if: >
+      contains(github.event.issue.labels.*.name, 'needs-input') &&
+      github.event.comment.user.type != 'Bot' &&
+      github.event.issue.state == 'open'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger re-evaluation via Airflow
+        env:
+          AIRFLOW_API_URL: ${{ secrets.AIRFLOW_API_URL }}
+          AIRFLOW_API_USER: ${{ secrets.AIRFLOW_API_USER }}
+          AIRFLOW_API_PASSWORD: ${{ secrets.AIRFLOW_API_PASSWORD }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+
+          # Get auth token
+          AUTH_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${AIRFLOW_API_URL}/auth/token" \
+            -H "Content-Type: application/json" \
+            -d "{\"username\":\"${AIRFLOW_API_USER}\",\"password\":\"${AIRFLOW_API_PASSWORD}\"}")
+          AUTH_HTTP_CODE=$(echo "${AUTH_RESPONSE}" | tail -n1)
+          AUTH_BODY=$(echo "${AUTH_RESPONSE}" | head -n-1)
+
+          if [ "${AUTH_HTTP_CODE}" != "200" ]; then
+            echo "Error: Airflow auth token request failed with HTTP ${AUTH_HTTP_CODE}"
+            echo "Response: ${AUTH_BODY}"
+            exit 1
+          fi
+
+          TOKEN=$(echo "${AUTH_BODY}" | jq -r '.access_token')
+
+          if [ -z "${TOKEN}" ] || [ "${TOKEN}" = "null" ]; then
+            echo "Error: Failed to extract access_token from auth response"
+            exit 1
+          fi
+
+          # Trigger DAG
+          TRIGGER_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${AIRFLOW_API_URL}/dags/omc_issue_analyzer/dagRuns" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"dag_run_id\": \"reeval_${ISSUE_NUMBER}_$(date +%s)\",
+              \"conf\": {\"issue_number\": ${ISSUE_NUMBER}},
+              \"note\": \"Re-evaluation triggered by user comment\"
+            }")
+          TRIGGER_HTTP_CODE=$(echo "${TRIGGER_RESPONSE}" | tail -n1)
+          TRIGGER_BODY=$(echo "${TRIGGER_RESPONSE}" | head -n-1)
+
+          if [ "${TRIGGER_HTTP_CODE}" != "200" ]; then
+            echo "Error: DAG trigger failed with HTTP ${TRIGGER_HTTP_CODE}"
+            echo "Response: ${TRIGGER_BODY}"
+            exit 1
+          fi
+
+          echo "Triggered re-evaluation for issue #${ISSUE_NUMBER}"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-customcode",
   "workspaces": ["packages/*"],
-  "version": "0.44.3",
+  "version": "0.44.4",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.44.3",
+  "version": "0.44.4",
   "lastUpdated": "2026-03-16T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- New `issue-comment-reeval.yml` workflow: re-evaluates issues via Airflow when users comment on `needs-input` labeled issues
- Migrated `issue-analyzer.yml` from SSH+Docker exec to Airflow REST API for consistency
- Added proper error handling (set -euo pipefail, HTTP response validation, token checks) to both workflows

## Test plan
- [ ] Verify AIRFLOW_API_URL, AIRFLOW_API_USER, AIRFLOW_API_PASSWORD secrets are configured in repo settings
- [ ] Create a test issue to verify issue-analyzer triggers correctly
- [ ] Add needs-input label to test issue, then comment to verify re-evaluation triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)