### PR TITLE
feat: v0.55.0 — eraser workflow, weekly rate limit statusline

### DIFF
--- a/.claude/rules/SHOULD-hud-statusline.md
+++ b/.claude/rules/SHOULD-hud-statusline.md
@@ -41,10 +41,10 @@ Implemented in `.claude/hooks/hooks.json` (PreToolUse → Agent/Task matcher).
 ### Format
 
 ```
-{Cost} | {project} | {branch} | RL:{rate_limit}% | CTX:{usage}%
+{Cost} | {project} | {branch} | RL:{rate_limit}% | WL:{weekly_limit}% | CTX:{usage}%
 ```
 
-Example: `$0.05 | my-project | develop | RL:45% | CTX:42%`
+Example: `$0.05 | my-project | develop | RL:45% | WL:72% | CTX:42%`
 
 ### Configuration
 
@@ -70,11 +70,16 @@ Set in `.claude/settings.local.json`. The command receives JSON via stdin with m
 | Rate Limit | < 50% | Green |
 | Rate Limit | 50-79% | Yellow |
 | Rate Limit | >= 80% | Red |
+| Weekly Limit | < 50% | Green |
+| Weekly Limit | 50-79% | Yellow |
+| Weekly Limit | >= 80% | Red |
 | Context | < 60% | Green |
 | Context | 60-79% | Yellow |
 | Context | >= 80% | Red |
 
 The `RL:{rate_limit}%` segment only appears when Claude Code v2.1.80+ provides `rate_limits` data. On older versions, this segment is omitted.
+
+The `WL:{weekly_limit}%` segment shows the 7-day rolling rate limit percentage. Both RL and WL segments are omitted on older versions.
 
 ## Integration
 

--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -66,16 +66,17 @@ fi
 
 # ---------------------------------------------------------------------------
 # 4. Single jq call — extract all fields as TSV
-#    Fields: model_name, project_dir, ctx_pct, ctx_size, cost_usd, rl_5h_pct
+#    Fields: model_name, project_dir, ctx_pct, ctx_size, cost_usd, rl_5h_pct, rl_7d_pct
 # ---------------------------------------------------------------------------
