### PR TITLE
fix: v0.53.1 — auto-tagging fix, workflow rename, custom workflow templates

### DIFF
--- a/.claude/skills/npm-version/SKILL.md
+++ b/.claude/skills/npm-version/SKILL.md
@@ -74,3 +74,30 @@ npm-version major
 # Update version without creating git tag
 npm-version patch --no-tag
 ```
+
+## Release Branch Integration
+
+When working with `auto-tag.yml` (automatic tag creation on release PR merge):
+
+1. `.npmrc` has `git-tag-version=false` — prevents local tag creation during `npm version`
+2. `auto-tag.yml` creates the tag on the **merge commit** when a `release/*` PR is merged to `develop`
+3. Do NOT manually push tags — let the CI workflow handle tag creation
+
+### Release Workflow
+
+```
+1. Create release branch: release/vX.Y.Z
+2. Run version bump (npm version / manual edit)  ← no local tag created
+3. Build dist, commit, push
+4. Create PR → merge to develop
+5. auto-tag.yml creates vX.Y.Z tag on merge commit  ← correct tag target
+6. release.yml triggers on tag → GitHub Release + npm publish
+```
+
+### Troubleshooting
+
+If a tag already exists on remote (from a previous failed attempt):
+```bash
+git push origin :refs/tags/vX.Y.Z   # delete remote tag
+# Then re-merge or let auto-tag.yml handle it
+```

--- a/.claude/skills/workflow-resume/SKILL.md
+++ b/.claude/skills/workflow-resume/SKILL.md
@@ -1,17 +1,17 @@
 ---
-name: workflow-resume
+name: omcustom:workflow:resume
 description: Resume a halted workflow from its last failure point
 scope: harness
 user-invocable: true
 effort: medium
 ---
 
-# /workflow:resume — Resume Halted Workflow
+# /omcustom:workflow:resume — Resume Halted Workflow
 
 ## Usage
 
 ```
-/workflow:resume            # Find and resume the most recent halted workflow
+/omcustom:workflow:resume            # Find and resume the most recent halted workflow
 ```
 
 ## Behavior

--- a/.claude/skills/workflow/SKILL.md
+++ b/.claude/skills/workflow/SKILL.md
@@ -1,20 +1,20 @@
 ---
-name: workflow
-description: Invoke YAML-defined workflows by name — /workflow omcustom-dev runs the full pipeline
+name: omcustom:workflow
+description: Invoke YAML-defined workflows by name — /omcustom:workflow omcustom-dev runs the full pipeline
 scope: harness
 user-invocable: true
 effort: high
 argument-hint: "<workflow-name> | (no args to list available)"
 ---
 
-# /workflow — Workflow Invocation
+# /omcustom:workflow — Workflow Invocation
 
 ## Usage
 
 ```
-/workflow omcustom-dev     # Run the omcustom-dev workflow
-/workflow                  # List available workflows
-/workflow:resume           # Resume a halted workflow
+/omcustom:workflow omcustom-dev     # Run the omcustom-dev workflow
+/omcustom:workflow                  # List available workflows
+/omcustom:workflow:resume           # Resume a halted workflow
 ```
 
 ## Behavior
@@ -35,7 +35,7 @@ Available workflows:
 4. Invoke workflow-runner skill with the loaded definition
 5. Report completion or failure
 
-### Resume Mode (/workflow:resume)
+### Resume Mode (/omcustom:workflow:resume)
 
 1. Check for state file: `/tmp/.claude-workflow-*-{PPID}.json`
 2. If found: show halted workflow name and failed step

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+git-tag-version=false

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.53.0",
-  "generatedAt": "2026-03-23T04:31:05.453Z",
-  "templateVersion": "0.53.0",
+  "generatorVersion": "0.53.1",
+  "generatedAt": "2026-03-23T06:26:28.205Z",
+  "templateVersion": "0.53.1",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",
@@ -355,8 +355,8 @@
       "component": "skills"
     },
     ".claude/skills/npm-version/SKILL.md": {
-      "templateHash": "6af5203fc46c54c4e0f439e7b4419a33772ef6b9b98057f52e91b7897151c5c0",
-      "size": 1380,
+      "templateHash": "c10a782e186a508a5ec6bbf211d1050bdc908bbd32f4e1e4d9adf492c994e565",
+      "size": 2312,
       "component": "skills"
     },
     ".claude/skills/research/SKILL.md": {
@@ -720,8 +720,8 @@
       "component": "skills"
     },
     ".claude/skills/workflow/SKILL.md": {
-      "templateHash": "d16fd264b03e26c89497bba12aae5ae10bcea39e9cb3433be5b4b5e6ff49d44c",
-      "size": 1396,
+      "templateHash": "6753ccd2bf7abe2629d82a9fa7813a2406e238bf9f6d3749080fd51dcb3c8fc9",
+      "size": 1459,
       "component": "skills"
     },
     ".claude/skills/workflow-runner/SKILL.md": {
@@ -750,8 +750,8 @@
       "component": "skills"
     },
     ".claude/skills/workflow-resume/SKILL.md": {
-      "templateHash": "866bada1ca7d812ec05d72e3dbd047cbef04f71cb876fc6c36b1cfd2c20cb11d",
-      "size": 713,
+      "templateHash": "3b996d003a9255e56a43f7733001cfdd4faf3adeae52c06dae976bfd91a75556",
+      "size": 740,
       "component": "skills"
     },
     ".claude/skills/sauron-watch/SKILL.md": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,8 +122,8 @@ oh-my-customcode로 구동됩니다.
 | `/deep-verify` | 다중 관점 릴리즈 품질 검증 |
 | `/professor-triage` | 이슈 교차 분석 트리아지 (omc_issue_analyzer 댓글 기반) |
 | `/release-plan` | verify-done 이슈 릴리즈 유닛 계획 생성 |
-| `/workflow` | YAML 워크플로우 실행 (예: /workflow omcustom-dev) |
-| `/workflow:resume` | 중단된 워크플로우 재개 |
+| `/omcustom:workflow` | YAML 워크플로우 실행 (예: /omcustom:workflow omcustom-dev) |
+| `/omcustom:workflow:resume` | 중단된 워크플로우 재개 |
 | `/omcustom:sauron-watch` | 전체 R017 검증 |
 | `/structured-dev-cycle` | 6단계 구조적 개발 사이클 (Plan → Verify → Implement → Verify → Compound → Done) |
 | `/omcustom:loop` | 백그라운드 에이전트 자동 계속 실행 |
@@ -392,8 +392,8 @@ oh-my-customcode로 구동됩니다.
 | `/deep-verify` | 다중 관점 릴리즈 품질 검증 |
 | `/professor-triage` | 이슈 교차 분석 트리아지 (omc_issue_analyzer 댓글 기반) |
 | `/release-plan` | verify-done 이슈 릴리즈 유닛 계획 생성 |
-| `/workflow` | YAML 워크플로우 실행 (예: /workflow omcustom-dev) |
-| `/workflow:resume` | 중단된 워크플로우 재개 |
+| `/omcustom:workflow` | YAML 워크플로우 실행 (예: /omcustom:workflow omcustom-dev) |
+| `/omcustom:workflow:resume` | 중단된 워크플로우 재개 |
 | `/omcustom:sauron-watch` | 전체 R017 검증 |
 | `/sdd-dev` | Spec-Driven Development 워크플로우 (sdd/ 폴더 기반) |
 | `/structured-dev-cycle` | 6단계 구조적 개발 사이클 (Plan → Verify → Implement → Verify → Compound → Done) |

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9305,7 +9305,7 @@ var init_package = __esm(() => {
   package_default = {
     name: "oh-my-customcode",
     workspaces: ["packages/*"],
-    version: "0.53.0",
+    version: "0.53.1",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1679,7 +1679,7 @@ import { join as join6 } from "node:path";
 var package_default = {
   name: "oh-my-customcode",
   workspaces: ["packages/*"],
-  version: "0.53.0",
+  version: "0.53.1",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-customcode",
   "workspaces": ["packages/*"],
-  "version": "0.53.0",
+  "version": "0.53.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.53.0",
+  "version": "0.53.1",
   "lastUpdated": "2026-03-16T00:00:00.000Z",
   "components": [
     {

--- a/workflows/templates/custom-docs.yaml
+++ b/workflows/templates/custom-docs.yaml
@@ -1,0 +1,19 @@
+# Example: Documentation update workflow
+
+name: custom-docs
+description: "Documentation scan and update pipeline"
+mode: confirm
+error: halt-and-report
+
+steps:
+  - name: scan
+    skill: omcustom:update-docs
+    description: Scan project structure for documentation gaps
+
+  - name: review
+    skill: dev-review
+    description: Review generated documentation
+
+  - name: release
+    action: create-pr
+    description: Create PR with documentation updates

--- a/workflows/templates/custom-review.yaml
+++ b/workflows/templates/custom-review.yaml
@@ -1,0 +1,37 @@
+# Example: Custom code review workflow
+# Copy to workflows/ directory and customize
+#
+# Available fields:
+#   name:        Workflow identifier (kebab-case: ^[a-z0-9-]+$)
+#   description: Human-readable description
+#   mode:        auto | confirm (auto = no confirmation, confirm = ask before each step)
+#   error:       halt-and-report (stop and save state on failure)
+#
+# Step fields:
+#   name:        Step identifier
+#   skill:       Skill name to invoke (must exist in .claude/skills/)
+#   action:      Built-in action: implement | create-pr
+#   description: Human-readable description
+#   input:       Reference to previous step output
+#   foreach:     Iterate over collection from previous step
+#
+# Note: Each step must have either 'skill' or 'action', not both.
+# Skill names are validated against .claude/skills/ directory.
+
+name: custom-review
+description: "Custom code review and fix pipeline"
+mode: confirm
+error: halt-and-report
+
+steps:
+  - name: review
+    skill: dev-review
+    description: Review code for best practices
+
+  - name: fix
+    action: implement
+    description: Fix review findings
+
+  - name: verify
+    skill: dev-review
+    description: Re-review to confirm fixes


### PR DESCRIPTION
## Summary

v0.53.1 패치 릴리즈: CI 태그 충돌 수정 + 워크플로우 개선

- **#630** (S): `.npmrc`에 `git-tag-version=false` 추가 — `npm version`의 자동 태그가 `auto-tag.yml`과 충돌하는 문제 해결. npm-version 스킬에 릴리즈 브랜치 가이드 추가.
- **#631** (XS): `/workflow` → `/omcustom:workflow` 리네이밍 — 커맨드 네이밍 컨벤션 통일
- **#632** (S): 사용자 커스텀 워크플로우 지원 — `workflows/templates/`에 예제 YAML 2개 추가 (custom-review, custom-docs). 전체 스키마 문서화.

### Changes

| File | Change |
|------|--------|
| `.npmrc` | **New** — `git-tag-version=false` |
| `npm-version/SKILL.md` | Release branch integration guide 추가 |
| `workflow/SKILL.md` | `name: omcustom:workflow` 리네이밍 |
| `workflow-resume/SKILL.md` | `name: omcustom:workflow:resume` 리네이밍 |
| `CLAUDE.md` | 양쪽 커맨드 테이블 업데이트 (4곳) |
| `workflows/templates/*.yaml` | **New** — 2개 예제 워크플로우 |

## Test plan

- [x] `bun run test` — 1475 pass, 0 fail
- [x] `bun run check` — passes
- [x] pre-commit hooks — passes
- [x] No bare `/workflow` entries remain in CLAUDE.md
- [ ] CI pipeline — awaiting

Closes #630, #631, #632

🤖 Generated with [Claude Code](https://claude.com/claude-code)