### PR TITLE
fix: add worktree detection to pre-commit hook (#544)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,6 +3,14 @@
 # Pre-commit hook for oh-my-customcode
 # Runs typecheck, lint, and tests before allowing commit
 
+# Worktree detection: .git is a file (not directory) in worktrees
+if [ -f .git ]; then
+    echo "Running pre-commit checks (worktree mode)..."
+    bun run typecheck 2>/dev/null || exit 1
+    echo "Worktree pre-commit passed (typecheck only — full suite runs in CI)."
+    exit 0
+fi
+
 echo "Running pre-commit checks..."
 
 # Run TypeScript type checking


### PR DESCRIPTION
## Summary

- Adds worktree detection (`[ -f .git ]`) at the top of `.husky/pre-commit`
- In worktree mode, runs `bun run typecheck` only and exits early — avoids the full lint+test+coverage suite
- Main repo path is completely unchanged; the new block exits before reaching existing code

## Root Cause

In a git worktree, `.git` is a **file** (`gitdir: ...`) rather than a directory. This caused:
1. `.claude/` files appearing as deleted under sparse checkout → pre-commit failures
2. `bun test` triggering recursive hook invocations via temp git repos in test fixtures
3. Agents resorting to `--no-verify` or getting stuck in 195+ tool call loops

## Fix

```bash
# Worktree detection: .git is a file (not directory) in worktrees
if [ -f .git ]; then
    echo "Running pre-commit checks (worktree mode)..."
    bun run typecheck 2>/dev/null || exit 1
    echo "Worktree pre-commit passed (typecheck only — full suite runs in CI)."
    exit 0
fi
```

## Test plan

- [ ] Verify that commits from a worktree pass with typecheck-only
- [ ] Verify that commits from the main repo still run the full suite (lint + tests + coverage)
- [ ] CI runs the full suite regardless of worktree context

Closes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)