### PR TITLE
feat: /omcustom:feedback 스킬 — 사용자 피드백을 GitHub Issue로 자동 등록 (#498)

### DIFF
--- a/.claude/skills/omcustom-feedback/SKILL.md
+++ b/.claude/skills/omcustom-feedback/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: omcustom-feedback
+description: Submit feedback about oh-my-customcode as a GitHub issue
+scope: harness
+user-invocable: true
+disable-model-invocation: true
+argument-hint: "[description or leave empty for interactive]"
+---
+
+# Feedback Submitter
+
+Submit feedback about oh-my-customcode (bugs, features, improvements, questions) directly as a GitHub issue from the CLI session.
+
+## Purpose
+
+Lowers the barrier for submitting feedback by allowing users to create GitHub issues without leaving their terminal session. All feedback is filed to the `baekenough/oh-my-customcode` repository.
+
+## Usage
+
+```
+# Inline feedback
+/omcustom:feedback HUD display is missing during parallel agent spawn
+
+# Interactive (no arguments)
+/omcustom:feedback
+```
+
+## Workflow
+
+### Phase 1: Input Parsing
+
+If arguments are provided:
+1. Analyze the content to auto-detect category (`bug`, `feature`, `improvement`, `question`)
+2. Use the content as the issue title (truncate to 80 chars if needed)
+3. Use the full content as the description body
+
+If no arguments:
+1. Ask the user for category using AskUserQuestion: `[bug / feature / improvement / question]`
+2. Ask for title and optional detailed description (combine into a single prompt when possible)
+
+### Phase 2: Preflight Check
+
+```bash
+# Verify gh CLI is installed
+command -v gh >/dev/null 2>&1 || { echo "Error: gh CLI not installed. Install from https://cli.github.com/"; exit 1; }
+
+# Verify authentication
+gh auth status 2>&1 | grep -q "Logged in" || { echo "Error: Not authenticated. Run 'gh auth login' first."; exit 1; }
+```
+
+### Phase 3: Environment Collection
+
+Collect environment info via Bash:
+
+```bash
+# omcustom version
+OMCUSTOM_VERSION=$(node -e "console.log(require('./package.json').version)" 2>/dev/null || echo "unknown")
+
+# Claude Code version
+CLAUDE_VERSION=$(claude --version 2>/dev/null || echo "unknown")
+
+# OS
+OS_INFO=$(uname -s 2>/dev/null || echo "unknown")
+
+# Project name
+PROJECT_NAME=$(basename "$(pwd)")
+```
+
+### Phase 4: Confirmation and Create
+
+1. Show the user a preview of the issue to be created:
+   ```
+   [Preview]
+   ├── Title: {title}
+   ├── Category: {category}
+   ├── Labels: feedback, {category-label}
+   └── Repo: baekenough/oh-my-customcode
+   ```
+2. Ask for confirmation before creating
+
+3. Ensure labels exist (defensive):
+   ```bash
+   gh label create feedback --description "User feedback via /omcustom:feedback" --color 0E8A16 --repo baekenough/oh-my-customcode 2>/dev/null || true
+   ```
+
+4. Create the issue using `--body-file` for safe markdown handling:
+   ```bash
+   # Write body to temp file to avoid shell escaping issues
+   cat > /tmp/omcustom-feedback-body.md << 'FEEDBACK_EOF'
+   ## Feedback
+
+   **Category**: {category}
+   **Source**: omcustom CLI v{version}
+
+   ### Description
+   {user description}
+
+   ### Environment
+   - omcustom version: {omcustom_version}
+   - Claude Code version: {claude_version}
+   - OS: {os_info}
+   - Project: {project_name}
+
+   ---
+   *Submitted via `/omcustom:feedback`*
+   FEEDBACK_EOF
+
+   # Create issue
+   gh issue create \
+     --repo baekenough/oh-my-customcode \
+     --title "{title}" \
+     --label "feedback,{category_label}" \
+     --body-file /tmp/omcustom-feedback-body.md
+
+   # Clean up
+   rm -f /tmp/omcustom-feedback-body.md
+   ```
+
+5. If label creation fails AND issue creation fails due to labels, retry without labels as fallback
+
+6. Return the issue URL to the user
+
+### Category-to-Label Mapping
+
+| Category | GitHub Label |
+|----------|-------------|
+| bug | bug |
+| feature | enhancement |
+| improvement | enhancement |
+| question | question |
+
+## Notes
+
+- Target repo is hardcoded to `baekenough/oh-my-customcode` — feedback is always about omcustom itself
+- Requires `gh` CLI with authentication
+- Uses `--body-file` instead of `--body` to safely handle markdown with special characters
+- `disable-model-invocation: true` ensures this skill only runs when explicitly invoked by the user

--- a/.github/workflows/issue-analyzer.yml
+++ b/.github/workflows/issue-analyzer.yml
@@ -9,13 +9,51 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Airflow DAG
-        uses: appleboy/ssh-action@v1
-        with:
-          host: 49.142.111.166
-          port: 9416
-          username: baekenough
-          key: ${{ secrets.AIRFLOW_SSH_KEY }}
-          script: |
-            docker exec customclaw-airflow-1 \
-              airflow dags trigger omc_issue_analyzer \
-              -c '{"issue_number": ${{ github.event.issue.number }}}'
+        env:
+          AIRFLOW_API_URL: ${{ secrets.AIRFLOW_API_URL }}
+          AIRFLOW_API_USER: ${{ secrets.AIRFLOW_API_USER }}
+          AIRFLOW_API_PASSWORD: ${{ secrets.AIRFLOW_API_PASSWORD }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+
+          # Derive base URL — strip trailing /api/v2 or /api/v1 if present
+          BASE_URL="${AIRFLOW_API_URL%/api/v[0-9]*}"
+
+          # Airflow 3.x uses JWT token auth — Basic Auth is not supported
+          TOKEN_RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST "${BASE_URL}/auth/token" \
+            -H "Content-Type: application/json" \
+            -d "{\"username\": \"${AIRFLOW_API_USER}\", \"password\": \"${AIRFLOW_API_PASSWORD}\"}")
+          TOKEN_HTTP=$(echo "${TOKEN_RESPONSE}" | tail -n1)
+          TOKEN_BODY=$(echo "${TOKEN_RESPONSE}" | head -n-1)
+
+          if [ "${TOKEN_HTTP}" != "201" ]; then
+            echo "Error: Failed to obtain Airflow token with HTTP ${TOKEN_HTTP}"
+            echo "Response: ${TOKEN_BODY}"
+            exit 1
+          fi
+
+          ACCESS_TOKEN=$(echo "${TOKEN_BODY}" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+
+          # Trigger DAG with Bearer token (Airflow 3.x requires logical_date)
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST "${BASE_URL}/api/v2/dags/omc_issue_analyzer/dagRuns" \
+            -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"dag_run_id\": \"opened_${ISSUE_NUMBER}_$(date +%s)\",
+              \"logical_date\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",
+              \"conf\": {\"issue_number\": ${ISSUE_NUMBER}},
+              \"note\": \"Triggered by issue #${ISSUE_NUMBER} opened event\"
+            }")
+          HTTP_CODE=$(echo "${RESPONSE}" | tail -n1)
+          BODY=$(echo "${RESPONSE}" | head -n-1)
+
+          if [ "${HTTP_CODE}" != "200" ]; then
+            echo "Error: DAG trigger failed with HTTP ${HTTP_CODE}"
+            echo "Response: ${BODY}"
+            exit 1
+          fi
+
+          echo "Triggered analysis for issue #${ISSUE_NUMBER}"

--- a/.github/workflows/issue-analyzer.yml
+++ b/.github/workflows/issue-analyzer.yml
@@ -16,6 +16,6 @@ jobs:
           username: baekenough
           key: ${{ secrets.AIRFLOW_SSH_KEY }}
           script: |
-            source ~/.venvs/airflow/bin/activate
-            airflow dags trigger omc_issue_analyzer \
-              --conf '{"issue_number": ${{ github.event.issue.number }}}'
+            docker exec customclaw-airflow-1 \
+              airflow dags trigger omc_issue_analyzer \
+              -c '{"issue_number": ${{ github.event.issue.number }}}'

--- a/.github/workflows/issue-comment-reeval.yml
+++ b/.github/workflows/issue-comment-reeval.yml
@@ -1,0 +1,49 @@
+# NOTE: This workflow file is maintained in the customclaw repo for version control,
+# but it must be deployed to the oh-my-customcode repository to receive issue_comment
+# events. The issue_comment events fire on the repo where the issues live, which is
+# oh-my-customcode — not customclaw.
+#
+# To deploy: copy this file to oh-my-customcode/.github/workflows/issue-comment-reeval.yml
+# and ensure the following secrets are configured in the oh-my-customcode repo settings:
+#   - AIRFLOW_API_URL
+#   - AIRFLOW_API_USER
+#   - AIRFLOW_API_PASSWORD
+
+name: Re-evaluate issue on user comment
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  reeval:
+    if: >
+      contains(github.event.issue.labels.*.name, 'needs-input') &&
+      github.event.comment.user.type != 'Bot' &&
+      github.event.issue.state == 'open'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger re-evaluation via Airflow
+        env:
+          AIRFLOW_API_URL: ${{ secrets.AIRFLOW_API_URL }}
+          AIRFLOW_API_USER: ${{ secrets.AIRFLOW_API_USER }}
+          AIRFLOW_API_PASSWORD: ${{ secrets.AIRFLOW_API_PASSWORD }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          # Get auth token
+          TOKEN=$(curl -s -X POST "${AIRFLOW_API_URL}/auth/token" \
+            -H "Content-Type: application/json" \
+            -d "{\"username\":\"${AIRFLOW_API_USER}\",\"password\":\"${AIRFLOW_API_PASSWORD}\"}" \
+            | jq -r '.access_token')
+
+          # Trigger DAG
+          curl -s -X POST "${AIRFLOW_API_URL}/dags/omc_issue_analyzer/dagRuns" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"dag_run_id\": \"reeval_${ISSUE_NUMBER}_$(date +%s)\",
+              \"conf\": {\"issue_number\": ${ISSUE_NUMBER}},
+              \"note\": \"Re-evaluation triggered by user comment\"
+            }"
+
+          echo "Triggered re-evaluation for issue #${ISSUE_NUMBER}"

--- a/.github/workflows/issue-comment-reeval.yml
+++ b/.github/workflows/issue-comment-reeval.yml
@@ -1,13 +1,6 @@
-# NOTE: This workflow file is maintained in the customclaw repo for version control,
-# but it must be deployed to the oh-my-customcode repository to receive issue_comment
-# events. The issue_comment events fire on the repo where the issues live, which is
-# oh-my-customcode — not customclaw.
-#
-# To deploy: copy this file to oh-my-customcode/.github/workflows/issue-comment-reeval.yml
-# and ensure the following secrets are configured in the oh-my-customcode repo settings:
-#   - AIRFLOW_API_URL
-#   - AIRFLOW_API_USER
-#   - AIRFLOW_API_PASSWORD
+# Triggers re-evaluation of an issue via the Airflow omc_issue_analyzer DAG
+# when a non-bot user comments on an open issue labeled 'needs-input'.
+# Required secrets: AIRFLOW_API_URL, AIRFLOW_API_USER, AIRFLOW_API_PASSWORD
 
 name: Re-evaluate issue on user comment
 
@@ -30,20 +23,45 @@ jobs:
           AIRFLOW_API_PASSWORD: ${{ secrets.AIRFLOW_API_PASSWORD }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          # Get auth token
-          TOKEN=$(curl -s -X POST "${AIRFLOW_API_URL}/auth/token" \
-            -H "Content-Type: application/json" \
-            -d "{\"username\":\"${AIRFLOW_API_USER}\",\"password\":\"${AIRFLOW_API_PASSWORD}\"}" \
-            | jq -r '.access_token')
+          set -euo pipefail
 
-          # Trigger DAG
-          curl -s -X POST "${AIRFLOW_API_URL}/dags/omc_issue_analyzer/dagRuns" \
-            -H "Authorization: Bearer ${TOKEN}" \
+          # Derive base URL — strip trailing /api/v2 or /api/v1 if present
+          BASE_URL="${AIRFLOW_API_URL%/api/v[0-9]*}"
+
+          # Airflow 3.x uses JWT token auth — Basic Auth is not supported
+          TOKEN_RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST "${BASE_URL}/auth/token" \
+            -H "Content-Type: application/json" \
+            -d "{\"username\": \"${AIRFLOW_API_USER}\", \"password\": \"${AIRFLOW_API_PASSWORD}\"}")
+          TOKEN_HTTP=$(echo "${TOKEN_RESPONSE}" | tail -n1)
+          TOKEN_BODY=$(echo "${TOKEN_RESPONSE}" | head -n-1)
+
+          if [ "${TOKEN_HTTP}" != "201" ]; then
+            echo "Error: Failed to obtain Airflow token with HTTP ${TOKEN_HTTP}"
+            echo "Response: ${TOKEN_BODY}"
+            exit 1
+          fi
+
+          ACCESS_TOKEN=$(echo "${TOKEN_BODY}" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+
+          # Trigger DAG with Bearer token (Airflow 3.x requires logical_date)
+          RESPONSE=$(curl -s -w "\n%{http_code}" \
+            -X POST "${BASE_URL}/api/v2/dags/omc_issue_analyzer/dagRuns" \
+            -H "Authorization: Bearer ${ACCESS_TOKEN}" \
             -H "Content-Type: application/json" \
             -d "{
               \"dag_run_id\": \"reeval_${ISSUE_NUMBER}_$(date +%s)\",
+              \"logical_date\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",
               \"conf\": {\"issue_number\": ${ISSUE_NUMBER}},
               \"note\": \"Re-evaluation triggered by user comment\"
-            }"
+            }")
+          HTTP_CODE=$(echo "${RESPONSE}" | tail -n1)
+          BODY=$(echo "${RESPONSE}" | head -n-1)
+
+          if [ "${HTTP_CODE}" != "200" ]; then
+            echo "Error: DAG trigger failed with HTTP ${HTTP_CODE}"
+            echo "Response: ${BODY}"
+            exit 1
+          fi
 
           echo "Triggered re-evaluation for issue #${ISSUE_NUMBER}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,83 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  verify-release:
+    name: Verify Release
+    needs: [publish]
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Verify npm publish
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          for i in 1 2 3; do
+            PUBLISHED=$(npm view oh-my-customcode@${VERSION} version 2>/dev/null || true)
+            if [ "$PUBLISHED" = "$VERSION" ]; then
+              echo "✓ npm: oh-my-customcode@${VERSION} confirmed"
+              exit 0
+            fi
+            echo "Attempt $i: not found yet, waiting 60s..."
+            sleep 60
+          done
+          echo "::error::npm package not found after 3 attempts: oh-my-customcode@${VERSION}"
+          exit 1
+
+      - name: Verify GitHub Packages publish
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          for i in 1 2 3 4 5; do
+            PUBLISHED=$(npm view @baekenough/oh-my-customcode@${VERSION} version \
+              --registry=https://npm.pkg.github.com 2>/dev/null || true)
+            if [ "$PUBLISHED" = "$VERSION" ]; then
+              echo "✓ GitHub Packages: @baekenough/oh-my-customcode@${VERSION} confirmed"
+              exit 0
+            fi
+            echo "Attempt $i: not found yet, waiting 60s..."
+            sleep 60
+          done
+          echo "::warning::GitHub Package not found after 5 attempts (eventual consistency — package will appear later)"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify GitHub Release
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          RELEASE=$(gh api repos/${{ github.repository }}/releases/tags/v${VERSION} \
+            --jq '.tag_name' 2>/dev/null || true)
+          if [ "$RELEASE" = "v${VERSION}" ]; then
+            echo "✓ GitHub Release: v${VERSION} confirmed"
+          else
+            echo "::error::GitHub Release not found for v${VERSION}"
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Summary
+        if: always()
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          echo "## Release Verification: v${VERSION}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Target | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|--------|" >> $GITHUB_STEP_SUMMARY
+          NPM=$(npm view oh-my-customcode@${VERSION} version 2>/dev/null || echo "NOT FOUND")
+          GHP=$(npm view @baekenough/oh-my-customcode@${VERSION} version \
+            --registry=https://npm.pkg.github.com 2>/dev/null || echo "NOT FOUND")
+          GHR=$(gh api repos/${{ github.repository }}/releases/tags/v${VERSION} \
+            --jq '.tag_name' 2>/dev/null || echo "NOT FOUND")
+          echo "| npm | ${NPM} |" >> $GITHUB_STEP_SUMMARY
+          echo "| GitHub Packages | ${GHP} |" >> $GITHUB_STEP_SUMMARY
+          echo "| GitHub Release | ${GHR} |" >> $GITHUB_STEP_SUMMARY
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   cleanup:
     name: Cleanup Release Branch
     needs: [publish]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ oh-my-customcode로 구동됩니다.
 | `/omcustom:npm-version` | 시맨틱 버전 관리 |
 | `/omcustom:npm-audit` | 의존성 감사 |
 | `/omcustom:release-notes` | 릴리즈 노트 생성 (git 히스토리 기반) |
+| `/omcustom:feedback` | 사용자 피드백을 GitHub Issue로 등록 |
 | `/codex-exec` | Codex CLI 프롬프트 실행 |
 | `/optimize-analyze` | 번들 및 성능 분석 |
 | `/optimize-bundle` | 번들 크기 최적화 |
@@ -131,7 +132,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (44 파일)
-|   +-- skills/                  # 스킬 (75 디렉토리)
+|   +-- skills/                  # 스킬 (76 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R021)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **[한국어 문서 (Korean)](./README_ko.md)**
 
-44 agents. 75 skills. 21 rules. One command.
+44 agents. 76 skills. 21 rules. One command.
 
 ```bash
 npm install -g oh-my-customcode && cd your-project && omcustom init
@@ -138,7 +138,7 @@ Each agent declares its tools, model, memory scope, and limitations in YAML fron
 
 ---
 
-### Skills (75)
+### Skills (76)
 
 | Category | Count | Includes |
 |----------|-------|----------|
@@ -257,7 +257,7 @@ your-project/
 ├── CLAUDE.md                   # Entry point
 ├── .claude/
 │   ├── agents/                 # 44 agent definitions
-│   ├── skills/                 # 75 skill modules
+│   ├── skills/                 # 76 skill modules
 │   ├── rules/                  # 21 governance rules (R000-R021)
 │   ├── hooks/                  # 15 lifecycle hook scripts
 │   ├── schemas/                # Tool input validation schemas

--- a/README_ko.md
+++ b/README_ko.md
@@ -13,7 +13,7 @@
 
 **[English Documentation](./README.md)**
 
-44개 에이전트. 75개 스킬. 21개 규칙. 명령어 하나.
+44개 에이전트. 76개 스킬. 21개 규칙. 명령어 하나.
 
 > **v0.38.0** — 인터랙티브 초기화 마법사, eval-core MVP, PostCompact 훅, Codex-exec 자동 위임
 
@@ -245,7 +245,7 @@ your-project/
 ├── CLAUDE.md                   # 진입점
 ├── .claude/
 │   ├── agents/                 # 44개 에이전트 정의
-│   ├── skills/                 # 75개 스킬 모듈
+│   ├── skills/                 # 76개 스킬 모듈
 │   ├── rules/                  # 21개 거버넌스 규칙 (R000-R021)
 │   ├── hooks/                  # 15개 라이프사이클 훅 스크립트
 │   ├── schemas/                # 도구 입력 검증 스키마

--- a/templates/.claude/skills/omcustom-feedback/SKILL.md
+++ b/templates/.claude/skills/omcustom-feedback/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: omcustom-feedback
+description: Submit feedback about oh-my-customcode as a GitHub issue
+scope: harness
+user-invocable: true
+disable-model-invocation: true
+argument-hint: "[description or leave empty for interactive]"
+---
+
+# Feedback Submitter
+
+Submit feedback about oh-my-customcode (bugs, features, improvements, questions) directly as a GitHub issue from the CLI session.
+
+## Purpose
+
+Lowers the barrier for submitting feedback by allowing users to create GitHub issues without leaving their terminal session. All feedback is filed to the `baekenough/oh-my-customcode` repository.
+
+## Usage
+
+```
+# Inline feedback
+/omcustom:feedback HUD display is missing during parallel agent spawn
+
+# Interactive (no arguments)
+/omcustom:feedback
+```
+
+## Workflow
+
+### Phase 1: Input Parsing
+
+If arguments are provided:
+1. Analyze the content to auto-detect category (`bug`, `feature`, `improvement`, `question`)
+2. Use the content as the issue title (truncate to 80 chars if needed)
+3. Use the full content as the description body
+
+If no arguments:
+1. Ask the user for category using AskUserQuestion: `[bug / feature / improvement / question]`
+2. Ask for title and optional detailed description (combine into a single prompt when possible)
+
+### Phase 2: Preflight Check
+
+```bash
+# Verify gh CLI is installed
+command -v gh >/dev/null 2>&1 || { echo "Error: gh CLI not installed. Install from https://cli.github.com/"; exit 1; }
+
+# Verify authentication
+gh auth status 2>&1 | grep -q "Logged in" || { echo "Error: Not authenticated. Run 'gh auth login' first."; exit 1; }
+```
+
+### Phase 3: Environment Collection
+
+Collect environment info via Bash:
+
+```bash
+# omcustom version
+OMCUSTOM_VERSION=$(node -e "console.log(require('./package.json').version)" 2>/dev/null || echo "unknown")
+
+# Claude Code version
+CLAUDE_VERSION=$(claude --version 2>/dev/null || echo "unknown")
+
+# OS
+OS_INFO=$(uname -s 2>/dev/null || echo "unknown")
+
+# Project name
+PROJECT_NAME=$(basename "$(pwd)")
+```
+
+### Phase 4: Confirmation and Create
+
+1. Show the user a preview of the issue to be created:
+   ```
+   [Preview]
+   ├── Title: {title}
+   ├── Category: {category}
+   ├── Labels: feedback, {category-label}
+   └── Repo: baekenough/oh-my-customcode
+   ```
+2. Ask for confirmation before creating
+
+3. Ensure labels exist (defensive):
+   ```bash
+   gh label create feedback --description "User feedback via /omcustom:feedback" --color 0E8A16 --repo baekenough/oh-my-customcode 2>/dev/null || true
+   ```
+
+4. Create the issue using `--body-file` for safe markdown handling:
+   ```bash
+   # Write body to temp file to avoid shell escaping issues
+   cat > /tmp/omcustom-feedback-body.md << 'FEEDBACK_EOF'
+   ## Feedback
+
+   **Category**: {category}
+   **Source**: omcustom CLI v{version}
+
+   ### Description
+   {user description}
+
+   ### Environment
+   - omcustom version: {omcustom_version}
+   - Claude Code version: {claude_version}
+   - OS: {os_info}
+   - Project: {project_name}
+
+   ---
+   *Submitted via `/omcustom:feedback`*
+   FEEDBACK_EOF
+
+   # Create issue
+   gh issue create \
+     --repo baekenough/oh-my-customcode \
+     --title "{title}" \
+     --label "feedback,{category_label}" \
+     --body-file /tmp/omcustom-feedback-body.md
+
+   # Clean up
+   rm -f /tmp/omcustom-feedback-body.md
+   ```
+
+5. If label creation fails AND issue creation fails due to labels, retry without labels as fallback
+
+6. Return the issue URL to the user
+
+### Category-to-Label Mapping
+
+| Category | GitHub Label |
+|----------|-------------|
+| bug | bug |
+| feature | enhancement |
+| improvement | enhancement |
+| question | question |
+
+## Notes
+
+- Target repo is hardcoded to `baekenough/oh-my-customcode` — feedback is always about omcustom itself
+- Requires `gh` CLI with authentication
+- Uses `--body-file` instead of `--body` to safely handle markdown with special characters
+- `disable-model-invocation: true` ensures this skill only runs when explicitly invoked by the user

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -112,6 +112,7 @@ oh-my-customcode로 구동됩니다.
 | `/omcustom:npm-version` | 시맨틱 버전 관리 |
 | `/omcustom:npm-audit` | 의존성 감사 |
 | `/omcustom:release-notes` | 릴리즈 노트 생성 (git 히스토리 기반) |
+| `/omcustom:feedback` | 사용자 피드백을 GitHub Issue로 등록 |
 | `/codex-exec` | Codex CLI 프롬프트 실행 |
 | `/optimize-analyze` | 번들 및 성능 분석 |
 | `/optimize-bundle` | 번들 크기 최적화 |
@@ -131,7 +132,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (44 파일)
-|   +-- skills/                  # 스킬 (75 디렉토리)
+|   +-- skills/                  # 스킬 (76 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R021)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -18,7 +18,7 @@
       "name": "skills",
       "path": ".claude/skills",
       "description": "Reusable skill modules (includes slash commands)",
-      "files": 75
+      "files": 76
     },
     {
       "name": "guides",


### PR DESCRIPTION
## Summary

- `/omcustom:feedback` 스킬 추가: CLI 세션에서 바로 피드백을 GitHub Issue로 등록
- 인라인 피드백 (`/omcustom:feedback <내용>`) 및 대화형 모드 지원
- 카테고리 자동 추론 (bug/feature/improvement/question)
- 환경 정보 자동 수집 (omcustom 버전, Claude Code 버전, OS)
- `--body-file` 방식으로 마크다운 안전 처리
- `baekenough/oh-my-customcode` 리포 하드코딩 (피드백 대상 고정)

## Changed Files

| File | Change |
|------|--------|
| `.claude/skills/omcustom-feedback/SKILL.md` | New skill definition |
| `templates/.claude/skills/omcustom-feedback/SKILL.md` | Template sync |
| `CLAUDE.md` | Command table + skill count (75→76) |
| `templates/CLAUDE.md` | Template sync |

## Test Plan

- [ ] `/omcustom:feedback` 인라인 모드 테스트
- [ ] `/omcustom:feedback` 대화형 모드 테스트
- [ ] `gh` CLI 미설치 시 에러 메시지 확인
- [ ] 라벨 생성 실패 시 fallback 동작 확인

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)