### PR TITLE
chore(release): v0.58.4

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.58.3",
-  "generatedAt": "2026-03-25T08:02:46.959Z",
-  "templateVersion": "0.58.3",
+  "generatorVersion": "0.58.4",
+  "generatedAt": "2026-03-25T08:12:36.141Z",
+  "templateVersion": "0.58.4",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,14 +1,14 @@
 # Architecture
 
-> oh-my-customcode v0.53.1
+> oh-my-customcode v0.58.4
 
 ## 1. System Overview
 
-oh-my-customcode is a batteries-included agent harness for Claude Code. It ships 46 pre-built subagents, 94 skills, 21 governing rules, and a comprehensive hook system — all wired together so that any Claude Code session inherits a complete multi-agent operating model without additional configuration. The core philosophy is: **"No expert? CREATE one, connect knowledge, and USE it."** When a task arrives with no matching specialist, the system auto-creates one by discovering relevant skills and guides, then immediately executes the task.
+oh-my-customcode is a batteries-included agent harness for Claude Code. It ships 46 pre-built subagents, 95 skills, 21 governing rules, and a comprehensive hook system — all wired together so that any Claude Code session inherits a complete multi-agent operating model without additional configuration. The core philosophy is: **"No expert? CREATE one, connect knowledge, and USE it."** When a task arrives with no matching specialist, the system auto-creates one by discovering relevant skills and guides, then immediately executes the task.
 
 The harness operates on three engineering pillars — **Context Engineering** (what goes into the prompt), **Architectural Constraints** (rules that shape agent behavior), and **Entropy Management** (hooks, verification, and observability that keep the system coherent at scale).
 
-Current version: **0.53.1** — distributed as `oh-my-customcode` on npm, CLI: `omcustom`.
+Current version: **0.58.4** — distributed as `oh-my-customcode` on npm, CLI: `omcustom`.
 
 ---
 
@@ -74,7 +74,7 @@ The takeover pattern — reverse-compiling an existing codebase into structured 
 |----------|-------|--------|
 | SW Engineer / Language | 6 | lang-golang-expert, lang-python-expert, lang-rust-expert, lang-kotlin-expert, lang-typescript-expert, lang-java21-expert |
 | SW Engineer / Backend | 6 | be-fastapi-expert, be-springboot-expert, be-go-backend-expert, be-express-expert, be-nestjs-expert, be-django-expert |
-| SW Engineer / Frontend | 4 | fe-vercel-agent, fe-vuejs-agent, fe-svelte-agent, fe-flutter-agent |
+| SW Engineer / Frontend | 5 | fe-vercel-agent, fe-vuejs-agent, fe-svelte-agent, fe-flutter-agent, fe-design-expert |
 | SW Engineer / Tooling | 3 | tool-npm-expert, tool-optimizer, tool-bun-expert |
 | Data Engineering | 6 | de-airflow-expert, de-dbt-expert, de-spark-expert, de-kafka-expert, de-snowflake-expert, de-pipeline-expert |
 | Database | 4 | db-supabase-expert, db-postgres-expert, db-redis-expert, db-alembic-expert |
@@ -605,6 +605,15 @@ The `context-budget-advisor.sh` PostToolUse hook monitors usage and emits adviso
 
 | Version | Key Changes |
 |---------|-------------|
