### PR TITLE
release: v0.60.1 — action-validator + peer-messaging + inspector docs

### DIFF
--- a/.claude/rules/MUST-agent-teams.md
+++ b/.claude/rules/MUST-agent-teams.md
@@ -25,6 +25,15 @@ Available when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or TeamCreate/SendMessag
 
 **When Agent Teams is enabled and criteria are met, usage is required.**
 
+### Scope: Intra-Session vs Cross-Session
+
+| Scope | Tool | Protocol | Use Case |
+|-------|------|----------|----------|
+| Intra-session | `SendMessage` (Agent Teams) | Peer-to-peer within team | Multi-agent collaboration in one session |
+| Cross-session | `send_message` (claude-peers-mcp) | Broker-mediated | Multi-terminal/project coordination |
+
+These are distinct mechanisms. Agent Teams `SendMessage` requires `TeamCreate` and operates within a single Claude Code session. claude-peers-mcp `send_message` operates across separate Claude Code processes via a localhost broker.
+
 ## Self-Check (Before Agent Tool)
 
 Before using Agent tool for 2+ agent tasks, complete this check:

--- a/.claude/skills/action-validator/SKILL.md
+++ b/.claude/skills/action-validator/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: action-validator
+description: Pre-action boundary checking — validates agent tool calls against declared capabilities and task contracts
+scope: core
+user-invocable: false
+---
+
+# Action Validator Skill
+
+## Purpose
+
+Advisory pre-action validation layer that checks agent tool calls against declared capabilities, file access scope (R002), and task contracts before execution. Inspired by AutoHarness (Google DeepMind) — enforcing action-space legality at agent boundaries.
+
+This skill does NOT block actions (R021 advisory-first model). It emits warnings when agents attempt operations outside their declared scope.
+
+## Validation Checks
+
+| Check | What | Against |
+|-------|------|---------|
+| Tool scope | Tool being called | Agent's `tools` frontmatter list |
+| File scope | File path in Write/Edit | R002 file access rules |
+| Domain scope | Target file extension | Agent's `domain` frontmatter |
+| Task contract | Operation type | Task description constraints |
+
+## Advisory Format
+
+```
+--- [Action Validator] Scope warning ---
+  Agent: {agent-name}
+  Tool: {tool-name}
+  Target: {file-path}
+  Issue: {description}
+  Declared scope: {agent's declared tools/domain}
+  💡 Suggestion: {recommended action}
+---
+```
+
+## Integration Points
+
+| System | How |
+|--------|-----|
+| PreToolUse hooks | Optional hook to check tool calls (advisory only) |
+| pipeline-guards | Complements pipeline stage gates |
+| adversarial-review | Provides action-space-legality criterion |
+| R002 (Permissions) | Validates against declared file access rules |
+| R010 (Orchestrator) | Orchestrator validates subagent scope claims |
+
+## Policy Cache Pattern
+
+For high-repetition agents (e.g., mgr-gitnerd commit workflows), capture validated decision paths as reusable policies:
+
+```yaml
+policy_cache:
+  agent: mgr-gitnerd
+  action: git-commit
+  validated_steps:
+    - tool: Bash
+      pattern: "git add *"
+      verdict: allow
+    - tool: Bash
+      pattern: "git commit *"
+      verdict: allow
+    - tool: Bash
+      pattern: "git push *"
+      verdict: warn_confirm
+```
+
+Policy caching reduces redundant LLM calls for well-understood workflows. Policies are advisory — the orchestrator may override.
+
+## Scope
+
+This skill is an advisory layer, not a hard enforcement mechanism:
+- **Does**: Emit warnings, log scope violations, suggest corrections
+- **Does NOT**: Block tool execution, modify agent behavior, override R021
+- **Future**: May integrate with PreToolUse hooks for automated checking (see R021 promotion criteria)

--- a/.claude/skills/adversarial-review/SKILL.md
+++ b/.claude/skills/adversarial-review/SKILL.md
@@ -70,3 +70,11 @@ Fix: Recommended remediation
 - Complements `dev-review` (best practices) with attacker perspective
 - Works with `sec-codeql-expert` for pattern-based + logic-based coverage
 - Can be chained: `dev-review` → `adversarial-review` for complete coverage
