### PR TITLE
feat: v0.61.0 — Permission Mode Guidance + CLI self-update check

### DIFF
--- a/.claude/rules/MUST-agent-design.md
+++ b/.claude/rules/MUST-agent-design.md
@@ -52,6 +52,23 @@ domain: backend              # backend | frontend | data-engineering | devops | 
 
 > **Note**: `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations` are supported in Claude Code v2.1.63+. Hook types `PostCompact`, `Elicitation`, `ElicitationResult` require v2.1.76+. `CwdChanged`, `FileChanged` hook events and `managed-settings.d/` drop-in directory require v2.1.83+. Conditional `if` field for hooks requires v2.1.85+.
 
+## Permission Mode Guidance
+
+When spawning agents via the Agent tool, CC applies a default `mode` of `acceptEdits` if not explicitly specified. To maintain consistent permission behavior:
+
+1. **Agent frontmatter `permissionMode`**: Declares the agent's intended permission level. CC respects this when the agent is spawned via Agent tool.
+2. **Agent tool `mode` parameter**: Overrides frontmatter at spawn time. Routing skills should pass this explicitly.
+3. **Recommendation**: For agents that modify files, set `permissionMode: bypassPermissions` in frontmatter if the project uses `bypassPermissions` mode.
+
+| Mode | Behavior |
+|------|----------|
+| `default` | CC decides per-tool prompting |
+| `acceptEdits` | Auto-accept file edits, prompt for others |
+| `bypassPermissions` | Skip all permission prompts |
+| `plan` | Require plan approval |
+| `dontAsk` | Non-interactive, deny unapproved |
+| `auto` | AI decides safety |
+
 <!-- DETAIL: Isolation/Token/Limitations/Escalation details
 ### Isolation Modes
 

--- a/.claude/skills/de-lead-routing/SKILL.md
+++ b/.claude/skills/de-lead-routing/SKILL.md
@@ -77,6 +77,8 @@ For **new pipeline code**, **DAG scaffolding**, or **SQL model generation**:
 ### Step 3: Expert Selection
 Route to appropriate DE expert based on tool/framework detection.
 
+> **Permission Mode**: When spawning agents, pass `mode: "bypassPermissions"` in the Agent tool call if the session uses bypassPermissions. Without explicit mode, CC defaults to `acceptEdits`.
+
 ### Step 4: Ontology-RAG Enrichment (R019)
 
 If `get_agent_for_task` MCP tool is available, call it with the original query and inject `suggested_skills` into the agent prompt. Skip silently on failure.

--- a/.claude/skills/dev-lead-routing/SKILL.md
+++ b/.claude/skills/dev-lead-routing/SKILL.md
@@ -112,6 +112,8 @@ For **new file creation**, **boilerplate**, or **test code generation**:
 ### Step 3: Expert Agent Selection
 Route to appropriate language/framework expert based on file extension and keyword mapping.
 
+> **Permission Mode**: When spawning agents, pass `mode: "bypassPermissions"` in the Agent tool call if the session uses bypassPermissions. Without explicit mode, CC defaults to `acceptEdits`.
+
 ### Step 4: Ontology-RAG Enrichment (R019)
 
 If `get_agent_for_task` MCP tool is available, call it with the original query and inject `suggested_skills` into the agent prompt. Skip silently on failure.

