### PR TITLE
feat: omcustom update --all + 대화형 업데이트 (#518)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "oh-my-customcode",
       "dependencies": {
         "@clack/prompts": "^1.1.0",
+        "@inquirer/prompts": "^8.3.2",
         "commander": "^14.0.2",
         "i18next": "^25.8.0",
         "yaml": "^2.8.2",
@@ -202,6 +203,38 @@
     "@iconify-json/simple-icons": ["@iconify-json/simple-icons@1.2.67", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-RGJRwlxyup54L1UDAjCshy3ckX5zcvYIU74YLSnUgHGvqh6B4mvksbGNHAIEp7dZQ6cM13RZVT5KC07CmnFNew=="],
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@inquirer/ansi": ["@inquirer/ansi@2.0.4", "", {}, "sha512-DpcZrQObd7S0R/U3bFdkcT5ebRwbTTC4D3tCc1vsJizmgPLxNJBo+AAFmrZwe8zk30P2QzgzGWZ3Q9uJwWuhIg=="],
+
+    "@inquirer/checkbox": ["@inquirer/checkbox@5.1.2", "", { "dependencies": { "@inquirer/ansi": "^2.0.4", "@inquirer/core": "^11.1.7", "@inquirer/figures": "^2.0.4", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-PubpMPO2nJgMufkoB3P2wwxNXEMUXnBIKi/ACzDUYfaoPuM7gSTmuxJeMscoLVEsR4qqrCMf5p0SiYGWnVJ8kw=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@6.0.10", "", { "dependencies": { "@inquirer/core": "^11.1.7", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-tiNyA73pgpQ0FQ7axqtoLUe4GDYjNCDcVsbgcA5anvwg2z6i+suEngLKKJrWKJolT//GFPZHwN30binDIHgSgQ=="],
+
+    "@inquirer/core": ["@inquirer/core@11.1.7", "", { "dependencies": { "@inquirer/ansi": "^2.0.4", "@inquirer/figures": "^2.0.4", "@inquirer/type": "^4.0.4", "cli-width": "^4.1.0", "fast-wrap-ansi": "^0.2.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-1BiBNDk9btIwYIzNZpkikIHXWeNzNncJePPqwDyVMhXhD1ebqbpn1mKGctpoqAbzywZfdG0O4tvmsGIcOevAPQ=="],
+
+    "@inquirer/editor": ["@inquirer/editor@5.0.10", "", { "dependencies": { "@inquirer/core": "^11.1.7", "@inquirer/external-editor": "^2.0.4", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-VJx4XyaKea7t8hEApTw5dxeIyMtWXre2OiyJcICCRZI4hkoHsMoCnl/KbUnJJExLbH9csLLHMVR144ZhFE1CwA=="],
+
+    "@inquirer/expand": ["@inquirer/expand@5.0.10", "", { "dependencies": { "@inquirer/core": "^11.1.7", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-fC0UHJPXsTRvY2fObiwuQYaAnHrp3aDqfwKUJSdfpgv18QUG054ezGbaRNStk/BKD5IPijeMKWej8VV8O5Q/eQ=="],
+
+    "@inquirer/external-editor": ["@inquirer/external-editor@2.0.4", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Prenuv9C1PHj2Itx0BcAOVBTonz02Hc2Nd2DbU67PdGUaqn0nPCnV34oDyyoaZHnmfRxkpuhh/u51ThkrO+RdA=="],
+
+    "@inquirer/figures": ["@inquirer/figures@2.0.4", "", {}, "sha512-eLBsjlS7rPS3WEhmOmh1znQ5IsQrxWzxWDxO51e4urv+iVrSnIHbq4zqJIOiyNdYLa+BVjwOtdetcQx1lWPpiQ=="],
+
+    "@inquirer/input": ["@inquirer/input@5.0.10", "", { "dependencies": { "@inquirer/core": "^11.1.7", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-nvZ6qEVeX/zVtZ1dY2hTGDQpVGD3R7MYPLODPgKO8Y+RAqxkrP3i/3NwF3fZpLdaMiNuK0z2NaYIx9tPwiSegQ=="],
+
+    "@inquirer/number": ["@inquirer/number@4.0.10", "", { "dependencies": { "@inquirer/core": "^11.1.7", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Ht8OQstxiS3APMGjHV0aYAjRAysidWdwurWEo2i8yI5xbhOBWqizT0+MU1S2GCcuhIBg+3SgWVjEoXgfhY+XaA=="],
+
+    "@inquirer/password": ["@inquirer/password@5.0.10", "", { "dependencies": { "@inquirer/ansi": "^2.0.4", "@inquirer/core": "^11.1.7", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-QbNyvIE8q2GTqKLYSsA8ATG+eETo+m31DSR0+AU7x3d2FhaTWzqQek80dj3JGTo743kQc6mhBR0erMjYw5jQ0A=="],
+
+    "@inquirer/prompts": ["@inquirer/prompts@8.3.2", "", { "dependencies": { "@inquirer/checkbox": "^5.1.2", "@inquirer/confirm": "^6.0.10", "@inquirer/editor": "^5.0.10", "@inquirer/expand": "^5.0.10", "@inquirer/input": "^5.0.10", "@inquirer/number": "^4.0.10", "@inquirer/password": "^5.0.10", "@inquirer/rawlist": "^5.2.6", "@inquirer/search": "^4.1.6", "@inquirer/select": "^5.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-yFroiSj2iiBFlm59amdTvAcQFvWS6ph5oKESls/uqPBect7rTU2GbjyZO2DqxMGuIwVA8z0P4K6ViPcd/cp+0w=="],
+
+    "@inquirer/rawlist": ["@inquirer/rawlist@5.2.6", "", { "dependencies": { "@inquirer/core": "^11.1.7", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-jfw0MLJ5TilNsa9zlJ6nmRM0ZFVZhhTICt4/6CU2Dv1ndY7l3sqqo1gIYZyMMDw0LvE1u1nzJNisfHEhJIxq5w=="],
+
+    "@inquirer/search": ["@inquirer/search@4.1.6", "", { "dependencies": { "@inquirer/core": "^11.1.7", "@inquirer/figures": "^2.0.4", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-3/6kTRae98hhDevENScy7cdFEuURnSpM3JbBNg8yfXLw88HgTOl+neUuy/l9W0No5NzGsLVydhBzTIxZP7yChQ=="],
+
+    "@inquirer/select": ["@inquirer/select@5.1.2", "", { "dependencies": { "@inquirer/ansi": "^2.0.4", "@inquirer/core": "^11.1.7", "@inquirer/figures": "^2.0.4", "@inquirer/type": "^4.0.4" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-kTK8YIkHV+f02y7bWCh7E0u2/11lul5WepVTclr3UMBtBr05PgcZNWfMa7FY57ihpQFQH/spLMHTcr0rXy50tA=="],
+
+    "@inquirer/type": ["@inquirer/type@4.0.4", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-PamArxO3cFJZoOzspzo6cxVlLeIftyBsZw/S9bKY5DzxqJVZgjoj1oP8d0rskKtp7sZxBycsoer1g6UeJV1BBA=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -451,7 +484,11 @@
 
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
+    "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
+
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -501,6 +538,12 @@
 
     "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
+    "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
+
+    "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
+
+    "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "focus-trap": ["focus-trap@7.8.0", "", { "dependencies": { "tabbable": "^6.4.0" } }, "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA=="],
@@ -526,6 +569,8 @@
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "i18next": ["i18next@25.8.0", "", { "dependencies": { "@babel/runtime": "^7.28.4" }, "peerDependencies": { "typescript": "^5" }, "optionalPeers": ["typescript"] }, "sha512-urrg4HMFFMQZ2bbKRK7IZ8/CTE7D8H4JRlAwqA2ZwDRFfdd0K/4cdbNNLgfn9mo+I/h9wJu61qJzH7jCFAhUZQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
@@ -599,6 +644,8 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
+
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "nodemailer": ["nodemailer@8.0.1", "", {}, "sha512-5kcldIXmaEjZcHR6F28IKGSgpmZHaF1IXLWFTG+Xh3S+Cce4MiakLtWY+PlBU69fLbRa8HlaGIrC/QolUpHkhg=="],
@@ -639,6 +686,8 @@
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "search-insights": ["search-insights@2.17.3", "", {}, "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
@@ -648,6 +697,8 @@
     "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
     "shiki": ["shiki@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/langs": "2.5.0", "@shikijs/themes": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sirv": ["sirv@3.0.2", "", { "dependencies": { "@polka/url": "^1.0.0-next.24", "mrmime": "^2.0.0", "totalist": "^3.0.0" } }, "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g=="],
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.1.0",
+    "@inquirer/prompts": "^8.3.2",
     "commander": "^14.0.2",
     "i18next": "^25.8.0",
     "yaml": "^2.8.2"

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -61,6 +61,7 @@ export function createProgram(): Command {
     .option('--guides', i18n.t('cli.update.guidesOption'))
     .option('--hooks', i18n.t('cli.update.hooksOption'))
     .option('--contexts', i18n.t('cli.update.contextsOption'))
+    .option('--all', i18n.t('cli.update.allOption'))
     .action(async (options) => {
       await updateCommand(options);
     });

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,8 +1,14 @@
 /**
  * omcustom update command
  * Updates agents to the latest version
+ *
+ * Supports three modes:
+ * 1. Single-project update (default): updates current directory
+ * 2. --all flag: batch update all outdated projects found by project discovery
+ * 3. Interactive (TTY, no --all): checkbox UI to select which projects to update
  */
 
+import packageJson from '../../package.json';
 import { type UpdateComponent, type UpdateOptions, update } from '../core/updater.js';
 import { i18n } from '../i18n/index.js';
 
@@ -30,6 +36,8 @@ export interface UpdateCommandOptions {
   hooks?: boolean;
   /** Update only contexts */
   contexts?: boolean;
+  /** Batch update all outdated projects found by project discovery */
+  all?: boolean;
 }
 
 /**
@@ -37,41 +45,186 @@ export interface UpdateCommandOptions {
  */
 export async function updateCommand(options: UpdateCommandOptions = {}): Promise<void> {
   try {
-    const targetDir = process.cwd();
-
-    // Build components list from flags
-    const components = buildComponentsList(options);
-
-    // Show dry run header if applicable
-    if (options.dryRun) {
-      console.log(i18n.t('cli.update.dryRunHeader'));
+    if (options.all) {
+      await updateAllProjects(options);
+      return;
     }
 
-    // Execute update
-    const updateOptions: UpdateOptions = {
-      targetDir,
-      components,
-      force: options.force,
-      preserveCustomizations: true,
-      forceOverwriteAll: options.forceOverwriteAll,
-      dryRun: options.dryRun,
-      backup: options.backup,
-    };
-
-    const result = await update(updateOptions);
-
-    // Print results
-    printUpdateResults(result);
-
-    // Exit with appropriate code
-    if (!result.success) {
-      process.exit(1);
+    if (process.stdout.isTTY && !options.dryRun) {
+      const didInteractive = await maybeRunInteractiveUpdate(options);
+      if (didInteractive) return;
     }
+
+    await updateSingleProject(process.cwd(), options);
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     console.error(i18n.t('cli.update.summaryFailed', { error: errorMessage }));
     process.exit(1);
   }
+}
+
+/**
+ * Update a single project directory
+ */
+async function updateSingleProject(
+  targetDir: string,
+  options: UpdateCommandOptions
+): Promise<boolean> {
+  // Build components list from flags
+  const components = buildComponentsList(options);
+
+  // Show dry run header if applicable
+  if (options.dryRun) {
+    console.log(i18n.t('cli.update.dryRunHeader'));
+  }
+
+  // Execute update
+  const updateOptions: UpdateOptions = {
+    targetDir,
+    components,
+    force: options.force,
+    preserveCustomizations: true,
+    forceOverwriteAll: options.forceOverwriteAll,
+    dryRun: options.dryRun,
+    backup: options.backup,
+  };
+
+  const result = await update(updateOptions);
+
+  // Print results
+  printUpdateResults(result);
+
+  if (!result.success) {
+    process.exit(1);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Batch update all outdated projects found by project discovery.
+ * Runs sequentially so progress output is readable.
+ */
+async function updateAllProjects(options: UpdateCommandOptions): Promise<void> {
+  const { findProjects } = await import('./projects.js');
+  const currentVersion = packageJson.version as string;
+
+  console.log(i18n.t('cli.update.allScanning'));
+  const projects = await findProjects();
+
+  if (projects.length === 0) {
+    console.log(i18n.t('cli.update.allNoneFound'));
+    return;
+  }
+
+  const outdated = projects.filter((p) => p.status === 'outdated');
+
+  if (outdated.length === 0) {
+    console.log(i18n.t('cli.update.allNoneOutdated'));
+    return;
+  }
+
+  console.log(i18n.t('cli.update.allOutdatedFound', { count: String(outdated.length) }));
+
+  let updatedCount = 0;
+  let failedCount = 0;
+
+  for (const [index, project] of outdated.entries()) {
+    const current = String(index + 1);
+    const total = String(outdated.length);
+    process.stdout.write(
+      `${i18n.t('cli.update.allProjectUpdating', { current, total, name: project.name })} `
+    );
+
+    try {
+      const components = buildComponentsList(options);
+      const updateOptions: UpdateOptions = {
+        targetDir: project.path,
+        components,
+        force: options.force,
+        preserveCustomizations: true,
+        forceOverwriteAll: options.forceOverwriteAll,
+        dryRun: options.dryRun,
+        backup: options.backup,
+      };
+
+      const result = await update(updateOptions);
+
+      if (result.success) {
+        const from = project.version ?? 'unknown';
+        const to = currentVersion;
+        console.log(i18n.t('cli.update.allProjectUpdated', { from, to }));
+        updatedCount++;
+      } else {
+        const errorMsg = result.error ?? 'unknown error';
+        console.log(i18n.t('cli.update.allProjectFailed', { error: errorMsg }));
+        failedCount++;
+      }
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.log(i18n.t('cli.update.allProjectFailed', { error: errorMessage }));
+      failedCount++;
+    }
+  }
+
+  console.log(
+    i18n.t('cli.update.allDone', {
+      updated: String(updatedCount),
+      failed: String(failedCount),
+    })
+  );
+}
+
+/**
+ * Interactive checkbox UI for selecting projects to update.
+ * Returns true if interactive mode was triggered (project list found),
+ * false if there are no discovered projects and we should fall back to
+ * single-project update.
+ */
+async function maybeRunInteractiveUpdate(options: UpdateCommandOptions): Promise<boolean> {
+  const { findProjects } = await import('./projects.js');
+  const currentVersion = packageJson.version as string;
+
+  const projects = await findProjects();
+
+  // Only enter interactive mode when multiple projects are discovered
+  if (projects.length <= 1) {
+    return false;
+  }
+
+  const { checkbox } = await import('@inquirer/prompts');
+
+  const choices = projects.map((p) => {
+    const versionLabel = p.version ?? 'unknown';
+    const isLatest = p.status === 'latest';
+    return {
+      name: `${p.name.padEnd(25)} ${versionLabel.padEnd(10)} → ${currentVersion}  (${p.path})`,
+      value: p.path,
+      checked: p.status === 'outdated',
+      disabled: isLatest ? (i18n.t('cli.update.projectLatestSuffix') as string) : false,
+    };
+  });
+
+  const selected = await checkbox({
+    message: i18n.t('cli.update.interactiveSelect'),
+    choices,
+  });
+
+  if (selected.length === 0) {
+    console.log(i18n.t('cli.update.interactiveNoneSelected'));
+    return true;
+  }
+
+  console.log(i18n.t('cli.update.interactiveUpdating'));
+
+  for (const projectPath of selected) {
+    await updateSingleProject(projectPath, options).catch((error: unknown) => {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error(i18n.t('cli.update.allProjectFailed', { error: errorMessage }));
+    });
+  }
+
+  return true;
 }
 
 /**
@@ -119,7 +272,9 @@ function printUpdateResults(result: UpdateResult): void {
 
   // Show preserved files
   if (result.preservedFiles.length > 0) {
-    console.log(i18n.t('cli.update.preservedFiles', { count: result.preservedFiles.length }));
+    console.log(
+      i18n.t('cli.update.preservedFiles', { count: String(result.preservedFiles.length) })
+    );
   }
 
   // Show backup path
@@ -138,8 +293,8 @@ function printUpdateResults(result: UpdateResult): void {
   if (result.success) {
     console.log(
       i18n.t('cli.update.summary', {
-        updated: result.updatedComponents.length,
-        skipped: result.skippedComponents.length,
+        updated: String(result.updatedComponents.length),
+        skipped: String(result.skippedComponents.length),
       })
     );
   } else if (result.error) {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -128,7 +128,20 @@
       "preservedFiles": "Preserved {{count}} user-customized files",
       "backupCreated": "Backup created at {{path}}",
       "summary": "Update complete: {{updated}} updated, {{skipped}} skipped",
-      "summaryFailed": "Update failed: {{error}}"
+      "summaryFailed": "Update failed: {{error}}",
+      "allOption": "Batch update all outdated projects found by project discovery",
+      "allScanning": "Scanning for oh-my-customcode projects...",
+      "allNoneFound": "No oh-my-customcode projects found.",
+      "allNoneOutdated": "All projects are up to date.",
+      "allOutdatedFound": "Found {{count}} outdated project(s). Updating...",
+      "allProjectUpdating": "  [{{current}}/{{total}}] {{name}}",
+      "allProjectUpdated": "  ✓ updated ({{from}} → {{to}})",
+      "allProjectFailed": "  ✗ failed: {{error}}",
+      "allDone": "Batch update complete: {{updated}} updated, {{failed}} failed.",
+      "interactiveSelect": "Select projects to update:",
+      "interactiveNoneSelected": "No projects selected. Exiting.",
+      "interactiveUpdating": "Updating selected projects...",
+      "projectLatestSuffix": "(latest)"
     },
     "list": {
       "description": "List installed components",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -128,7 +128,20 @@
       "preservedFiles": "사용자 커스터마이징 파일 {{count}}개 보존됨",
       "backupCreated": "백업 생성됨: {{path}}",
       "summary": "업데이트 완료: {{updated}}개 업데이트, {{skipped}}개 건너뜀",
-      "summaryFailed": "업데이트 실패: {{error}}"
+      "summaryFailed": "업데이트 실패: {{error}}",
+      "allOption": "프로젝트 탐색으로 발견된 모든 outdated 프로젝트 일괄 업데이트",
+      "allScanning": "oh-my-customcode 프로젝트 검색 중...",
+      "allNoneFound": "oh-my-customcode 프로젝트를 찾을 수 없습니다.",
+      "allNoneOutdated": "모든 프로젝트가 최신 버전입니다.",
+      "allOutdatedFound": "{{count}}개의 outdated 프로젝트가 있습니다. 업데이트 중...",
+      "allProjectUpdating": "  [{{current}}/{{total}}] {{name}}",
+      "allProjectUpdated": "  ✓ 업데이트됨 ({{from}} → {{to}})",
+      "allProjectFailed": "  ✗ 실패: {{error}}",
+      "allDone": "일괄 업데이트 완료: {{updated}}개 업데이트됨, {{failed}}개 실패.",
+      "interactiveSelect": "업데이트할 프로젝트 선택:",
+      "interactiveNoneSelected": "선택된 프로젝트가 없습니다. 종료합니다.",
+      "interactiveUpdating": "선택된 프로젝트 업데이트 중...",
+      "projectLatestSuffix": "(최신)"
     },
     "list": {
       "description": "설치된 컴포넌트 목록 표시",

--- a/tests/unit/cli/update.test.ts
+++ b/tests/unit/cli/update.test.ts
@@ -612,6 +612,549 @@ describe('update command', () => {
     });
   });
 
+  describe('updateCommand --all flag', () => {
+    it('should run batch update for all outdated projects', async () => {
+      mock.module('../../../src/core/provider.js', () => ({
+        detectProvider: async () => ({
+          provider: 'claude',
+          source: 'override',
+          confidence: 'high',
+          reason: 'test',
+        }),
+      }));
+
+      const mockUpdate = mock(async () => ({
+        success: true,
+        updatedComponents: ['rules'],
+        skippedComponents: [],
+        preservedFiles: [],
+        backedUpPaths: [],
+        previousVersion: '0.1.0',
+        newVersion: '0.45.0',
+        warnings: [],
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mockUpdate,
+      }));
+
+      mock.module('../../../src/cli/projects.js', () => ({
+        findProjects: async () => [
+          {
+            name: 'project-a',
+            path: '/tmp/project-a',
+            version: '0.44.0',
+            installedAt: null,
+            updatedAt: null,
+            status: 'outdated',
+            detectionMethod: 'lockfile',
+          },
+          {
+            name: 'project-b',
+            path: '/tmp/project-b',
+            version: '0.45.0',
+            installedAt: null,
+            updatedAt: null,
+            status: 'latest',
+            detectionMethod: 'lockfile',
+          },
+        ],
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      await updateCommand({ all: true });
+
+      // Only project-a (outdated) should be updated
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+      expect(consoleLogSpy).toHaveBeenCalled();
+      expect(exitCode).toBeUndefined();
+    });
+
+    it('should report no outdated projects when all are latest', async () => {
+      mock.module('../../../src/core/provider.js', () => ({
+        detectProvider: async () => ({
+          provider: 'claude',
+          source: 'override',
+          confidence: 'high',
+          reason: 'test',
+        }),
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mock(async () => ({})),
+      }));
+
+      mock.module('../../../src/cli/projects.js', () => ({
+        findProjects: async () => [
+          {
+            name: 'project-a',
+            path: '/tmp/project-a',
+            version: '0.45.0',
+            installedAt: null,
+            updatedAt: null,
+            status: 'latest',
+            detectionMethod: 'lockfile',
+          },
+        ],
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      await updateCommand({ all: true });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      expect(exitCode).toBeUndefined();
+    });
+
+    it('should report when no projects found', async () => {
+      mock.module('../../../src/core/provider.js', () => ({
+        detectProvider: async () => ({
+          provider: 'claude',
+          source: 'override',
+          confidence: 'high',
+          reason: 'test',
+        }),
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mock(async () => ({})),
+      }));
+
+      mock.module('../../../src/cli/projects.js', () => ({
+        findProjects: async () => [],
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      await updateCommand({ all: true });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      expect(exitCode).toBeUndefined();
+    });
+
+    it('should handle update failure for individual project in --all mode', async () => {
+      mock.module('../../../src/core/provider.js', () => ({
+        detectProvider: async () => ({
+          provider: 'claude',
+          source: 'override',
+          confidence: 'high',
+          reason: 'test',
+        }),
+      }));
+
+      const mockUpdate = mock(async () => ({
+        success: false,
+        updatedComponents: [],
+        skippedComponents: [],
+        preservedFiles: [],
+        backedUpPaths: [],
+        previousVersion: '0.44.0',
+        newVersion: '0.44.0',
+        warnings: [],
+        error: 'Permission denied',
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mockUpdate,
+      }));
+
+      mock.module('../../../src/cli/projects.js', () => ({
+        findProjects: async () => [
+          {
+            name: 'project-a',
+            path: '/tmp/project-a',
+            version: '0.44.0',
+            installedAt: null,
+            updatedAt: null,
+            status: 'outdated',
+            detectionMethod: 'lockfile',
+          },
+        ],
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      await updateCommand({ all: true });
+
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+      // allDone message should still be printed
+      expect(consoleLogSpy).toHaveBeenCalled();
+      // Should NOT exit with error (batch mode continues)
+      expect(exitCode).toBeUndefined();
+    });
+
+    it('should handle thrown exception for individual project in --all mode', async () => {
+      mock.module('../../../src/core/provider.js', () => ({
+        detectProvider: async () => ({
+          provider: 'claude',
+          source: 'override',
+          confidence: 'high',
+          reason: 'test',
+        }),
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mock(async () => {
+          throw new Error('Network error');
+        }),
+      }));
+
+      mock.module('../../../src/cli/projects.js', () => ({
+        findProjects: async () => [
+          {
+            name: 'project-a',
+            path: '/tmp/project-a',
+            version: '0.44.0',
+            installedAt: null,
+            updatedAt: null,
+            status: 'outdated',
+            detectionMethod: 'lockfile',
+          },
+        ],
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      await updateCommand({ all: true });
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      expect(exitCode).toBeUndefined();
+    });
+  });
+
+  describe('updateCommand interactive mode (TTY, no --all)', () => {
+    let originalIsTTY: boolean | undefined;
+
+    beforeEach(() => {
+      originalIsTTY = process.stdout.isTTY;
+    });
+
+    afterEach(() => {
+      // Restore isTTY
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: originalIsTTY,
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    it('should fall back to single-project update when only 1 project found', async () => {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      mock.module('../../../src/core/provider.js', () => ({
+        detectProvider: async () => ({
+          provider: 'claude',
+          source: 'override',
+          confidence: 'high',
+          reason: 'test',
+        }),
+      }));
+
+      const mockUpdate = mock(async () => ({
+        success: true,
+        updatedComponents: ['rules'],
+        skippedComponents: [],
+        preservedFiles: [],
+        backedUpPaths: [],
+        previousVersion: '0.1.0',
+        newVersion: '0.45.0',
+        warnings: [],
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mockUpdate,
+      }));
+
+      // Only 1 project → interactive mode skipped, falls back to single-project
+      mock.module('../../../src/cli/projects.js', () => ({
+        findProjects: async () => [
+          {
+            name: 'my-project',
+            path: tempDir,
+            version: '0.44.0',
+            installedAt: null,
+            updatedAt: null,
+            status: 'outdated',
+            detectionMethod: 'lockfile',
+          },
+        ],
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      await updateCommand({});
+
+      // update called once (single project = cwd)
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+      expect(exitCode).toBeUndefined();
+    });
+
+    it('should not enter interactive mode when not a TTY', async () => {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: false,
+        writable: true,
+        configurable: true,
+      });
+
+      mock.module('../../../src/core/provider.js', () => ({
+        detectProvider: async () => ({
+          provider: 'claude',
+          source: 'override',
+          confidence: 'high',
+          reason: 'test',
+        }),
+      }));
+
+      const mockUpdate = mock(async () => ({
+        success: true,
+        updatedComponents: ['rules'],
+        skippedComponents: [],
+        preservedFiles: [],
+        backedUpPaths: [],
+        previousVersion: '0.1.0',
+        newVersion: '0.45.0',
+        warnings: [],
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mockUpdate,
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      await updateCommand({});
+
+      // Single project update in non-TTY mode
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+      expect(exitCode).toBeUndefined();
+    });
+
+    it('should not enter interactive mode when dry-run is set', async () => {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      mock.module('../../../src/core/provider.js', () => ({
+        detectProvider: async () => ({
+          provider: 'claude',
+          source: 'override',
+          confidence: 'high',
+          reason: 'test',
+        }),
+      }));
+
+      const mockUpdate = mock(async () => ({
+        success: true,
+        updatedComponents: [],
+        skippedComponents: ['rules'],
+        preservedFiles: [],
+        backedUpPaths: [],
+        previousVersion: '0.1.0',
+        newVersion: '0.45.0',
+        warnings: [],
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mockUpdate,
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      await updateCommand({ dryRun: true });
+
+      const callArgs = mockUpdate.mock.calls[0]?.[0];
+      expect(callArgs.dryRun).toBe(true);
+      expect(exitCode).toBeUndefined();
+    });
+
+    it('should run interactive checkbox and update selected projects', async () => {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      mock.module('../../../src/core/provider.js', () => ({
+        detectProvider: async () => ({
+          provider: 'claude',
+          source: 'override',
+          confidence: 'high',
+          reason: 'test',
+        }),
+      }));
+
+      const mockUpdate = mock(async () => ({
+        success: true,
+        updatedComponents: ['rules'],
+        skippedComponents: [],
+        preservedFiles: [],
+        backedUpPaths: [],
+        previousVersion: '0.44.0',
+        newVersion: '0.45.0',
+        warnings: [],
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mockUpdate,
+      }));
+
+      mock.module('../../../src/cli/projects.js', () => ({
+        findProjects: async () => [
+          {
+            name: 'project-a',
+            path: '/tmp/project-a',
+            version: '0.44.0',
+            installedAt: null,
+            updatedAt: null,
+            status: 'outdated',
+            detectionMethod: 'lockfile',
+          },
+          {
+            name: 'project-b',
+            path: '/tmp/project-b',
+            version: '0.45.0',
+            installedAt: null,
+            updatedAt: null,
+            status: 'latest',
+            detectionMethod: 'lockfile',
+          },
+        ],
+      }));
+
+      // Mock @inquirer/prompts checkbox to return project-a path
+      mock.module('@inquirer/prompts', () => ({
+        checkbox: mock(async () => ['/tmp/project-a']),
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      await updateCommand({});
+
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+      expect(exitCode).toBeUndefined();
+    });
+
+    it('should exit gracefully when no projects selected in interactive mode', async () => {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      mock.module('../../../src/core/provider.js', () => ({
+        detectProvider: async () => ({
+          provider: 'claude',
+          source: 'override',
+          confidence: 'high',
+          reason: 'test',
+        }),
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mock(async () => ({})),
+      }));
+
+      mock.module('../../../src/cli/projects.js', () => ({
+        findProjects: async () => [
+          {
+            name: 'project-a',
+            path: '/tmp/project-a',
+            version: '0.44.0',
+            installedAt: null,
+            updatedAt: null,
+            status: 'outdated',
+            detectionMethod: 'lockfile',
+          },
+          {
+            name: 'project-b',
+            path: '/tmp/project-b',
+            version: '0.44.0',
+            installedAt: null,
+            updatedAt: null,
+            status: 'outdated',
+            detectionMethod: 'lockfile',
+          },
+        ],
+      }));
+
+      // Return empty selection
+      mock.module('@inquirer/prompts', () => ({
+        checkbox: mock(async () => []),
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      await updateCommand({});
+
+      expect(consoleLogSpy).toHaveBeenCalled();
+      expect(exitCode).toBeUndefined();
+    });
+
+    it('should handle update failure in interactive mode gracefully', async () => {
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+
+      mock.module('../../../src/core/provider.js', () => ({
+        detectProvider: async () => ({
+          provider: 'claude',
+          source: 'override',
+          confidence: 'high',
+          reason: 'test',
+        }),
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mock(async () => {
+          throw new Error('Disk full');
+        }),
+      }));
+
+      mock.module('../../../src/cli/projects.js', () => ({
+        findProjects: async () => [
+          {
+            name: 'project-a',
+            path: '/tmp/project-a',
+            version: '0.44.0',
+            installedAt: null,
+            updatedAt: null,
+            status: 'outdated',
+            detectionMethod: 'lockfile',
+          },
+          {
+            name: 'project-b',
+            path: '/tmp/project-b',
+            version: '0.44.0',
+            installedAt: null,
+            updatedAt: null,
+            status: 'outdated',
+            detectionMethod: 'lockfile',
+          },
+        ],
+      }));
+
+      mock.module('@inquirer/prompts', () => ({
+        checkbox: mock(async () => ['/tmp/project-a']),
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      await updateCommand({});
+
+      expect(consoleErrorSpy).toHaveBeenCalled();
+      expect(exitCode).toBeUndefined();
+    });
+  });
+
   describe('updateCommand error handling', () => {
     it('should exit with code 1 when update fails', async () => {
       mock.module('../../../src/core/provider.js', () => ({


### PR DESCRIPTION
## Summary
- `omcustom update --all` — 프로젝트 탐색으로 발견된 모든 outdated 프로젝트 일괄 업데이트 (CI/스크립트용)
- `omcustom update` 대화형 체크박스 UI — TTY에서 2개 이상 프로젝트 발견 시 @inquirer/prompts 기반 선택 업데이트
- 기존 단일 프로젝트 업데이트 동작 유지 (TTY가 아니거나 1개 이하 프로젝트일 때)
- Closes #518

## Changes
- `src/cli/update.ts` — `--all` batch 모드, 대화형 `maybeRunInteractiveUpdate()`, 리팩토링된 `updateSingleProject()`
- `src/cli/index.ts` — `--all` 옵션 등록
- `src/i18n/locales/en.json` + `ko.json` — 새 메시지 키 추가
- `package.json` + `bun.lock` — `@inquirer/prompts@8.3.2` 의존성 추가

## Test plan
- [ ] `omcustom update --all` 실행 시 모든 outdated 프로젝트 순차 업데이트 확인
- [ ] TTY에서 `omcustom update` 실행 시 체크박스 UI 표시 확인
- [ ] 기존 `omcustom update --dry-run`, `--force`, `--agents` 등 단일 프로젝트 옵션 동작 유지 확인
- [ ] CI: 1222 기존 테스트 패스 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)