### PR TITLE
release: v0.44.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-customcode",
   "workspaces": ["packages/*"],
-  "version": "0.44.5",
+  "version": "0.44.6",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.44.5",
+  "version": "0.44.6",
   "lastUpdated": "2026-03-16T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary

Hotfix release for Airflow CI workflow authentication issues discovered after v0.44.5.

- **JWT auth restored** — Airflow 3.x requires JWT token auth; Basic Auth is not supported
- **Airflow API v2 compatibility** — Added required `logical_date` field for DAG run creation via `/api/v2`
- **GitHub Secrets** — Updated Airflow API credentials (wrong password in v0.44.5)

## Changes

- `fix: migrate Airflow CI workflows to JWT token auth for Airflow 3.x` (commit b9c6c0a, already on develop)
- `chore: bump version to 0.44.6`

## Test plan

- [ ] CI passes on this PR
- [ ] Merge to develop
- [ ] Create GitHub Release v0.44.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)