+| v0.58.4 | Documentation sync to v0.58.4 |
+| v0.58.3 | feedback-collector fix, cost-cap-advisor TSV, updater.ts CRLF |
+| v0.58.2 | RL/WL renewal countdown in statusline |
+| v0.58.1 | post-release-followup skill, auto-dev workflow 7th step |
+| v0.58.0 | Impeccable AI design language (fe-design-expert, 4 guides) |
+| v0.57.0 | `omcustom update --hard`, `/omcustom:auto-improve`, Epic #535 completion |
+| v0.56.0 | PostCompact R000 enforcement, workflow --list |
+| v0.55.0 | Statusline WL segment, eraser workflow |
+| v0.54.0 | ARCHITECTURE.md full synchronization, Eraser diagrams |
 | v0.53.1 | Auto-tagging fix (.npmrc git-tag-version=false); /omcustom:workflow rename; custom workflow templates |
 | v0.53.0 | Dashboard All Projects removal; project detail view; eval-core DB connection for evaluations; user feedback integration (#562) |
 | v0.52.0 | Feedback collector hook; routing miss analysis; /omcustom:improve-report; R018 scope constraint |

--- a/ARCHITECTURE_ko.md
+++ b/ARCHITECTURE_ko.md
@@ -1,12 +1,12 @@
 # 아키텍처
 
-> oh-my-customcode v0.53.1
+> oh-my-customcode v0.58.4
 
 ## 1. 시스템 개요
 
-oh-my-customcode는 Claude Code를 위한 배터리 포함형 에이전트 하네스입니다. 45개의 사전 구축된 서브에이전트, 92개의 스킬, 21개의 거버넌스 규칙, 훅 시스템이 모두 연결되어 있어 추가 설정 없이 Claude Code 세션에 완전한 멀티 에이전트 운영 모델이 적용됩니다. 핵심 철학: **"전문가가 없으면? 만들고, 지식을 연결하고, 사용한다."** 매칭되는 전문가가 없는 작업이 들어오면 시스템이 자동으로 관련 스킬과 가이드를 탐색하여 새 에이전트를 생성한 뒤 즉시 작업을 실행합니다.
+oh-my-customcode는 Claude Code를 위한 배터리 포함형 에이전트 하네스입니다. 46개의 사전 구축된 서브에이전트, 95개의 스킬, 21개의 거버넌스 규칙, 훅 시스템이 모두 연결되어 있어 추가 설정 없이 Claude Code 세션에 완전한 멀티 에이전트 운영 모델이 적용됩니다. 핵심 철학: **"전문가가 없으면? 만들고, 지식을 연결하고, 사용한다."** 매칭되는 전문가가 없는 작업이 들어오면 시스템이 자동으로 관련 스킬과 가이드를 탐색하여 새 에이전트를 생성한 뒤 즉시 작업을 실행합니다.
 
-현재 버전: **0.53.1** -- npm 패키지명 `oh-my-customcode`, CLI: `omcustom`
+현재 버전: **0.58.4** -- npm 패키지명 `oh-my-customcode`, CLI: `omcustom`
 
 ### 1.1 컴파일레이션 메타포
 
@@ -64,7 +64,7 @@ oh-my-customcode는 에이전트 시스템을 "소스 코드"로, 실행 중인 
 |----------|------|----------|
 | SW Engineer / 언어 | 6 | lang-golang-expert, lang-python-expert, lang-rust-expert, lang-kotlin-expert, lang-typescript-expert, lang-java21-expert |
 | SW Engineer / 백엔드 | 6 | be-fastapi-expert, be-springboot-expert, be-go-backend-expert, be-express-expert, be-nestjs-expert, be-django-expert |
-| SW Engineer / 프론트엔드 | 4 | fe-vercel-agent, fe-vuejs-agent, fe-svelte-agent, fe-flutter-agent |
+| SW Engineer / 프론트엔드 | 5 | fe-vercel-agent, fe-vuejs-agent, fe-svelte-agent, fe-flutter-agent, fe-design-expert |
 | SW Engineer / 툴링 | 3 | tool-npm-expert, tool-optimizer, tool-bun-expert |
 | 데이터 엔지니어링 | 6 | de-airflow-expert, de-dbt-expert, de-spark-expert, de-kafka-expert, de-snowflake-expert, de-pipeline-expert |
 | 데이터베이스 | 4 | db-supabase-expert, db-postgres-expert, db-redis-expert, db-alembic-expert |
@@ -74,9 +74,9 @@ oh-my-customcode는 에이전트 시스템을 "소스 코드"로, 실행 중인 
 | QA | 3 | qa-planner, qa-writer, qa-engineer |
 | 매니저 | 6 | mgr-creator, mgr-updater, mgr-supplier, mgr-gitnerd, mgr-sauron, mgr-claude-code-bible |
 | 시스템 | 2 | sys-memory-keeper, sys-naggy |
-| **합계** | **45** | |
+| **합계** | **46** | |
 
-### 3.3 스킬 카탈로그 (92개)
+### 3.3 스킬 카탈로그 (95개)
 
 **라우팅 스킬 (4개, context: fork)**
 
@@ -530,6 +530,15 @@ Claude Code v2.1.72 ~ v2.1.81+ 테스트 및 호환 확인.
 
 | 버전 | 주요 변경 사항 |
 |------|--------------|
+| v0.58.4 | 문서 v0.58.4 동기화 |
+| v0.58.3 | feedback-collector 수정, cost-cap-advisor TSV, updater.ts CRLF |
+| v0.58.2 | RL/WL 리뉴얼 카운트다운 statusline 표시 |
+| v0.58.1 | post-release-followup 스킬, auto-dev 워크플로우 7단계 |
+| v0.58.0 | Impeccable AI 디자인 언어 (fe-design-expert, 가이드 4개) |
+| v0.57.0 | `omcustom update --hard`, `/omcustom:auto-improve`, Epic #535 완결 |
+| v0.56.0 | PostCompact R000 enforcement, workflow --list |
+| v0.55.0 | Statusline WL 세그먼트, eraser 워크플로우 |
+| v0.54.0 | ARCHITECTURE.md 전면 동기화, Eraser 다이어그램 |
 | v0.53.1 | 자동 태깅 수정 (.npmrc git-tag-version=false); /omcustom:workflow 이름 변경; 커스텀 워크플로우 템플릿 |
 | v0.53.0 | 대시보드 All Projects 제거; 프로젝트 상세 페이지; eval-core DB 연결; 사용자 피드백 통합 (#562) |
 | v0.52.0 | feedback-collector 훅; 라우팅 미스 분석; /omcustom:improve-report; R018 스코프 제약 |

--- a/README_ko.md
+++ b/README_ko.md
@@ -15,7 +15,7 @@
 
 46개 에이전트. 95개 스킬. 21개 규칙. 명령어 하나.
 
-> **v0.46.0** — Rate Limit 모니터링, Skill Effort Override, 멀티프로젝트 Web UI, 일괄 업데이트, SDD 워크플로우, Ambiguity Gate
+> **v0.58.4** — Impeccable AI 디자인 언어, post-release-followup 워크플로우, feedback-collector 수정, cost-cap-advisor TSV, 문서 동기화
 
 ```bash
 npm install -g oh-my-customcode && cd your-project && omcustom init

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9307,7 +9307,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.58.3",
+    version: "0.58.4",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1683,7 +1683,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.58.3",
+  version: "0.58.4",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.58.3",
+  "version": "0.58.4",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.58.3",
+  "version": "0.58.4",
   "lastUpdated": "2026-03-24T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- docs: README_ko.md version tagline v0.46.0 → v0.58.4 (#668)
- docs: ARCHITECTURE.md/ARCHITECTURE_ko.md version v0.53.1 → v0.58.4 (#668)
- docs: 9 version history entries added (v0.54.0–v0.58.4)
- docs: counts corrected (46 agents, 95 skills, 21 rules, 31 guides)

## Test plan
- [x] 1501 tests pass, 0 fail
- [x] Version strings updated in 3 files
- [x] Agent counts corrected in ARCHITECTURE tables
- [x] Skill counts corrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)