### PR TITLE
feat: v0.53.0 — Web UI improvements, eval-core DB, user feedback integration

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.52.0",
-  "generatedAt": "2026-03-21T09:09:39.524Z",
-  "templateVersion": "0.52.0",
+  "generatorVersion": "0.53.0",
+  "generatedAt": "2026-03-23T04:31:05.453Z",
+  "templateVersion": "0.53.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9305,7 +9305,7 @@ var init_package = __esm(() => {
   package_default = {
     name: "oh-my-customcode",
     workspaces: ["packages/*"],
-    version: "0.52.0",
+    version: "0.53.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1679,7 +1679,7 @@ import { join as join6 } from "node:path";
 var package_default = {
   name: "oh-my-customcode",
   workspaces: ["packages/*"],
-  version: "0.52.0",
+  version: "0.53.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/docs/superpowers/plans/2026-03-23-v0.53.0-release.md
+++ b/docs/superpowers/plans/2026-03-23-v0.53.0-release.md
@@ -1,0 +1,77 @@
+# Release Plan — Generated 2026-03-23
+
+> Source: open issues labeled `verify-done` as of 2026-03-23
+> Issues excluded (already in open PRs): none
+> Epics excluded (tracked separately): #624, #535
+
+---
+
+## v0.53.0 Release Plan
+
+**Estimated scope**: S-M (XS+S+S+S) | **Issues**: 4 | **Parallelizable**: 4 (all independent)
+
+| # | Priority | Size | Title | Dependencies |
+|---|----------|------|-------|-------------|
+| #625 | P2 | XS | 대시보드 All Projects 섹션 제거 | none |
+| #626 | P2 | S | 프로젝트별 상세 페이지 — ?project=X 쿼리 파라미터 | none |
+| #627 | P2 | S | Evaluations 데이터 수집 — eval-core DB 연결 수정 | none |
+| #562 | P2 | S | 사용자 명시적 피드백 연계 — feedback Issue 분석 소스 | #561 ✅ (resolved) |
+
+### Implementation Order
+
+All 4 issues are independent — parallel execution recommended.
+
+1. #625 — 대시보드 All Projects UI 섹션 및 server 데이터 로딩 제거 (suggested agent: fe-svelte-agent)
+2. #626 — ?project=X 전용 상세 뷰 UI 구현, layout.server.ts 인프라 활용 (suggested agent: fe-svelte-agent)
+3. #627 — eval-reader.ts DB 경로/스키마 연결 수정, evaluations 라우트 데이터 표시 (suggested agent: fe-svelte-agent)
+4. #562 — feedback 라벨 Issue 파싱, eval-core 분석 파이프라인 통합 (suggested agent: lang-typescript-expert)
+
+### Notes
+
+- #625, #626, #627은 Epic #624 (Web UI 개선)의 하위 이슈 — 이 릴리즈로 Epic #624 완결
+- #562는 Epic #535 (세션 피드백 자동 개선) Phase 2 — improve-report와 통합
+- #626은 professor-triage에서 M→S로 축소됨 (layout.server.ts 인프라 대부분 완성)
+- 4건 모두 독립적이므로 Agent Teams 활용 권장 (R018: 3+ agents)
+
+---
+
+## v0.54.0 Release Plan
+
+**Estimated scope**: L | **Issues**: 1 | **Parallelizable**: N/A
+
+| # | Priority | Size | Title | Dependencies |
+|---|----------|------|-------|-------------|
+| #563 | P2 | L | /omcustom:auto-improve 스킬 — 개선 사항 자동 적용 워크플로우 | #561 ✅, #559 ✅ |
+
+### Implementation Order
+
+1. #563 — worktree 격리 → 변경 적용 → sauron 검증 → PR 생성 파이프라인 (suggested agent: mgr-creator + qa-engineer)
+
+### Notes
+
+- Epic #535 Phase 3 — 고위험 자동 적용 기능이므로 단독 릴리즈
+- worktree isolation, sauron verification, PR-based approval 등 다중 안전장치 필수
+- 자기 참조 방지 (auto-improve 스킬 자체는 개선 범위 제외)
+- improvementActions 테이블 상태 전이 기록 필요
+
+---
+
+## Summary
+
+| Release | Issues | Size | P1 | P2 | P3 |
+|---------|--------|------|----|----|-----|
+| v0.53.0 | 4 | S-M | 0 | 4 | 0 |
+| v0.54.0 | 1 | L | 0 | 1 | 0 |
+
+### Epic Completion Tracking
+
+| Epic | Status After Plan |
+|------|-------------------|
+| #624 (Web UI 개선) | **Complete** after v0.53.0 (#625, #626, #627) |
+| #535 (세션 피드백 자동 개선) | Phase 2 complete after v0.53.0 (#562), Phase 3 after v0.54.0 (#563) |
+
+### Remaining from Epic #535
+
+| Phase | Issue | Planned Release |
+|-------|-------|----------------|
+| Phase 4 | #564 (충돌 해결 & 쿨다운) | Not yet verify-done — future release |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-customcode",
   "workspaces": ["packages/*"],
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/packages/eval-core/src/__tests__/user-feedback.test.ts
+++ b/packages/eval-core/src/__tests__/user-feedback.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Tests for user-feedback module: parseIssueToFeedback, fetchUserFeedbackIssues,
+ * and userFeedbackToSuggestions (integration with feedback.ts).
+ */
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+// Mock node:child_process before any imports that use it.
+// Bun hoists mock.module calls, so this applies to all subsequent imports.
+const mockExecSync = mock(() => '[]');
+
+mock.module('node:child_process', () => ({
+  execSync: mockExecSync,
+}));
+
+import { fetchUserFeedbackIssues, parseIssueToFeedback } from '../query/user-feedback.js';
+import { userFeedbackToSuggestions } from '../query/feedback.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeIssue(overrides: {
+  number?: number;
+  title?: string;
+  body?: string;
+  createdAt?: string;
+}) {
+  return {
+    number: overrides.number ?? 1,
+    title: overrides.title ?? 'Test issue',
+    body: overrides.body ?? '',
+    createdAt: overrides.createdAt ?? '2026-01-01T00:00:00Z',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseIssueToFeedback — target extraction
+// ---------------------------------------------------------------------------
+
+describe('parseIssueToFeedback', () => {
+  describe('targetType detection', () => {
+    it('defaults to general when no keywords match', () => {
+      const entry = parseIssueToFeedback(makeIssue({ title: 'Something is wrong' }));
+      expect(entry.targetType).toBe('general');
+      expect(entry.target).toBe('general');
+    });
+
+    it('detects agent from title "agent: xxx"', () => {
+      const entry = parseIssueToFeedback(makeIssue({ title: 'agent: lang-golang-expert fails' }));
+      expect(entry.targetType).toBe('agent');
+      expect(entry.target).toBe('lang-golang-expert');
+    });
+
+    it('detects agent from Korean "에이전트: xxx"', () => {
+      const entry = parseIssueToFeedback(makeIssue({ title: '에이전트: mgr-gitnerd 오류' }));
+      expect(entry.targetType).toBe('agent');
+      expect(entry.target).toBe('mgr-gitnerd');
+    });
+
+    it('detects skill from title "skill: xxx"', () => {
+      const entry = parseIssueToFeedback(makeIssue({ title: 'skill: dev-review broken' }));
+      expect(entry.targetType).toBe('skill');
+      expect(entry.target).toBe('dev-review');
+    });
+
+    it('detects skill from Korean "스킬: xxx"', () => {
+      const entry = parseIssueToFeedback(makeIssue({ title: '스킬: deep-plan 실패' }));
+      expect(entry.targetType).toBe('skill');
+      expect(entry.target).toBe('deep-plan');
+    });
+
+    it('detects rule from "R007" in title', () => {
+      const entry = parseIssueToFeedback(makeIssue({ title: 'R007 identification missing' }));
+      expect(entry.targetType).toBe('rule');
+      expect(entry.target).toBe('R007');
+    });
+
+    it('normalizes rule ID to uppercase', () => {
+      const entry = parseIssueToFeedback(makeIssue({ title: 'r009 not followed' }));
+      expect(entry.targetType).toBe('rule');
+      expect(entry.target).toBe('R009');
+    });
+
+    it('detects rule from body when not in title', () => {
+      const entry = parseIssueToFeedback(
+        makeIssue({ title: 'Parallel execution issue', body: 'The R009 rule is violated here' })
+      );
+      expect(entry.targetType).toBe('rule');
+      expect(entry.target).toBe('R009');
+    });
+
+    it('rule overrides skill (rule has highest precedence)', () => {
+      const entry = parseIssueToFeedback(
+        makeIssue({ title: 'skill: dev-review violates R010' })
+      );
+      expect(entry.targetType).toBe('rule');
+      expect(entry.target).toBe('R010');
+    });
+
+    it('rule overrides agent', () => {
+      const entry = parseIssueToFeedback(
+        makeIssue({ title: 'agent: mgr-gitnerd breaks R007 identification' })
+      );
+      expect(entry.targetType).toBe('rule');
+      expect(entry.target).toBe('R007');
+    });
+
+    it('skill overrides agent', () => {
+      const entry = parseIssueToFeedback(
+        makeIssue({ title: 'agent: lang-python-expert using skill: python-best-practices fails' })
+      );
+      expect(entry.targetType).toBe('skill');
+      expect(entry.target).toBe('python-best-practices');
+    });
+  });
+
+  describe('sentiment detection', () => {
+    it('defaults to suggestion', () => {
+      const entry = parseIssueToFeedback(makeIssue({ title: 'Please add feature X' }));
+      expect(entry.sentiment).toBe('suggestion');
+    });
+
+    it('detects negative for "bug" in title', () => {
+      const entry = parseIssueToFeedback(makeIssue({ title: 'bug: routing miss in dev-lead' }));
+      expect(entry.sentiment).toBe('negative');
+    });
+
+    it('detects negative for "fail" in title', () => {
+      const entry = parseIssueToFeedback(makeIssue({ title: 'agent fails consistently' }));
+      expect(entry.sentiment).toBe('negative');
+    });
+
+    it('detects negative for "broken" in title', () => {
+      const entry = parseIssueToFeedback(makeIssue({ title: 'broken: dev-review skill' }));
+      expect(entry.sentiment).toBe('negative');
+    });
+
+    it('detects negative for Korean "실패"', () => {
+      const entry = parseIssueToFeedback(makeIssue({ title: '에이전트 실패 문제' }));
+      expect(entry.sentiment).toBe('negative');
+    });
+
+    it('detects positive for "great"', () => {
+      const entry = parseIssueToFeedback(makeIssue({ title: 'great improvement in routing' }));
+      expect(entry.sentiment).toBe('positive');
+    });
+
+    it('detects positive for "good"', () => {
+      const entry = parseIssueToFeedback(makeIssue({ title: 'good job on skill dev-review' }));
+      expect(entry.sentiment).toBe('positive');
+    });
+
+    it('detects positive for Korean "좋"', () => {
+      const entry = parseIssueToFeedback(makeIssue({ title: '좋은 에이전트 설계' }));
+      expect(entry.sentiment).toBe('positive');
+    });
+  });
+
+  describe('output fields', () => {
+    it('preserves original title and body casing', () => {
+      const entry = parseIssueToFeedback(
+        makeIssue({ number: 42, title: 'Bug: Agent: lang-Python-Expert', body: 'Some body text' })
+      );
+      expect(entry.issueNumber).toBe(42);
+      expect(entry.title).toBe('Bug: Agent: lang-Python-Expert');
+      expect(entry.body).toBe('Some body text');
+    });
+
+    it('sets feedbackSource to user_explicit', () => {
+      const entry = parseIssueToFeedback(makeIssue({}));
+      expect(entry.feedbackSource).toBe('user_explicit');
+    });
+
+    it('handles null/undefined body gracefully', () => {
+      const entry = parseIssueToFeedback({ number: 1, title: 'test', body: '', createdAt: '2026-01-01T00:00:00Z' });
+      expect(entry.body).toBe('');
+      expect(entry.targetType).toBe('general');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchUserFeedbackIssues — mocked execSync
+// ---------------------------------------------------------------------------
+
+describe('fetchUserFeedbackIssues', () => {
+  beforeEach(() => {
+    mockExecSync.mockReset();
+  });
+
+  it('returns empty array when gh returns empty list', () => {
+    mockExecSync.mockImplementation(() => '[]');
+    const result = fetchUserFeedbackIssues();
+    expect(result).toEqual([]);
+  });
+
+  it('parses issues returned by gh CLI', () => {
+    mockExecSync.mockImplementation(() =>
+      JSON.stringify([
+        {
+          number: 10,
+          title: 'bug: agent: lang-typescript-expert fails',
+          body: '',
+          createdAt: '2026-03-01T00:00:00Z',
+        },
+      ])
+    );
+    const result = fetchUserFeedbackIssues();
+    expect(result).toHaveLength(1);
+    expect(result[0].issueNumber).toBe(10);
+    expect(result[0].targetType).toBe('agent');
+    expect(result[0].sentiment).toBe('negative');
+  });
+
+  it('returns empty array when execSync throws (gh not available)', () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('command not found: gh');
+    });
+    const result = fetchUserFeedbackIssues();
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when JSON is malformed', () => {
+    mockExecSync.mockImplementation(() => 'not-json');
+    const result = fetchUserFeedbackIssues();
+    expect(result).toEqual([]);
+  });
+
+  it('passes correct gh CLI command with timeout', () => {
+    mockExecSync.mockImplementation(() => '[]');
+    fetchUserFeedbackIssues();
+    expect(mockExecSync).toHaveBeenCalledWith(
+      'gh issue list --label feedback --state all --json number,title,body,createdAt --limit 50',
+      { encoding: 'utf-8', timeout: 10000 }
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// userFeedbackToSuggestions — filtering and mapping
+// ---------------------------------------------------------------------------
+
+describe('userFeedbackToSuggestions', () => {
+  it('returns empty array for empty input', () => {
+    expect(userFeedbackToSuggestions([])).toEqual([]);
+  });
+
+  it('filters out general targetType entries', () => {
+    const entries = [
+      {
+        issueNumber: 1,
+        title: 'Something wrong',
+        body: '',
+        createdAt: '2026-01-01T00:00:00Z',
+        target: 'general',
+        targetType: 'general' as const,
+        sentiment: 'negative' as const,
+        feedbackSource: 'user_explicit' as const,
+      },
+    ];
+    expect(userFeedbackToSuggestions(entries)).toEqual([]);
+  });
+
+  it('filters out non-negative sentiment entries', () => {
+    const entries = [
+      {
+        issueNumber: 2,
+        title: 'great skill',
+        body: '',
+        createdAt: '2026-01-01T00:00:00Z',
+        target: 'dev-review',
+        targetType: 'skill' as const,
+        sentiment: 'positive' as const,
+        feedbackSource: 'user_explicit' as const,
+      },
+      {
+        issueNumber: 3,
+        title: 'add feature to dev-review',
+        body: '',
+        createdAt: '2026-01-01T00:00:00Z',
+        target: 'dev-review',
+        targetType: 'skill' as const,
+        sentiment: 'suggestion' as const,
+        feedbackSource: 'user_explicit' as const,
+      },
+    ];
+    expect(userFeedbackToSuggestions(entries)).toEqual([]);
+  });
+
+  it('maps negative agent entry to ImprovementSuggestion correctly', () => {
+    const entries = [
+      {
+        issueNumber: 5,
+        title: 'bug: agent: lang-golang-expert fails',
+        body: '',
+        createdAt: '2026-01-01T00:00:00Z',
+        target: 'lang-golang-expert',
+        targetType: 'agent' as const,
+        sentiment: 'negative' as const,
+        feedbackSource: 'user_explicit' as const,
+      },
+    ];
+    const suggestions = userFeedbackToSuggestions(entries);
+    expect(suggestions).toHaveLength(1);
+    const s = suggestions[0];
+    expect(s.target).toBe('lang-golang-expert');
+    expect(s.targetType).toBe('agent');
+    expect(s.actionType).toBe('revise');
+    expect(s.confidence).toBe('medium');
+    expect(s.description).toContain('#5');
+    expect(s.evidence.metric).toBe('user_feedback');
+    expect(s.evidence.value).toBe(1);
+    expect(s.evidence.threshold).toBe(0);
+    expect(s.evidence.sessionCount).toBe(1);
+  });
+
+  it('maps negative skill entry to ImprovementSuggestion', () => {
+    const entries = [
+      {
+        issueNumber: 7,
+        title: 'broken: skill: dev-review',
+        body: '',
+        createdAt: '2026-01-01T00:00:00Z',
+        target: 'dev-review',
+        targetType: 'skill' as const,
+        sentiment: 'negative' as const,
+        feedbackSource: 'user_explicit' as const,
+      },
+    ];
+    const suggestions = userFeedbackToSuggestions(entries);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].targetType).toBe('skill');
+  });
+
+  it('maps negative rule entry to ImprovementSuggestion', () => {
+    const entries = [
+      {
+        issueNumber: 9,
+        title: 'R007 identification missing',
+        body: '',
+        createdAt: '2026-01-01T00:00:00Z',
+        target: 'R007',
+        targetType: 'rule' as const,
+        sentiment: 'negative' as const,
+        feedbackSource: 'user_explicit' as const,
+      },
+    ];
+    const suggestions = userFeedbackToSuggestions(entries);
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0].targetType).toBe('rule');
+    expect(suggestions[0].target).toBe('R007');
+  });
+
+  it('processes multiple entries, keeping only negative non-general ones', () => {
+    const entries = [
+      {
+        issueNumber: 1,
+        title: 'bug: agent: lang-go',
+        body: '',
+        createdAt: '2026-01-01T00:00:00Z',
+        target: 'lang-go',
+        targetType: 'agent' as const,
+        sentiment: 'negative' as const,
+        feedbackSource: 'user_explicit' as const,
+      },
+      {
+        issueNumber: 2,
+        title: 'good feedback',
+        body: '',
+        createdAt: '2026-01-01T00:00:00Z',
+        target: 'lang-go',
+        targetType: 'agent' as const,
+        sentiment: 'positive' as const,
+        feedbackSource: 'user_explicit' as const,
+      },
+      {
+        issueNumber: 3,
+        title: 'general issue',
+        body: '',
+        createdAt: '2026-01-01T00:00:00Z',
+        target: 'general',
+        targetType: 'general' as const,
+        sentiment: 'negative' as const,
+        feedbackSource: 'user_explicit' as const,
+      },
+      {
+        issueNumber: 4,
+        title: 'broken: skill: deep-plan',
+        body: '',
+        createdAt: '2026-01-01T00:00:00Z',
+        target: 'deep-plan',
+        targetType: 'skill' as const,
+        sentiment: 'negative' as const,
+        feedbackSource: 'user_explicit' as const,
+      },
+    ];
+    const suggestions = userFeedbackToSuggestions(entries);
+    expect(suggestions).toHaveLength(2);
+    expect(suggestions[0].target).toBe('lang-go');
+    expect(suggestions[1].target).toBe('deep-plan');
+  });
+});

--- a/packages/eval-core/src/cli/analyze.cmd.ts
+++ b/packages/eval-core/src/cli/analyze.cmd.ts
@@ -145,8 +145,16 @@ function parseYaml(content: string): ImprovementRulesFile {
   return { rules };
 }
 
+function countUserFeedbackSuggestions(suggestions: ImprovementSuggestion[]): number {
+  return suggestions.filter((s) => s.evidence.metric === 'user_feedback').length;
+}
+
 function formatTable(suggestions: ImprovementSuggestion[], routingMiss: RoutingMissPattern): string {
   const lines: string[] = ['Improvement Suggestions', '='.repeat(80), ''];
+  const userFeedbackCount = countUserFeedbackSuggestions(suggestions);
+  if (userFeedbackCount > 0) {
+    lines.push(`User feedback issues included: ${userFeedbackCount}`, '');
+  }
 
   if (suggestions.length === 0) {
     lines.push('No improvement suggestions found (insufficient data or all metrics within thresholds).');
@@ -180,11 +188,12 @@ function formatTable(suggestions: ImprovementSuggestion[], routingMiss: RoutingM
 }
 
 function formatMarkdown(suggestions: ImprovementSuggestion[], routingMiss: RoutingMissPattern): string {
+  const userFeedbackCount = countUserFeedbackSuggestions(suggestions);
   const lines: string[] = [
     '# Improvement Suggestions',
     '',
     `Generated: ${new Date().toISOString()}`,
-    '',
+    ...(userFeedbackCount > 0 ? [`User feedback issues included: ${userFeedbackCount}`, ''] : ['']),
   ];
 
   if (suggestions.length === 0) {
@@ -274,7 +283,8 @@ export const analyzeCommand = new Command('analyze')
     ]);
 
     if (format === 'json') {
-      console.log(JSON.stringify({ suggestions, routingMiss, rules: rulesFile?.rules ?? [] }, null, 2));
+      const userFeedbackCount = countUserFeedbackSuggestions(suggestions);
+      console.log(JSON.stringify({ suggestions, routingMiss, rules: rulesFile?.rules ?? [], userFeedbackCount }, null, 2));
     } else if (format === 'markdown') {
       console.log(formatMarkdown(suggestions, routingMiss));
     } else {

--- a/packages/eval-core/src/query/feedback.ts
+++ b/packages/eval-core/src/query/feedback.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, gte, sql } from 'drizzle-orm';
 import type { EvalDb } from '../db/client.js';
 import { agentInvocations, improvementActions } from '../db/schema.js';
+import { fetchUserFeedbackIssues, type UserFeedbackEntry } from './user-feedback.js';
 
 /**
  * Opposing action pairs that conflict when targeting the same entity.
@@ -391,6 +392,11 @@ export async function getImprovementSuggestions(
     });
   }
 
+  // Merge user-explicit feedback from GitHub issues
+  const userFeedback = fetchUserFeedbackIssues();
+  const userSuggestions = userFeedbackToSuggestions(userFeedback);
+  suggestions.push(...userSuggestions);
+
   // Apply conflict resolution
   const resolved = filterConflicts(suggestions);
 
@@ -402,6 +408,28 @@ export async function getImprovementSuggestions(
   return filtered.sort(
     (a, b) => (confidenceOrder[a.confidence] ?? 2) - (confidenceOrder[b.confidence] ?? 2)
   );
+}
+
+/**
+ * Converts user-explicit feedback entries into ImprovementSuggestion format.
+ * Only negative-sentiment entries with a specific target (non-general) are included.
+ */
+export function userFeedbackToSuggestions(entries: UserFeedbackEntry[]): ImprovementSuggestion[] {
+  return entries
+    .filter((e) => e.targetType !== 'general' && e.sentiment === 'negative')
+    .map((e) => ({
+      target: e.target,
+      targetType: (e.targetType === 'general' ? 'agent' : e.targetType) as ImprovementSuggestion['targetType'],
+      actionType: 'revise' as const,
+      description: `User feedback (issue #${e.issueNumber}): "${e.title}"`,
+      confidence: 'medium' as const,
+      evidence: {
+        metric: 'user_feedback',
+        value: 1,
+        threshold: 0,
+        sessionCount: 1,
+      },
+    }));
 }
 
 /**

--- a/packages/eval-core/src/query/user-feedback.ts
+++ b/packages/eval-core/src/query/user-feedback.ts
@@ -1,0 +1,106 @@
+import { execSync } from 'node:child_process';
+
+export interface UserFeedbackEntry {
+  issueNumber: number;
+  title: string;
+  body: string;
+  createdAt: string;
+  /** Extracted target: agent name, skill name, or rule ID */
+  target: string;
+  targetType: 'agent' | 'skill' | 'rule' | 'general';
+  sentiment: 'positive' | 'negative' | 'suggestion';
+  feedbackSource: 'user_explicit';
+}
+
+/**
+ * Parses a GitHub issue into a UserFeedbackEntry.
+ * Extracts target, targetType, and sentiment from title/body text.
+ * Precedence for targetType: rule > skill > agent > general.
+ * Issue content is treated as plain text — never evaluated as code.
+ */
+export function parseIssueToFeedback(issue: {
+  number: number;
+  title: string;
+  body: string;
+  createdAt: string;
+}): UserFeedbackEntry {
+  const title = issue.title.toLowerCase();
+  const body = (issue.body ?? '').toLowerCase();
+  const combined = `${title} ${body}`;
+
+  let target = 'general';
+  let targetType: UserFeedbackEntry['targetType'] = 'general';
+
+  // Agent patterns: "agent: xxx", "에이전트: xxx"
+  const agentMatch = combined.match(/(?:agent|에이전트)[:\s]+([a-z][\w-]+)/);
+  if (agentMatch) {
+    target = agentMatch[1];
+    targetType = 'agent';
+  }
+
+  // Skill patterns (overrides agent): "skill: xxx", "스킬: xxx"
+  const skillMatch = combined.match(/(?:skill|스킬)[:\s]+([a-z][\w-]+)/);
+  if (skillMatch) {
+    target = skillMatch[1];
+    targetType = 'skill';
+  }
+
+  // Rule patterns (highest precedence): "R0xx"
+  const ruleMatch = combined.match(/\b(R\d{3})\b/i);
+  if (ruleMatch) {
+    target = ruleMatch[1].toUpperCase();
+    targetType = 'rule';
+  }
+
+  // Sentiment detection from title keywords
+  let sentiment: UserFeedbackEntry['sentiment'] = 'suggestion';
+  if (
+    title.includes('bug') ||
+    title.includes('fail') ||
+    title.includes('broken') ||
+    title.includes('실패')
+  ) {
+    sentiment = 'negative';
+  } else if (
+    title.includes('great') ||
+    title.includes('good') ||
+    title.includes('좋') ||
+    title.includes('잘')
+  ) {
+    sentiment = 'positive';
+  }
+
+  return {
+    issueNumber: issue.number,
+    title: issue.title,
+    body: issue.body ?? '',
+    createdAt: issue.createdAt,
+    target,
+    targetType,
+    sentiment,
+    feedbackSource: 'user_explicit',
+  };
+}
+
+/**
+ * Fetches GitHub issues labeled 'feedback' using the gh CLI.
+ * Returns an empty array if gh is unavailable or there are no matching issues.
+ * Applies a 10-second timeout to avoid hanging.
+ */
+export function fetchUserFeedbackIssues(): UserFeedbackEntry[] {
+  try {
+    const raw = execSync(
+      'gh issue list --label feedback --state all --json number,title,body,createdAt --limit 50',
+      { encoding: 'utf-8', timeout: 10000 }
+    );
+    const issues = JSON.parse(raw) as Array<{
+      number: number;
+      title: string;
+      body: string;
+      createdAt: string;
+    }>;
+    return issues.map(parseIssueToFeedback);
+  } catch {
+    return [];
+  }
+}

--- a/packages/serve/src/lib/server/eval-reader.ts
+++ b/packages/serve/src/lib/server/eval-reader.ts
@@ -9,6 +9,7 @@ import { readFileSync, readdirSync } from 'fs';
 
 const HOME = process.env.HOME ?? process.env.USERPROFILE ?? '~';
 const EVAL_DIR = join(HOME, '.omcustom', 'evaluations');
+const EVAL_CORE_DB_PATH = join(HOME, '.config', 'oh-my-customcode', 'eval-core.sqlite');
 
 // ---------------------------------------------------------------------------
 // Types
@@ -144,8 +145,55 @@ function readTaskOutcomesSync(): TaskOutcome[] {
 	return outcomes;
 }
 
+function readEvalCoreSessionsSync(): TaskOutcome[] {
+	try {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const { Database } = require('bun:sqlite') as { Database: new (path: string, options?: { readonly?: boolean }) => { query: (sql: string) => { all: () => unknown[] }; close: () => void } };
+		const db = new Database(EVAL_CORE_DB_PATH, { readonly: true });
+		const rows = db.query(`
+			SELECT agent_type, outcome, model, timestamp, session_id
+			FROM agent_invocations
+			ORDER BY timestamp DESC
+			LIMIT 1000
+		`).all() as Array<{
+			agent_type: string;
+			outcome: string;
+			model: string;
+			timestamp: string;
+			session_id: string;
+		}>;
+		db.close();
+
+		return rows.map((r) => ({
+			agent_type: r.agent_type,
+			outcome: r.outcome,
+			model: r.model,
+			timestamp: r.timestamp,
+			session_id: r.session_id
+		}));
+	} catch {
+		return [];
+	}
+}
+
 export async function getSessionSummaries(): Promise<SessionSummary[]> {
-	const outcomes = readTaskOutcomesSync();
+	// Primary: eval-core DB (persistent across sessions)
+	const dbOutcomes = readEvalCoreSessionsSync();
+	// Secondary: /tmp JSONL (live session data)
+	const tmpOutcomes = readTaskOutcomesSync();
+
+	// Merge, deduplicating by session_id + timestamp + agent_type
+	const seen = new Set<string>();
+	const outcomes: TaskOutcome[] = [];
+
+	for (const o of [...tmpOutcomes, ...dbOutcomes]) {
+		const key = `${o.session_id ?? ''}:${o.timestamp ?? ''}:${o.agent_type ?? ''}`;
+		if (!seen.has(key)) {
+			seen.add(key);
+			outcomes.push(o);
+		}
+	}
+
 	const evaluations = await getEvaluations();
 
 	// Group outcomes by session_id

--- a/packages/serve/src/routes/+page.server.ts
+++ b/packages/serve/src/routes/+page.server.ts
@@ -1,12 +1,51 @@
 import type { PageServerLoad } from './$types';
 import { getAnalytics, type AnalyticsData } from '$lib/server/analytics';
-import { findProjectsForServe } from '$lib/server/projects';
+import { readdir } from 'fs/promises';
+import { join } from 'path';
 
+interface ProjectDetail {
+	agentCount: number;
+	skillCount: number;
+	guideCount: number;
+	ruleCount: number;
+}
+
+async function getProjectDetail(root: string): Promise<ProjectDetail> {
+	const count = async (dir: string, pattern?: string) => {
+		try {
+			const entries = await readdir(dir);
+			return pattern ? entries.filter((e) => e.endsWith(pattern)).length : entries.length;
+		} catch {
+			return 0;
+		}
+	};
+
+	// For skills, count directories containing SKILL.md
+	let skillCount = 0;
+	try {
+		const skillDirs = await readdir(join(root, '.claude', 'skills'));
+		for (const d of skillDirs) {
+			try {
+				await readdir(join(root, '.claude', 'skills', d)); // check it's a dir
+				skillCount++;
+			} catch {
+				/* skip files */
+			}
+		}
+	} catch {
+		/* no skills dir */
+	}
+
+	return {
+		agentCount: await count(join(root, '.claude', 'agents'), '.md'),
+		skillCount,
+		guideCount: await count(join(root, 'guides')),
+		ruleCount: await count(join(root, '.claude', 'rules'), '.md')
+	};
+}
 
 export const load: PageServerLoad = async ({ parent }) => {
 	const { root, selectedProject } = await parent();
-
-	const allProjects = await findProjectsForServe();
 
 	// Analytics loaded separately so a failure doesn't break the entire page
 	let analytics: AnalyticsData | null = null;
@@ -21,19 +60,12 @@ export const load: PageServerLoad = async ({ parent }) => {
 		analytics = null;
 	}
 
-	// Summary across all discovered projects
-	const projectSummary = {
-		total: allProjects.length,
-		latest: allProjects.filter((p) => p.status === 'latest').length,
-		outdated: allProjects.filter((p) => p.status === 'outdated').length,
-		unknown: allProjects.filter((p) => p.status === 'unknown').length
-	};
+	const projectDetail = await getProjectDetail(root);
 
 	return {
 		root,
 		selectedProject,
-		projectSummary,
-		projects: allProjects.slice(0, 6), // Show up to 6 projects on dashboard
-		analytics
+		analytics,
+		projectDetail
 	};
 };

--- a/packages/serve/src/routes/+page.svelte
+++ b/packages/serve/src/routes/+page.svelte
@@ -3,26 +3,8 @@
 
 	export let data: PageData;
 
-	const statusConfig: Record<string, { label: string; dot: string; badge: string }> = {
-		latest: {
-			label: 'Latest',
-			dot: 'text-emerald-500',
-			badge: 'bg-emerald-950 text-emerald-400 border-emerald-800'
-		},
-		outdated: {
-			label: 'Outdated',
-			dot: 'text-amber-500',
-			badge: 'bg-amber-950 text-amber-400 border-amber-800'
-		},
-		unknown: {
-			label: 'Unknown',
-			dot: 'text-zinc-600',
-			badge: 'bg-zinc-900 text-zinc-500 border-zinc-700'
-		}
-	};
-
 	$: currentProjectLabel = data.selectedProject
-		? data.projects.find((p) => p.slug === data.selectedProject)?.name ?? 'Selected Project'
+		? data.selectedProject
 		: data.root?.split('/').pop() ?? 'Default Project';
 
 	$: projectParam = data.selectedProject ? `?project=${data.selectedProject}` : '';
@@ -160,55 +142,28 @@
 		</div>
 	{/if}
 
-	<!-- All projects overview -->
+	<!-- Project overview -->
 	<div>
-		<div class="mb-3">
-			<h2 class="text-xs font-semibold uppercase tracking-wider text-zinc-400">
-				All Projects
-				<span class="ml-2 font-normal normal-case text-zinc-600">
-					{data.projectSummary.total} found —
-					<span class="text-emerald-500">{data.projectSummary.latest} latest</span>,
-					<span class="text-amber-500">{data.projectSummary.outdated} outdated</span>
-				</span>
-			</h2>
+		<h2 class="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-400">
+			Project Overview
+		</h2>
+		<div class="grid grid-cols-2 gap-4 lg:grid-cols-4">
+			<a href="/agents{projectParam}" class="rounded-lg border border-zinc-800 p-4 transition-colors hover:border-zinc-700">
+				<div class="text-2xl font-bold text-zinc-100">{data.projectDetail.agentCount}</div>
+				<div class="mt-1 text-xs text-zinc-500">Agents</div>
+			</a>
+			<a href="/skills{projectParam}" class="rounded-lg border border-zinc-800 p-4 transition-colors hover:border-zinc-700">
+				<div class="text-2xl font-bold text-zinc-100">{data.projectDetail.skillCount}</div>
+				<div class="mt-1 text-xs text-zinc-500">Skills</div>
+			</a>
+			<a href="/guides{projectParam}" class="rounded-lg border border-zinc-800 p-4 transition-colors hover:border-zinc-700">
+				<div class="text-2xl font-bold text-zinc-100">{data.projectDetail.guideCount}</div>
+				<div class="mt-1 text-xs text-zinc-500">Guides</div>
+			</a>
+			<a href="/rules{projectParam}" class="rounded-lg border border-zinc-800 p-4 transition-colors hover:border-zinc-700">
+				<div class="text-2xl font-bold text-zinc-100">{data.projectDetail.ruleCount}</div>
+				<div class="mt-1 text-xs text-zinc-500">Rules</div>
+			</a>
 		</div>
-
-		{#if data.projects.length > 0}
-			<div class="space-y-2">
-				{#each data.projects as project}
-					{@const config = statusConfig[project.status] ?? statusConfig.unknown}
-					<div class="flex items-center justify-between rounded-lg border border-zinc-800 px-5 py-4 transition-colors hover:border-zinc-700">
-						<div class="flex min-w-0 items-center gap-3">
-							<span class="text-xs {config.dot}">●</span>
-							<div class="min-w-0">
-								<span class="font-medium text-zinc-200">{project.name}</span>
-								<p class="mt-0.5 truncate text-xs text-zinc-600" title={project.path}>{project.path}</p>
-							</div>
-						</div>
-						<div class="ml-4 flex shrink-0 items-center gap-3">
-							{#if project.version}
-								<span class="text-xs text-zinc-600">v{project.version}</span>
-							{/if}
-							<span class="rounded border px-2 py-0.5 text-xs font-medium {config.badge}">
-								{config.label}
-							</span>
-						</div>
-					</div>
-				{/each}
-
-				{#if data.projectSummary.total > data.projects.length}
-					<div class="rounded-lg border border-zinc-800/50 px-5 py-3 text-center text-xs text-zinc-600">
-						+{data.projectSummary.total - data.projects.length} more projects
-					</div>
-				{/if}
-			</div>
-		{:else}
-			<div class="rounded-lg border border-zinc-800 p-8 text-center">
-				<p class="text-sm text-zinc-600">No oh-my-customcode projects found.</p>
-				<p class="mt-2 text-xs text-zinc-700">
-					Searched: ~/workspace, ~/projects, ~/dev, ~/src, ~/code, ~/repos, ~/work
-				</p>
-			</div>
-		{/if}
 	</div>
 </div>

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.52.0",
+  "version": "0.53.0",
   "lastUpdated": "2026-03-16T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary

v0.53.0 릴리즈: Epic #624 완결 + Epic #535 Phase 2

- **#625** (XS): 대시보드 All Projects 섹션 제거 — UI 및 서버 데이터 로딩 정리
- **#626** (S): 프로젝트별 상세 뷰 — `?project=X` 활성 시 agents/skills/guides/rules 카운트 표시
- **#627** (S): Evaluations 데이터 파이프라인 수정 — eval-core SQLite DB를 `bun:sqlite`로 연결
- **#562** (S): 사용자 명시적 피드백 연계 — `feedback` 라벨 GitHub Issue를 eval-core 분석 소스로 통합

### Key Changes

| Area | Change |
|------|--------|
| Dashboard | Removed All Projects section, added Project Overview grid |
| eval-reader.ts | Added `bun:sqlite` reader for `eval-core.sqlite` with dedup merge |
| feedback.ts | Added `userFeedbackToSuggestions()` for user_explicit source |
| user-feedback.ts | New module: parse feedback-labeled GitHub issues (gh CLI) |
| analyze.cmd.ts | Display user feedback count in CLI output |

### Epic Status

- **#624** (Web UI 개선): **COMPLETE** — all 3 child issues (#625, #626, #627) resolved
- **#535** (세션 피드백 자동 개선): Phase 2 complete (#562)

## Test plan

- [x] `bun run test` — 1475 pass, 0 fail (+34 new tests)
- [x] `bun run check` (packages/serve) — passes (pre-existing a11y warning only)
- [x] `bun run build` — successful
- [ ] CI pipeline — awaiting

Closes #625, #626, #627, #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)