### PR TITLE
fix: unify workflow command namespace to /omcustom:workflow

### DIFF
--- a/.claude/skills/post-release-followup/SKILL.md
+++ b/.claude/skills/post-release-followup/SKILL.md
@@ -10,7 +10,7 @@ effort: medium
 
 ## Purpose
 
-After PR creation in the omcustom-dev release workflow, collect unaddressed findings and present actionable follow-up recommendations. The user chooses: execute now, register as issues, or skip.
+After PR creation in the auto-dev release workflow, collect unaddressed findings and present actionable follow-up recommendations. The user chooses: execute now, register as issues, or skip.
 
 ## Workflow
 

--- a/.claude/skills/workflow/SKILL.md
+++ b/.claude/skills/workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: omcustom:workflow
-description: Invoke YAML-defined workflows by name — /omcustom:workflow omcustom-dev runs the full pipeline
+description: Invoke YAML-defined workflows by name — /omcustom:workflow auto-dev runs the full pipeline
 scope: harness
 user-invocable: true
 effort: high
@@ -12,7 +12,7 @@ argument-hint: "<workflow-name> | (no args to list available)"
 ## Usage
 
 ```
-/omcustom:workflow omcustom-dev     # Run the omcustom-dev workflow
+/omcustom:workflow auto-dev     # Run the auto-dev workflow
 /omcustom:workflow                  # List available workflows
 /omcustom:workflow:resume           # Resume a halted workflow
 ```

--- a/templates/.claude/skills/workflow/SKILL.md
+++ b/templates/.claude/skills/workflow/SKILL.md
@@ -1,20 +1,20 @@
 ---
-name: workflow
-description: Invoke YAML-defined workflows by name — /workflow omcustom-dev runs the full pipeline
+name: omcustom:workflow
+description: Invoke YAML-defined workflows by name — /omcustom:workflow auto-dev runs the full pipeline
 scope: harness
 user-invocable: true
 effort: high
 argument-hint: "<workflow-name> | (no args to list available)"
 ---
 
-# /workflow — Workflow Invocation
+# /omcustom:workflow — Workflow Invocation
 
 ## Usage
 
 ```
-/workflow omcustom-dev     # Run the omcustom-dev workflow
-/workflow                  # List available workflows
-/workflow:resume           # Resume a halted workflow
+/omcustom:workflow auto-dev     # Run the auto-dev workflow
+/omcustom:workflow                  # List available workflows
+/omcustom:workflow:resume           # Resume a halted workflow
 ```
 
 ## Behavior
@@ -24,7 +24,7 @@ argument-hint: "<workflow-name> | (no args to list available)"
 Scan `workflows/*.yaml` and display:
 ```
 Available workflows:
-  omcustom-dev — verify-done issues release batch: triage → plan → implement → verify → PR
+  auto-dev — verify-done issues release batch: triage → plan → implement → verify → PR
 ```
 
 ### Run Mode (with workflow name)
@@ -35,7 +35,7 @@ Available workflows:
 4. Invoke workflow-runner skill with the loaded definition
 5. Report completion or failure
 
-### Resume Mode (/workflow:resume)
+### Resume Mode (/omcustom:workflow:resume)
 
 1. Check for state file: `/tmp/.claude-workflow-*-{PPID}.json`
 2. If found: show halted workflow name and failed step

--- a/templates/workflows/auto-dev.yaml
+++ b/templates/workflows/auto-dev.yaml
@@ -1,8 +1,8 @@
-# /workflow:omcustom-dev — Full-auto release pipeline
-# Collects verify-done issues → triage → plan → implement → verify → PR
+# /omcustom:workflow auto-dev — Full-auto release pipeline
+# Collects verify-done issues → triage → plan → implement → verify → PR → followup
 
-name: omcustom-dev
-description: "verify-done issues release batch: triage → plan → implement → verify → PR"
+name: auto-dev
+description: "verify-done issues release batch: triage → plan → implement → verify → PR → followup"
 mode: auto
 error: halt-and-report
 
@@ -33,3 +33,7 @@ steps:
   - name: release
     action: create-pr
     description: Create release branch and pull request
+
+  - name: followup
+    skill: post-release-followup
+    description: Recommend follow-up actions — user chooses to execute now or register as issues

--- a/workflows/auto-dev.yaml
+++ b/workflows/auto-dev.yaml
@@ -1,7 +1,7 @@
-# /workflow:omcustom-dev — Full-auto release pipeline
+# /omcustom:workflow auto-dev — Full-auto release pipeline
 # Collects verify-done issues → triage → plan → implement → verify → PR → followup
 
-name: omcustom-dev
+name: auto-dev
 description: "verify-done issues release batch: triage → plan → implement → verify → PR → followup"
 mode: auto
 error: halt-and-report


### PR DESCRIPTION
## Summary

- **`templates/.claude/skills/workflow/SKILL.md`**: Renamed skill `name` from `workflow` to `omcustom:workflow`, updated all inline usage examples (`/workflow` → `/omcustom:workflow`, `/workflow:resume` → `/omcustom:workflow:resume`)
- **`workflows/auto-dev.yaml`** and **`templates/workflows/auto-dev.yaml`**: Updated header comment from `/workflow:omcustom-dev` to `/omcustom:workflow auto-dev` to match the canonical invocation format
- **`.claude/skills/workflow/SKILL.md`** and **`.claude/skills/post-release-followup/SKILL.md`**: Updated description and example references from `omcustom-dev` to `auto-dev` following the workflow rename in v0.58.1

## Why

Consumer projects that install oh-my-customcode via `omcustom init` received a `workflow` skill with a bare `/workflow` command, while the source project uses `/omcustom:workflow`. This namespace mismatch meant consumer projects had a different invocation path than documented. Aligning the template skill name to `omcustom:workflow` ensures all projects use the same slash command namespace.

## Test plan

- [ ] Verify `templates/.claude/skills/workflow/SKILL.md` has `name: omcustom:workflow`
- [ ] Verify `workflows/auto-dev.yaml` header comment reads `/omcustom:workflow auto-dev`
- [ ] Verify `templates/workflows/auto-dev.yaml` matches source workflow (7 steps including followup)
- [ ] CI template-sync check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)