### PR TITLE
fix: installer config.version after init (v0.62.2)

### DIFF
--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9307,7 +9307,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.62.1",
+    version: "0.62.2",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {
@@ -27514,6 +27514,8 @@ async function installEntryDocWithTracking(targetDir, options, result) {
 }
 async function updateInstallConfig(targetDir, options, installedComponents) {
   const config = await loadConfig(targetDir);
+  const manifest = await getTemplateManifest();
+  config.version = manifest.version;
   config.language = options.language ?? DEFAULT_LANGUAGE2;
   config.domain = options.domain;
   config.installedAt = new Date().toISOString();
@@ -27565,6 +27567,25 @@ async function install(options) {
     error("install.failed", { error: message });
   }
   return result;
+}
+async function getTemplateManifest() {
+  const packageRoot = getPackageRoot();
+  const layout = getProviderLayout();
+  const manifestPath = join7(packageRoot, "templates", layout.manifestFile);
+  if (await fileExists(manifestPath)) {
+    return readJsonFile(manifestPath);
+  }
+  return {
+    version: "0.0.0",
+    lastUpdated: new Date().toISOString(),
+    components: getAllComponents().map((name) => ({
+      name,
+      path: getComponentPath(name),
+      description: `${name} component`,
+      files: 0
+    })),
+    source: "https://github.com/baekenough/oh-my-customcode"
+  };
 }
 function getAllComponents() {
   return ["rules", "agents", "skills", "guides", "hooks", "contexts", "ontology"];

--- a/dist/index.js
+++ b/dist/index.js
@@ -1427,6 +1427,8 @@ async function installEntryDocWithTracking(targetDir, options, result) {
 }
 async function updateInstallConfig(targetDir, options, installedComponents) {
   const config = await loadConfig(targetDir);
+  const manifest = await getTemplateManifest();
+  config.version = manifest.version;
   config.language = options.language ?? DEFAULT_LANGUAGE;
   config.domain = options.domain;
   config.installedAt = new Date().toISOString();
@@ -1683,7 +1685,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.62.1",
+  version: "0.62.2",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.62.1",
+  "version": "0.62.2",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -360,6 +360,8 @@ async function updateInstallConfig(
   installedComponents: InstallComponent[]
 ): Promise<void> {
   const config = await loadConfig(targetDir);
+  const manifest = await getTemplateManifest();
+  config.version = manifest.version;
   config.language = options.language ?? DEFAULT_LANGUAGE;
   config.domain = options.domain;
   config.installedAt = new Date().toISOString();

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.62.1",
+  "version": "0.62.2",
   "lastUpdated": "2026-03-24T00:00:00.000Z",
   "components": [
     {

--- a/tests/unit/core/installer.test.ts
+++ b/tests/unit/core/installer.test.ts
@@ -244,6 +244,23 @@ describe('installer', () => {
       // Should have warnings about existing files
       expect(result.warnings.length).toBeGreaterThanOrEqual(0);
     });
+
+    it('should set config.version to template manifest version after install', async () => {
+      const manifest = await getTemplateManifest();
+
+      await install({
+        targetDir: tempDir,
+        skipConfirm: true,
+      });
+
+      const fs = await import('node:fs/promises');
+      const configPath = join(tempDir, '.omcustomrc.json');
+      const raw = await fs.readFile(configPath, 'utf-8');
+      const config = JSON.parse(raw) as { version?: string };
+
+      expect(config.version).toBeDefined();
+      expect(config.version).toBe(manifest.version);
+    });
   });
 
   describe('copyTemplates', () => {


### PR DESCRIPTION
## Summary
- Fix `updateInstallConfig()` to set `config.version` from template manifest (#696)
- `omcustom doctor` now correctly reports version after fresh `omcustom init`
- Added test: verify config.version matches manifest after install

## Root cause
`installer.ts:updateInstallConfig()` set `language`, `domain`, `installedAt`, `installedComponents` but not `version`. `doctor-framework.ts:getInstalledVersion()` reads `config.version` from `.omcustomrc.json` — always null after init.

## Test plan
- [ ] `bun test` — 1511 pass, 0 fail (+1 new test)
- [ ] New test: `should set config.version to template manifest version after install`

Closes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)