+- Works with `action-validator` for action-space legality checking
+
+### Action-Space Legality (AutoHarness Pattern)
+
+- [ ] Do agents only call tools within their declared `tools` frontmatter?
+- [ ] Do file operations stay within R002-declared access scope?
+- [ ] Are domain boundaries respected (backend agent not editing frontend files)?
+- [ ] Could an agent's task contract be tightened without losing functionality?

--- a/.claude/skills/monitoring-setup/SKILL.md
+++ b/.claude/skills/monitoring-setup/SKILL.md
@@ -114,3 +114,32 @@ OTEL_LOGS_EXPORTER=otlp
 OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 ```
+
+## HTTP-Level Inspection (Optional)
+
+For deeper payload-level debugging beyond aggregated metrics, [Claude Inspector](https://github.com/kangraemin/claude-inspector) provides MITM proxy inspection of Claude Code HTTP traffic.
+
+| Aspect | OTel Monitoring (this skill) | Claude Inspector |
+|--------|------------------------------|-----------------|
+| Layer | Application (hooks, stdout) | HTTP (MITM proxy) |
+| Metrics | Aggregated (cost, tokens, duration) | Per-request payload breakdown |
+| Cache visibility | Not available | Prompt Cache hit/miss rates |
+| Sub-agent view | Summary via hooks | Full parent vs sub-agent context comparison |
+| Setup | Built-in (hooks + statusline) | External tool (Homebrew on macOS) |
+
+### When to Use
+
+- **OTel monitoring**: Daily operations, cost tracking, performance trends
+- **Claude Inspector**: Debugging specific payload issues, measuring CLAUDE.md token impact, verifying ecomode (R013) effectiveness, profiling sub-agent context inheritance
+
+### Setup
+
+```bash
+# macOS
+brew install kangraemin/tap/claude-inspector
+
+# Run proxy
+claude-inspector
+```
+
+Claude Inspector is external to oh-my-customcode and does not require any project configuration changes.

--- a/.claude/skills/peer-messaging/SKILL.md
+++ b/.claude/skills/peer-messaging/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: peer-messaging
+description: Cross-session Claude Code instance messaging via claude-peers-mcp broker
+scope: core
+user-invocable: false
+---
+
+# Peer Messaging Skill
+
+## Purpose
+
+Enables cross-session coordination between multiple Claude Code instances through the claude-peers-mcp broker. Complements Agent Teams (R018, intra-session) with inter-session messaging.
+
+## Scope Clarification
+
+| Scope | Mechanism | Tools | Use Case |
+|-------|-----------|-------|----------|
+| Intra-session agents | Agent Teams (R018) | TeamCreate, SendMessage | Single session multi-agent collaboration |
+| Cross-session instances | claude-peers-mcp | list_peers, send_message | Multi-terminal/project real-time coordination |
+| Cross-session memory | claude-mem | save_memory, search | Async memory persistence |
+
+> **Important**: R018's `SendMessage` and claude-peers-mcp's `send_message` are different tools with different scopes. Do not confuse them.
+
+## MCP Tool Mapping
+
+| Tool | Purpose | oh-my-customcode Scenario |
+|------|---------|---------------------------|
+| `list_peers` | Discover active Claude instances | `omcustom:status` system overview |
+| `send_message` | Send message to peer | Cross-project workflow coordination |
+| `set_summary` | Broadcast current task summary | DAG cross-project step sync |
+| `check_messages` | Read incoming messages | Receive coordination signals |
+
+## Use Cases
+
+### Multi-Project Workflow
+Terminal A runs `auto-dev` on project-1; Terminal B works on dependent project-2. Peers coordinate via messages when blocking dependencies are resolved.
+
+### Cross-Project QA
+Share test infrastructure state between projects running concurrent test suites.
+
+### DAG Bridge
+`dag-orchestration` cross-project steps can use peer messaging for synchronization (currently impossible without this tool).
+
+## Setup
+
+```bash
+# Install broker (optional MCP server)
+npm install -g claude-peers-mcp
+
+# Add to MCP config
+claude mcp add claude-peers-mcp -- npx claude-peers-mcp
+```
+
+## Integration
+
+- Works with R018 Agent Teams (different scope, complementary)
+- Works with claude-mem (async vs sync messaging)
+- Works with `omcustom:status` (peer discovery)
+- Broker runs on localhost:7899 (SQLite-backed)

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.60.0",
-  "generatedAt": "2026-03-27T06:10:35.409Z",
-  "templateVersion": "0.60.0",
+  "generatorVersion": "0.60.1",
+  "generatedAt": "2026-03-27T06:28:19.555Z",
+  "templateVersion": "0.60.1",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",
@@ -60,8 +60,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-teams.md": {
-      "templateHash": "bd3de495872eb656d8fa3e159c78b48837c82a1e28bf1463943b1f9d70baa631",
-      "size": 14674,
+      "templateHash": "9386917793a9803ba58079dc283a2df9d06e137cf5107916ab2c8a2ca841cda9",
+      "size": 15257,
       "component": "rules"
     },
     ".claude/rules/MAY-optimization.md": {
@@ -660,8 +660,8 @@
       "component": "skills"
     },
     ".claude/skills/adversarial-review/SKILL.md": {
-      "templateHash": "e98becfc15926600a8aa6accdb7227339eb2f3315c39d367acec75d02349f4f1",
-      "size": 2591,
+      "templateHash": "039dcfac33a806c1ef859b7c6ef3f91c4ff16cac87da2f18b57d4ab68116ed56",
+      "size": 3010,
       "component": "skills"
     },
     ".claude/skills/supabase-postgres-best-practices/SKILL.md": {
@@ -687,6 +687,11 @@
     ".claude/skills/npm-audit/SKILL.md": {
       "templateHash": "0fa3e6331e1798721beef45974a9210673aeb9199cd3d81ac64117015d23d80d",
       "size": 1206,
+      "component": "skills"
+    },
+    ".claude/skills/peer-messaging/SKILL.md": {
+      "templateHash": "42eeb1b5ef13ad0a684eb8c58ba7a3a8fce2586c5d28bdc197be6ccbf4f46bd5",
+      "size": 2223,
       "component": "skills"
     },
     ".claude/skills/kotlin-best-practices/SKILL.md": {
@@ -727,6 +732,11 @@
     ".claude/skills/kafka-best-practices/SKILL.md": {
       "templateHash": "5c158819dae9be2c7d201e365fd53dd4fed7a5b5e0254e52e120ba9490bce642",
       "size": 1629,
+      "component": "skills"
+    },
+    ".claude/skills/action-validator/SKILL.md": {
+      "templateHash": "27d69c8b83e35728d25730e1319e9895728e8e5f2509fb28bf43c789097fa905",
+      "size": 2520,
       "component": "skills"
     },
     ".claude/skills/workflow/SKILL.md": {
@@ -805,8 +815,8 @@
       "component": "skills"
     },
     ".claude/skills/monitoring-setup/SKILL.md": {
-      "templateHash": "8506c0ceb00e78ebfcf386a09fc70389605b68d11a6caa18d46df4a49d2f3ae6",
-      "size": 3746,
+      "templateHash": "c80356bf67ae659a216c0c0f1df060ca0f1bfbde9f01496ae5a9ebbc68a3dcf9",
+      "size": 4946,
       "component": "skills"
     },
     ".claude/skills/omcustom-loop/SKILL.md": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (46 파일)
-|   +-- skills/                  # 스킬 (95 디렉토리)
+|   +-- skills/                  # 스킬 (97 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R021)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **[한국어 문서 (Korean)](./README_ko.md)**
 
-46 agents. 95 skills. 21 rules. One command.
+46 agents. 97 skills. 21 rules. One command.
 
 ```bash
 npm install -g oh-my-customcode && cd your-project && omcustom init
