### PR TITLE
release: v0.51.2

### DIFF
--- a/.claude/hooks/scripts/agent-teams-advisor.sh
+++ b/.claude/hooks/scripts/agent-teams-advisor.sh
@@ -21,6 +21,22 @@ if [ -f "$ENV_STATUS" ]; then
   fi
 fi
 
+# Batch context detection: check for workflow or release-plan state
+BATCH_ISSUES=0
+# Use wildcard to match any workflow name: /tmp/.claude-workflow-*-${PPID}.json
+WORKFLOW_FILE=$(ls /tmp/.claude-workflow-*-"${PPID}".json 2>/dev/null | head -1 || true)
+if [ -n "$WORKFLOW_FILE" ] && [ -f "$WORKFLOW_FILE" ]; then
+  BATCH_ISSUES=$(jq -r '.issue_count // 0' "$WORKFLOW_FILE" 2>/dev/null || echo 0)
+fi
+
+# Also check release-plan context (existence only — if file exists, treat as batch)
+RELEASE_PLAN="/tmp/.claude-release-plan-${PPID}"
+if [ -f "$RELEASE_PLAN" ]; then
+  if [ "$BATCH_ISSUES" -lt 3 ]; then
+    BATCH_ISSUES=3
+  fi
+fi
+
 # Extract task info from input
 agent_type=$(echo "$input" | jq -r '.tool_input.subagent_type // "unknown"')
 prompt_preview=$(echo "$input" | jq -r '.tool_input.description // ""' | head -c 60)
@@ -37,8 +53,14 @@ else
 fi
 echo "$COUNT" > "$COUNTER_FILE"
 
