### PR TITLE
fix: resolve empty project page when accessing /projects?project=slug (#537)

### DIFF
--- a/packages/serve/src/routes/+error.svelte
+++ b/packages/serve/src/routes/+error.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+</script>
+
+<div class="flex min-h-screen items-center justify-center bg-zinc-950">
+	<div class="text-center">
+		<div class="text-6xl font-bold text-zinc-700 mb-4">{$page.status}</div>
+		<h1 class="text-xl font-semibold text-zinc-300 mb-2">
+			{#if $page.status === 404}
+				Page not found
+			{:else if $page.status === 403}
+				Access denied
+			{:else if $page.status >= 500}
+				Server error
+			{:else}
+				Something went wrong
+			{/if}
+		</h1>
+		<p class="text-zinc-600 text-sm mb-6">
+			{$page.error?.message ?? 'An unexpected error occurred.'}
+		</p>
+		<a
+			href="/"
+			class="inline-block rounded px-4 py-2 text-sm font-medium bg-zinc-800 text-zinc-200 hover:bg-zinc-700 transition-colors"
+		>
+			Back to Dashboard
+		</a>
+	</div>
+</div>

--- a/packages/serve/src/routes/projects/+page.server.ts
+++ b/packages/serve/src/routes/projects/+page.server.ts
@@ -6,9 +6,20 @@ import { fail } from '@sveltejs/kit';
 
 const execAsync = promisify(exec);
 
-export const load: PageServerLoad = async () => {
+export const load: PageServerLoad = async ({ parent }) => {
+	const { selectedProject } = await parent();
 	const projects = await findProjectsForServe();
-	return { projects };
+
+	// Find the selected project if a slug is provided
+	const selectedProjectData = selectedProject
+		? (projects.find((p) => p.slug === selectedProject) ?? null)
+		: null;
+
+	return {
+		projects,
+		selectedProject,
+		selectedProjectData
+	};
 };
 
 export const actions: Actions = {

--- a/packages/serve/src/routes/projects/+page.svelte
+++ b/packages/serve/src/routes/projects/+page.svelte
@@ -33,12 +33,24 @@
 	<div class="mb-8 flex items-center justify-between">
 		<div>
 			<h1 class="text-2xl font-bold text-zinc-50">Projects</h1>
-			<p class="mt-1 text-sm text-zinc-500">
-				{data.projects.length} projects found —
-				<span class="text-emerald-400">{latestCount} latest</span>,
-				<span class="text-amber-400">{outdatedCount} outdated</span>,
-				<span class="text-zinc-500">{unknownCount} unknown</span>
-			</p>
+			{#if data.selectedProject && !data.selectedProjectData}
+				<p class="mt-1 text-sm text-amber-400">
+					Project "<span class="font-mono">{data.selectedProject}</span>" not found —
+					showing all {data.projects.length} discovered projects
+				</p>
+			{:else if data.selectedProject && data.selectedProjectData}
+				<p class="mt-1 text-sm text-zinc-500">
+					Viewing: <span class="text-zinc-300 font-medium">{data.selectedProjectData.name}</span>
+					<span class="text-zinc-700 ml-1">— {data.projects.length} total projects</span>
+				</p>
+			{:else}
+				<p class="mt-1 text-sm text-zinc-500">
+					{data.projects.length} projects found —
+					<span class="text-emerald-400">{latestCount} latest</span>,
+					<span class="text-amber-400">{outdatedCount} outdated</span>,
+					<span class="text-zinc-500">{unknownCount} unknown</span>
+				</p>
+			{/if}
 		</div>
 
 		{#if outdatedCount > 0}
@@ -79,22 +91,53 @@
 		</div>
 	{/if}
 
+	<!-- Not found state: project slug specified but not found -->
+	{#if data.selectedProject && !data.selectedProjectData}
+		<div class="mb-6 rounded-lg border border-amber-800/50 bg-amber-950/20 p-5">
+			<div class="flex items-start gap-3">
+				<span class="text-amber-400 text-lg mt-0.5">⚠</span>
+				<div>
+					<p class="text-amber-300 font-medium">Project not found</p>
+					<p class="text-amber-600 text-sm mt-1">
+						No project with slug "<span class="font-mono text-amber-400">{data.selectedProject}</span>"
+						was discovered. The project may not exist, may not have been indexed yet,
+						or may be in a directory outside the default search paths.
+					</p>
+					<p class="text-zinc-600 text-xs mt-2">
+						Searched: ~/workspace, ~/projects, ~/dev, ~/src, ~/code, ~/repos, ~/work
+					</p>
+				</div>
+			</div>
+		</div>
+	{/if}
+
 	<!-- Project cards -->
 	<div class="space-y-3">
 		{#each data.projects as project}
 			{@const config = statusConfig[project.status] ?? statusConfig.unknown}
+			{@const isSelected = project.slug === data.selectedProject}
 			<div
-				class="rounded-lg border border-zinc-800 p-5 transition-colors hover:border-zinc-700"
+				class="rounded-lg border p-5 transition-colors {isSelected
+					? 'border-emerald-700 bg-emerald-950/10 hover:border-emerald-600'
+					: 'border-zinc-800 hover:border-zinc-700'}"
 			>
 				<div class="flex items-center justify-between">
 					<div class="min-w-0 flex-1">
 						<div class="flex items-center gap-3">
-							<h3 class="text-lg font-semibold text-zinc-100">{project.name}</h3>
+							{#if isSelected}
+								<span class="text-emerald-400 text-xs">▶</span>
+							{/if}
+							<h3 class="text-lg font-semibold {isSelected ? 'text-emerald-100' : 'text-zinc-100'}">{project.name}</h3>
 							<span
 								class="rounded border px-2 py-0.5 text-xs font-medium {config.badge}"
 							>
 								{config.label}
 							</span>
+							{#if isSelected}
+								<span class="rounded border border-emerald-800 bg-emerald-950 px-2 py-0.5 text-xs font-medium text-emerald-400">
+									Active
+								</span>
+							{/if}
 						</div>
 						<p class="mt-1 truncate text-sm text-zinc-500" title={project.path}>
 							{project.path}


### PR DESCRIPTION
## Summary

- `/projects?project=slug` previously showed an empty/confusing page because the route's `load` function ignored the `?project=` query param entirely
- Updated `+page.server.ts` to call `parent()` and receive `selectedProject` from the layout, then look up the matching project data
- Updated `+page.svelte` to show a highlighted "Active" state for the selected project, a "not found" warning when the slug doesn't match any discovered project, and a contextual header message
- Added `/routes/+error.svelte` for proper 404 and server error page rendering

## Root Cause

The `/projects/+page.server.ts` used `async () =>` instead of `async ({ parent })`, so it never had access to `selectedProject` from the layout. The Svelte page component had no way to know which project was selected or show a meaningful state for an unknown slug.

## Test plan

- [ ] Visit `/projects` with no query param → shows all projects with count summary
- [ ] Visit `/projects?project=<valid-slug>` → selected project card highlighted with emerald border + "Active" badge, header shows project name
- [ ] Visit `/projects?project=nonexistent` → amber warning banner shown, all projects still listed
- [ ] Visit a non-existent route (e.g. `/doesnotexist`) → clean 404 error page with "Back to Dashboard" link

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)