@@ -146,7 +146,7 @@ Each agent declares its tools, model, memory scope, and limitations in YAML fron
 
 ---
 
-### Skills (95)
+### Skills (97)
 
 | Category | Count | Includes |
 |----------|-------|----------|
@@ -282,7 +282,7 @@ your-project/
 ├── CLAUDE.md                   # Entry point
 ├── .claude/
 │   ├── agents/                 # 46 agent definitions
-│   ├── skills/                 # 95 skill modules
+│   ├── skills/                 # 97 skill modules
 │   ├── rules/                  # 21 governance rules (R000-R021)
 │   ├── hooks/                  # 15 lifecycle hook scripts
 │   ├── schemas/                # Tool input validation schemas

--- a/README_ko.md
+++ b/README_ko.md
@@ -13,7 +13,7 @@
 
 **[English Documentation](./README.md)**
 
-46개 에이전트. 95개 스킬. 21개 규칙. 명령어 하나.
+46개 에이전트. 97개 스킬. 21개 규칙. 명령어 하나.
 
 > **v0.58.4** — Impeccable AI 디자인 언어, post-release-followup 워크플로우, feedback-collector 수정, cost-cap-advisor TSV, 문서 동기화
 
@@ -136,7 +136,7 @@ Agent(arch-documenter):haiku      ┘
 
 ---
 
