### PR TITLE
feat: v0.62.3 — Graph keyboard a11y & zoom UX (#699, #700)

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,7 +1,7 @@
 {
   "lockfileVersion": 1,
   "generatorVersion": "0.62.3",
-  "generatedAt": "2026-03-28T03:00:45.160Z",
+  "generatedAt": "2026-03-28T03:24:31.434Z",
   "templateVersion": "0.62.3",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.62.0",
-  "generatedAt": "2026-03-28T01:34:24.580Z",
-  "templateVersion": "0.62.0",
+  "generatorVersion": "0.62.3",
+  "generatedAt": "2026-03-28T03:00:45.160Z",
+  "templateVersion": "0.62.3",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",
@@ -70,8 +70,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-continuous-improvement.md": {
-      "templateHash": "e462929005906abd284a9d21d8c68d2673887c46975b5fa7d9d54bc9905bc906",
-      "size": 1531,
+      "templateHash": "4e152a62f0c6f749a4fef1f268bdc9da1bf211ea886ff68bb0d354b91b246470",
+      "size": 2090,
       "component": "rules"
     },
     ".claude/rules/MUST-permissions.md": {

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,14 +1,14 @@
 # Architecture
 
-> oh-my-customcode v0.58.4
+> oh-my-customcode v0.62.3
 
 ## 1. System Overview
 
-oh-my-customcode is a batteries-included agent harness for Claude Code. It ships 46 pre-built subagents, 95 skills, 21 governing rules, and a comprehensive hook system — all wired together so that any Claude Code session inherits a complete multi-agent operating model without additional configuration. The core philosophy is: **"No expert? CREATE one, connect knowledge, and USE it."** When a task arrives with no matching specialist, the system auto-creates one by discovering relevant skills and guides, then immediately executes the task.
+oh-my-customcode is a batteries-included agent harness for Claude Code. It ships 46 pre-built subagents, 97 skills, 21 governing rules, and a comprehensive hook system — all wired together so that any Claude Code session inherits a complete multi-agent operating model without additional configuration. The core philosophy is: **"No expert? CREATE one, connect knowledge, and USE it."** When a task arrives with no matching specialist, the system auto-creates one by discovering relevant skills and guides, then immediately executes the task.
 
 The harness operates on three engineering pillars — **Context Engineering** (what goes into the prompt), **Architectural Constraints** (rules that shape agent behavior), and **Entropy Management** (hooks, verification, and observability that keep the system coherent at scale).
 
-Current version: **0.58.4** — distributed as `oh-my-customcode` on npm, CLI: `omcustom`.
+Current version: **0.62.3** — distributed as `oh-my-customcode` on npm, CLI: `omcustom`.
 
 ---
 
@@ -88,7 +88,7 @@ The takeover pattern — reverse-compiling an existing codebase into structured 
 
 Each agent is defined in `.claude/agents/{name}.md` with YAML frontmatter specifying model, tools, skills, memory scope, and optional features (soul identity, escalation policy, isolation mode).
 
-### 3.3 Skill Catalog (95 skills)
+### 3.3 Skill Catalog (97 skills)
 
 **Routing skills (4, context: fork)**
 
@@ -113,7 +113,7 @@ analysis, create-agent, update-docs, update-external, audit-agents, fix-refs, de
 
 **System / internal skills**
 
-intent-detection, model-escalation, stuck-recovery, result-aggregation, multi-model-verification, pr-auto-improve, memory-management, claude-code-bible, cve-triage, jinja2-prompts, skills-sh-search, reasoning-sandwich, evaluator-optimizer, systematic-debugging, workflow-runner, alembic-best-practices
+intent-detection, model-escalation, stuck-recovery, result-aggregation, multi-model-verification, pr-auto-improve, memory-management, claude-code-bible, cve-triage, jinja2-prompts, skills-sh-search, reasoning-sandwich, evaluator-optimizer, systematic-debugging, workflow-runner, alembic-best-practices, action-validator, peer-messaging
 
 ### 3.4 Guide Library (31 topics)
 
@@ -605,6 +605,12 @@ The `context-budget-advisor.sh` PostToolUse hook monitors usage and emits adviso
 
 | Version | Key Changes |
 |---------|-------------|
+| v0.62.3 | Graph keyboard accessibility, zoom-responsive labels, tooltip clamping |
+| v0.62.0–v0.62.2 | D3 force-directed dependency graph; CI lockfile-sync gate; R016 defect response matrix; installer config.version fix |
+| v0.61.0 | Permission Mode Guidance R006; CLI self-update check |
+| v0.60.0–v0.60.1 | CC v2.1.83-85 compat; action-validator + peer-messaging skills; monitoring-setup Inspector |
+| v0.59.0–v0.59.1 | HTML comment token optimization (CLAUDE.md 550→286 lines, 10 rules); professor-triage Phase 5B mandatory |
+| v0.58.5–v0.58.6 | CI template-sync validation; test suite expansion; CLAUDE.md dedup 48% reduction |
 | v0.58.4 | Documentation sync to v0.58.4 |
 | v0.58.3 | feedback-collector fix, cost-cap-advisor TSV, updater.ts CRLF |
 | v0.58.2 | RL/WL renewal countdown in statusline |

--- a/ARCHITECTURE_ko.md
+++ b/ARCHITECTURE_ko.md
@@ -1,12 +1,12 @@
 # 아키텍처
 
-> oh-my-customcode v0.58.4
+> oh-my-customcode v0.62.3
 
 ## 1. 시스템 개요
 
-oh-my-customcode는 Claude Code를 위한 배터리 포함형 에이전트 하네스입니다. 46개의 사전 구축된 서브에이전트, 95개의 스킬, 21개의 거버넌스 규칙, 훅 시스템이 모두 연결되어 있어 추가 설정 없이 Claude Code 세션에 완전한 멀티 에이전트 운영 모델이 적용됩니다. 핵심 철학: **"전문가가 없으면? 만들고, 지식을 연결하고, 사용한다."** 매칭되는 전문가가 없는 작업이 들어오면 시스템이 자동으로 관련 스킬과 가이드를 탐색하여 새 에이전트를 생성한 뒤 즉시 작업을 실행합니다.
+oh-my-customcode는 Claude Code를 위한 배터리 포함형 에이전트 하네스입니다. 46개의 사전 구축된 서브에이전트, 97개의 스킬, 21개의 거버넌스 규칙, 훅 시스템이 모두 연결되어 있어 추가 설정 없이 Claude Code 세션에 완전한 멀티 에이전트 운영 모델이 적용됩니다. 핵심 철학: **"전문가가 없으면? 만들고, 지식을 연결하고, 사용한다."** 매칭되는 전문가가 없는 작업이 들어오면 시스템이 자동으로 관련 스킬과 가이드를 탐색하여 새 에이전트를 생성한 뒤 즉시 작업을 실행합니다.
 
-현재 버전: **0.58.4** -- npm 패키지명 `oh-my-customcode`, CLI: `omcustom`
+현재 버전: **0.62.3** -- npm 패키지명 `oh-my-customcode`, CLI: `omcustom`
 
 ### 1.1 컴파일레이션 메타포
 
@@ -58,7 +58,7 @@ oh-my-customcode는 에이전트 시스템을 "소스 코드"로, 실행 중인 
 | R020 | MUST | 완료 검증 | 작업 완료 선언 전 task-type-specific 검증 |
 | R021 | MUST | Enforcement Policy | Advisory-first 시행 모델, 강화 승격 기준 |
 
-### 3.2 에이전트 분류 (45개)
+### 3.2 에이전트 분류 (46개)
 
 | 카테고리 | 수량 | 에이전트 |
 |----------|------|----------|
@@ -76,7 +76,7 @@ oh-my-customcode는 에이전트 시스템을 "소스 코드"로, 실행 중인 
 | 시스템 | 2 | sys-memory-keeper, sys-naggy |
 | **합계** | **46** | |
 
-### 3.3 스킬 카탈로그 (95개)
+### 3.3 스킬 카탈로그 (97개)
 
 **라우팅 스킬 (4개, context: fork)**
 
@@ -101,9 +101,9 @@ analysis, create-agent, update-docs, update-external, audit-agents, fix-refs, de
 
 **시스템 / 내부 스킬**
 
-intent-detection, model-escalation, stuck-recovery, result-aggregation, multi-model-verification, pr-auto-improve, memory-management, claude-code-bible, cve-triage, jinja2-prompts, skills-sh-search, reasoning-sandwich, evaluator-optimizer, systematic-debugging, workflow-runner, alembic-best-practices
+intent-detection, model-escalation, stuck-recovery, result-aggregation, multi-model-verification, pr-auto-improve, memory-management, claude-code-bible, cve-triage, jinja2-prompts, skills-sh-search, reasoning-sandwich, evaluator-optimizer, systematic-debugging, workflow-runner, alembic-best-practices, action-validator, peer-messaging
 
-### 3.4 가이드 라이브러리 (30개 토픽)
+### 3.4 가이드 라이브러리 (31개 토픽)
 
 | 카테고리 | 가이드 |
 |----------|--------|
@@ -530,6 +530,12 @@ Claude Code v2.1.72 ~ v2.1.81+ 테스트 및 호환 확인.
 
 | 버전 | 주요 변경 사항 |
 |------|--------------|
+| v0.62.3 | Graph 키보드 접근성, 줌 반응형 레이블, 툴팁 경계 보정 |
+| v0.62.0–v0.62.2 | D3 force-directed 의존성 그래프; CI lockfile-sync 게이트; R016 결함 대응 매트릭스; installer config.version 수정 |
+| v0.61.0 | Permission Mode Guidance R006; CLI 자체 업데이트 체크 |
+| v0.60.0–v0.60.1 | CC v2.1.83-85 호환; action-validator + peer-messaging 스킬; monitoring-setup Inspector |
+| v0.59.0–v0.59.1 | HTML 주석 토큰 최적화 (CLAUDE.md 550→286줄, 10 rules); professor-triage Phase 5B 필수화 |
+| v0.58.5–v0.58.6 | CI template-sync 검증; 테스트 스위트 확장; CLAUDE.md 중복 제거 48% 감소 |
 | v0.58.4 | 문서 v0.58.4 동기화 |
 | v0.58.3 | feedback-collector 수정, cost-cap-advisor TSV, updater.ts CRLF |
 | v0.58.2 | RL/WL 리뉴얼 카운트다운 statusline 표시 |

--- a/README_ko.md
+++ b/README_ko.md
@@ -15,7 +15,7 @@
 
 46개 에이전트. 97개 스킬. 21개 규칙. 명령어 하나.
 
-> **v0.58.4** — Impeccable AI 디자인 언어, post-release-followup 워크플로우, feedback-collector 수정, cost-cap-advisor TSV, 문서 동기화
+> **v0.62.3** — D3 의존성 그래프, 키보드 접근성, CI lockfile-sync 게이트, Permission Mode 가이드, HTML 주석 토큰 최적화
 
 ```bash
 npm install -g oh-my-customcode && cd your-project && omcustom init

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9307,7 +9307,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.62.2",
+    version: "0.62.3",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1685,7 +1685,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.62.2",
+  version: "0.62.3",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/docs/superpowers/plans/2026-03-28-v0.62.3-release.md
+++ b/docs/superpowers/plans/2026-03-28-v0.62.3-release.md
@@ -1,0 +1,28 @@
+# Release Plan — Generated 2026-03-28
+
+> Source: open issues labeled `verify-done` as of 2026-03-28
+> Issues excluded (already in open PRs): none
+
+## v0.62.3 Release Plan
+
+**Estimated scope**: S+S = M total | **Issues**: 2 | **Parallelizable**: 2
+
+| # | Priority | Size | Title | Dependencies |
+|---|----------|------|-------|-------------|
+| #699 | P3 | S | Graph: keyboard accessibility for node navigation | none |
+| #700 | P3 | S | Graph: zoom-responsive labels and tooltip edge clamping | none |
+
+### Implementation Order
+1. #699 — Add tabindex, keyboard handlers (Enter/Space/Arrow), prefers-reduced-motion to graph nodes (suggested agent: fe-svelte-agent)
+2. #700 — Zoom-level label visibility control + tooltip viewport clamping (suggested agent: fe-svelte-agent)
+
+### Notes
+- Both issues target the same file: `packages/serve/src/routes/graph/+page.svelte`
+- Issues are independent and can be implemented in parallel or sequentially
+- No breaking changes, no dependency updates required
+- Both are UX polishing improvements to the D3 dependency graph added in v0.62.0
+
+## Summary
+| Release | Issues | Size | P1 | P2 | P3 |
+|---------|--------|------|----|----|-----|
+| v0.62.3 | 2 | M | 0 | 0 | 2 |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.62.2",
+  "version": "0.62.3",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/packages/serve/src/routes/graph/+page.svelte
+++ b/packages/serve/src/routes/graph/+page.svelte
@@ -13,6 +13,7 @@
 	let svgEl = $state<SVGSVGElement | null>(null);
 	let searchQuery = $state('');
 	let activeFilter = $state<'all' | 'agent' | 'skill' | 'guide'>('all');
+	let currentZoomScale = $state(1);
 	let tooltip = $state<{ visible: boolean; x: number; y: number; node: GraphNode | null }>({
 		visible: false,
 		x: 0,
@@ -81,6 +82,13 @@
 			.scaleExtent([0.1, 4])
 			.on('zoom', (event) => {
 				g.attr('transform', event.transform);
+				const k = event.transform.k;
+				const wasHidden = currentZoomScale < 0.5;
+				const shouldHide = k < 0.5;
+				currentZoomScale = k;
+				if (wasHidden !== shouldHide) {
+					g.selectAll('.node text').attr('display', shouldHide ? 'none' : null);
+				}
 			});
 
 		svg.call(zoom);
@@ -127,6 +135,12 @@
 
 		simulationRef = simulation;
 
+		// Reduced-motion: skip animation, position nodes immediately
+		if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+			simulation.alpha(0).stop();
+			simulation.tick(300);
+		}
+
 		// Arrow markers
 		const defs = svg.append('defs');
 		for (const [rel, color] of [
@@ -170,6 +184,9 @@
 			.join('g')
 			.attr('class', 'node')
 			.attr('cursor', 'pointer')
+			.attr('tabindex', '0')
+			.attr('role', 'button')
+			.attr('aria-label', (d: any) => d.label)
 			.call(
 				d3
 					.drag<SVGGElement, any>()
@@ -238,24 +255,28 @@
 				.text(d.label);
 		});
 
+		// Clamp tooltip position within SVG container
+		function clampTooltip(clientX: number, clientY: number): { x: number; y: number } {
+			const containerRect = svgEl!.getBoundingClientRect();
+			const tooltipWidth = 192; // max-w-48 = 12rem
+			const tooltipHeight = 80;
+			let tx = clientX - containerRect.left + 12;
+			let ty = clientY - containerRect.top - 8;
+			if (tx + tooltipWidth > containerRect.width) tx = tx - tooltipWidth - 24;
+			if (ty + tooltipHeight > containerRect.height) ty = containerRect.height - tooltipHeight - 8;
+			if (ty < 0) ty = 8;
+			return { x: tx, y: ty };
+		}
+
 		// Node interactions
 		nodeSel
 			.on('mouseover', (event, d: any) => {
-				const rect = svgEl!.getBoundingClientRect();
-				tooltip = {
-					visible: true,
-					x: event.clientX - rect.left + 12,
-					y: event.clientY - rect.top - 8,
-					node: d
-				};
+				const { x, y } = clampTooltip(event.clientX, event.clientY);
+				tooltip = { visible: true, x, y, node: d };
 			})
 			.on('mousemove', (event) => {
-				const rect = svgEl!.getBoundingClientRect();
-				tooltip = {
-					...tooltip,
-					x: event.clientX - rect.left + 12,
-					y: event.clientY - rect.top - 8
-				};
+				const { x, y } = clampTooltip(event.clientX, event.clientY);
+				tooltip = { ...tooltip, x, y };
 			})
 			.on('mouseout', () => {
 				tooltip = { ...tooltip, visible: false };
@@ -268,6 +289,26 @@
 				} else {
 					selectedNode = d.id;
 					updateHighlight(d.id, linkSel, nodeSel);
+				}
+			})
+			.on('keydown', (event, d: any) => {
+				if (event.key === 'Enter' || event.key === ' ') {
+					event.preventDefault();
+					if (selectedNode === d.id) {
+						selectedNode = null;
+						updateHighlight(null, linkSel, nodeSel);
+					} else {
+						selectedNode = d.id;
+						updateHighlight(d.id, linkSel, nodeSel);
+					}
+				} else if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+					event.preventDefault();
+					const adjacent = getAdjacentNodes(d.id, simEdges);
+					if (adjacent.length > 0) focusNode(adjacent[0], nodeSel);
+				} else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+					event.preventDefault();
+					const adjacent = getAdjacentNodes(d.id, simEdges);
+					if (adjacent.length > 0) focusNode(adjacent[adjacent.length - 1], nodeSel);
 				}
 			});
 
@@ -283,6 +324,25 @@
 		});
 
 		return { linkSel, nodeSel, simNodes, simEdges };
+	}
+
+	function getAdjacentNodes(nodeId: string, edges: any[]): string[] {
+		const adjacent: string[] = [];
+		for (const e of edges) {
+			const src = typeof e.source === 'object' ? e.source.id : e.source;
+			const tgt = typeof e.target === 'object' ? e.target.id : e.target;
+			if (src === nodeId && !adjacent.includes(tgt)) adjacent.push(tgt);
+			if (tgt === nodeId && !adjacent.includes(src)) adjacent.push(src);
+		}
+		return adjacent;
+	}
+
+	function focusNode(nodeId: string, nodeSel: d3.Selection<any, any, any, any>) {
+		nodeSel
+			.filter((d: any) => d.id === nodeId)
+			.each(function () {
+				(this as SVGGElement).focus();
+			});
 	}
 
 	function updateHighlight(
@@ -423,8 +483,8 @@
 		<svg
 			bind:this={svgEl}
 			class="w-full h-full"
-			role="img"
-			aria-label="Dependency graph visualization"
+			role="application"
+			aria-label="Dependency graph visualization. Use Tab to navigate nodes, Enter or Space to select, Arrow keys to move between connected nodes."
 		></svg>
 
 		<!-- Tooltip -->

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.62.2",
+  "version": "0.62.3",
   "lastUpdated": "2026-03-24T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary

- Add keyboard accessibility to the dependency graph (`/graph` route): `tabindex`, `Enter`/`Space`/`Arrow` key navigation for nodes, SVG `role=\"application\"`
- Add `prefers-reduced-motion` support: instant layout convergence for users with motion sensitivity
- Hide node labels at zoom level < 0.5 (threshold-based optimization for dense graphs)
- Clamp tooltip position to stay within viewport bounds

## Files Changed

- `packages/serve/src/routes/graph/+page.svelte` — source changes
- `package.json` — version bump 0.62.2 → 0.62.3
- `templates/manifest.json` — version bump 0.62.2 → 0.62.3
- `dist/cli/index.js`, `dist/index.js` — build artifacts
- `docs/superpowers/plans/2026-03-28-v0.62.3-release.md` — release plan
- `.omcustom.lock.json` — lockfile sync

## Test Results

- 1511 pass, 0 fail
- Function coverage: 98.10% | Line coverage: 97.68% (threshold: 95%)

## Issues

Closes #699
Closes #700