-# Warn from 2nd Task call onward -- Agent Teams may be more appropriate
-if [ "$COUNT" -ge 2 ]; then
+# Warn when batch context detected (even on first call) or from 2nd call onward
+if [ "$BATCH_ISSUES" -ge 3 ] && [ "$COUNT" -eq 1 ]; then
+  echo "" >&2
+  echo "--- [R018 Advisor] Batch context detected (${BATCH_ISSUES} issues) ---" >&2
+  echo "  RECOMMENDATION: Use Agent Teams (TeamCreate) for this batch." >&2
+  echo "  Current: Agent(${agent_type}) -- ${prompt_preview}" >&2
+  echo "-----------------------------------------------------------" >&2
+elif [ "$COUNT" -ge 2 ]; then
   echo "" >&2
   echo "--- [R018 Advisor] Agent/Task tool call #${COUNT} in this session ---" >&2
   echo "  WARNING: Multiple Task calls detected. Consider Agent Teams if:" >&2

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.51.1",
-  "generatedAt": "2026-03-21T07:30:42.207Z",
-  "templateVersion": "0.51.1",
+  "generatorVersion": "0.51.2",
+  "generatedAt": "2026-03-21T07:34:14.288Z",
+  "templateVersion": "0.51.2",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,7 +1,7 @@
 {
   "lockfileVersion": 1,
   "generatorVersion": "0.51.1",
-  "generatedAt": "2026-03-21T07:03:44.159Z",
+  "generatedAt": "2026-03-21T07:30:42.207Z",
   "templateVersion": "0.51.1",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
@@ -940,8 +940,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/agent-teams-advisor.sh": {
-      "templateHash": "38092e619487387f086de0b85147e8c7fa694c633149b14e8e08da0cd6435a41",
-      "size": 1846,
+      "templateHash": "e9ed54a62710e149ab2ecf8437e5f81585cc63f5e79919db9a66046402859d56",
+      "size": 2857,
       "component": "hooks"
     },
     ".claude/hooks/scripts/stuck-detector.sh": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9305,7 +9305,7 @@ var init_package = __esm(() => {
   package_default = {
     name: "oh-my-customcode",
     workspaces: ["packages/*"],
-    version: "0.51.1",
+    version: "0.51.2",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1679,7 +1679,7 @@ import { join as join6 } from "node:path";
 var package_default = {
   name: "oh-my-customcode",
   workspaces: ["packages/*"],
-  version: "0.51.1",
+  version: "0.51.2",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-customcode",
   "workspaces": ["packages/*"],
-  "version": "0.51.1",
+  "version": "0.51.2",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/packages/serve/src/routes/+page.server.ts
+++ b/packages/serve/src/routes/+page.server.ts
@@ -1,5 +1,4 @@
 import type { PageServerLoad } from './$types';
-import { getAgents, getSkills, getGuides, getRules } from '$lib/server/data';
 import { getAnalytics, type AnalyticsData } from '$lib/server/analytics';
 import { findProjectsForServe } from '$lib/server/projects';
 
@@ -7,13 +6,7 @@ import { findProjectsForServe } from '$lib/server/projects';
 export const load: PageServerLoad = async ({ parent }) => {
 	const { root, selectedProject } = await parent();
 
-	const [agents, skills, guides, rules, allProjects] = await Promise.all([
-		getAgents(root),
-		getSkills(root),
-		getGuides(root),
-		getRules(root),
-		findProjectsForServe()
-	]);
+	const allProjects = await findProjectsForServe();
 
 	// Analytics loaded separately so a failure doesn't break the entire page
 	let analytics: AnalyticsData | null = null;
@@ -28,14 +21,6 @@ export const load: PageServerLoad = async ({ parent }) => {
 		analytics = null;
 	}
 
-	// Project-level counts for currently selected project
-	const projectStats = {
-		agents: agents.length,
-		skills: skills.length,
-		guides: guides.length,
-		rules: rules.length
-	};
-
 	// Summary across all discovered projects
 	const projectSummary = {
 		total: allProjects.length,
@@ -47,7 +32,6 @@ export const load: PageServerLoad = async ({ parent }) => {
 	return {
 		root,
 		selectedProject,
-		projectStats,
 		projectSummary,
 		projects: allProjects.slice(0, 6), // Show up to 6 projects on dashboard
 		analytics

--- a/packages/serve/src/routes/+page.svelte
+++ b/packages/serve/src/routes/+page.svelte
@@ -3,20 +3,6 @@
 
 	export let data: PageData;
 
-	const summaryCards = [
-		{ label: 'Agents', key: 'agents' as const, href: '/agents', icon: '◈', color: 'emerald' },
-		{ label: 'Skills', key: 'skills' as const, href: '/skills', icon: '◆', color: 'sky' },
-		{ label: 'Guides', key: 'guides' as const, href: '/guides', icon: '◉', color: 'violet' },
-		{ label: 'Rules', key: 'rules' as const, href: '/rules', icon: '◇', color: 'amber' }
-	];
-
-	const colorMap: Record<string, string> = {
-		emerald: 'border-emerald-800 bg-emerald-950/40 hover:bg-emerald-950/70 text-emerald-300',
-		sky: 'border-sky-800 bg-sky-950/40 hover:bg-sky-950/70 text-sky-300',
-		violet: 'border-violet-800 bg-violet-950/40 hover:bg-violet-950/70 text-violet-300',
-		amber: 'border-amber-800 bg-amber-950/40 hover:bg-amber-950/70 text-amber-300'
-	};
-
 	const statusConfig: Record<string, { label: string; dot: string; badge: string }> = {
 		latest: {
 			label: 'Latest',
@@ -51,20 +37,6 @@
 			<span class="ml-2 text-zinc-600">·</span>
 			<code class="ml-2 text-xs text-zinc-600">{data.root}</code>
 		</p>
-	</div>
-
-	<!-- Summary cards — agents, skills, guides, rules -->
-	<div class="mb-10 grid grid-cols-2 gap-4 lg:grid-cols-4">
-		{#each summaryCards as card}
-			<a
-				href="{card.href}{projectParam}"
-				class="rounded-lg border p-5 transition-colors {colorMap[card.color]}"
-			>
-				<div class="mb-2 text-2xl">{card.icon}</div>
-				<div class="text-3xl font-bold">{data.projectStats[card.key]}</div>
-				<div class="mt-1 text-sm opacity-80">{card.label}</div>
-			</a>
-		{/each}
 	</div>
 
 	<!-- Analytics section -->

--- a/packages/serve/src/routes/projects/+page.server.ts
+++ b/packages/serve/src/routes/projects/+page.server.ts
@@ -1,6 +1,0 @@
-import { redirect } from '@sveltejs/kit';
-import type { PageServerLoad } from './$types';
-
-export const load: PageServerLoad = async () => {
-	redirect(301, '/');
-};

--- a/packages/serve/src/routes/projects/+page.svelte
+++ b/packages/serve/src/routes/projects/+page.svelte
@@ -1,8 +1,0 @@
-<script lang="ts">
-	import { goto } from '$app/navigation';
-	import { onMount } from 'svelte';
-
-	onMount(() => {
-		goto('/', { replaceState: true });
-	});
-</script>

--- a/templates/.claude/hooks/scripts/agent-teams-advisor.sh
+++ b/templates/.claude/hooks/scripts/agent-teams-advisor.sh
@@ -21,6 +21,22 @@ if [ -f "$ENV_STATUS" ]; then
   fi
 fi
 
+# Batch context detection: check for workflow or release-plan state
+BATCH_ISSUES=0
+# Use wildcard to match any workflow name: /tmp/.claude-workflow-*-${PPID}.json
+WORKFLOW_FILE=$(ls /tmp/.claude-workflow-*-"${PPID}".json 2>/dev/null | head -1 || true)
+if [ -n "$WORKFLOW_FILE" ] && [ -f "$WORKFLOW_FILE" ]; then
+  BATCH_ISSUES=$(jq -r '.issue_count // 0' "$WORKFLOW_FILE" 2>/dev/null || echo 0)
+fi
+
+# Also check release-plan context (existence only — if file exists, treat as batch)
+RELEASE_PLAN="/tmp/.claude-release-plan-${PPID}"
+if [ -f "$RELEASE_PLAN" ]; then
+  if [ "$BATCH_ISSUES" -lt 3 ]; then
+    BATCH_ISSUES=3
+  fi
+fi
+
 # Extract task info from input
 agent_type=$(echo "$input" | jq -r '.tool_input.subagent_type // "unknown"')
 prompt_preview=$(echo "$input" | jq -r '.tool_input.description // ""' | head -c 60)
@@ -37,8 +53,14 @@ else
 fi
 echo "$COUNT" > "$COUNTER_FILE"
 
-# Warn from 2nd Task call onward -- Agent Teams may be more appropriate
-if [ "$COUNT" -ge 2 ]; then
+# Warn when batch context detected (even on first call) or from 2nd call onward
+if [ "$BATCH_ISSUES" -ge 3 ] && [ "$COUNT" -eq 1 ]; then
+  echo "" >&2
+  echo "--- [R018 Advisor] Batch context detected (${BATCH_ISSUES} issues) ---" >&2
+  echo "  RECOMMENDATION: Use Agent Teams (TeamCreate) for this batch." >&2
+  echo "  Current: Agent(${agent_type}) -- ${prompt_preview}" >&2
+  echo "-----------------------------------------------------------" >&2
+elif [ "$COUNT" -ge 2 ]; then
   echo "" >&2
   echo "--- [R018 Advisor] Agent/Task tool call #${COUNT} in this session ---" >&2
   echo "  WARNING: Multiple Task calls detected. Consider Agent Teams if:" >&2

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.51.1",
+  "version": "0.51.2",
   "lastUpdated": "2026-03-16T00:00:00.000Z",
   "components": [
     {

--- a/tests/unit/core/hooks-scripts.test.ts
+++ b/tests/unit/core/hooks-scripts.test.ts
@@ -697,6 +697,62 @@ describe('agent-teams-advisor.sh', () => {
       expect(result.exitCode).toBe(0);
     }
   });
+
+  // --- Batch context detection ---
+
+  it('should warn on FIRST call when workflow file has 3+ issues', async () => {
+    const workflowFile = `/tmp/.claude-workflow-test-${process.pid}.json`;
+    await writeFile(workflowFile, JSON.stringify({ issue_count: 5 }));
+    try {
+      const input = makeAdvisorInput('lang-typescript-expert', 'Process issues');
+      const result = await runHookScript(AGENT_TEAMS_ADVISOR_SCRIPT, input);
+      expect(result.stderr).toContain('R018 Advisor');
+      expect(result.stderr).toContain('Batch context detected');
+      expect(result.stderr).toContain('5');
+    } finally {
+      await unlink(workflowFile).catch(() => {});
+    }
+  });
+
+  it('should warn on FIRST call when release-plan file exists', async () => {
+    const releasePlanFile = `/tmp/.claude-release-plan-${process.pid}`;
+    await writeFile(releasePlanFile, 'release plan content');
+    try {
+      const input = makeAdvisorInput('lang-golang-expert', 'Release fixes');
+      const result = await runHookScript(AGENT_TEAMS_ADVISOR_SCRIPT, input);
+      expect(result.stderr).toContain('R018 Advisor');
+      expect(result.stderr).toContain('Batch context detected');
+    } finally {
+      await unlink(releasePlanFile).catch(() => {});
+    }
+  });
+
+  it('should NOT warn on first call when workflow file has fewer than 3 issues', async () => {
+    const workflowFile = `/tmp/.claude-workflow-test-${process.pid}.json`;
+    await writeFile(workflowFile, JSON.stringify({ issue_count: 2 }));
+    try {
+      const input = makeAdvisorInput('lang-typescript-expert', 'Process issues');
+      const result = await runHookScript(AGENT_TEAMS_ADVISOR_SCRIPT, input);
+      expect(result.stderr).not.toContain('R018 Advisor');
+    } finally {
+      await unlink(workflowFile).catch(() => {});
+    }
+  });
+
+  it('should use batch warning format (not sequential) when batch context detected on first call', async () => {
+    const workflowFile = `/tmp/.claude-workflow-test-${process.pid}.json`;
+    await writeFile(workflowFile, JSON.stringify({ issue_count: 4 }));
+    try {
+      const input = makeAdvisorInput('mgr-gitnerd', 'Deploy batch');
+      const result = await runHookScript(AGENT_TEAMS_ADVISOR_SCRIPT, input);
+      expect(result.stderr).toContain('Batch context detected');
+      expect(result.stderr).toContain('RECOMMENDATION');
+      // Batch warning is different from sequential warning
+      expect(result.stderr).not.toContain('Multiple Task calls detected');
+    } finally {
+      await unlink(workflowFile).catch(() => {});
+    }
+  });
 });
 
 // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **fix(#619)**: R018 agent-teams-advisor.sh batch context detection — warns on first Agent call when workflow/release-plan context has 3+ issues
- **fix(#574)**: Remove summary cards (Agents/Skills/Guides/Rules counts) from Web UI dashboard
- **fix(#575)**: Remove /projects route and page from Web UI

## Changes
| Category | Detail |
|----------|--------|
| Bug fix | R018 advisor batch detection improvement |
| UI cleanup | Dashboard summary cards removed |
| UI cleanup | Projects page and route removed |
| Version | 0.51.1 → 0.51.2 |

## Closes
- Closes #619
- Closes #574
- Closes #575

## Test plan
- [x] 1432 tests pass, 0 fail
- [x] Build succeeds
- [x] Agent Teams used for implementation (R018)

🤖 Generated with [Claude Code](https://claude.com/claude-code)