-## 스킬 (95개)
+## 스킬 (97개)
 
 | 카테고리 | 수 | 포함 |
 |---------|-----|------|
@@ -269,7 +269,7 @@ your-project/
 ├── CLAUDE.md                   # 진입점
 ├── .claude/
 │   ├── agents/                 # 46개 에이전트 정의
-│   ├── skills/                 # 95개 스킬 모듈
+│   ├── skills/                 # 97개 스킬 모듈
 │   ├── rules/                  # 21개 거버넌스 규칙 (R000-R021)
 │   ├── hooks/                  # 15개 라이프사이클 훅 스크립트
 │   ├── schemas/                # 도구 입력 검증 스키마

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9307,7 +9307,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.60.0",
+    version: "0.60.1",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1683,7 +1683,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.60.0",
+  version: "0.60.1",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.60.0",
+  "version": "0.60.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-agent-teams.md
+++ b/templates/.claude/rules/MUST-agent-teams.md
@@ -25,6 +25,15 @@ Available when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or TeamCreate/SendMessag
 
 **When Agent Teams is enabled and criteria are met, usage is required.**
 
+### Scope: Intra-Session vs Cross-Session
+
+| Scope | Tool | Protocol | Use Case |
+|-------|------|----------|----------|
+| Intra-session | `SendMessage` (Agent Teams) | Peer-to-peer within team | Multi-agent collaboration in one session |
+| Cross-session | `send_message` (claude-peers-mcp) | Broker-mediated | Multi-terminal/project coordination |
+
+These are distinct mechanisms. Agent Teams `SendMessage` requires `TeamCreate` and operates within a single Claude Code session. claude-peers-mcp `send_message` operates across separate Claude Code processes via a localhost broker.
+
 ## Self-Check (Before Agent Tool)
 
 Before using Agent tool for 2+ agent tasks, complete this check:

--- a/templates/.claude/skills/action-validator/SKILL.md
+++ b/templates/.claude/skills/action-validator/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: action-validator
+description: Pre-action boundary checking — validates agent tool calls against declared capabilities and task contracts
+scope: core
+user-invocable: false
+---
+
+# Action Validator Skill
+
+## Purpose
+
+Advisory pre-action validation layer that checks agent tool calls against declared capabilities, file access scope (R002), and task contracts before execution. Inspired by AutoHarness (Google DeepMind) — enforcing action-space legality at agent boundaries.
+
+This skill does NOT block actions (R021 advisory-first model). It emits warnings when agents attempt operations outside their declared scope.
+
+## Validation Checks
+
+| Check | What | Against |
+|-------|------|---------|
+| Tool scope | Tool being called | Agent's `tools` frontmatter list |
+| File scope | File path in Write/Edit | R002 file access rules |
+| Domain scope | Target file extension | Agent's `domain` frontmatter |
+| Task contract | Operation type | Task description constraints |
+
+## Advisory Format
+
+```
+--- [Action Validator] Scope warning ---
+  Agent: {agent-name}
+  Tool: {tool-name}
+  Target: {file-path}
+  Issue: {description}
+  Declared scope: {agent's declared tools/domain}
+  💡 Suggestion: {recommended action}
+---
+```
+
+## Integration Points
+
+| System | How |
+|--------|-----|
+| PreToolUse hooks | Optional hook to check tool calls (advisory only) |
+| pipeline-guards | Complements pipeline stage gates |
+| adversarial-review | Provides action-space-legality criterion |
+| R002 (Permissions) | Validates against declared file access rules |
+| R010 (Orchestrator) | Orchestrator validates subagent scope claims |
+
+## Policy Cache Pattern
+
+For high-repetition agents (e.g., mgr-gitnerd commit workflows), capture validated decision paths as reusable policies:
+
+```yaml
+policy_cache:
+  agent: mgr-gitnerd
+  action: git-commit
+  validated_steps:
+    - tool: Bash
+      pattern: "git add *"
+      verdict: allow
+    - tool: Bash
+      pattern: "git commit *"
+      verdict: allow
+    - tool: Bash
+      pattern: "git push *"
+      verdict: warn_confirm
+```
+
+Policy caching reduces redundant LLM calls for well-understood workflows. Policies are advisory — the orchestrator may override.
+
+## Scope
+
+This skill is an advisory layer, not a hard enforcement mechanism:
+- **Does**: Emit warnings, log scope violations, suggest corrections
+- **Does NOT**: Block tool execution, modify agent behavior, override R021
+- **Future**: May integrate with PreToolUse hooks for automated checking (see R021 promotion criteria)

