### PR TITLE
fix: release v0.45.3

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9305,7 +9305,7 @@ var init_package = __esm(() => {
   package_default = {
     name: "oh-my-customcode",
     workspaces: ["packages/*"],
-    version: "0.45.1",
+    version: "0.45.3",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {
@@ -9483,8 +9483,16 @@ async function searchDirectory(dir2, depth, results, currentVersion, seen) {
     await Promise.all(subdirs.map((subdir) => searchDirectory(join9(dir2, subdir.name), depth + 1, results, currentVersion, seen)));
   }
 }
+async function getTemplateVersion() {
+  const manifestPath = resolveTemplatePath("manifest.json");
+  if (await fileExists(manifestPath)) {
+    const manifest = await readJsonFile(manifestPath);
+    return manifest.version;
+  }
+  return package_default.version;
+}
 async function findProjects(options = {}) {
-  const currentVersion = package_default.version;
+  const currentVersion = await getTemplateVersion();
   const home = homedir2();
   const seen = new Set;
   const results = [];
@@ -9571,7 +9579,7 @@ oh-my-customcode 적용 프로젝트 (${projects.length}개):`);
 현재 설치 버전: v${currentVersion}`);
 }
 async function projectsCommand(options = {}) {
-  const currentVersion = package_default.version;
+  const currentVersion = await getTemplateVersion();
   const format = options.format || "table";
   console.log("  oh-my-customcode 적용 프로젝트를 검색 중...");
   try {
@@ -9593,6 +9601,7 @@ async function projectsCommand(options = {}) {
 var DEFAULT_SEARCH_DIRS, MAX_SEARCH_DEPTH = 3, projects_default;
 var init_projects = __esm(() => {
   init_package();
+  init_fs();
   DEFAULT_SEARCH_DIRS = ["workspace", "projects", "dev", "src", "code", "repos", "work"];
   projects_default = projectsCommand;
 });
@@ -30011,6 +30020,16 @@ async function update(options) {
     info("update.start", { targetDir: options.targetDir });
     const config = await loadConfig(options.targetDir);
     result.previousVersion = config.version;
+    const targetPkgPath = join14(options.targetDir, "package.json");
+    if (await fileExists(targetPkgPath)) {
+      const targetPkg = await readJsonFile(targetPkgPath);
+      if (targetPkg.name === "oh-my-customcode") {
+        warn("update.self_update_skipped");
+        result.success = true;
+        result.warnings.push("Skipped: source project cannot update itself");
+        return result;
+      }
+    }
     const updateCheck = await checkForUpdates(options.targetDir);
     result.newVersion = updateCheck.latestVersion;
     if (!updateCheck.hasUpdates && !options.force) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-customcode",
   "workspaces": ["packages/*"],
-  "version": "0.45.2",
+  "version": "0.45.3",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/src/cli/projects.ts
+++ b/src/cli/projects.ts
@@ -7,6 +7,7 @@
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 import packageJson from '../../package.json';
+import { fileExists, readJsonFile, resolveTemplatePath } from '../utils/fs.js';
 
 /**
  * Lock file schema for .omcustom.lock.json
@@ -224,10 +225,23 @@ async function searchDirectory(
 }
 
 /**
+ * Get the version from the bundled templates/manifest.json.
+ * Falls back to the CLI package version if the manifest is unavailable.
+ */
+async function getTemplateVersion(): Promise<string> {
+  const manifestPath = resolveTemplatePath('manifest.json');
+  if (await fileExists(manifestPath)) {
+    const manifest = await readJsonFile<{ version: string }>(manifestPath);
+    return manifest.version;
+  }
+  return packageJson.version as string;
+}
+
+/**
  * Find all projects on the machine where oh-my-customcode is installed
  */
 export async function findProjects(options: ProjectsOptions = {}): Promise<ProjectInfo[]> {
-  const currentVersion = packageJson.version as string;
+  const currentVersion = await getTemplateVersion();
   const home = homedir();
   const seen = new Set<string>();
   const results: ProjectInfo[] = [];
@@ -367,7 +381,7 @@ function formatProjectsSimple(projects: ProjectInfo[], currentVersion: string): 
  * Execute the projects command
  */
 export async function projectsCommand(options: ProjectsOptions = {}): Promise<ProjectsResult> {
-  const currentVersion = packageJson.version as string;
+  const currentVersion = await getTemplateVersion();
   const format = options.format || 'table';
 
   console.log('  oh-my-customcode 적용 프로젝트를 검색 중...');

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -459,6 +459,17 @@ export async function update(options: UpdateOptions): Promise<UpdateResult> {
     const config = await loadConfig(options.targetDir);
     result.previousVersion = config.version;
 
+    const targetPkgPath = join(options.targetDir, 'package.json');
+    if (await fileExists(targetPkgPath)) {
+      const targetPkg = await readJsonFile<{ name?: string }>(targetPkgPath);
+      if (targetPkg.name === 'oh-my-customcode') {
+        warn('update.self_update_skipped');
+        result.success = true;
+        result.warnings.push('Skipped: source project cannot update itself');
+        return result;
+      }
+    }
+
     const updateCheck = await checkForUpdates(options.targetDir);
     result.newVersion = updateCheck.latestVersion;
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.45.2",
+  "version": "0.45.3",
   "lastUpdated": "2026-03-16T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- Fix version comparison inconsistency between `omcustom projects` and `omcustom update` (#525)
- `computeStatus()` now uses template manifest version as canonical "latest" instead of CLI binary version
- Added self-update guard: source project (oh-my-customcode itself) cannot accidentally update itself

## Test plan
- [x] All 1233 tests pass
- [x] TypeScript compilation clean