--- a/.claude/skills/qa-lead-routing/SKILL.md
+++ b/.claude/skills/qa-lead-routing/SKILL.md
@@ -45,6 +45,8 @@ quality_analysis   → qa-planner + qa-engineer (parallel)
 full_qa_cycle      → all agents (sequential)
 ```
 
+> **Permission Mode**: When spawning agents, pass `mode: "bypassPermissions"` in the Agent tool call if the session uses bypassPermissions. Without explicit mode, CC defaults to `acceptEdits`.
+
 ### Ontology-RAG Enrichment (R019)
 
 If `get_agent_for_task` MCP tool is available, call it with the original query and inject `suggested_skills` into the agent prompt. Skip silently on failure.

--- a/.claude/skills/secretary-routing/SKILL.md
+++ b/.claude/skills/secretary-routing/SKILL.md
@@ -80,6 +80,8 @@ If the selected agent has `soul: true` in frontmatter, read and prepend `.claude
 5. Report result to user
 ```
 
+> **Permission Mode**: When spawning agents, pass `mode: "bypassPermissions"` in the Agent tool call if the session uses bypassPermissions. Without explicit mode, CC defaults to `acceptEdits`.
+
 ### 2. Batch/Parallel Task Routing
 
 When command requires multiple independent operations:

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.60.1",
-  "generatedAt": "2026-03-27T06:28:19.555Z",
-  "templateVersion": "0.60.1",
+  "generatorVersion": "0.61.0",
+  "generatedAt": "2026-03-27T14:00:07.907Z",
+  "templateVersion": "0.61.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",
@@ -45,8 +45,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
-      "templateHash": "e2065e3c94c05d5ba44fd2fe9678a39d7c20f3df56e82574a9c005f0b1a9773d",
-      "size": 8002,
+      "templateHash": "154d3b23b42fb645c7121cb1bdee8a4da5b5faa6668fa38a18020cd8d7c32e83",
+      "size": 8931,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
@@ -425,8 +425,8 @@
       "component": "skills"
     },
     ".claude/skills/qa-lead-routing/SKILL.md": {
-      "templateHash": "852a2ead0d9571c0ac86ae7f6f623ed73b215ff5f45d443c4d3f1e39c4ffe295",
-      "size": 3493,
+      "templateHash": "c047ea64c37ba8b3aadce357e4ffb17ae003f5cc5d6952480b04e8a6a8739c75",
+      "size": 3687,
       "component": "skills"
     },
     ".claude/skills/memory-recall/SKILL.md": {
@@ -470,8 +470,8 @@
       "component": "skills"
     },
     ".claude/skills/secretary-routing/SKILL.md": {
-      "templateHash": "9349c3a4d5c1003456600eec0955e6390d262e3bc440dd5306c37c336855fb3d",
-      "size": 4682,
+      "templateHash": "f70434282d118f95cb95478420c0d0fd5a211ff69f5a2d6828dc5ffc980433dc",
+      "size": 4876,
       "component": "skills"
     },
     ".claude/skills/systematic-debugging/condition-based-waiting.md": {
@@ -635,8 +635,8 @@
       "component": "skills"
     },
     ".claude/skills/dev-lead-routing/SKILL.md": {
-      "templateHash": "a684fa235aa0bdb702d20bf499e7fc35d01dc99f467f3890c4f4aa6786481453",
-      "size": 6022,
+      "templateHash": "6ea42f82b21b25ed6ba6bbdc3d0b44123cffcf1591e719d35be2a0960edf8384",
+      "size": 6216,
       "component": "skills"
     },
     ".claude/skills/scout/SKILL.md": {
@@ -895,8 +895,8 @@
       "component": "skills"
     },
     ".claude/skills/de-lead-routing/SKILL.md": {
-      "templateHash": "37d5c526d9971896d23863af9b97370620356527cbd9ed9eb3243456c4e5c68a",
-      "size": 7933,
+      "templateHash": "0918d2b25f137907ee64ad0eae5a554aca9efd3df5754f0834939041f94984cb",
+      "size": 8127,
       "component": "skills"
     },
     ".claude/skills/stuck-recovery/SKILL.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9307,7 +9307,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.60.1",
+    version: "0.61.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {
@@ -24787,7 +24787,8 @@ var en_default = {
       interactiveSelect: "Select projects to update:",
       interactiveNoneSelected: "No projects selected. Exiting.",
       interactiveUpdating: "Updating selected projects...",
-      projectLatestSuffix: "(latest)"
+      projectLatestSuffix: "(latest)",
+      newVersionAvailable: "[Info] oh-my-customcode v{{latest}} available (current: v{{current}}). Run 'npm i -g oh-my-customcode' to upgrade."
     },
     list: {
       description: "List installed components",
@@ -25171,7 +25172,8 @@ var ko_default = {
       interactiveSelect: "업데이트할 프로젝트 선택:",
       interactiveNoneSelected: "선택된 프로젝트가 없습니다. 종료합니다.",
       interactiveUpdating: "선택된 프로젝트 업데이트 중...",
-      projectLatestSuffix: "(최신)"
+      projectLatestSuffix: "(최신)",
+      newVersionAvailable: "[정보] oh-my-customcode v{{latest}} 사용 가능 (현재: v{{current}}). 'npm i -g oh-my-customcode'를 실행하여 업그레이드하세요."
     },
     list: {
       description: "설치된 컴포넌트 목록 표시",
@@ -30501,7 +30503,19 @@ async function loadCustomizationManifest(targetDir) {
 }
 
 // src/cli/update.ts
-async function updateCommand(options = {}) {
+async function checkCliVersion(checkFn) {
+  try {
+    const result = checkFn({ currentVersion: package_default.version });
+    if (result.updateAvailable && result.latestVersion) {
+      console.log(i18n.t("cli.update.newVersionAvailable", {
+        latest: result.latestVersion,
+        current: package_default.version
+      }));
+    }
+  } catch {}
+}
+async function updateCommand(options = {}, cliVersionCheck = checkSelfUpdate) {
+  await checkCliVersion(cliVersionCheck);
   try {
     if (options.all) {
       await updateAllProjects(options);
@@ -30538,7 +30552,6 @@ async function updateSingleProject(targetDir, options) {
   printUpdateResults(result);
   if (!result.success) {
     process.exit(1);
-    return false;
   }
   return true;
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1683,7 +1683,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.60.1",
+  version: "0.61.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.60.1",
+  "version": "0.61.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -9,6 +9,7 @@
  */
 
 import packageJson from '../../package.json';
+import { checkSelfUpdate } from '../core/self-update.js';
 import { type UpdateComponent, type UpdateOptions, update } from '../core/updater.js';
 import { i18n } from '../i18n/index.js';
 
@@ -43,9 +44,36 @@ export interface UpdateCommandOptions {
 }
 
 /**
+ * Non-blocking check for a newer CLI version.
+ * Prints an informational message if a newer version is available.
+ * Silently swallows any error (offline, npm timeout, malformed response).
+ */
+async function checkCliVersion(checkFn: typeof checkSelfUpdate): Promise<void> {
+  try {
+    const result = checkFn({ currentVersion: packageJson.version as string });
+    if (result.updateAvailable && result.latestVersion) {
+      console.log(
+        i18n.t('cli.update.newVersionAvailable', {
+          latest: result.latestVersion,
+          current: packageJson.version as string,
+        })
+      );
+    }
+  } catch {
+    // Non-blocking: silently ignore any version check failures
+  }
+}
+
+/**
  * Execute the update command
  */
-export async function updateCommand(options: UpdateCommandOptions = {}): Promise<void> {
+export async function updateCommand(
+  options: UpdateCommandOptions = {},
+  cliVersionCheck: typeof checkSelfUpdate = checkSelfUpdate
+): Promise<void> {
+  // Non-blocking CLI self-update notification (inform but never block)
+  await checkCliVersion(cliVersionCheck);
+
   try {
     if (options.all) {
       await updateAllProjects(options);
@@ -99,7 +127,6 @@ async function updateSingleProject(
 
   if (!result.success) {
     process.exit(1);
-    return false;
   }
   return true;
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -143,7 +143,8 @@
       "interactiveSelect": "Select projects to update:",
       "interactiveNoneSelected": "No projects selected. Exiting.",
       "interactiveUpdating": "Updating selected projects...",
-      "projectLatestSuffix": "(latest)"
+      "projectLatestSuffix": "(latest)",
+      "newVersionAvailable": "[Info] oh-my-customcode v{{latest}} available (current: v{{current}}). Run 'npm i -g oh-my-customcode' to upgrade."
     },
     "list": {
       "description": "List installed components",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -143,7 +143,8 @@
       "interactiveSelect": "업데이트할 프로젝트 선택:",
       "interactiveNoneSelected": "선택된 프로젝트가 없습니다. 종료합니다.",
       "interactiveUpdating": "선택된 프로젝트 업데이트 중...",
-      "projectLatestSuffix": "(최신)"
+      "projectLatestSuffix": "(최신)",
+      "newVersionAvailable": "[정보] oh-my-customcode v{{latest}} 사용 가능 (현재: v{{current}}). 'npm i -g oh-my-customcode'를 실행하여 업그레이드하세요."
     },
     "list": {
       "description": "설치된 컴포넌트 목록 표시",

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -52,6 +52,23 @@ domain: backend              # backend | frontend | data-engineering | devops | 
 
 > **Note**: `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations` are supported in Claude Code v2.1.63+. Hook types `PostCompact`, `Elicitation`, `ElicitationResult` require v2.1.76+. `CwdChanged`, `FileChanged` hook events and `managed-settings.d/` drop-in directory require v2.1.83+. Conditional `if` field for hooks requires v2.1.85+.
 
+## Permission Mode Guidance
+
+When spawning agents via the Agent tool, CC applies a default `mode` of `acceptEdits` if not explicitly specified. To maintain consistent permission behavior:
+
+1. **Agent frontmatter `permissionMode`**: Declares the agent's intended permission level. CC respects this when the agent is spawned via Agent tool.
+2. **Agent tool `mode` parameter**: Overrides frontmatter at spawn time. Routing skills should pass this explicitly.
+3. **Recommendation**: For agents that modify files, set `permissionMode: bypassPermissions` in frontmatter if the project uses `bypassPermissions` mode.
+
+| Mode | Behavior |
+|------|----------|
+| `default` | CC decides per-tool prompting |
+| `acceptEdits` | Auto-accept file edits, prompt for others |
+| `bypassPermissions` | Skip all permission prompts |
+| `plan` | Require plan approval |
+| `dontAsk` | Non-interactive, deny unapproved |
+| `auto` | AI decides safety |
+
 <!-- DETAIL: Isolation/Token/Limitations/Escalation details
 ### Isolation Modes
 

--- a/templates/.claude/skills/de-lead-routing/SKILL.md
+++ b/templates/.claude/skills/de-lead-routing/SKILL.md
@@ -77,6 +77,8 @@ For **new pipeline code**, **DAG scaffolding**, or **SQL model generation**:
 ### Step 3: Expert Selection
 Route to appropriate DE expert based on tool/framework detection.
 
+> **Permission Mode**: When spawning agents, pass `mode: "bypassPermissions"` in the Agent tool call if the session uses bypassPermissions. Without explicit mode, CC defaults to `acceptEdits`.
+
 ### Step 4: Ontology-RAG Enrichment (R019)
 
 If `get_agent_for_task` MCP tool is available, call it with the original query and inject `suggested_skills` into the agent prompt. Skip silently on failure.

--- a/templates/.claude/skills/dev-lead-routing/SKILL.md
+++ b/templates/.claude/skills/dev-lead-routing/SKILL.md
@@ -13,7 +13,7 @@ context: fork
 | Type | Agents |
 |------|--------|
 | Language | lang-golang-expert, lang-python-expert, lang-rust-expert, lang-kotlin-expert, lang-typescript-expert, lang-java21-expert |
-| Frontend | fe-vercel-agent, fe-vuejs-agent, fe-svelte-agent, fe-flutter-agent |
+| Frontend | fe-vercel-agent, fe-vuejs-agent, fe-svelte-agent, fe-flutter-agent, fe-design-expert |
 | Backend | be-fastapi-expert, be-springboot-expert, be-go-backend-expert, be-nestjs-expert, be-express-expert, be-django-expert |
 | Tooling | tool-npm-expert, tool-optimizer, tool-bun-expert |
 | Database | db-supabase-expert, db-postgres-expert, db-redis-expert |
@@ -55,6 +55,7 @@ context: fork
 | vue | fe-vuejs-agent |
 | svelte | fe-svelte-agent |
 | flutter, dart, riverpod, bloc, widget | fe-flutter-agent |
+| design, typography, color, motion, ux writing, ui design, "design system", "design review", impeccable | fe-design-expert |
 | fastapi | be-fastapi-expert |
 | django | be-django-expert |
 | spring, springboot | be-springboot-expert |
@@ -110,6 +111,8 @@ For **new file creation**, **boilerplate**, or **test code generation**:
 
 ### Step 3: Expert Agent Selection
 Route to appropriate language/framework expert based on file extension and keyword mapping.
+
+> **Permission Mode**: When spawning agents, pass `mode: "bypassPermissions"` in the Agent tool call if the session uses bypassPermissions. Without explicit mode, CC defaults to `acceptEdits`.
 
 ### Step 4: Ontology-RAG Enrichment (R019)
 

--- a/templates/.claude/skills/qa-lead-routing/SKILL.md
+++ b/templates/.claude/skills/qa-lead-routing/SKILL.md
@@ -45,6 +45,8 @@ quality_analysis   → qa-planner + qa-engineer (parallel)
 full_qa_cycle      → all agents (sequential)
 ```
 
