### PR TITLE
feat: add post-release followup step to omcustom-dev workflow

### DIFF
--- a/.claude/skills/post-release-followup/SKILL.md
+++ b/.claude/skills/post-release-followup/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: post-release-followup
+description: Analyze release workflow findings and recommend follow-up actions — execute immediately or register as issues
+scope: harness
+user-invocable: false
+effort: medium
+---
+
+# Post-Release Follow-up
+
+## Purpose
+
+After PR creation in the omcustom-dev release workflow, collect unaddressed findings and present actionable follow-up recommendations. The user chooses: execute now, register as issues, or skip.
+
+## Workflow
+
+### 1. Collect Follow-up Candidates
+
+Gather unfinished work from multiple sources:
+
+**Source A — Remaining open issues**:
+- Run: `gh issue list --label verify-done --state open --json number,title,labels`
+- These are triaged issues NOT included in the current release
+
+**Source B — Deep-verify findings**:
+- Read the latest deep-verify output from `.claude/outputs/sessions/{today}/`
+- Extract any MEDIUM or LOW severity findings that were flagged but not fixed
+
+**Source C — Triage deferred items**:
+- Read the latest professor-triage output from `.claude/outputs/sessions/{today}/`
+- Extract items explicitly marked as deferred or P3
+
+**Source D — TODO markers in changed files**:
+- Run: `git diff develop...HEAD --name-only` to get changed files
+- Search changed files for `TODO`, `FIXME`, `HACK` markers added in this release
+
+### 2. Deduplicate and Categorize
+
+Remove duplicates (same issue referenced from multiple sources). Categorize:
+
+| Category | Criteria | Default Action |
+|----------|----------|----------------|
+| **Immediate** | P1/P2 remaining issues, MEDIUM+ verify findings | Execute now |
+| **Trackable** | P3 issues, LOW verify findings, new TODOs | Register as issue |
+| **Informational** | Already-tracked issues, cosmetic notes | Skip |
+
+### 3. Present to User
+
+Display follow-up summary:
+
+```
+[Follow-up] {n}개 후속 작업 발견
+
+━━━ 즉시 실행 추천 ({count}개) ━━━
+  1. {description} — 출처: {source}
+  2. {description} — 출처: {source}
+
+━━━ 이슈 등록 추천 ({count}개) ━━━
+  3. {description} — 출처: {source}
+  4. {description} — 출처: {source}
+
+━━━ 참고 사항 ({count}개) ━━━
+  5. {description} — 이미 #{issue_number}로 추적 중
+
+선택:
+  [A] 추천대로 실행 (즉시 실행 + 이슈 등록)
+  [B] 모두 즉시 실행
+  [C] 모두 이슈 등록
+  [D] 개별 선택 (항목별로 질문)
+  [E] 건너뛰기
+```
+
+Use AskUserQuestion (or equivalent user prompt) to get the choice.
+
+### 4. Process User Choice
+
+**Option A (추천대로)**:
+- "Immediate" items → delegate to appropriate specialist agents for execution
+- "Trackable" items → create GitHub issues via `gh issue create`
+- "Informational" items → skip
+
+**Option B (모두 즉시 실행)**:
+- All Immediate + Trackable items → delegate to specialist agents
+- Follow implementation patterns from the release workflow
+
+**Option C (모두 이슈 등록)**:
+- All Immediate + Trackable items → `gh issue create` with appropriate labels
+- Label: `professor` for auto-triage in next workflow run
+
+**Option D (개별 선택)**:
+- For each item, ask: `[{n}] {description} — 실행(E) / 이슈(I) / 건너뛰기(S)?`
+- Process each per user choice
+
+**Option E (건너뛰기)**:
+- Skip all follow-up actions
+- Complete workflow
+
+### 5. Report
+
+```
+[Follow-up Complete]
+├── 즉시 실행: {n}개 완료
+├── 이슈 등록: {n}개 (#{numbers})
+├── 건너뛰기: {n}개
+└── 총 처리: {total}개
+```
+
+## Issue Creation Template
+
+When creating follow-up issues:
+
+```bash
+gh issue create \
+  --title "{concise description}" \
+  --body "## Source\n\nDiscovered during v{version} release workflow.\n\n## Context\n\n{detailed context from triage/verify}\n\n## Suggested Action\n\n{recommendation}" \
+  --label "professor"
+```
+
+Add priority label (`P1`, `P2`, `P3`) based on categorization.
+
+## Notes
+
+- This skill runs in the main conversation context (via workflow skill step)
+- User interaction is expected — this is NOT a fully automated step
+- All file modifications delegated to specialist subagents per R010
+- Issue creation uses `gh` CLI directly (read-only operation pattern)
+- If no follow-up candidates found, report "No follow-up actions needed" and complete

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -88,7 +88,7 @@ The takeover pattern — reverse-compiling an existing codebase into structured 
 
 Each agent is defined in `.claude/agents/{name}.md` with YAML frontmatter specifying model, tools, skills, memory scope, and optional features (soul identity, escalation policy, isolation mode).
 