-IFS=$'\t' read -r model_name project_dir ctx_pct ctx_size cost_usd rl_5h_pct <<< "$(
+IFS=$'\t' read -r model_name project_dir ctx_pct ctx_size cost_usd rl_5h_pct rl_7d_pct <<< "$(
     printf '%s' "$json" | jq -r '[
         (.model.display_name // "unknown"),
         (.workspace.current_dir // ""),
         (if .context_window.used != null and .context_window.total != null and .context_window.total > 0 then (.context_window.used / .context_window.total * 100) elif .context_window.used_percentage != null then .context_window.used_percentage else 0 end),
         (.context_window.context_window_size // 0),
         (.cost.total_cost_usd // 0),
-        (.rate_limits.five_hour.used_percentage // -1)
+        (.rate_limits.five_hour.used_percentage // -1),
+        (.rate_limits.seven_day.used_percentage // -1)
     ] | @tsv'
 )"
 
@@ -84,7 +85,7 @@ IFS=$'\t' read -r model_name project_dir ctx_pct ctx_size cost_usd rl_5h_pct <<<
 # ---------------------------------------------------------------------------
 COST_BRIDGE_FILE="/tmp/.claude-cost-${PPID}"
 _tmp="${COST_BRIDGE_FILE}.tmp.$$"
-printf '%s\t%s\t%s\t%s\n' "$cost_usd" "$ctx_pct" "$(date +%s)" "$rl_5h_pct" > "$_tmp" 2>/dev/null && mv -f "$_tmp" "$COST_BRIDGE_FILE" 2>/dev/null || true
+printf '%s\t%s\t%s\t%s\t%s\n' "$cost_usd" "$ctx_pct" "$(date +%s)" "$rl_5h_pct" "$rl_7d_pct" > "$_tmp" 2>/dev/null && mv -f "$_tmp" "$COST_BRIDGE_FILE" 2>/dev/null || true
 
 # ---------------------------------------------------------------------------
 # 5. Model display name + color (bash 3.2 compatible case pattern matching)
@@ -271,6 +272,27 @@ if [[ "$rl_5h_int" -ge 0 ]]; then
 fi
 
 # ---------------------------------------------------------------------------
+# 9c. Weekly rate limit percentage with color (v2.1.80+, optional)
+# ---------------------------------------------------------------------------
+wl_display=""
+wl_color=""
+wl_7d_int="${rl_7d_pct%%.*}"
+if ! [[ "$wl_7d_int" =~ ^-?[0-9]+$ ]]; then
+    wl_7d_int=-1
+fi
+
+if [[ "$wl_7d_int" -ge 0 ]]; then
+    wl_display="WL:${wl_7d_int}%"
+    if [[ "$wl_7d_int" -ge 80 ]]; then
+        wl_color="${COLOR_CTX_CRIT}"     # Red    (>= 80%)
+    elif [[ "$wl_7d_int" -ge 50 ]]; then
+        wl_color="${COLOR_CTX_WARN}"     # Yellow (50-79%)
+    else
+        wl_color="${COLOR_CTX_OK}"       # Green  (< 50%)
+    fi
+fi
+
+# ---------------------------------------------------------------------------
 # 10. Assemble and output the status line
 # ---------------------------------------------------------------------------
 # Format branch with optional OSC 8 hyperlink
@@ -293,19 +315,27 @@ if [[ -n "$rl_display" ]]; then
     rl_segment=" | ${rl_color}${rl_display}${COLOR_RESET}"
 fi
 
+# Build the WL segment (with separator) if present
+wl_segment=""
+if [[ -n "$wl_display" ]]; then
+    wl_segment=" | ${wl_color}${wl_display}${COLOR_RESET}"
+fi
+
 if [[ -n "$git_branch" ]]; then
-    printf "${cost_color}%s${COLOR_RESET} | %s | %s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
+    printf "${cost_color}%s${COLOR_RESET} | %s | %s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
         "$cost_display" \
         "$project_name" \
         "$branch_display" \
         "$pr_segment" \
         "$rl_segment" \
+        "$wl_segment" \
         "$ctx_display"
 else
-    printf "${cost_color}%s${COLOR_RESET} | %s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
+    printf "${cost_color}%s${COLOR_RESET} | %s%s%s%s | ${ctx_color}%s${COLOR_RESET}\n" \
         "$cost_display" \
         "$project_name" \
         "$pr_segment" \
         "$rl_segment" \
+        "$wl_segment" \
         "$ctx_display"
 fi

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.54.0",
-  "generatedAt": "2026-03-23T08:44:44.583Z",
-  "templateVersion": "0.54.0",
+  "generatorVersion": "0.55.0",
+  "generatedAt": "2026-03-23T09:02:20.483Z",
+  "templateVersion": "0.55.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",
@@ -10,8 +10,8 @@
       "component": "rules"
     },
     ".claude/rules/SHOULD-hud-statusline.md": {
-      "templateHash": "2d2dc89e0565ad90071e196f517ea1a11e88d34be73a5f29b0a60e55abde0797",
-      "size": 2082,
+      "templateHash": "20314179ca96f1589120f5bc5820345a28bac9f97c189920ebcbfc27d3bb0d72",
+      "size": 2348,
       "component": "rules"
     },
     ".claude/rules/MUST-orchestrator-coordination.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9305,7 +9305,7 @@ var init_package = __esm(() => {
   package_default = {
     name: "oh-my-customcode",
     workspaces: ["packages/*"],
-    version: "0.54.0",
+    version: "0.55.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1679,7 +1679,7 @@ import { join as join6 } from "node:path";
 var package_default = {
   name: "oh-my-customcode",
   workspaces: ["packages/*"],
-  version: "0.54.0",
+  version: "0.55.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oh-my-customcode",
   "workspaces": ["packages/*"],
-  "version": "0.54.0",
+  "version": "0.55.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.54.0",
+  "version": "0.55.0",
   "lastUpdated": "2026-03-16T00:00:00.000Z",
   "components": [
     {

--- a/workflows/eraser.yaml
+++ b/workflows/eraser.yaml
@@ -1,0 +1,45 @@
+# /omcustom:workflow eraser — Architecture documentation sync via Eraser MCP
+# Analyzes ARCHITECTURE.md, updates text, generates/replaces diagrams
+
+name: eraser
+description: "Architecture documentation sync: analyze → update text → generate/replace diagrams → verify"
+mode: confirm
+error: halt-and-report
+
+steps:
+  - name: analyze
+    action: implement
+    description: >
+      Compare ARCHITECTURE.md counts/versions against actual codebase.
+      Run: agent count (ls .claude/agents/*.md | wc -l),
+      skill count (find .claude/skills -name SKILL.md | wc -l),
+      guide count (find guides -mindepth 1 -maxdepth 1 -type d | wc -l).
+      Compare with documented values. List outdated sections.
+
+  - name: update-text
+    action: implement
+    description: >
+      Update ARCHITECTURE.md and ARCHITECTURE_ko.md text content:
+      version numbers, agent/skill/guide counts, feature descriptions,
+      new sections for recently added features, version history.
+      Delegate to arch-documenter agent.
+
+  - name: generate-diagrams
+    action: implement
+    description: >
+      Use Eraser MCP to generate/replace diagrams in assets/diagrams/.
+      Diagram types: renderCloudArchitectureDiagram (system overview),
+      renderSequenceDiagram (API flows), renderFlowchart (decision flows).
+      Settings: imageQuality 2, format png, background true, theme light,
+      typeface clean, colorMode bold.
+      Download generated images and save to assets/diagrams/.
+
+  - name: verify
+    skill: dev-review
+    description: >
+      Verify all image references are valid, counts match filesystem,
+      no broken links, English and Korean docs are synchronized.
+
+  - name: release
+    action: create-pr
+    description: Create PR with documentation updates


### PR DESCRIPTION
## Summary

- **#635** (L): `/omcustom:workflow eraser` — Eraser MCP 기반 아키텍처 문서 자동화 워크플로우 (5 steps: analyze → update-text → generate-diagrams → verify → release)
- **#639** (S): statusline에 WL (weekly rate limit) 세그먼트 추가 — `RL:n% | WL:n% | CTX:n%` 형식

### Changes

| File | Change |
|------|--------|
| `workflows/eraser.yaml` | **New** — 5-step architecture sync workflow |
| `.claude/statusline.sh` | 7-day rate limit 추출, WL 표시, 색상 코딩 |
| `.claude/rules/SHOULD-hud-statusline.md` | WL 포맷, 색상 테이블, 호환성 설명 |

## Test plan

- [x] `bun run test` — 1475 pass, 0 fail
- [x] `bash -n statusline.sh` — syntax OK
- [x] pre-commit hooks — passes
- [ ] CI — awaiting

Closes #635, #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)