+> **Permission Mode**: When spawning agents, pass `mode: "bypassPermissions"` in the Agent tool call if the session uses bypassPermissions. Without explicit mode, CC defaults to `acceptEdits`.
+
 ### Ontology-RAG Enrichment (R019)
 
 If `get_agent_for_task` MCP tool is available, call it with the original query and inject `suggested_skills` into the agent prompt. Skip silently on failure.

--- a/templates/.claude/skills/secretary-routing/SKILL.md
+++ b/templates/.claude/skills/secretary-routing/SKILL.md
@@ -80,6 +80,8 @@ If the selected agent has `soul: true` in frontmatter, read and prepend `.claude
 5. Report result to user
 ```
 
+> **Permission Mode**: When spawning agents, pass `mode: "bypassPermissions"` in the Agent tool call if the session uses bypassPermissions. Without explicit mode, CC defaults to `acceptEdits`.
+
 ### 2. Batch/Parallel Task Routing
 
 When command requires multiple independent operations:

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.60.1",
+  "version": "0.61.0",
   "lastUpdated": "2026-03-24T00:00:00.000Z",
   "components": [
     {

--- a/tests/unit/cli/update.test.ts
+++ b/tests/unit/cli/update.test.ts
@@ -1238,6 +1238,144 @@ describe('update command', () => {
     });
   });
 