-### 3.3 Skill Catalog (94 skills)
+### 3.3 Skill Catalog (95 skills)
 
 **Routing skills (4, context: fork)**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (46 파일)
-|   +-- skills/                  # 스킬 (94 디렉토리)
+|   +-- skills/                  # 스킬 (95 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R021)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)
@@ -410,7 +410,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (46 파일)
-|   +-- skills/                  # 스킬 (94 디렉토리)
+|   +-- skills/                  # 스킬 (95 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R021)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **[한국어 문서 (Korean)](./README_ko.md)**
 
-46 agents. 94 skills. 21 rules. One command.
+46 agents. 95 skills. 21 rules. One command.
 
 ```bash
 npm install -g oh-my-customcode && cd your-project && omcustom init
@@ -146,7 +146,7 @@ Each agent declares its tools, model, memory scope, and limitations in YAML fron
 
 ---
 
-### Skills (94)
+### Skills (95)
 
 | Category | Count | Includes |
 |----------|-------|----------|
@@ -282,7 +282,7 @@ your-project/
 ├── CLAUDE.md                   # Entry point
 ├── .claude/
 │   ├── agents/                 # 46 agent definitions
-│   ├── skills/                 # 94 skill modules
+│   ├── skills/                 # 95 skill modules
 │   ├── rules/                  # 21 governance rules (R000-R021)
 │   ├── hooks/                  # 15 lifecycle hook scripts
 │   ├── schemas/                # Tool input validation schemas

--- a/README_ko.md
+++ b/README_ko.md
@@ -13,7 +13,7 @@
 
 **[English Documentation](./README.md)**
 
-46개 에이전트. 94개 스킬. 21개 규칙. 명령어 하나.
+46개 에이전트. 95개 스킬. 21개 규칙. 명령어 하나.
 
 > **v0.46.0** — Rate Limit 모니터링, Skill Effort Override, 멀티프로젝트 Web UI, 일괄 업데이트, SDD 워크플로우, Ambiguity Gate
 
@@ -136,7 +136,7 @@ Agent(arch-documenter):haiku      ┘
 
 ---
 
-## 스킬 (94개)
+## 스킬 (95개)
 
 | 카테고리 | 수 | 포함 |
 |---------|-----|------|
@@ -269,7 +269,7 @@ your-project/
 ├── CLAUDE.md                   # 진입점
 ├── .claude/
 │   ├── agents/                 # 46개 에이전트 정의
-│   ├── skills/                 # 94개 스킬 모듈
+│   ├── skills/                 # 95개 스킬 모듈
 │   ├── rules/                  # 21개 거버넌스 규칙 (R000-R021)
 │   ├── hooks/                  # 15개 라이프사이클 훅 스크립트
 │   ├── schemas/                # 도구 입력 검증 스키마

--- a/templates/.claude/skills/post-release-followup/SKILL.md
+++ b/templates/.claude/skills/post-release-followup/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: post-release-followup
+description: Analyze release workflow findings and recommend follow-up actions — execute immediately or register as issues
+scope: harness
+user-invocable: false
+effort: medium
+---
+
+# Post-Release Follow-up
+
+## Purpose
+
+After PR creation in the omcustom-dev release workflow, collect unaddressed findings and present actionable follow-up recommendations. The user chooses: execute now, register as issues, or skip.
+
+## Workflow
+
+### 1. Collect Follow-up Candidates
+
+Gather unfinished work from multiple sources:
+
+**Source A — Remaining open issues**:
+- Run: `gh issue list --label verify-done --state open --json number,title,labels`
+- These are triaged issues NOT included in the current release
+
+**Source B — Deep-verify findings**:
+- Read the latest deep-verify output from `.claude/outputs/sessions/{today}/`
+- Extract any MEDIUM or LOW severity findings that were flagged but not fixed
+
+**Source C — Triage deferred items**:
+- Read the latest professor-triage output from `.claude/outputs/sessions/{today}/`
+- Extract items explicitly marked as deferred or P3
+
+**Source D — TODO markers in changed files**:
+- Run: `git diff develop...HEAD --name-only` to get changed files
+- Search changed files for `TODO`, `FIXME`, `HACK` markers added in this release
+
+### 2. Deduplicate and Categorize
+
+Remove duplicates (same issue referenced from multiple sources). Categorize:
+
+| Category | Criteria | Default Action |
+|----------|----------|----------------|
+| **Immediate** | P1/P2 remaining issues, MEDIUM+ verify findings | Execute now |
+| **Trackable** | P3 issues, LOW verify findings, new TODOs | Register as issue |
+| **Informational** | Already-tracked issues, cosmetic notes | Skip |
+
+### 3. Present to User
+
+Display follow-up summary:
+
+```
+[Follow-up] {n}개 후속 작업 발견
+
+━━━ 즉시 실행 추천 ({count}개) ━━━
+  1. {description} — 출처: {source}
+  2. {description} — 출처: {source}
+
+━━━ 이슈 등록 추천 ({count}개) ━━━
+  3. {description} — 출처: {source}
+  4. {description} — 출처: {source}
+
+━━━ 참고 사항 ({count}개) ━━━
+  5. {description} — 이미 #{issue_number}로 추적 중
+
+선택:
+  [A] 추천대로 실행 (즉시 실행 + 이슈 등록)
+  [B] 모두 즉시 실행
+  [C] 모두 이슈 등록
+  [D] 개별 선택 (항목별로 질문)
+  [E] 건너뛰기
+```
+
+Use AskUserQuestion (or equivalent user prompt) to get the choice.
+
+### 4. Process User Choice
+
+**Option A (추천대로)**:
+- "Immediate" items → delegate to appropriate specialist agents for execution
+- "Trackable" items → create GitHub issues via `gh issue create`
+- "Informational" items → skip
+
+**Option B (모두 즉시 실행)**:
+- All Immediate + Trackable items → delegate to specialist agents
+- Follow implementation patterns from the release workflow
+
+**Option C (모두 이슈 등록)**:
+- All Immediate + Trackable items → `gh issue create` with appropriate labels
+- Label: `professor` for auto-triage in next workflow run
+
+**Option D (개별 선택)**:
+- For each item, ask: `[{n}] {description} — 실행(E) / 이슈(I) / 건너뛰기(S)?`
+- Process each per user choice
+
+**Option E (건너뛰기)**:
+- Skip all follow-up actions
+- Complete workflow
+
+### 5. Report
+
+```
+[Follow-up Complete]
+├── 즉시 실행: {n}개 완료
+├── 이슈 등록: {n}개 (#{numbers})
+├── 건너뛰기: {n}개
+└── 총 처리: {total}개
+```
+
+## Issue Creation Template
+
+When creating follow-up issues:
+
+```bash
+gh issue create \
+  --title "{concise description}" \
+  --body "## Source\n\nDiscovered during v{version} release workflow.\n\n## Context\n\n{detailed context from triage/verify}\n\n## Suggested Action\n\n{recommendation}" \
+  --label "professor"
+```
+
+Add priority label (`P1`, `P2`, `P3`) based on categorization.
+
+## Notes
+
+- This skill runs in the main conversation context (via workflow skill step)
+- User interaction is expected — this is NOT a fully automated step
+- All file modifications delegated to specialist subagents per R010
+- Issue creation uses `gh` CLI directly (read-only operation pattern)
+- If no follow-up candidates found, report "No follow-up actions needed" and complete

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -18,7 +18,7 @@
       "name": "skills",
       "path": ".claude/skills",
       "description": "Reusable skill modules (includes slash commands)",
-      "files": 94
+      "files": 95
     },
     {
       "name": "guides",

--- a/workflows/omcustom-dev.yaml
+++ b/workflows/omcustom-dev.yaml
@@ -1,8 +1,8 @@
 # /workflow:omcustom-dev — Full-auto release pipeline
-# Collects verify-done issues → triage → plan → implement → verify → PR
+# Collects verify-done issues → triage → plan → implement → verify → PR → followup
 
 name: omcustom-dev
-description: "verify-done issues release batch: triage → plan → implement → verify → PR"
+description: "verify-done issues release batch: triage → plan → implement → verify → PR → followup"
 mode: auto
 error: halt-and-report
 
@@ -33,3 +33,7 @@ steps:
   - name: release
     action: create-pr
     description: Create release branch and pull request
+
+  - name: followup
+    skill: post-release-followup
+    description: Recommend follow-up actions — user chooses to execute now or register as issues


### PR DESCRIPTION
## Summary
- Added `post-release-followup` skill that runs after PR creation in omcustom-dev workflow
- Collects unaddressed findings from 4 sources (open issues, deep-verify, triage, TODO markers)
- Categorizes into Immediate/Trackable/Informational and presents 5 user options (A-E)
- Updated skill count across all docs (94 → 95)
- Also synced skill to `templates/.claude/skills/` to keep template validation tests green

## Test plan
- [ ] Run `/omcustom:workflow omcustom-dev` and verify followup step executes after release
- [ ] Verify skill correctly collects remaining open issues via `gh issue list`
- [ ] Verify user interaction (A-E options) works as expected
- [ ] Verify issue creation template produces well-formatted issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)