### PR TITLE
fix: v0.46.1 hotfix — build script, Web UI crash, statusline colors

### DIFF
--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -31,13 +31,13 @@ if [[ -n "${NO_COLOR}" || "${TERM}" == "dumb" ]]; then
     COLOR_CTX_WARN=""
     COLOR_CTX_CRIT=""
 else
-    COLOR_RESET="\033[0m"
-    COLOR_OPUS="\033[1;35m"    # Magenta bold
-    COLOR_SONNET="\033[0;36m"  # Cyan
-    COLOR_HAIKU="\033[0;32m"   # Green
-    COLOR_CTX_OK="\033[0;32m"  # Green   (< 60%)
-    COLOR_CTX_WARN="\033[0;33m" # Yellow (60-79%)
-    COLOR_CTX_CRIT="\033[0;31m" # Red    (>= 80%)
+    COLOR_RESET=$'\033[0m'
+    COLOR_OPUS=$'\033[1;35m'    # Magenta bold
+    COLOR_SONNET=$'\033[0;36m'  # Cyan
+    COLOR_HAIKU=$'\033[0;32m'   # Green
+    COLOR_CTX_OK=$'\033[0;32m'  # Green   (< 60%)
+    COLOR_CTX_WARN=$'\033[0;33m' # Yellow (60-79%)
+    COLOR_CTX_CRIT=$'\033[0;31m' # Red    (>= 80%)
 fi
 
 # ---------------------------------------------------------------------------

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,7 +1,7 @@
 {
   "lockfileVersion": 1,
   "generatorVersion": "0.46.1",
-  "generatedAt": "2026-03-20T01:56:35.625Z",
+  "generatedAt": "2026-03-20T01:59:09.625Z",
   "templateVersion": "0.46.1",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.46.0",
-  "generatedAt": "2026-03-20T01:45:43.936Z",
-  "templateVersion": "0.46.0",
+  "generatorVersion": "0.46.1",
+  "generatedAt": "2026-03-20T01:56:35.625Z",
+  "templateVersion": "0.46.1",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,7 +1,7 @@
 {
   "lockfileVersion": 1,
   "generatorVersion": "0.46.1",
-  "generatedAt": "2026-03-20T01:59:09.625Z",
+  "generatedAt": "2026-03-20T02:04:25.449Z",
   "templateVersion": "0.46.1",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -27758,7 +27758,7 @@ async function startServeBackground(projectRoot, port = DEFAULT_PORT) {
       OMCUSTOM_PORT: String(port),
       OMCUSTOM_HOST: "localhost",
       OMCUSTOM_ORIGIN: `http://localhost:${port}`,
-      OMCUSTOM_PROJECT_ROOT: projectRoot
+      OMX_PROJECT_ROOT: projectRoot
     },
     stdio: "ignore",
     detached: true
@@ -29684,7 +29684,7 @@ function runForeground(projectRoot, port) {
       OMCUSTOM_PORT: String(port),
       OMCUSTOM_HOST: "localhost",
       OMCUSTOM_ORIGIN: `http://localhost:${port}`,
-      OMCUSTOM_PROJECT_ROOT: projectRoot
+      OMX_PROJECT_ROOT: projectRoot
     },
     stdio: "inherit"
   });

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9305,7 +9305,7 @@ var init_package = __esm(() => {
   package_default = {
     name: "oh-my-customcode",
     workspaces: ["packages/*"],
-    version: "0.46.0",
+    version: "0.46.1",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-customcode",
   "workspaces": ["packages/*"],
-  "version": "0.46.0",
+  "version": "0.46.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/packages/serve/src/lib/server/data.ts
+++ b/packages/serve/src/lib/server/data.ts
@@ -8,8 +8,8 @@ import { parseFrontmatter } from './frontmatter.js';
 
 async function findProjectRoot(startDir: string): Promise<string> {
 	// Honor explicit env var first
-	if (process.env.OMCUSTOM_PROJECT_ROOT) {
-		return process.env.OMCUSTOM_PROJECT_ROOT;
+	if (process.env.OMX_PROJECT_ROOT) {
+		return process.env.OMX_PROJECT_ROOT;
 	}
 
 	let dir = startDir;

--- a/scripts/sync-source-lockfile.ts
+++ b/scripts/sync-source-lockfile.ts
@@ -1,0 +1,10 @@
+import { generateAndWriteLockfileForDir } from '../src/core/lockfile.js';
+
+const result = await generateAndWriteLockfileForDir(process.cwd());
+
+if (result.warning) {
+  console.error(`sync-source-lockfile: ${result.warning}`);
+  process.exit(1);
+}
+
+console.log(`sync-source-lockfile: wrote .omcustom.lock.json (${result.fileCount} files)`);

--- a/src/cli/serve-commands.ts
+++ b/src/cli/serve-commands.ts
@@ -81,7 +81,7 @@ function runForeground(projectRoot: string, port: number): void {
       OMCUSTOM_PORT: String(port),
       OMCUSTOM_HOST: 'localhost',
       OMCUSTOM_ORIGIN: `http://localhost:${port}`,
-      OMCUSTOM_PROJECT_ROOT: projectRoot,
+      OMX_PROJECT_ROOT: projectRoot,
     },
     stdio: 'inherit',
   });

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -78,7 +78,7 @@ export async function startServeBackground(
       OMCUSTOM_PORT: String(port),
       OMCUSTOM_HOST: 'localhost',
       OMCUSTOM_ORIGIN: `http://localhost:${port}`,
-      OMCUSTOM_PROJECT_ROOT: projectRoot,
+      OMX_PROJECT_ROOT: projectRoot,
     },
     stdio: 'ignore',
     detached: true,

--- a/templates/.claude/statusline.sh
+++ b/templates/.claude/statusline.sh
@@ -31,13 +31,13 @@ if [[ -n "${NO_COLOR}" || "${TERM}" == "dumb" ]]; then
     COLOR_CTX_WARN=""
     COLOR_CTX_CRIT=""
 else
-    COLOR_RESET="\033[0m"
-    COLOR_OPUS="\033[1;35m"    # Magenta bold
-    COLOR_SONNET="\033[0;36m"  # Cyan
-    COLOR_HAIKU="\033[0;32m"   # Green
-    COLOR_CTX_OK="\033[0;32m"  # Green   (< 60%)
-    COLOR_CTX_WARN="\033[0;33m" # Yellow (60-79%)
-    COLOR_CTX_CRIT="\033[0;31m" # Red    (>= 80%)
+    COLOR_RESET=$'\033[0m'
+    COLOR_OPUS=$'\033[1;35m'    # Magenta bold
+    COLOR_SONNET=$'\033[0;36m'  # Cyan
+    COLOR_HAIKU=$'\033[0;32m'   # Green
+    COLOR_CTX_OK=$'\033[0;32m'  # Green   (< 60%)
+    COLOR_CTX_WARN=$'\033[0;33m' # Yellow (60-79%)
+    COLOR_CTX_CRIT=$'\033[0;31m' # Red    (>= 80%)
 fi
 
 # ---------------------------------------------------------------------------

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.46.0",
+  "version": "0.46.1",
   "lastUpdated": "2026-03-16T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary

- Commit `scripts/sync-source-lockfile.ts` that was missing from v0.46.0 (caused CI build failure)
- Fix Web UI crash: rename `OMCUSTOM_PROJECT_ROOT` → `OMX_PROJECT_ROOT` to avoid SvelteKit envPrefix conflict
- Fix statusline RL segment ANSI escape codes rendered as raw text
- Delete incomplete v0.46.0 GitHub Release
- Bump version to 0.46.1

## Issues

- Fixes #529 — missing build script causing CI failure
- Fixes #530 — Web UI crash on startup due to envPrefix conflict
- Fixes #532 — statusline RL segment ANSI colors not rendered

Closes #529, #530, #532