### PR TITLE
fix(ci): migrate issue-comment-reeval from JWT to Basic Auth (#501)

### DIFF
--- a/.github/workflows/issue-analyzer.yml
+++ b/.github/workflows/issue-analyzer.yml
@@ -16,6 +16,6 @@ jobs:
           username: baekenough
           key: ${{ secrets.AIRFLOW_SSH_KEY }}
           script: |
-            source ~/.venvs/airflow/bin/activate
-            airflow dags trigger omc_issue_analyzer \
-              --conf '{"issue_number": ${{ github.event.issue.number }}}'
+            docker exec customclaw-airflow-1 \
+              airflow dags trigger omc_issue_analyzer \
+              -c '{"issue_number": ${{ github.event.issue.number }}}'

--- a/.github/workflows/issue-comment-reeval.yml
+++ b/.github/workflows/issue-comment-reeval.yml
@@ -1,0 +1,49 @@
+# NOTE: This workflow file is maintained in the customclaw repo for version control,
+# but it must be deployed to the oh-my-customcode repository to receive issue_comment
+# events. The issue_comment events fire on the repo where the issues live, which is
+# oh-my-customcode — not customclaw.
+#
+# To deploy: copy this file to oh-my-customcode/.github/workflows/issue-comment-reeval.yml
+# and ensure the following secrets are configured in the oh-my-customcode repo settings:
+#   - AIRFLOW_API_URL
+#   - AIRFLOW_API_USER
+#   - AIRFLOW_API_PASSWORD
+
+name: Re-evaluate issue on user comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  reeval:
+    if: >
+      contains(github.event.issue.labels.*.name, 'needs-input') &&
+      github.event.comment.user.type != 'Bot' &&
+      github.event.issue.state == 'open'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger re-evaluation via Airflow
+        env:
+          AIRFLOW_API_URL: ${{ secrets.AIRFLOW_API_URL }}
+          AIRFLOW_API_USER: ${{ secrets.AIRFLOW_API_USER }}
+          AIRFLOW_API_PASSWORD: ${{ secrets.AIRFLOW_API_PASSWORD }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          # Get auth token
+          TOKEN=$(curl -s -X POST "${AIRFLOW_API_URL}/auth/token" \
+            -H "Content-Type: application/json" \
+            -d "{\"username\":\"${AIRFLOW_API_USER}\",\"password\":\"${AIRFLOW_API_PASSWORD}\"}" \
+            | jq -r '.access_token')
+
+          # Trigger DAG
+          curl -s -X POST "${AIRFLOW_API_URL}/dags/omc_issue_analyzer/dagRuns" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"dag_run_id\": \"reeval_${ISSUE_NUMBER}_$(date +%s)\",
+              \"conf\": {\"issue_number\": ${ISSUE_NUMBER}},
+              \"note\": \"Re-evaluation triggered by user comment\"
+            }"
+
+          echo "Triggered re-evaluation for issue #${ISSUE_NUMBER}"

--- a/.github/workflows/issue-comment-reeval.yml
+++ b/.github/workflows/issue-comment-reeval.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   reeval:
     if: >
-      contains(github.event.issue.labels.*.name, 'needs-input') &&
+      contains(github.event.issue.labels.*.name, 'needs-opinion') &&
       github.event.comment.user.type != 'Bot' &&
       github.event.issue.state == 'open'
     runs-on: ubuntu-latest
@@ -30,15 +30,9 @@ jobs:
           AIRFLOW_API_PASSWORD: ${{ secrets.AIRFLOW_API_PASSWORD }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          # Get auth token
-          TOKEN=$(curl -s -X POST "${AIRFLOW_API_URL}/auth/token" \
-            -H "Content-Type: application/json" \
-            -d "{\"username\":\"${AIRFLOW_API_USER}\",\"password\":\"${AIRFLOW_API_PASSWORD}\"}" \
-            | jq -r '.access_token')
-
-          # Trigger DAG
-          curl -s -X POST "${AIRFLOW_API_URL}/dags/omc_issue_analyzer/dagRuns" \
-            -H "Authorization: Bearer ${TOKEN}" \
+          # Trigger DAG via Basic Auth
+          curl -f -s -X POST "${AIRFLOW_API_URL}/api/v1/dags/omc_issue_analyzer/dagRuns" \
+            -u "${AIRFLOW_API_USER}:${AIRFLOW_API_PASSWORD}" \
             -H "Content-Type: application/json" \
             -d "{
               \"dag_run_id\": \"reeval_${ISSUE_NUMBER}_$(date +%s)\",


### PR DESCRIPTION
## Summary
- JWT 토큰 인증(`/auth/token` + Bearer) → Basic Auth(`curl -u`) 전환
- `curl -f` 에러 핸들링 추가로 silent failure 방지
- `jq` 의존성 제거
- Airflow API 엔드포인트에 `/api/v1/` 접두사 추가
- 라벨 조건 `needs-input` → `needs-opinion` 업데이트

## Test plan
- [ ] PR 머지 후 `needs-opinion` 라벨이 있는 이슈에 코멘트 작성하여 워크플로우 트리거 확인
- [ ] Airflow 로그에서 Basic Auth 인증 성공 및 DAG 실행 확인

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)