### PR TITLE
feat: inject CLAUDE.md context into issue analysis and CLI prompts (#496)

### DIFF
--- a/.github/scripts/analyze-issue.ts
+++ b/.github/scripts/analyze-issue.ts
@@ -16,6 +16,8 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
 
 // ============================================================================
 // Interfaces
@@ -53,10 +55,110 @@ const CONFIG = {
   maxTokens: 8000,
 };
 
-const DEFAULT_PROJECT_CONTEXT = `oh-my-customcode is an npm package for customizing Claude Code.
-Key components: Agents (42), Skills (55), Rules (19), Guides (22).
-Commands: omcustom init, list, doctor.
-Tech: TypeScript/Bun, GitHub Actions, npm.`;
+const DEFAULT_PROJECT_CONTEXT = `oh-my-customcode는 Claude Code를 커스터마이징하는 AI 에이전트 시스템 npm 패키지입니다.
+
+## 아키텍처 개요
+
+핵심 구성요소:
+- Agents (44): 특화된 AI 서브에이전트 전문가들
+- Skills (75): 재사용 가능한 지식 및 워크플로우 정의
+- Rules (14): 전역 동작 규칙 (R000-R021)
+- Guides (2): 레퍼런스 문서
+
+## 에이전트 카테고리
+
+| 카테고리 | 에이전트 수 | 예시 |
+|----------|------------|------|
+| SW Engineer / Language | 6 | lang-typescript-expert, lang-golang-expert, lang-python-expert |
+| SW Engineer / Backend | 6 | be-fastapi-expert, be-springboot-expert, be-nestjs-expert |
+| SW Engineer / Frontend | 4 | fe-vercel-agent, fe-vuejs-agent, fe-svelte-agent |
+| SW Engineer / Tooling | 3 | tool-npm-expert, tool-optimizer, tool-bun-expert |
+| DE Engineer | 6 | de-airflow-expert, de-dbt-expert, de-kafka-expert |
+| Database | 3 | db-supabase-expert, db-postgres-expert, db-redis-expert |
+| Security | 1 | sec-codeql-expert |
+| SW Architect | 2 | arch-documenter, arch-speckit-agent |
+| Infra Engineer | 2 | infra-docker-expert, infra-aws-expert |
+| QA Team | 3 | qa-planner, qa-writer, qa-engineer |
+| Manager | 6 | mgr-creator, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
+| System | 2 | sys-memory-keeper, sys-naggy |
+
+## 오케스트레이션 패턴
+
+메인 대화(오케스트레이터)가 라우팅 스킬을 통해 서브에이전트에 위임:
+- secretary-routing → 매니저 에이전트 (mgr-creator, mgr-gitnerd 등)
+- dev-lead-routing → 언어/프레임워크 전문가 (lang-*, be-*, fe-* 등)
+- de-lead-routing → 데이터 엔지니어링 전문가 (de-* 등)
+- qa-lead-routing → QA 워크플로우 조율
+
+## 핵심 규칙 요약
+
+- R007 에이전트 식별: 모든 응답은 \`┌─ Agent:\` 헤더로 시작
+- R009 병렬 실행: 독립 작업 2개 이상 시 병렬 에이전트 실행
+- R010 오케스트레이터: 오케스트레이터는 파일 수정 금지, 서브에이전트에 위임
+- R006 에이전트 설계: 에이전트(.claude/agents/) 와 스킬(.claude/skills/) 관심사 분리
+
+## 디렉토리 구조
+
+\`\`\`
+.claude/
+├── agents/    # 44개 서브에이전트 정의 (kebab-case .md 파일)
+├── skills/    # 75개 스킬 디렉토리 (각 SKILL.md 포함)
+├── rules/     # 14개 전역 규칙 (R000-R021)
+└── hooks/     # 보안/검증/HUD 훅 스크립트
+guides/        # 2개 레퍼런스 문서 토픽
+\`\`\`
+
+## 핵심 철학
+
+"전문가가 없으면? 만들고, 지식을 연결하고, 사용한다."
+(No expert? CREATE one, connect knowledge, and USE it.)
+
+## 기술 스택
+
+TypeScript/Bun, GitHub Actions, npm 패키지 배포.
+CLI 커맨드: omcustom init, list, doctor.`;
+
+// ============================================================================
+// Context File Loading
+// ============================================================================
+
+function loadContextFile(filename: string): string | null {
+  try {
+    const scriptDir = import.meta.dir;
+    const filePath = resolve(scriptDir, 'context', filename);
+    if (existsSync(filePath)) {
+      return readFileSync(filePath, 'utf-8');
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function buildSystemPrompt(): string {
+  const externalPrompt = loadContextFile('analysis-system-prompt.md');
+  if (externalPrompt) {
+    return externalPrompt;
+  }
+
+  const projectSummary = loadContextFile('project-summary.md') || DEFAULT_PROJECT_CONTEXT;
+
+  return `You are an expert issue analyst for the oh-my-customcode project.
+
+## Project Context
+
+${projectSummary}
+
+## Analysis Guidelines
+
+- GitHub 이슈를 분석하고 한국어로 인사이트를 제공합니다.
+- 기술 용어, 파일명, 코드 참조는 영어 그대로 유지합니다.
+- 실행 가능하고 구체적인 인사이트를 제공합니다.
+- 간결하지만 포괄적으로 분석합니다.
+- 정보가 부족하면 명확화 질문을 포함합니다.
+- 기술 용어(API, CLI, TypeScript 등), 파일명(*.ts, CLAUDE.md 등), 코드(함수명, 변수명)는 영어로 유지합니다.
+- 응답은 반드시 유효한 JSON 형식으로만 출력합니다.`;
+}
 
 // ============================================================================
 // Helper Functions
@@ -144,15 +246,12 @@ function getIssueData(issueNumber: number): Promise<IssueData> {
 }
 
 function buildPrompt(issue: IssueData): string {
-  const projectContext = process.env.PROJECT_CONTEXT || DEFAULT_PROJECT_CONTEXT;
+  // Try external project-summary file first, then env var override, then built-in default
+  const externalSummary = loadContextFile('project-summary.md');
+  const projectContext = process.env.PROJECT_CONTEXT || externalSummary || DEFAULT_PROJECT_CONTEXT;
 
-  return `GitHub 이슈를 분석하고 한국어로 인사이트를 제공하세요.
-기술 용어, 파일명, 코드 참조는 영어 그대로 유지하세요.
+  return `## Issue Details
 
-## Project Context
-${projectContext}
-
-## Issue Details
 **Number**: #${issue.number}
 **Title**: ${issue.title}
 **Author**: @${issue.author}
@@ -160,37 +259,26 @@ ${projectContext}
 **Body**:
 ${issue.body}
 
-## 분석 항목
+## Project Context (참고용)
+${projectContext}
 
-다음 구조로 한국어 분석을 제공하세요:
+## 분석 요청
 
-1. **요약**: 이 이슈가 무엇에 대한 것인지 간략히
-2. **유형**: Bug, Feature Request, Documentation, Question, Enhancement, Refactor, Other 중 하나
-3. **우선순위**: High/Medium/Low + 명확한 이유
-4. **기술적 고려사항**: 고려할 핵심 기술 측면
-5. **예상 난관**: 잠재적 어려움이나 차단 요소
-6. **제안 접근법**: 단계별 구현 제안
-7. **연관 영역**: 영향받을 수 있는 코드베이스 영역
-8. **질문**: 이슈 작성자에게 명확화 질문 (필요 시)
+다음 구조로 한국어 분석을 JSON 형식으로 제공하세요:
 
-JSON 형식으로 응답:
 {
-  "summary": "...",
-  "type": "...",
-  "priority": "...",
-  "priority_reason": "...",
-  "technical_points": ["...", "..."],
-  "challenges": ["...", "..."],
-  "suggested_approach": ["...", "..."],
-  "related_areas": ["...", "..."],
-  "questions": ["...", "..."]
+  "summary": "이 이슈가 무엇에 대한 것인지 간략히",
+  "type": "Bug | Feature Request | Documentation | Question | Enhancement | Refactor | Other 중 하나",
+  "priority": "High | Medium | Low",
+  "priority_reason": "우선순위 판단 근거",
+  "technical_points": ["고려할 핵심 기술 측면", "..."],
+  "challenges": ["잠재적 어려움이나 차단 요소", "..."],
+  "suggested_approach": ["단계별 구현 제안", "..."],
+  "related_areas": ["영향받을 수 있는 코드베이스 영역", "..."],
+  "questions": ["이슈 작성자에게 명확화 질문 (필요 시)", "..."]
 }
 
-중요:
-- 실행 가능하고 구체적인 인사이트 제공
-- 간결하지만 포괄적으로
-- 정보가 부족하면 질문에 기재
-- 기술 용어(API, CLI, TypeScript 등), 파일명(*.ts, CLAUDE.md 등), 코드(함수명, 변수명)는 영어 유지`;
+JSON만 출력하세요. 다른 텍스트 없이.`;
 }
 
 async function analyzeIssueWithClaude(issue: IssueData): Promise<AnalysisResult> {
@@ -201,11 +289,13 @@ async function analyzeIssueWithClaude(issue: IssueData): Promise<AnalysisResult>
   });
 
   const prompt = buildPrompt(issue);
+  const systemPrompt = buildSystemPrompt();
 
   try {
     const message = await client.messages.create({
       model: CONFIG.model,
       max_tokens: CONFIG.maxTokens,
+      system: systemPrompt,
       messages: [
         {
           role: 'user',

--- a/.github/scripts/context/analysis-system-prompt.md
+++ b/.github/scripts/context/analysis-system-prompt.md
@@ -1,0 +1,58 @@
+당신은 oh-my-customcode 프로젝트의 전문 이슈 분석가입니다.
+
+## 역할
+GitHub 이슈를 분석하여 한국어로 정확한 기술적 인사이트를 제공합니다.
+기술 용어, 파일명, 코드 참조는 영어 그대로 유지합니다.
+
+## 프로젝트 아키텍처
+
+oh-my-customcode는 Claude Code를 커스터마이징하는 AI 에이전트 시스템입니다.
+
+### 핵심 구성요소
+- **Agents (44)**: 전문 서브에이전트 (.claude/agents/)
+  - SW Engineer: lang-*, be-*, fe-* (언어/백엔드/프론트엔드)
+  - Data Engineering: de-* (Airflow, dbt, Spark, Kafka, Snowflake)
+  - Database: db-* (Supabase, PostgreSQL, Redis)
+  - Infrastructure: infra-* (Docker, AWS)
+  - Security: sec-codeql-expert
+  - QA: qa-planner, qa-writer, qa-engineer
+  - Manager: mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron
+  - System: sys-memory-keeper, sys-naggy
+- **Skills (75)**: 재사용 가능한 지식과 워크플로우 (.claude/skills/)
+- **Rules (14)**: 강제 규칙 R000-R021 (.claude/rules/)
+- **Guides (2)**: 레퍼런스 문서 (guides/)
+
+### 오케스트레이션 패턴
+메인 대화가 유일한 오케스트레이터입니다:
+- secretary-routing → 매니저 에이전트 라우팅
+- dev-lead-routing → 언어/프레임워크 전문가 라우팅
+- de-lead-routing → 데이터 엔지니어링 전문가 라우팅
+- qa-lead-routing → QA 워크플로우 조율
+
+### 핵심 규칙
+- R007: 모든 응답에 에이전트 식별 필수
+- R009: 독립 작업 2개 이상은 병렬 실행
+- R010: 오케스트레이터는 파일 수정 금지, 서브에이전트에 위임
+- R006: 에이전트/스킬/가이드 관심사 분리
+
+### 프로젝트 구조
+```
+.claude/
+├── agents/     # 서브에이전트 정의 (44 파일)
+├── skills/     # 스킬 (75 디렉토리)
+├── rules/      # 전역 규칙
+├── hooks/      # 훅 스크립트
+└── contexts/   # 컨텍스트 파일
+guides/          # 레퍼런스 문서
+packages/        # npm 패키지 소스
+```
+
+### 핵심 철학
+"전문가가 없으면? 만들고, 지식을 연결하고, 사용한다."
+
+## 분석 지침
+1. 프로젝트 아키텍처를 이해한 상태에서 이슈를 분석하세요
+2. 이슈가 어떤 구성요소(agents, skills, rules, guides)에 영향을 미치는지 파악하세요
+3. 관련 라우팅 스킬과 에이전트를 식별하세요
+4. 기존 규칙(R000-R021)과의 관계를 고려하세요
+5. 구체적이고 실행 가능한 인사이트를 제공하세요

--- a/.github/scripts/context/project-summary.md
+++ b/.github/scripts/context/project-summary.md
@@ -1,0 +1,15 @@
+oh-my-customcode는 Claude Code를 커스터마이징하는 AI 에이전트 시스템(npm 패키지)입니다.
+
+**아키텍처**: 44개 전문 에이전트, 75개 스킬, 14개 규칙, 2개 가이드로 구성.
+라우팅 스킬(secretary/dev-lead/de-lead/qa-lead)이 작업을 전문 서브에이전트에 위임하는 오케스트레이션 패턴.
+
+**에이전트 분류**:
+- SW Engineer (언어 6, 백엔드 6, 프론트엔드 4, 도구 3)
+- Data Engineering 6, Database 3, Security 1, Infrastructure 2
+- QA 3, Manager 6, System 2, Architect 2
+
+**핵심 규칙**: R006 관심사 분리, R007 에이전트 식별, R009 병렬 실행, R010 오케스트레이터 위임.
+
+**기술 스택**: TypeScript/Bun, GitHub Actions, npm.
+**CLI 명령**: omcustom init, list, doctor.
+**디렉토리**: .claude/agents/, .claude/skills/, .claude/rules/, guides/, packages/.

--- a/.github/workflows/issue-analyzer.yml
+++ b/.github/workflows/issue-analyzer.yml
@@ -16,6 +16,6 @@ jobs:
           username: baekenough
           key: ${{ secrets.AIRFLOW_SSH_KEY }}
           script: |
-            source ~/.venvs/airflow/bin/activate
-            airflow dags trigger omc_issue_analyzer \
-              --conf '{"issue_number": ${{ github.event.issue.number }}}'
+            docker exec customclaw-airflow-1 \
+              airflow dags trigger omc_issue_analyzer \
+              -c '{"issue_number": ${{ github.event.issue.number }}}'

--- a/.github/workflows/issue-comment-reeval.yml
+++ b/.github/workflows/issue-comment-reeval.yml
@@ -1,0 +1,49 @@
+# NOTE: This workflow file is maintained in the customclaw repo for version control,
+# but it must be deployed to the oh-my-customcode repository to receive issue_comment
+# events. The issue_comment events fire on the repo where the issues live, which is
+# oh-my-customcode — not customclaw.
+#
+# To deploy: copy this file to oh-my-customcode/.github/workflows/issue-comment-reeval.yml
+# and ensure the following secrets are configured in the oh-my-customcode repo settings:
+#   - AIRFLOW_API_URL
+#   - AIRFLOW_API_USER
+#   - AIRFLOW_API_PASSWORD
+
+name: Re-evaluate issue on user comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  reeval:
+    if: >
+      contains(github.event.issue.labels.*.name, 'needs-input') &&
+      github.event.comment.user.type != 'Bot' &&
+      github.event.issue.state == 'open'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger re-evaluation via Airflow
+        env:
+          AIRFLOW_API_URL: ${{ secrets.AIRFLOW_API_URL }}
+          AIRFLOW_API_USER: ${{ secrets.AIRFLOW_API_USER }}
+          AIRFLOW_API_PASSWORD: ${{ secrets.AIRFLOW_API_PASSWORD }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          # Get auth token
+          TOKEN=$(curl -s -X POST "${AIRFLOW_API_URL}/auth/token" \
+            -H "Content-Type: application/json" \
+            -d "{\"username\":\"${AIRFLOW_API_USER}\",\"password\":\"${AIRFLOW_API_PASSWORD}\"}" \
+            | jq -r '.access_token')
+
+          # Trigger DAG
+          curl -s -X POST "${AIRFLOW_API_URL}/dags/omc_issue_analyzer/dagRuns" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"dag_run_id\": \"reeval_${ISSUE_NUMBER}_$(date +%s)\",
+              \"conf\": {\"issue_number\": ${ISSUE_NUMBER}},
+              \"note\": \"Re-evaluation triggered by user comment\"
+            }"
+
+          echo "Triggered re-evaluation for issue #${ISSUE_NUMBER}"

--- a/packages/serve/src/lib/server/claude-cli.ts
+++ b/packages/serve/src/lib/server/claude-cli.ts
@@ -3,6 +3,17 @@ import { promisify } from 'util';
 
 const execAsync = promisify(exec);
 
+const PROJECT_RULES = `oh-my-customcode project rules:
+- Agent files: .claude/agents/{kebab-case}.md with YAML frontmatter (name, description, model, tools)
+- Skill files: .claude/skills/{kebab-case}/SKILL.md with YAML frontmatter (name, description, scope)
+- Guide files: guides/{name}/README.md (pure markdown, NO frontmatter)
+- R006: Separate concerns — agents define WHAT, skills define HOW, guides are reference docs
+- Naming: lang-* (languages), be-* (backends), fe-* (frontends), de-* (data engineering), db-* (databases), infra-* (infrastructure), mgr-* (managers), sec-* (security), qa-* (QA), arch-* (architecture), tool-* (tooling)
+- Models: sonnet (general), opus (complex reasoning), haiku (fast/simple)
+- Tools: always include Read, Grep, Glob. Add Write, Edit for code modification. Add Bash for execution.
+- Memory scopes: user, project, local
+- Scope values: core (universal), harness (agent/skill management), package (package-specific)`;
+
 export interface ValidationResult {
 	passed: boolean;
 	warnings: string[];
@@ -21,6 +32,8 @@ Check:
 3. File follows naming conventions
 4. Body has required sections
 5. No obvious issues
+
+${PROJECT_RULES}
 
 Output a JSON object with this exact structure:
 {"passed": true/false, "warnings": ["..."], "errors": ["..."]}
@@ -154,6 +167,8 @@ The file must follow this structure:
 ## References
 {Links to official docs, related guides}
 
+${PROJECT_RULES}
+
 Rules:
 - NO frontmatter (no --- blocks)
 - Write in English
@@ -209,6 +224,8 @@ scope: {core | harness | package}
 
 {Verification checklist}
 
+${PROJECT_RULES}
+
 Rules:
 - name must be kebab-case
 - Use existing naming conventions: *-best-practices for tech expertise, *-routing for orchestration
@@ -251,6 +268,8 @@ tools:
 
 ## Workflow
 {Numbered steps}
+
+${PROJECT_RULES}
 
 Rules:
 - name must be kebab-case (e.g., lang-rust-expert, be-fastapi-expert)


### PR DESCRIPTION
## Summary
- \`analyze-issue.ts\`에 Anthropic API \`system\` 파라미터 추가로 프로젝트 아키텍처 컨텍스트 주입
- \`DEFAULT_PROJECT_CONTEXT\`를 44개 에이전트, 75개 스킬, 14개 규칙, 2개 가이드 기준으로 확장
- \`.github/scripts/context/\` 디렉토리에 외부 컨텍스트 파일 분리 (유지보수성 확보)
- \`claude-cli.ts\`의 모든 프롬프트(검증/에이전트 생성/스킬 생성/가이드 생성)에 \`PROJECT_RULES\` 주입

## Changes
- \`analyze-issue.ts\`: \`system\` param, \`loadContextFile()\`, \`buildSystemPrompt()\`, expanded \`DEFAULT_PROJECT_CONTEXT\`
- \`context/analysis-system-prompt.md\`: 이슈 분석용 시스템 프롬프트
- \`context/project-summary.md\`: 프로젝트 구조 요약
- \`claude-cli.ts\`: \`PROJECT_RULES\` constant + injection into all build*Prompt functions

## Closes
Closes #496

## Test plan
- [ ] \`analyze-issue.ts\` 실행 시 system prompt가 API 호출에 포함되는지 확인
- [ ] 외부 컨텍스트 파일 없을 때 DEFAULT_PROJECT_CONTEXT fallback 동작 확인
- [ ] PROJECT_CONTEXT 환경변수 오버라이드가 여전히 동작하는지 확인
- [ ] claude-cli.ts를 통한 에이전트/스킬/가이드 생성 시 PROJECT_RULES가 포함되는지 확인