--- a/templates/.claude/skills/adversarial-review/SKILL.md
+++ b/templates/.claude/skills/adversarial-review/SKILL.md
@@ -70,3 +70,11 @@ Fix: Recommended remediation
 - Complements `dev-review` (best practices) with attacker perspective
 - Works with `sec-codeql-expert` for pattern-based + logic-based coverage
 - Can be chained: `dev-review` → `adversarial-review` for complete coverage
+- Works with `action-validator` for action-space legality checking
+
+### Action-Space Legality (AutoHarness Pattern)
+
+- [ ] Do agents only call tools within their declared `tools` frontmatter?
+- [ ] Do file operations stay within R002-declared access scope?
+- [ ] Are domain boundaries respected (backend agent not editing frontend files)?
+- [ ] Could an agent's task contract be tightened without losing functionality?

--- a/templates/.claude/skills/monitoring-setup/SKILL.md
+++ b/templates/.claude/skills/monitoring-setup/SKILL.md
@@ -114,3 +114,32 @@ OTEL_LOGS_EXPORTER=otlp
 OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 ```
+
+## HTTP-Level Inspection (Optional)
+
+For deeper payload-level debugging beyond aggregated metrics, [Claude Inspector](https://github.com/kangraemin/claude-inspector) provides MITM proxy inspection of Claude Code HTTP traffic.
+
+| Aspect | OTel Monitoring (this skill) | Claude Inspector |
+|--------|------------------------------|-----------------|
+| Layer | Application (hooks, stdout) | HTTP (MITM proxy) |
+| Metrics | Aggregated (cost, tokens, duration) | Per-request payload breakdown |
+| Cache visibility | Not available | Prompt Cache hit/miss rates |
+| Sub-agent view | Summary via hooks | Full parent vs sub-agent context comparison |
+| Setup | Built-in (hooks + statusline) | External tool (Homebrew on macOS) |
+
+### When to Use
+
+- **OTel monitoring**: Daily operations, cost tracking, performance trends
+- **Claude Inspector**: Debugging specific payload issues, measuring CLAUDE.md token impact, verifying ecomode (R013) effectiveness, profiling sub-agent context inheritance
+
+### Setup
+
+```bash
+# macOS
+brew install kangraemin/tap/claude-inspector
+
+# Run proxy
+claude-inspector
+```
+
+Claude Inspector is external to oh-my-customcode and does not require any project configuration changes.

--- a/templates/.claude/skills/peer-messaging/SKILL.md
+++ b/templates/.claude/skills/peer-messaging/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: peer-messaging
+description: Cross-session Claude Code instance messaging via claude-peers-mcp broker
+scope: core
+user-invocable: false
+---
+
+# Peer Messaging Skill
+
+## Purpose
+
+Enables cross-session coordination between multiple Claude Code instances through the claude-peers-mcp broker. Complements Agent Teams (R018, intra-session) with inter-session messaging.
+
+## Scope Clarification
+
+| Scope | Mechanism | Tools | Use Case |
+|-------|-----------|-------|----------|
+| Intra-session agents | Agent Teams (R018) | TeamCreate, SendMessage | Single session multi-agent collaboration |
+| Cross-session instances | claude-peers-mcp | list_peers, send_message | Multi-terminal/project real-time coordination |
+| Cross-session memory | claude-mem | save_memory, search | Async memory persistence |
+
+> **Important**: R018's `SendMessage` and claude-peers-mcp's `send_message` are different tools with different scopes. Do not confuse them.
+
+## MCP Tool Mapping
+
+| Tool | Purpose | oh-my-customcode Scenario |
+|------|---------|---------------------------|
+| `list_peers` | Discover active Claude instances | `omcustom:status` system overview |
+| `send_message` | Send message to peer | Cross-project workflow coordination |
+| `set_summary` | Broadcast current task summary | DAG cross-project step sync |
+| `check_messages` | Read incoming messages | Receive coordination signals |
+
+## Use Cases
+
+### Multi-Project Workflow
+Terminal A runs `auto-dev` on project-1; Terminal B works on dependent project-2. Peers coordinate via messages when blocking dependencies are resolved.
+
+### Cross-Project QA
+Share test infrastructure state between projects running concurrent test suites.
+
+### DAG Bridge
+`dag-orchestration` cross-project steps can use peer messaging for synchronization (currently impossible without this tool).
+
+## Setup
+
+```bash
+# Install broker (optional MCP server)
+npm install -g claude-peers-mcp
+
+# Add to MCP config
+claude mcp add claude-peers-mcp -- npx claude-peers-mcp
+```
+
+## Integration
+
+- Works with R018 Agent Teams (different scope, complementary)
+- Works with claude-mem (async vs sync messaging)
+- Works with `omcustom:status` (peer discovery)
+- Broker runs on localhost:7899 (SQLite-backed)

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -138,7 +138,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (46 파일)
-|   +-- skills/                  # 스킬 (95 디렉토리)
+|   +-- skills/                  # 스킬 (97 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R021)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.60.0",
+  "version": "0.60.1",
   "lastUpdated": "2026-03-24T00:00:00.000Z",
   "components": [
     {
@@ -18,7 +18,7 @@
       "name": "skills",
       "path": ".claude/skills",
       "description": "Reusable skill modules (includes slash commands)",
-      "files": 95
+      "files": 97
     },
     {
       "name": "guides",


### PR DESCRIPTION
## Summary

- **#684** — New `action-validator` skill: pre-action boundary checking based on AutoHarness pattern (INTEGRATE P2)
- **#685** — New `peer-messaging` skill: cross-session coordination via claude-peers-mcp broker (INTEGRATE P3)
- **#686** — `monitoring-setup` extended with Claude Inspector HTTP-level inspection section; `adversarial-review` gains action-space-legality checklist (INTEGRATE P3)
- **R018** — Added intra-session vs cross-session scope clarification table (`SendMessage` vs `send_message`)
- Skills count: 95 → 97

## Changes

| File | Type | Description |
|------|------|-------------|
| `.claude/skills/action-validator/SKILL.md` | New | Pre-action boundary checker (AutoHarness pattern) |
| `.claude/skills/peer-messaging/SKILL.md` | New | cross-session peer messaging via claude-peers-mcp |
| `.claude/skills/adversarial-review/SKILL.md` | Modified | Action-space-legality checklist added |
| `.claude/skills/monitoring-setup/SKILL.md` | Modified | Claude Inspector section added |
| `.claude/rules/MUST-agent-teams.md` | Modified | Intra-session vs cross-session scope table |
| `templates/` | Synced | All above mirrored in templates/ |
| `package.json` / `templates/manifest.json` | Modified | Version bump 0.60.0 → 0.60.1 |
| `dist/` | Rebuilt | Build artifacts updated |
| `CLAUDE.md` / `README.md` / `README_ko.md` | Modified | Count updates |

## Test plan

- [x] `bun run build` passes (1.18 MB CLI bundle, 87.66 KB index)
- [x] All 1507 tests pass, 0 fail
- [x] Function coverage 98.10%, line coverage 97.68% (threshold: 95%)
- [x] Lint: 0 errors (1 pre-existing warning in test file, not introduced by this PR)
- [x] 19 files staged — no untracked backup/docs/packages files included
- [ ] CI checks pass on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)