+  describe('updateCommand CLI self-update notification', () => {
+    it('should print info message when a newer CLI version is available', async () => {
+      mock.module('../../../src/core/provider.js', () => ({
+        detectProvider: async () => ({
+          provider: 'claude',
+          source: 'override',
+          confidence: 'high',
+          reason: 'test',
+        }),
+      }));
+
+      const mockUpdate = mock(async () => ({
+        success: true,
+        updatedComponents: [],
+        skippedComponents: [],
+        preservedFiles: [],
+        backedUpPaths: [],
+        previousVersion: '0.60.1',
+        newVersion: '0.60.1',
+        warnings: [],
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mockUpdate,
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+      const { checkSelfUpdate: realCheckSelfUpdate } = await import(
+        '../../../src/core/self-update.js'
+      );
+
+      // Stub: newer version available
+      const stubbedCheck: typeof realCheckSelfUpdate = () => ({
+        checked: true,
+        updateAvailable: true,
+        latestVersion: '0.99.0',
+        usedCache: false,
+      });
+
+      await updateCommand({}, stubbedCheck);
+
+      const allLogs = consoleLogSpy.mock.calls.flat().join('\n');
+      expect(allLogs).toContain('0.99.0');
+    });
+
+    it('should not print info message when already on latest version', async () => {
+      mock.module('../../../src/core/provider.js', () => ({
+        detectProvider: async () => ({
+          provider: 'claude',
+          source: 'override',
+          confidence: 'high',
+          reason: 'test',
+        }),
+      }));
+
+      const mockUpdate = mock(async () => ({
+        success: true,
+        updatedComponents: [],
+        skippedComponents: [],
+        preservedFiles: [],
+        backedUpPaths: [],
+        previousVersion: '0.60.1',
+        newVersion: '0.60.1',
+        warnings: [],
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mockUpdate,
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+      const { checkSelfUpdate: realCheckSelfUpdate } = await import(
+        '../../../src/core/self-update.js'
+      );
+
+      const logsBeforeUpdate: string[] = [];
+      consoleLogSpy.mockImplementation((msg: string) => {
+        logsBeforeUpdate.push(msg as string);
+      });
+
+      // Stub: already on latest
+      const stubbedCheck: typeof realCheckSelfUpdate = () => ({
+        checked: true,
+        updateAvailable: false,
+        latestVersion: '0.60.1',
+        usedCache: false,
+      });
+
+      await updateCommand({}, stubbedCheck);
+
+      const allLogs = logsBeforeUpdate.join('\n');
+      expect(allLogs).not.toContain('npm i -g oh-my-customcode');
+    });
+
+    it('should continue update normally when version check throws an error', async () => {
+      mock.module('../../../src/core/provider.js', () => ({
+        detectProvider: async () => ({
+          provider: 'claude',
+          source: 'override',
+          confidence: 'high',
+          reason: 'test',
+        }),
+      }));
+
+      const mockUpdate = mock(async () => ({
+        success: true,
+        updatedComponents: ['rules'],
+        skippedComponents: [],
+        preservedFiles: [],
+        backedUpPaths: [],
+        previousVersion: '0.60.0',
+        newVersion: '0.60.1',
+        warnings: [],
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mockUpdate,
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+      const { checkSelfUpdate: realCheckSelfUpdate } = await import(
+        '../../../src/core/self-update.js'
+      );
+
+      // Stub: throws (e.g., offline, npm timeout)
+      const failingCheck: typeof realCheckSelfUpdate = () => {
+        throw new Error('ENOTFOUND registry.npmjs.org');
+      };
+
+      // Should not throw — update continues
+      await updateCommand({}, failingCheck);
+
+      // The underlying project update still ran
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+      expect(exitCode).toBeUndefined();
+    });
+  });
+
   describe('updateCommand error handling', () => {
     it('should exit with code 1 when update fails', async () => {
       mock.module('../../../src/core/provider.js', () => ({


### PR DESCRIPTION
## Summary
- **#690** Permission mode auto-switch: Added Permission Mode Guidance to R006 and all 4 routing skills with explicit `mode` parameter recommendation
- **#681** CLI update version check: Added non-blocking self-update notification to `omcustom update` command

## Changes
- `.claude/rules/MUST-agent-design.md`: New Permission Mode Guidance section
- 4 routing skills: permissionMode spawn note
- `src/cli/update.ts`: `checkCliVersion()` with DI-friendly `cliVersionCheck` param
- `src/i18n/locales/{en,ko}.json`: `newVersionAvailable` key
- `tests/unit/cli/update.test.ts`: 3 new tests (+1510 total)
- All templates synced

## Test plan
- [x] `bun test` — 1510 pass, 0 fail
- [x] `bun run build` — success
- [x] Template sync verified (diff shows no divergence)
- [x] Deep verification: 0 HIGH, 0 MEDIUM findings

Closes #690, Closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)