### PR TITLE
fix: enforce mandatory triage comment posting (v0.59.1)

### DIFF
--- a/.claude/skills/professor-triage/SKILL.md
+++ b/.claude/skills/professor-triage/SKILL.md
@@ -156,7 +156,7 @@ Template:
 ## Pending Actions (Confirmation Required)
 ```
 
-**5B: Issue comments** — Delegate to mgr-gitnerd to post on each analyzed issue:
+**5B: Issue comments (MANDATORY)** — Every analyzed issue MUST receive a triage comment. This is not optional — even for issues created in the same session or with existing analysis. Skipping comments breaks the triage audit trail. Delegate to mgr-gitnerd to post on each analyzed issue:
 
 ```
 ## 🔬 Professor Triage — Cross-Analysis Result
@@ -168,6 +168,15 @@ Template:
 
 ---
 _Cross-analyzed by `/professor-triage` with {N} related issues_
+```
+
+### Phase 5C: Comment Verification Gate
+
+Before proceeding to Phase 6, verify ALL analyzed issues received comments:
+```bash
+# For each issue NNN in the batch:
+gh issue view NNN --json comments --jq '.comments | map(select(.body | contains("Professor Triage"))) | length'
+# Must be >= 1 for every issue. If any is 0, Phase 5B was skipped — go back and post.
 ```
 
 ### Phase 6: Act

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9307,7 +9307,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.59.0",
+    version: "0.59.1",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1683,7 +1683,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.59.0",
+  version: "0.59.1",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.59.0",
+  "version": "0.59.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/professor-triage/SKILL.md
+++ b/templates/.claude/skills/professor-triage/SKILL.md
@@ -156,7 +156,7 @@ Template:
 ## Pending Actions (Confirmation Required)
 ```
 
-**5B: Issue comments** — Delegate to mgr-gitnerd to post on each analyzed issue:
+**5B: Issue comments (MANDATORY)** — Every analyzed issue MUST receive a triage comment. This is not optional — even for issues created in the same session or with existing analysis. Skipping comments breaks the triage audit trail. Delegate to mgr-gitnerd to post on each analyzed issue:
 
 ```
 ## 🔬 Professor Triage — Cross-Analysis Result
@@ -168,6 +168,15 @@ Template:
 
 ---
 _Cross-analyzed by `/professor-triage` with {N} related issues_
+```
+
+### Phase 5C: Comment Verification Gate
+
+Before proceeding to Phase 6, verify ALL analyzed issues received comments:
+```bash
+# For each issue NNN in the batch:
+gh issue view NNN --json comments --jq '.comments | map(select(.body | contains("Professor Triage"))) | length'
+# Must be >= 1 for every issue. If any is 0, Phase 5B was skipped — go back and post.
 ```
 
 ### Phase 6: Act

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.59.0",
+  "version": "0.59.1",
   "lastUpdated": "2026-03-24T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- professor-triage Phase 5B를 MANDATORY로 강화
- Phase 5C Comment Verification Gate 신규 추가
- 버전 0.59.0 → 0.59.1

## Problem
auto-dev 워크플로우의 triage step에서 이슈에 분석 댓글을 게시하지 않고 인라인 판정만 수행하는 문제 (#689)

## Fix
- Phase 5B에 "MANDATORY" 표시 + audit trail 파손 경고 추가
- Phase 5C: 모든 이슈에 "Professor Triage" 포함 댓글이 있는지 검증하는 gate 추가

Closes #689

## Test plan
- [x] bun test — 1507 pass, 0 fail
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)