### PR TITLE
feat: session auto-collection with projects and feedback schema (#534)

### DIFF
--- a/packages/eval-core/drizzle.config.ts
+++ b/packages/eval-core/drizzle.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+  schema: './src/db/schema.ts',
+  out: './drizzle',
+  dialect: 'sqlite',
+});

--- a/packages/eval-core/src/__tests__/schema-query.test.ts
+++ b/packages/eval-core/src/__tests__/schema-query.test.ts
@@ -1,0 +1,891 @@
+/**
+ * Tests for eval-core schema, query functions, and migration.
+ * Uses in-memory SQLite for isolation.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { drizzle } from 'drizzle-orm/bun-sqlite';
+import { eq } from 'drizzle-orm';
+import * as schema from '../db/schema.js';
+import type { EvalDb } from '../db/client.js';
+import { runMigrations } from '../db/migrate.js';
+import {
+  getAgentStats,
+  getDashboardStats,
+  getProjectStats,
+  getRecentSessions,
+} from '../query/dashboard.js';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createInMemoryDb(): EvalDb {
+  const sqlite = new Database(':memory:');
+  sqlite.run('PRAGMA foreign_keys = ON');
+  return drizzle(sqlite, { schema });
+}
+
+function seedProjects(db: EvalDb) {
+  const now = new Date().toISOString();
+  db.insert(schema.projects)
+    .values([
+      { name: 'project-a', cwd: '/home/user/project-a', lastSeenAt: now },
+      { name: 'project-b', cwd: '/home/user/project-b', lastSeenAt: now },
+    ])
+    .run();
+}
+
+function seedSession(
+  db: EvalDb,
+  sessionId: string,
+  projectId: number | null,
+  cwd: string | null = null,
+  startedAt = '2026-01-01T10:00:00.000Z',
+  endedAt: string | null = '2026-01-01T10:30:00.000Z'
+) {
+  db.insert(schema.sessions)
+    .values({
+      sessionId,
+      projectId,
+      startedAt,
+      endedAt,
+      cwd,
+      durationMs: endedAt
+        ? new Date(endedAt).getTime() - new Date(startedAt).getTime()
+        : null,
+      tokenSource: 'estimated',
+    })
+    .run();
+}
+
+function seedTurn(db: EvalDb, sessionId: string, turnId: string, timestamp: string) {
+  db.insert(schema.turns)
+    .values({
+      sessionId,
+      threadId: 'thread-1',
+      turnId,
+      timestamp,
+    })
+    .run();
+}
+
+function seedInvocation(
+  db: EvalDb,
+  sessionId: string,
+  ppid: string,
+  agentType: string,
+  outcome: 'success' | 'failure'
+) {
+  db.insert(schema.agentInvocations)
+    .values({
+      sessionPpid: ppid,
+      sessionId,
+      agentType,
+      model: 'claude-sonnet-4-6',
+      outcome,
+      timestamp: new Date().toISOString(),
+    })
+    .run();
+}
+
+// ---------------------------------------------------------------------------
+// Schema DDL — apply CREATE TABLE to in-memory DB
+// ---------------------------------------------------------------------------
+
+function applyDdl(db: EvalDb, sqlite: Database) {
+  const statements = [
+    `CREATE TABLE IF NOT EXISTS projects (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      cwd TEXT NOT NULL UNIQUE,
+      last_seen_at TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
+    `CREATE TABLE IF NOT EXISTS sessions (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL UNIQUE,
+      project_id INTEGER REFERENCES projects(id),
+      started_at TEXT NOT NULL,
+      ended_at TEXT,
+      cwd TEXT,
+      pid INTEGER,
+      duration_ms INTEGER,
+      input_tokens INTEGER,
+      output_tokens INTEGER,
+      total_tokens INTEGER,
+      estimated_cost_usd REAL,
+      token_source TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
+    `CREATE TABLE IF NOT EXISTS turns (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL REFERENCES sessions(session_id),
+      thread_id TEXT NOT NULL,
+      turn_id TEXT NOT NULL UNIQUE,
+      input_preview TEXT,
+      output_preview TEXT,
+      input_chars INTEGER,
+      output_chars INTEGER,
+      estimated_input_tokens INTEGER,
+      estimated_output_tokens INTEGER,
+      timestamp TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
+    `CREATE TABLE IF NOT EXISTS agent_invocations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_ppid TEXT NOT NULL,
+      session_id TEXT,
+      timestamp TEXT NOT NULL,
+      agent_type TEXT NOT NULL,
+      model TEXT NOT NULL,
+      outcome TEXT NOT NULL,
+      pattern_used TEXT,
+      skill_name TEXT,
+      description TEXT,
+      error_summary TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
+    `CREATE TABLE IF NOT EXISTS evaluations (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      turn_id TEXT REFERENCES turns(turn_id),
+      session_id TEXT REFERENCES sessions(session_id),
+      score INTEGER,
+      verdict TEXT,
+      tags TEXT,
+      comment TEXT,
+      evaluated_at TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
+    `CREATE TABLE IF NOT EXISTS session_feedback (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL REFERENCES sessions(session_id),
+      rating INTEGER,
+      tags TEXT,
+      comment TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
+  ];
+  for (const sql of statements) {
+    sqlite.run(sql);
+  }
+}
+
+// Create an in-memory DB with DDL applied. Returns both the drizzle wrapper
+// and the raw sqlite handle so tests can verify via raw SQL if needed.
+function makeDb(): { db: EvalDb; sqlite: Database } {
+  const sqlite = new Database(':memory:');
+  sqlite.run('PRAGMA foreign_keys = ON');
+  const db = drizzle(sqlite, { schema });
+  applyDdl(db, sqlite);
+  return { db, sqlite };
+}
+
+// ---------------------------------------------------------------------------
+// Migration tests
+// ---------------------------------------------------------------------------
+
+describe('runMigrations', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'eval-core-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates all expected tables', () => {
+    const dbPath = join(tmpDir, 'test.db');
+    runMigrations(dbPath);
+    const db = new Database(dbPath);
+    const tables = db
+      .prepare<{ name: string }, []>(
+        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+      )
+      .all();
+    const names = tables.map((t) => t.name);
+    expect(names).toContain('projects');
+    expect(names).toContain('sessions');
+    expect(names).toContain('turns');
+    expect(names).toContain('agent_invocations');
+    expect(names).toContain('evaluations');
+    expect(names).toContain('session_feedback');
+    db.close();
+  });
+
+  it('is idempotent — running twice does not throw', () => {
+    const dbPath = join(tmpDir, 'idempotent.db');
+    expect(() => {
+      runMigrations(dbPath);
+      runMigrations(dbPath);
+    }).not.toThrow();
+  });
+
+  it('creates indexes for performance-critical columns', () => {
+    const dbPath = join(tmpDir, 'indexes.db');
+    runMigrations(dbPath);
+    const db = new Database(dbPath);
+    const indexes = db
+      .prepare<{ name: string }, []>(
+        "SELECT name FROM sqlite_master WHERE type='index' ORDER BY name"
+      )
+      .all();
+    const indexNames = indexes.map((i) => i.name);
+    expect(indexNames).toContain('idx_projects_cwd');
+    expect(indexNames).toContain('idx_sessions_session_id');
+    expect(indexNames).toContain('idx_sessions_project_id');
+    expect(indexNames).toContain('idx_turns_session_id');
+    expect(indexNames).toContain('idx_invocations_ppid');
+    expect(indexNames).toContain('idx_feedback_session_id');
+    db.close();
+  });
+
+  it('enables WAL journal mode', () => {
+    const dbPath = join(tmpDir, 'wal.db');
+    runMigrations(dbPath);
+    const db = new Database(dbPath);
+    const row = db.prepare<{ journal_mode: string }, []>('PRAGMA journal_mode').get();
+    expect(row?.journal_mode).toBe('wal');
+    db.close();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema: FK constraints
+// ---------------------------------------------------------------------------
+
+describe('schema FK constraints', () => {
+  it('rejects session referencing non-existent project', () => {
+    const { sqlite } = makeDb();
+    expect(() => {
+      sqlite.run(
+        `INSERT INTO sessions (session_id, project_id, started_at) VALUES ('s1', 999, '2026-01-01T00:00:00Z')`
+      );
+    }).toThrow();
+  });
+
+  it('allows session with NULL project_id (project association is optional)', () => {
+    const { sqlite } = makeDb();
+    expect(() => {
+      sqlite.run(
+        `INSERT INTO sessions (session_id, project_id, started_at) VALUES ('s1', NULL, '2026-01-01T00:00:00Z')`
+      );
+    }).not.toThrow();
+  });
+
+  it('rejects turn referencing non-existent session', () => {
+    const { sqlite } = makeDb();
+    expect(() => {
+      sqlite.run(
+        `INSERT INTO turns (session_id, thread_id, turn_id, timestamp)
+         VALUES ('nonexistent', 'th1', 'tr1', '2026-01-01T00:00:00Z')`
+      );
+    }).toThrow();
+  });
+
+  it('rejects session_feedback referencing non-existent session', () => {
+    const { sqlite } = makeDb();
+    expect(() => {
+      sqlite.run(
+        `INSERT INTO session_feedback (session_id, rating) VALUES ('ghost-session', 5)`
+      );
+    }).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema: uniqueness constraints
+// ---------------------------------------------------------------------------
+
+describe('schema uniqueness constraints', () => {
+  it('rejects duplicate project cwd', () => {
+    const { db } = makeDb();
+    const now = new Date().toISOString();
+    db.insert(schema.projects)
+      .values({ name: 'p', cwd: '/home/dup', lastSeenAt: now })
+      .run();
+    expect(() => {
+      db.insert(schema.projects)
+        .values({ name: 'p2', cwd: '/home/dup', lastSeenAt: now })
+        .run();
+    }).toThrow();
+  });
+
+  it('allows two projects with different cwd but same name', () => {
+    const { db } = makeDb();
+    const now = new Date().toISOString();
+    db.insert(schema.projects)
+      .values([
+        { name: 'same-name', cwd: '/path/one', lastSeenAt: now },
+        { name: 'same-name', cwd: '/path/two', lastSeenAt: now },
+      ])
+      .run();
+    const rows = db.select().from(schema.projects).all();
+    expect(rows).toHaveLength(2);
+  });
+
+  it('rejects duplicate session_id', () => {
+    const { db } = makeDb();
+    seedSession(db, 'sess-dup', null);
+    expect(() => {
+      seedSession(db, 'sess-dup', null);
+    }).toThrow();
+  });
+
+  it('rejects duplicate turn_id', () => {
+    const { db } = makeDb();
+    seedSession(db, 'sess-1', null, null, '2026-01-01T10:00:00.000Z', '2026-01-01T11:00:00.000Z');
+    seedTurn(db, 'sess-1', 'turn-dup', '2026-01-01T10:05:00.000Z');
+    expect(() => {
+      seedTurn(db, 'sess-1', 'turn-dup', '2026-01-01T10:06:00.000Z');
+    }).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Project CRUD
+// ---------------------------------------------------------------------------
+
+describe('project CRUD', () => {
+  it('inserts and retrieves a project', () => {
+    const { db } = makeDb();
+    const now = new Date().toISOString();
+    db.insert(schema.projects)
+      .values({ name: 'my-project', cwd: '/workspace/my-project', lastSeenAt: now })
+      .run();
+    const row = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.cwd, '/workspace/my-project'))
+      .get();
+    expect(row).toBeDefined();
+    expect(row?.name).toBe('my-project');
+    expect(row?.cwd).toBe('/workspace/my-project');
+  });
+
+  it('updates lastSeenAt on project upsert pattern', () => {
+    const { db } = makeDb();
+    const first = '2026-01-01T00:00:00.000Z';
+    const second = '2026-01-02T00:00:00.000Z';
+    db.insert(schema.projects)
+      .values({ name: 'p', cwd: '/cwd', lastSeenAt: first })
+      .run();
+    db.update(schema.projects)
+      .set({ lastSeenAt: second })
+      .where(eq(schema.projects.cwd, '/cwd'))
+      .run();
+    const row = db.select().from(schema.projects).where(eq(schema.projects.cwd, '/cwd')).get();
+    expect(row?.lastSeenAt).toBe(second);
+  });
+
+  it('autoIncrement generates distinct IDs', () => {
+    const { db } = makeDb();
+    const now = new Date().toISOString();
+    db.insert(schema.projects)
+      .values([
+        { name: 'a', cwd: '/a', lastSeenAt: now },
+        { name: 'b', cwd: '/b', lastSeenAt: now },
+        { name: 'c', cwd: '/c', lastSeenAt: now },
+      ])
+      .run();
+    const rows = db.select().from(schema.projects).all();
+    const ids = rows.map((r) => r.id);
+    expect(new Set(ids).size).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session-project association
+// ---------------------------------------------------------------------------
+
+describe('session-project association', () => {
+  it('links session to correct project via projectId', () => {
+    const { db } = makeDb();
+    seedProjects(db);
+    const project = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.cwd, '/home/user/project-a'))
+      .get();
+    expect(project).toBeDefined();
+    seedSession(db, 'sess-linked', project!.id);
+    const sess = db
+      .select()
+      .from(schema.sessions)
+      .where(eq(schema.sessions.sessionId, 'sess-linked'))
+      .get();
+    expect(sess?.projectId).toBe(project!.id);
+  });
+
+  it('allows sessions without project (projectId = null)', () => {
+    const { db } = makeDb();
+    seedSession(db, 'sess-orphan', null);
+    const sess = db
+      .select()
+      .from(schema.sessions)
+      .where(eq(schema.sessions.sessionId, 'sess-orphan'))
+      .get();
+    expect(sess?.projectId).toBeNull();
+  });
+
+  it('multiple sessions can belong to the same project', () => {
+    const { db } = makeDb();
+    seedProjects(db);
+    const project = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.cwd, '/home/user/project-a'))
+      .get();
+    seedSession(db, 'sess-a1', project!.id, null, '2026-01-01T10:00:00Z', '2026-01-01T10:30:00Z');
+    seedSession(db, 'sess-a2', project!.id, null, '2026-01-02T10:00:00Z', '2026-01-02T10:30:00Z');
+    const rows = db
+      .select()
+      .from(schema.sessions)
+      .where(eq(schema.sessions.projectId, project!.id))
+      .all();
+    expect(rows).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// session_feedback schema (schema-only — no query helpers yet)
+// ---------------------------------------------------------------------------
+
+describe('session_feedback schema', () => {
+  it('inserts feedback linked to a valid session', () => {
+    const { db } = makeDb();
+    seedSession(db, 'sess-fb', null);
+    db.insert(schema.sessionFeedback)
+      .values({
+        sessionId: 'sess-fb',
+        rating: 5,
+        tags: JSON.stringify(['helpful', 'concise']),
+        comment: 'Great session',
+      })
+      .run();
+    const rows = db
+      .select()
+      .from(schema.sessionFeedback)
+      .where(eq(schema.sessionFeedback.sessionId, 'sess-fb'))
+      .all();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.rating).toBe(5);
+    expect(rows[0]?.comment).toBe('Great session');
+  });
+
+  it('allows multiple feedback entries per session', () => {
+    const { db } = makeDb();
+    seedSession(db, 'sess-multi-fb', null);
+    db.insert(schema.sessionFeedback)
+      .values([
+        { sessionId: 'sess-multi-fb', rating: 4 },
+        { sessionId: 'sess-multi-fb', rating: 3, comment: 'Could be better' },
+      ])
+      .run();
+    const rows = db
+      .select()
+      .from(schema.sessionFeedback)
+      .where(eq(schema.sessionFeedback.sessionId, 'sess-multi-fb'))
+      .all();
+    expect(rows).toHaveLength(2);
+  });
+
+  it('allows null rating and comment (optional fields)', () => {
+    const { db } = makeDb();
+    seedSession(db, 'sess-min-fb', null);
+    db.insert(schema.sessionFeedback)
+      .values({ sessionId: 'sess-min-fb' })
+      .run();
+    const row = db
+      .select()
+      .from(schema.sessionFeedback)
+      .where(eq(schema.sessionFeedback.sessionId, 'sess-min-fb'))
+      .get();
+    expect(row?.rating).toBeNull();
+    expect(row?.comment).toBeNull();
+  });
+
+  it('rejects feedback with rating out of declared range via app-level validation concern', () => {
+    // SQLite does not enforce CHECK constraints unless added to DDL.
+    // The current schema does NOT include a CHECK constraint on rating.
+    // This test documents the absence and serves as a reminder for future enforcement.
+    const { db } = makeDb();
+    seedSession(db, 'sess-bad-rating', null);
+    // Rating = 99 is stored without error — schema has no CHECK constraint yet
+    db.insert(schema.sessionFeedback)
+      .values({ sessionId: 'sess-bad-rating', rating: 99 })
+      .run();
+    const row = db
+      .select()
+      .from(schema.sessionFeedback)
+      .where(eq(schema.sessionFeedback.sessionId, 'sess-bad-rating'))
+      .get();
+    // Documents current behavior: app must validate 1-5 range
+    expect(row?.rating).toBe(99);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query: getProjectStats
+// ---------------------------------------------------------------------------
+
+describe('getProjectStats', () => {
+  it('returns empty array when no projects exist', () => {
+    const { db } = makeDb();
+    const stats = getProjectStats(db);
+    expect(stats).toEqual([]);
+  });
+
+  it('returns correct sessionCount, totalTurns, totalInvocations', () => {
+    const { db } = makeDb();
+    seedProjects(db);
+    const project = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.cwd, '/home/user/project-a'))
+      .get()!;
+
+    seedSession(db, 'sess-pa-1', project.id, null, '2026-01-01T10:00:00Z', '2026-01-01T11:00:00Z');
+    seedSession(db, 'sess-pa-2', project.id, null, '2026-01-02T10:00:00Z', '2026-01-02T11:00:00Z');
+    seedTurn(db, 'sess-pa-1', 'turn-pa-1', '2026-01-01T10:05:00Z');
+    seedTurn(db, 'sess-pa-1', 'turn-pa-2', '2026-01-01T10:10:00Z');
+    seedInvocation(db, 'sess-pa-1', 'ppid-1', 'lang-typescript-expert', 'success');
+
+    const stats = getProjectStats(db);
+    const pa = stats.find((s) => s.cwd === '/home/user/project-a');
+    expect(pa).toBeDefined();
+    expect(pa?.sessionCount).toBe(2);
+    expect(pa?.totalTurns).toBe(2);
+    expect(pa?.totalInvocations).toBe(1);
+  });
+
+  it('orders projects by lastSeenAt descending', () => {
+    const { db } = makeDb();
+    db.insert(schema.projects)
+      .values([
+        { name: 'older', cwd: '/older', lastSeenAt: '2026-01-01T00:00:00Z' },
+        { name: 'newer', cwd: '/newer', lastSeenAt: '2026-01-02T00:00:00Z' },
+      ])
+      .run();
+    const stats = getProjectStats(db);
+    expect(stats[0]?.name).toBe('newer');
+    expect(stats[1]?.name).toBe('older');
+  });
+
+  it('returns zero counts for project with no sessions', () => {
+    const { db } = makeDb();
+    const now = new Date().toISOString();
+    db.insert(schema.projects)
+      .values({ name: 'empty-project', cwd: '/empty', lastSeenAt: now })
+      .run();
+    const stats = getProjectStats(db);
+    expect(stats[0]?.sessionCount).toBe(0);
+    expect(stats[0]?.totalTurns).toBe(0);
+    expect(stats[0]?.totalInvocations).toBe(0);
+  });
+
+  it('does not count sessions/turns from other projects', () => {
+    const { db } = makeDb();
+    seedProjects(db);
+    const pa = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.cwd, '/home/user/project-a'))
+      .get()!;
+    const pb = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.cwd, '/home/user/project-b'))
+      .get()!;
+
+    seedSession(db, 'sess-a', pa.id, null, '2026-01-01T10:00:00Z', '2026-01-01T11:00:00Z');
+    seedSession(db, 'sess-b', pb.id, null, '2026-01-01T10:00:00Z', '2026-01-01T11:00:00Z');
+    seedTurn(db, 'sess-a', 'turn-a', '2026-01-01T10:05:00Z');
+    seedTurn(db, 'sess-b', 'turn-b', '2026-01-01T10:05:00Z');
+
+    const stats = getProjectStats(db);
+    const statsA = stats.find((s) => s.cwd === '/home/user/project-a');
+    const statsB = stats.find((s) => s.cwd === '/home/user/project-b');
+    expect(statsA?.totalTurns).toBe(1);
+    expect(statsB?.totalTurns).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query: getRecentSessions
+// ---------------------------------------------------------------------------
+
+describe('getRecentSessions', () => {
+  it('returns empty array when no sessions exist', () => {
+    const { db } = makeDb();
+    const result = getRecentSessions(db);
+    expect(result).toEqual([]);
+  });
+
+  it('respects limit parameter', () => {
+    const { db } = makeDb();
+    for (let i = 0; i < 25; i++) {
+      seedSession(
+        db,
+        `sess-${i.toString().padStart(2, '0')}`,
+        null,
+        null,
+        `2026-01-${String(i + 1).padStart(2, '0')}T10:00:00Z`,
+        `2026-01-${String(i + 1).padStart(2, '0')}T11:00:00Z`
+      );
+    }
+    const result = getRecentSessions(db, 5);
+    expect(result).toHaveLength(5);
+  });
+
+  it('returns sessions ordered by startedAt descending', () => {
+    const { db } = makeDb();
+    seedSession(db, 'older-sess', null, null, '2026-01-01T10:00:00Z', '2026-01-01T11:00:00Z');
+    seedSession(db, 'newer-sess', null, null, '2026-01-02T10:00:00Z', '2026-01-02T11:00:00Z');
+    const result = getRecentSessions(db, 10);
+    expect(result[0]?.sessionId).toBe('newer-sess');
+    expect(result[1]?.sessionId).toBe('older-sess');
+  });
+
+  it('includes projectName when session has a project', () => {
+    const { db } = makeDb();
+    seedProjects(db);
+    const project = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.cwd, '/home/user/project-a'))
+      .get()!;
+    seedSession(db, 'sess-with-proj', project.id);
+    const result = getRecentSessions(db, 10);
+    expect(result[0]?.projectName).toBe('project-a');
+    expect(result[0]?.projectId).toBe(project.id);
+  });
+
+  it('returns null projectName for sessions without a project', () => {
+    const { db } = makeDb();
+    seedSession(db, 'sess-no-proj', null);
+    const result = getRecentSessions(db, 10);
+    expect(result[0]?.projectName).toBeNull();
+    expect(result[0]?.projectId).toBeNull();
+  });
+
+  it('includes correct turnCount and invocationCount', () => {
+    const { db } = makeDb();
+    seedSession(db, 'sess-counts', null, null, '2026-01-01T10:00:00Z', '2026-01-01T11:00:00Z');
+    seedTurn(db, 'sess-counts', 'turn-c1', '2026-01-01T10:05:00Z');
+    seedTurn(db, 'sess-counts', 'turn-c2', '2026-01-01T10:10:00Z');
+    seedInvocation(db, 'sess-counts', 'ppid-x', 'lang-python-expert', 'success');
+    seedInvocation(db, 'sess-counts', 'ppid-x', 'lang-golang-expert', 'failure');
+    const result = getRecentSessions(db, 10);
+    const s = result.find((r) => r.sessionId === 'sess-counts');
+    expect(s?.turnCount).toBe(2);
+    expect(s?.invocationCount).toBe(2);
+  });
+
+  it('uses default limit of 20', () => {
+    const { db } = makeDb();
+    for (let i = 0; i < 22; i++) {
+      seedSession(
+        db,
+        `sess-def-${i}`,
+        null,
+        null,
+        `2026-01-01T${String(i).padStart(2, '0')}:00:00Z`,
+        `2026-01-01T${String(i).padStart(2, '0')}:30:00Z`
+      );
+    }
+    const result = getRecentSessions(db);
+    expect(result).toHaveLength(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query: getAgentStats
+// ---------------------------------------------------------------------------
+
+describe('getAgentStats', () => {
+  it('returns empty array when no invocations exist', () => {
+    const { db } = makeDb();
+    const stats = getAgentStats(db);
+    expect(stats).toEqual([]);
+  });
+
+  it('computes successRate correctly', () => {
+    const { db } = makeDb();
+    seedSession(db, 'sess-ag', null);
+    seedInvocation(db, 'sess-ag', 'ppid-1', 'lang-typescript-expert', 'success');
+    seedInvocation(db, 'sess-ag', 'ppid-1', 'lang-typescript-expert', 'success');
+    seedInvocation(db, 'sess-ag', 'ppid-1', 'lang-typescript-expert', 'failure');
+    const stats = getAgentStats(db);
+    const ts = stats.find((s) => s.agentType === 'lang-typescript-expert');
+    expect(ts?.totalInvocations).toBe(3);
+    expect(ts?.successCount).toBe(2);
+    expect(ts?.failureCount).toBe(1);
+    expect(ts?.successRate).toBeCloseTo(2 / 3);
+  });
+
+  it('returns successRate = 0 when all invocations are failures', () => {
+    const { db } = makeDb();
+    seedSession(db, 'sess-fail', null);
+    seedInvocation(db, 'sess-fail', 'ppid-2', 'mgr-gitnerd', 'failure');
+    seedInvocation(db, 'sess-fail', 'ppid-2', 'mgr-gitnerd', 'failure');
+    const stats = getAgentStats(db);
+    const s = stats.find((a) => a.agentType === 'mgr-gitnerd');
+    expect(s?.successRate).toBe(0);
+    expect(s?.failureCount).toBe(2);
+  });
+
+  it('returns successRate = 1 when all invocations succeed', () => {
+    const { db } = makeDb();
+    seedSession(db, 'sess-win', null);
+    seedInvocation(db, 'sess-win', 'ppid-3', 'qa-engineer', 'success');
+    seedInvocation(db, 'sess-win', 'ppid-3', 'qa-engineer', 'success');
+    const stats = getAgentStats(db);
+    const s = stats.find((a) => a.agentType === 'qa-engineer');
+    expect(s?.successRate).toBe(1);
+  });
+
+  it('orders agents by total invocations descending', () => {
+    const { db } = makeDb();
+    seedSession(db, 'sess-order', null);
+    seedInvocation(db, 'sess-order', 'ppid-4', 'less-used', 'success');
+    seedInvocation(db, 'sess-order', 'ppid-4', 'more-used', 'success');
+    seedInvocation(db, 'sess-order', 'ppid-4', 'more-used', 'success');
+    const stats = getAgentStats(db);
+    expect(stats[0]?.agentType).toBe('more-used');
+    expect(stats[1]?.agentType).toBe('less-used');
+  });
+
+  it('does not count agents across different sessions incorrectly', () => {
+    const { db } = makeDb();
+    seedSession(db, 'sess-x1', null);
+    seedSession(db, 'sess-x2', null);
+    seedInvocation(db, 'sess-x1', 'ppid-a', 'agent-x', 'success');
+    seedInvocation(db, 'sess-x2', 'ppid-b', 'agent-x', 'failure');
+    const stats = getAgentStats(db);
+    const s = stats.find((a) => a.agentType === 'agent-x');
+    expect(s?.totalInvocations).toBe(2);
+    expect(s?.successCount).toBe(1);
+    expect(s?.failureCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query: getDashboardStats
+// ---------------------------------------------------------------------------
+
+describe('getDashboardStats', () => {
+  it('returns zero counts on empty database', () => {
+    const { db } = makeDb();
+    const stats = getDashboardStats(db);
+    expect(stats.totalSessions).toBe(0);
+    expect(stats.totalTurns).toBe(0);
+    expect(stats.totalInvocations).toBe(0);
+    expect(stats.totalProjects).toBe(0);
+    expect(stats.recentSessions).toEqual([]);
+    expect(stats.topAgents).toEqual([]);
+  });
+
+  it('aggregates counts correctly', () => {
+    const { db } = makeDb();
+    seedProjects(db);
+    const project = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.cwd, '/home/user/project-a'))
+      .get()!;
+    seedSession(db, 'sess-d1', project.id, null, '2026-01-01T10:00:00Z', '2026-01-01T11:00:00Z');
+    seedSession(db, 'sess-d2', project.id, null, '2026-01-02T10:00:00Z', '2026-01-02T11:00:00Z');
+    seedTurn(db, 'sess-d1', 'turn-d1', '2026-01-01T10:05:00Z');
+    seedInvocation(db, 'sess-d1', 'ppid-d', 'lang-golang-expert', 'success');
+
+    const stats = getDashboardStats(db);
+    expect(stats.totalSessions).toBe(2);
+    expect(stats.totalTurns).toBe(1);
+    expect(stats.totalInvocations).toBe(1);
+    expect(stats.totalProjects).toBe(2); // project-a + project-b from seedProjects
+  });
+
+  it('recentSessions is capped at 10', () => {
+    const { db } = makeDb();
+    for (let i = 0; i < 15; i++) {
+      seedSession(
+        db,
+        `sess-dash-${i}`,
+        null,
+        null,
+        `2026-01-${String(i + 1).padStart(2, '0')}T10:00:00Z`,
+        `2026-01-${String(i + 1).padStart(2, '0')}T11:00:00Z`
+      );
+    }
+    const stats = getDashboardStats(db);
+    expect(stats.recentSessions.length).toBeLessThanOrEqual(10);
+  });
+
+  it('topAgents is capped at 10', () => {
+    const { db } = makeDb();
+    seedSession(db, 'sess-top', null);
+    for (let i = 0; i < 15; i++) {
+      seedInvocation(db, 'sess-top', 'ppid-top', `agent-type-${i}`, 'success');
+    }
+    const stats = getDashboardStats(db);
+    expect(stats.topAgents.length).toBeLessThanOrEqual(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases: collect upsertProject behavior
+// ---------------------------------------------------------------------------
+
+describe('upsertProject (via collect logic)', () => {
+  it('reuses existing project for same cwd', () => {
+    const { db } = makeDb();
+    const now = new Date().toISOString();
+    // First insert
+    db.insert(schema.projects)
+      .values({ name: 'my-proj', cwd: '/workspace/my-proj', lastSeenAt: now })
+      .run();
+    // Simulate upsert: update if exists (same as collect/index.ts upsertProject logic)
+    const existing = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.cwd, '/workspace/my-proj'))
+      .get();
+    expect(existing).toBeDefined();
+    const laterTime = new Date(Date.now() + 5000).toISOString();
+    db.update(schema.projects)
+      .set({ lastSeenAt: laterTime })
+      .where(eq(schema.projects.cwd, '/workspace/my-proj'))
+      .run();
+    const rows = db.select().from(schema.projects).all();
+    // Only one project entry — not duplicated
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.lastSeenAt).toBe(laterTime);
+  });
+
+  it('creates new project for previously unseen cwd', () => {
+    const { db } = makeDb();
+    const now = new Date().toISOString();
+    const noExisting = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.cwd, '/new/path'))
+      .get();
+    expect(noExisting).toBeUndefined();
+    db.insert(schema.projects)
+      .values({ name: 'new', cwd: '/new/path', lastSeenAt: now })
+      .run();
+    const row = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.cwd, '/new/path'))
+      .get();
+    expect(row?.name).toBe('new');
+  });
+});

--- a/packages/eval-core/src/cli/index.ts
+++ b/packages/eval-core/src/cli/index.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env bun
 import { Command } from 'commander';
 import { collectCommand } from './collect.cmd.js';
+import { listCommand } from './list.cmd.js';
 import { migrateCommand } from './migrate.cmd.js';
+import { showCommand } from './show.cmd.js';
 
 const program = new Command()
   .name('eval-core')
@@ -10,5 +12,7 @@ const program = new Command()
 
 program.addCommand(collectCommand);
 program.addCommand(migrateCommand);
+program.addCommand(listCommand);
+program.addCommand(showCommand);
 
 program.parse();

--- a/packages/eval-core/src/cli/list.cmd.ts
+++ b/packages/eval-core/src/cli/list.cmd.ts
@@ -1,0 +1,126 @@
+import { Command } from 'commander';
+import { createDb } from '../db/client.js';
+import { runMigrations } from '../db/migrate.js';
+import { getProjectStats, getRecentSessions } from '../query/index.js';
+import { getDefaultConfig } from '../types/config.js';
+
+interface ListCliOptions {
+  dbPath?: string;
+  limit?: string;
+  format?: string;
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return '-';
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${minutes}m${secs}s`;
+}
+
+function formatCost(usd: number | null): string {
+  if (usd === null) return '-';
+  return `$${usd.toFixed(4)}`;
+}
+
+const listProjectsCommand = new Command('projects')
+  .description('List all tracked projects')
+  .option('--db-path <path>', 'Database file path')
+  .option('--format <format>', 'Output format: table | json', 'table')
+  .action((options: ListCliOptions) => {
+    const config = getDefaultConfig();
+    const dbPath = options.dbPath ?? config.sqlitePath;
+    runMigrations(dbPath);
+    const db = createDb(dbPath);
+    const stats = getProjectStats(db);
+
+    if (options.format === 'json') {
+      console.log(JSON.stringify(stats, null, 2));
+      return;
+    }
+
+    if (stats.length === 0) {
+      console.log('No projects found. Run `eval-core collect` to import session data.');
+      return;
+    }
+
+    console.log(`\nProjects (${stats.length})\n`);
+    console.log(
+      'ID'.padEnd(4) +
+        'Name'.padEnd(25) +
+        'Sessions'.padEnd(10) +
+        'Turns'.padEnd(8) +
+        'Invocations'.padEnd(13) +
+        'Last Seen'
+    );
+    console.log('-'.repeat(80));
+
+    for (const p of stats) {
+      const lastSeen = p.lastSeenAt.split('T')[0];
+      console.log(
+        String(p.id).padEnd(4) +
+          p.name.slice(0, 23).padEnd(25) +
+          String(p.sessionCount).padEnd(10) +
+          String(p.totalTurns).padEnd(8) +
+          String(p.totalInvocations).padEnd(13) +
+          lastSeen
+      );
+    }
+    console.log('');
+  });
+
+const listSessionsCommand = new Command('sessions')
+  .description('List recent sessions')
+  .option('--db-path <path>', 'Database file path')
+  .option('--limit <n>', 'Number of sessions to show', '20')
+  .option('--format <format>', 'Output format: table | json', 'table')
+  .action((options: ListCliOptions) => {
+    const config = getDefaultConfig();
+    const dbPath = options.dbPath ?? config.sqlitePath;
+    runMigrations(dbPath);
+    const db = createDb(dbPath);
+    const limit = parseInt(options.limit ?? '20', 10);
+    const sessions = getRecentSessions(db, limit);
+
+    if (options.format === 'json') {
+      console.log(JSON.stringify(sessions, null, 2));
+      return;
+    }
+
+    if (sessions.length === 0) {
+      console.log('No sessions found. Run `eval-core collect` to import session data.');
+      return;
+    }
+
+    console.log(`\nRecent Sessions (${sessions.length})\n`);
+    console.log(
+      'Session ID'.padEnd(22) +
+        'Project'.padEnd(20) +
+        'Started'.padEnd(20) +
+        'Duration'.padEnd(10) +
+        'Turns'.padEnd(7) +
+        'Cost'
+    );
+    console.log('-'.repeat(85));
+
+    for (const s of sessions) {
+      const started = s.startedAt.replace('T', ' ').slice(0, 19);
+      const project = (s.projectName ?? s.cwd ?? '-').slice(0, 18);
+      const sessionShort = s.sessionId.slice(0, 20);
+      console.log(
+        sessionShort.padEnd(22) +
+          project.padEnd(20) +
+          started.padEnd(20) +
+          formatDuration(s.durationMs).padEnd(10) +
+          String(s.turnCount).padEnd(7) +
+          formatCost(s.estimatedCostUsd)
+      );
+    }
+    console.log('');
+  });
+
+export const listCommand = new Command('list')
+  .description('List projects or sessions')
+  .addCommand(listProjectsCommand)
+  .addCommand(listSessionsCommand);

--- a/packages/eval-core/src/cli/show.cmd.ts
+++ b/packages/eval-core/src/cli/show.cmd.ts
@@ -1,0 +1,100 @@
+import { Command } from 'commander';
+import { eq } from 'drizzle-orm';
+import { createDb } from '../db/client.js';
+import { agentInvocations, sessions, turns } from '../db/schema.js';
+import { runMigrations } from '../db/migrate.js';
+import { getDefaultConfig } from '../types/config.js';
+
+interface ShowCliOptions {
+  dbPath?: string;
+  format?: string;
+}
+
+export const showCommand = new Command('show')
+  .description('Show session detail by session ID (prefix match supported)')
+  .argument('<session-id>', 'Session ID or prefix')
+  .option('--db-path <path>', 'Database file path')
+  .option('--format <format>', 'Output format: text | json', 'text')
+  .action((sessionIdArg: string, options: ShowCliOptions) => {
+    const config = getDefaultConfig();
+    const dbPath = options.dbPath ?? config.sqlitePath;
+    runMigrations(dbPath);
+    const db = createDb(dbPath);
+
+    // Prefix match: find a session whose ID starts with the provided prefix
+    const allSessions = db.select().from(sessions).all();
+    const session = allSessions.find(
+      (s) => s.sessionId === sessionIdArg || s.sessionId.startsWith(sessionIdArg)
+    );
+
+    if (!session) {
+      console.error(`Session not found: ${sessionIdArg}`);
+      process.exit(1);
+    }
+
+    const sessionTurns = db
+      .select()
+      .from(turns)
+      .where(eq(turns.sessionId, session.sessionId))
+      .all();
+
+    const sessionInvocations = db
+      .select()
+      .from(agentInvocations)
+      .where(eq(agentInvocations.sessionId, session.sessionId))
+      .all();
+
+    const detail = {
+      session,
+      turns: sessionTurns,
+      invocations: sessionInvocations,
+    };
+
+    if (options.format === 'json') {
+      console.log(JSON.stringify(detail, null, 2));
+      return;
+    }
+
+    // Text format
+    const durationMs = session.durationMs;
+    const durationStr = durationMs != null
+      ? `${Math.floor(durationMs / 1000)}s`
+      : 'ongoing';
+
+    console.log('\n' + '='.repeat(60));
+    console.log(`Session: ${session.sessionId}`);
+    console.log('='.repeat(60));
+    console.log(`Started:   ${session.startedAt}`);
+    console.log(`Ended:     ${session.endedAt ?? 'ongoing'}`);
+    console.log(`Duration:  ${durationStr}`);
+    console.log(`CWD:       ${session.cwd ?? '-'}`);
+    console.log(`PID:       ${session.pid ?? '-'}`);
+    console.log(`Cost:      ${session.estimatedCostUsd != null ? `$${session.estimatedCostUsd.toFixed(4)}` : '-'}`);
+    console.log('');
+
+    console.log(`Turns (${sessionTurns.length})`);
+    console.log('-'.repeat(60));
+    for (const t of sessionTurns) {
+      const ts = t.timestamp.replace('T', ' ').slice(0, 19);
+      const input = (t.inputPreview ?? '').slice(0, 60).replace(/\n/g, ' ');
+      const output = (t.outputPreview ?? '').slice(0, 60).replace(/\n/g, ' ');
+      console.log(`  [${ts}] ${t.turnId.slice(0, 8)}`);
+      if (input) console.log(`    Input:  ${input}`);
+      if (output) console.log(`    Output: ${output}`);
+    }
+
+    if (sessionInvocations.length > 0) {
+      console.log('');
+      console.log(`Agent Invocations (${sessionInvocations.length})`);
+      console.log('-'.repeat(60));
+      for (const inv of sessionInvocations) {
+        const ts = inv.timestamp.replace('T', ' ').slice(0, 19);
+        const status = inv.outcome === 'success' ? '✓' : '✗';
+        console.log(`  ${status} [${ts}] ${inv.agentType} (${inv.model})`);
+        if (inv.skillName) console.log(`    Skill: ${inv.skillName}`);
+        if (inv.errorSummary) console.log(`    Error: ${inv.errorSummary}`);
+      }
+    }
+
+    console.log('');
+  });

--- a/packages/eval-core/src/collect/index.ts
+++ b/packages/eval-core/src/collect/index.ts
@@ -1,6 +1,7 @@
 import { eq } from 'drizzle-orm';
+import { basename } from 'node:path';
 import { createDb, type EvalDb } from '../db/client.js';
-import { agentInvocations, sessions, turns } from '../db/schema.js';
+import { agentInvocations, projects, sessions, turns } from '../db/schema.js';
 import { parseOutcomeFile } from './outcome-parser.js';
 import { parseSessionHistory } from './session-parser.js';
 import { estimateTokens } from './token-estimator.js';
@@ -35,6 +36,24 @@ export async function collect(options: CollectOptions): Promise<CollectResult> {
   return { sessions: sessionCount, turns: turnCount, invocations: invocationCount };
 }
 
+function upsertProject(db: EvalDb, cwd: string, now: string): number {
+  const name = basename(cwd) || cwd;
+  const existing = db.select().from(projects).where(eq(projects.cwd, cwd)).get();
+
+  if (existing) {
+    db.update(projects).set({ lastSeenAt: now }).where(eq(projects.cwd, cwd)).run();
+    return existing.id;
+  }
+
+  const result = db
+    .insert(projects)
+    .values({ name, cwd, lastSeenAt: now })
+    .returning({ id: projects.id })
+    .get();
+
+  return result.id;
+}
+
 function collectSessions(db: EvalDb, options: CollectOptions): number {
   const sessionFile = `${options.omxLogsDir}/session-history.jsonl`;
   const rawSessions = parseSessionHistory(sessionFile);
@@ -52,10 +71,18 @@ function collectSessions(db: EvalDb, options: CollectOptions): number {
         : null;
 
     if (!options.dryRun) {
+      const now = new Date().toISOString();
+      let projectId: number | null = null;
+
+      if (raw.cwd) {
+        projectId = upsertProject(db, raw.cwd, now);
+      }
+
       db
         .insert(sessions)
         .values({
           sessionId: raw.session_id,
+          projectId,
           startedAt: raw.started_at,
           endedAt: raw.ended_at ?? null,
           cwd: raw.cwd,

--- a/packages/eval-core/src/db/migrate.ts
+++ b/packages/eval-core/src/db/migrate.ts
@@ -10,9 +10,17 @@ export function runMigrations(dbPath: string): void {
 
   // Create tables using bun:sqlite (SQL DDL, not shell)
   const statements = [
+    `CREATE TABLE IF NOT EXISTS projects (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL,
+      cwd TEXT NOT NULL UNIQUE,
+      last_seen_at TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
     `CREATE TABLE IF NOT EXISTS sessions (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       session_id TEXT NOT NULL UNIQUE,
+      project_id INTEGER REFERENCES projects(id),
       started_at TEXT NOT NULL,
       ended_at TEXT,
       cwd TEXT,
@@ -64,16 +72,34 @@ export function runMigrations(dbPath: string): void {
       evaluated_at TEXT NOT NULL,
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     )`,
+    `CREATE TABLE IF NOT EXISTS session_feedback (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL REFERENCES sessions(session_id),
+      rating INTEGER,
+      tags TEXT,
+      comment TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
+    'CREATE INDEX IF NOT EXISTS idx_projects_cwd ON projects(cwd)',
     'CREATE INDEX IF NOT EXISTS idx_sessions_session_id ON sessions(session_id)',
+    'CREATE INDEX IF NOT EXISTS idx_sessions_project_id ON sessions(project_id)',
     'CREATE INDEX IF NOT EXISTS idx_turns_session_id ON turns(session_id)',
     'CREATE INDEX IF NOT EXISTS idx_invocations_ppid ON agent_invocations(session_ppid)',
     'CREATE INDEX IF NOT EXISTS idx_invocations_agent_type ON agent_invocations(agent_type)',
     'CREATE INDEX IF NOT EXISTS idx_evaluations_session_id ON evaluations(session_id)',
     'CREATE INDEX IF NOT EXISTS idx_evaluations_turn_id ON evaluations(turn_id)',
+    'CREATE INDEX IF NOT EXISTS idx_feedback_session_id ON session_feedback(session_id)',
   ];
 
   for (const sql of statements) {
     db.run(sql);
+  }
+
+  // Migrations: add project_id column to existing sessions table (idempotent)
+  try {
+    db.run('ALTER TABLE sessions ADD COLUMN project_id INTEGER REFERENCES projects(id)');
+  } catch {
+    // Column already exists — ignore
   }
 
   db.close();

--- a/packages/eval-core/src/db/schema.ts
+++ b/packages/eval-core/src/db/schema.ts
@@ -1,8 +1,19 @@
 import { integer, real, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 
+export const projects = sqliteTable('projects', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  name: text('name').notNull(),
+  cwd: text('cwd').notNull().unique(),
+  lastSeenAt: text('last_seen_at').notNull(),
+  createdAt: text('created_at')
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
+});
+
 export const sessions = sqliteTable('sessions', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   sessionId: text('session_id').notNull().unique(),
+  projectId: integer('project_id').references(() => projects.id),
   startedAt: text('started_at').notNull(),
   endedAt: text('ended_at'),
   cwd: text('cwd'),
@@ -63,6 +74,19 @@ export const evaluations = sqliteTable('evaluations', {
   tags: text('tags'),                   // JSON array string: ["good_prompt", "wrong_routing"]
   comment: text('comment'),
   evaluatedAt: text('evaluated_at').notNull(),
+  createdAt: text('created_at')
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
+});
+
+export const sessionFeedback = sqliteTable('session_feedback', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  sessionId: text('session_id')
+    .notNull()
+    .references(() => sessions.sessionId),
+  rating: integer('rating'),            // 1-5
+  tags: text('tags'),                   // JSON array string
+  comment: text('comment'),
   createdAt: text('created_at')
     .notNull()
     .$defaultFn(() => new Date().toISOString()),

--- a/packages/eval-core/src/index.ts
+++ b/packages/eval-core/src/index.ts
@@ -1,5 +1,13 @@
 export * from './types/index.js';
 export { createDb, type EvalDb } from './db/client.js';
-export { agentInvocations, evaluations, sessions, turns } from './db/schema.js';
+export {
+  agentInvocations,
+  evaluations,
+  projects,
+  sessionFeedback,
+  sessions,
+  turns,
+} from './db/schema.js';
 export { collect, type CollectOptions, type CollectResult } from './collect/index.js';
 export { runMigrations } from './db/migrate.js';
+export * from './query/index.js';

--- a/packages/eval-core/src/query/dashboard.ts
+++ b/packages/eval-core/src/query/dashboard.ts
@@ -1,4 +1,4 @@
-import { count, desc, eq, sql } from 'drizzle-orm';
+import { and, count, desc, eq, sql } from 'drizzle-orm';
 import type { EvalDb } from '../db/client.js';
 import { agentInvocations, projects, sessions, turns } from '../db/schema.js';
 import type { AgentStat, DashboardStats, ProjectStats, SessionStats } from './types.js';
@@ -112,7 +112,10 @@ export function getAgentStats(db: EvalDb): AgentStat[] {
       .select({ total: count(agentInvocations.id) })
       .from(agentInvocations)
       .where(
-        sql`${agentInvocations.agentType} = ${row.agentType} AND ${agentInvocations.outcome} = 'success'`
+        and(
+          eq(agentInvocations.agentType, row.agentType),
+          eq(agentInvocations.outcome, 'success')
+        )
       )
       .get();
 

--- a/packages/eval-core/src/query/dashboard.ts
+++ b/packages/eval-core/src/query/dashboard.ts
@@ -1,0 +1,150 @@
+import { count, desc, eq, sql } from 'drizzle-orm';
+import type { EvalDb } from '../db/client.js';
+import { agentInvocations, projects, sessions, turns } from '../db/schema.js';
+import type { AgentStat, DashboardStats, ProjectStats, SessionStats } from './types.js';
+
+export function getProjectStats(db: EvalDb): ProjectStats[] {
+  const rows = db
+    .select({
+      id: projects.id,
+      name: projects.name,
+      cwd: projects.cwd,
+      lastSeenAt: projects.lastSeenAt,
+      createdAt: projects.createdAt,
+      sessionCount: count(sessions.id),
+    })
+    .from(projects)
+    .leftJoin(sessions, eq(sessions.projectId, projects.id))
+    .groupBy(projects.id)
+    .orderBy(desc(projects.lastSeenAt))
+    .all();
+
+  return rows.map((row) => {
+    const turnCountRow = db
+      .select({ total: count(turns.id) })
+      .from(turns)
+      .innerJoin(sessions, eq(turns.sessionId, sessions.sessionId))
+      .where(eq(sessions.projectId, row.id))
+      .get();
+
+    const invCountRow = db
+      .select({ total: count(agentInvocations.id) })
+      .from(agentInvocations)
+      .innerJoin(sessions, eq(agentInvocations.sessionId, sessions.sessionId))
+      .where(eq(sessions.projectId, row.id))
+      .get();
+
+    return {
+      id: row.id,
+      name: row.name,
+      cwd: row.cwd,
+      lastSeenAt: row.lastSeenAt,
+      createdAt: row.createdAt,
+      sessionCount: row.sessionCount,
+      totalTurns: turnCountRow?.total ?? 0,
+      totalInvocations: invCountRow?.total ?? 0,
+    };
+  });
+}
+
+export function getRecentSessions(db: EvalDb, limit = 20): SessionStats[] {
+  const rows = db
+    .select({
+      id: sessions.id,
+      sessionId: sessions.sessionId,
+      projectId: sessions.projectId,
+      projectName: projects.name,
+      startedAt: sessions.startedAt,
+      endedAt: sessions.endedAt,
+      cwd: sessions.cwd,
+      durationMs: sessions.durationMs,
+      estimatedCostUsd: sessions.estimatedCostUsd,
+    })
+    .from(sessions)
+    .leftJoin(projects, eq(sessions.projectId, projects.id))
+    .orderBy(desc(sessions.startedAt))
+    .limit(limit)
+    .all();
+
+  return rows.map((row) => {
+    const turnCountRow = db
+      .select({ total: count(turns.id) })
+      .from(turns)
+      .where(eq(turns.sessionId, row.sessionId))
+      .get();
+
+    const invCountRow = db
+      .select({ total: count(agentInvocations.id) })
+      .from(agentInvocations)
+      .where(eq(agentInvocations.sessionId, row.sessionId))
+      .get();
+
+    return {
+      id: row.id,
+      sessionId: row.sessionId,
+      projectId: row.projectId ?? null,
+      projectName: row.projectName ?? null,
+      startedAt: row.startedAt,
+      endedAt: row.endedAt ?? null,
+      cwd: row.cwd ?? null,
+      durationMs: row.durationMs ?? null,
+      turnCount: turnCountRow?.total ?? 0,
+      invocationCount: invCountRow?.total ?? 0,
+      estimatedCostUsd: row.estimatedCostUsd ?? null,
+    };
+  });
+}
+
+export function getAgentStats(db: EvalDb): AgentStat[] {
+  const rows = db
+    .select({
+      agentType: agentInvocations.agentType,
+      total: count(agentInvocations.id),
+      lastUsed: sql<string>`MAX(${agentInvocations.timestamp})`,
+    })
+    .from(agentInvocations)
+    .groupBy(agentInvocations.agentType)
+    .orderBy(desc(count(agentInvocations.id)))
+    .all();
+
+  return rows.map((row) => {
+    const successRow = db
+      .select({ total: count(agentInvocations.id) })
+      .from(agentInvocations)
+      .where(
+        sql`${agentInvocations.agentType} = ${row.agentType} AND ${agentInvocations.outcome} = 'success'`
+      )
+      .get();
+
+    const successCount = successRow?.total ?? 0;
+    const failureCount = row.total - successCount;
+
+    return {
+      agentType: row.agentType,
+      totalInvocations: row.total,
+      successCount,
+      failureCount,
+      successRate: row.total > 0 ? successCount / row.total : 0,
+      lastUsed: row.lastUsed,
+    };
+  });
+}
+
+export function getDashboardStats(db: EvalDb): DashboardStats {
+  const totalSessionsRow = db.select({ total: count(sessions.id) }).from(sessions).get();
+  const totalTurnsRow = db.select({ total: count(turns.id) }).from(turns).get();
+  const totalInvocationsRow = db
+    .select({ total: count(agentInvocations.id) })
+    .from(agentInvocations)
+    .get();
+  const totalProjectsRow = db.select({ total: count(projects.id) }).from(projects).get();
+
+  return {
+    totalSessions: totalSessionsRow?.total ?? 0,
+    totalTurns: totalTurnsRow?.total ?? 0,
+    totalInvocations: totalInvocationsRow?.total ?? 0,
+    totalProjects: totalProjectsRow?.total ?? 0,
+    recentSessions: getRecentSessions(db, 10),
+    topAgents: getAgentStats(db).slice(0, 10),
+  };
+}

--- a/packages/eval-core/src/query/index.ts
+++ b/packages/eval-core/src/query/index.ts
@@ -1,0 +1,2 @@
+export * from './types.js';
+export { getDashboardStats, getAgentStats, getProjectStats, getRecentSessions } from './dashboard.js';

--- a/packages/eval-core/src/query/types.ts
+++ b/packages/eval-core/src/query/types.ts
@@ -1,0 +1,42 @@
+export interface ProjectStats {
+  id: number;
+  name: string;
+  cwd: string;
+  lastSeenAt: string;
+  createdAt: string;
+  sessionCount: number;
+  totalTurns: number;
+  totalInvocations: number;
+}
+
+export interface SessionStats {
+  id: number;
+  sessionId: string;
+  projectId: number | null;
+  projectName: string | null;
+  startedAt: string;
+  endedAt: string | null;
+  cwd: string | null;
+  durationMs: number | null;
+  turnCount: number;
+  invocationCount: number;
+  estimatedCostUsd: number | null;
+}
+
+export interface AgentStat {
+  agentType: string;
+  totalInvocations: number;
+  successCount: number;
+  failureCount: number;
+  successRate: number;
+  lastUsed: string;
+}
+
+export interface DashboardStats {
+  totalSessions: number;
+  totalTurns: number;
+  totalInvocations: number;
+  totalProjects: number;
+  recentSessions: SessionStats[];
+  topAgents: AgentStat[];
+}


### PR DESCRIPTION
## Summary

- Add `drizzle.config.ts` so `bun run db:generate` works out-of-the-box
- Extend schema with `projects` table (tracks cwd → project name mapping) and `session_feedback` table
- Add nullable `project_id` FK to `sessions` table
- `collectSessions()` now upserts projects and links `sessions.project_id` automatically on each collect run
- New query layer (`src/query/`) with `getProjectStats()`, `getRecentSessions()`, `getAgentStats()`, `getDashboardStats()`
- Two new CLI commands: `eval-core list projects|sessions` and `eval-core show <session-id-prefix>`
- `runMigrations()` updated with idempotent `ALTER TABLE` for safe upgrades on existing DBs

## Test plan

- [ ] `bun run typecheck` passes in `packages/eval-core/` (verified: 0 errors)
- [ ] `eval-core migrate` creates all 6 tables including `projects` and `session_feedback`
- [ ] `eval-core collect` populates `projects` table and links `sessions.project_id`
- [ ] `eval-core list projects` and `eval-core list sessions` render table output
- [ ] `eval-core show <prefix>` shows session detail
- [ ] Running `migrate` on an existing DB (without `projects` column) completes without error

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)