### PR TITLE
feat: graph accessibility improvements (v0.62.4)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> oh-my-customcode v0.62.3
+> oh-my-customcode v0.62.4
 
 ## 1. System Overview
 
@@ -605,6 +605,7 @@ The `context-budget-advisor.sh` PostToolUse hook monitors usage and emits adviso
 
 | Version | Key Changes |
 |---------|-------------|
+| v0.62.4 | Graph circular keyboard nav, aria-live announcements, skip link, focus-visible styling |
 | v0.62.3 | Graph keyboard accessibility, zoom-responsive labels, tooltip clamping |
 | v0.62.0–v0.62.2 | D3 force-directed dependency graph; CI lockfile-sync gate; R016 defect response matrix; installer config.version fix |
 | v0.61.0 | Permission Mode Guidance R006; CLI self-update check |

--- a/ARCHITECTURE_ko.md
+++ b/ARCHITECTURE_ko.md
@@ -1,12 +1,12 @@
 # 아키텍처
 
-> oh-my-customcode v0.62.3
+> oh-my-customcode v0.62.4
 
 ## 1. 시스템 개요
 
 oh-my-customcode는 Claude Code를 위한 배터리 포함형 에이전트 하네스입니다. 46개의 사전 구축된 서브에이전트, 97개의 스킬, 21개의 거버넌스 규칙, 훅 시스템이 모두 연결되어 있어 추가 설정 없이 Claude Code 세션에 완전한 멀티 에이전트 운영 모델이 적용됩니다. 핵심 철학: **"전문가가 없으면? 만들고, 지식을 연결하고, 사용한다."** 매칭되는 전문가가 없는 작업이 들어오면 시스템이 자동으로 관련 스킬과 가이드를 탐색하여 새 에이전트를 생성한 뒤 즉시 작업을 실행합니다.
 
-현재 버전: **0.62.3** -- npm 패키지명 `oh-my-customcode`, CLI: `omcustom`
+현재 버전: **0.62.4** -- npm 패키지명 `oh-my-customcode`, CLI: `omcustom`
 
 ### 1.1 컴파일레이션 메타포
 
@@ -530,6 +530,7 @@ Claude Code v2.1.72 ~ v2.1.81+ 테스트 및 호환 확인.
 
 | 버전 | 주요 변경 사항 |
 |------|--------------|
+| v0.62.4 | Graph 순환 키보드 탐색, aria-live 알림, 스킵 링크, focus-visible 스타일링 |
 | v0.62.3 | Graph 키보드 접근성, 줌 반응형 레이블, 툴팁 경계 보정 |
 | v0.62.0–v0.62.2 | D3 force-directed 의존성 그래프; CI lockfile-sync 게이트; R016 결함 대응 매트릭스; installer config.version 수정 |
 | v0.61.0 | Permission Mode Guidance R006; CLI 자체 업데이트 체크 |

--- a/README_ko.md
+++ b/README_ko.md
@@ -15,7 +15,7 @@
 
 46개 에이전트. 97개 스킬. 21개 규칙. 명령어 하나.
 
-> **v0.62.3** — D3 의존성 그래프, 키보드 접근성, CI lockfile-sync 게이트, Permission Mode 가이드, HTML 주석 토큰 최적화
+> **v0.62.4** — D3 의존성 그래프, 키보드 접근성, aria-live/skip link/focus-visible, CI lockfile-sync 게이트
 
 ```bash
 npm install -g oh-my-customcode && cd your-project && omcustom init

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9307,7 +9307,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.62.3",
+    version: "0.62.4",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1685,7 +1685,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.62.3",
+  version: "0.62.4",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/docs/superpowers/plans/2026-03-28-v0.62.4-release.md
+++ b/docs/superpowers/plans/2026-03-28-v0.62.4-release.md
@@ -1,0 +1,53 @@
+# Release Plan — Generated 2026-03-28
+
+> Source: open issues labeled `verify-done` as of 2026-03-28
+> Issues excluded (already in open PRs): none
+
+## v0.62.4 Release Plan
+
+**Estimated scope**: S-M total | **Issues**: 4 | **Parallelizable**: 4
+
+| # | Priority | Size | Title | Dependencies |
+|---|----------|------|-------|-------------|
+| #709 | P3 | XS | Graph: skip link for screen reader users | none |
+| #706 | P3 | S | Graph: circular arrow key navigation between adjacent nodes | none |
+| #707 | P3 | S | Graph: aria-live region for node selection announcements | none |
+| #708 | P3 | S | Graph: focus-visible styling for keyboard-navigated SVG nodes | none |
+
+### Implementation Order
+1. #709 — Add skip-to-content link before SVG graph (suggested agent: fe-svelte-agent)
+2. #706 — Implement circular arrow key navigation in D3 force graph (suggested agent: fe-svelte-agent)
+3. #707 — Add aria-live region for announcing node selection changes (suggested agent: fe-svelte-agent)
+4. #708 — Add focus-visible CSS styles for keyboard-focused SVG nodes (suggested agent: fe-svelte-agent)
+
+### Notes
+- All 4 issues are independent and fully parallelizable
+- All target the same file: `packages/serve/src/routes/graph/+page.svelte`
+- WCAG 2.1 AA accessibility improvements for the dependency graph visualization
+- No breaking changes
+
+---
+
+## v0.62.5 Release Plan
+
+**Estimated scope**: M | **Issues**: 1 | **Parallelizable**: 1
+
+| # | Priority | Size | Title | Dependencies |
+|---|----------|------|-------|-------------|
+| #710 | P3 | M | Graph: Playwright accessibility E2E tests | v0.62.4 features recommended first |
+
+### Implementation Order
+1. #710 — Set up Playwright test framework and write accessibility E2E tests for graph page (suggested agent: qa-engineer)
+
+### Notes
+- Depends on v0.62.4 accessibility features being implemented for meaningful test targets
+- Requires Playwright dependency addition and test configuration
+- Test scope: keyboard navigation, screen reader announcements, skip links, focus management
+
+---
+
+## Summary
+| Release | Issues | Size | P1 | P2 | P3 |
+|---------|--------|------|----|----|-----|
+| v0.62.4 | 4 | S-M | 0 | 0 | 4 |
+| v0.62.5 | 1 | M | 0 | 0 | 1 |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.62.3",
+  "version": "0.62.4",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/packages/serve/src/routes/graph/+page.svelte
+++ b/packages/serve/src/routes/graph/+page.svelte
@@ -21,6 +21,7 @@
 		node: null
 	});
 	let selectedNode = $state<string | null>(null);
+	let liveMessage = $state('');
 
 	const graphData = $derived(data.graphData);
 
@@ -304,11 +305,35 @@
 				} else if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
 					event.preventDefault();
 					const adjacent = getAdjacentNodes(d.id, simEdges);
-					if (adjacent.length > 0) focusNode(adjacent[0], nodeSel);
+					if (adjacent.length > 0) {
+						const currentFocused = document.activeElement;
+						let currentIdx = -1;
+						if (currentFocused) {
+							nodeSel.each(function (nd: any, i: number) {
+								if (this === currentFocused) {
+									currentIdx = adjacent.indexOf(nd.id);
+								}
+							});
+						}
+						const nextIdx = currentIdx >= 0 ? (currentIdx + 1) % adjacent.length : 0;
+						focusNode(adjacent[nextIdx], nodeSel);
+					}
 				} else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
 					event.preventDefault();
 					const adjacent = getAdjacentNodes(d.id, simEdges);
-					if (adjacent.length > 0) focusNode(adjacent[adjacent.length - 1], nodeSel);
+					if (adjacent.length > 0) {
+						const currentFocused = document.activeElement;
+						let currentIdx = -1;
+						if (currentFocused) {
+							nodeSel.each(function (nd: any, i: number) {
+								if (this === currentFocused) {
+									currentIdx = adjacent.indexOf(nd.id);
+								}
+							});
+						}
+						const nextIdx = currentIdx >= 0 ? (currentIdx - 1 + adjacent.length) % adjacent.length : adjacent.length - 1;
+						focusNode(adjacent[nextIdx], nodeSel);
+					}
 				}
 			});
 
@@ -432,6 +457,21 @@
 		graphRefs = buildGraph(nodes, edges);
 		selectedNode = null;
 	});
+
+	$effect(() => {
+		const nodeId = selectedNode;
+		if (!nodeId) {
+			liveMessage = '';
+			return;
+		}
+		const node = graphData.nodes.find((n) => n.id === nodeId);
+		if (node) {
+			const connections = graphData.edges.filter(
+				(e) => e.source === nodeId || e.target === nodeId
+			).length;
+			liveMessage = `${node.label}, ${node.type}, ${connections} connections`;
+		}
+	});
 </script>
 
 <!-- ============================================================ -->
@@ -480,12 +520,17 @@
 
 	<!-- Graph canvas -->
 	<div class="relative flex-1 overflow-hidden">
+		<a
+			href="#after-graph"
+			class="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:bg-zinc-800 focus:text-zinc-100 focus:px-4 focus:py-2 focus:rounded focus:top-2 focus:left-2"
+		>Skip graph</a>
 		<svg
 			bind:this={svgEl}
 			class="w-full h-full"
 			role="application"
 			aria-label="Dependency graph visualization. Use Tab to navigate nodes, Enter or Space to select, Arrow keys to move between connected nodes."
 		></svg>
+		<div id="after-graph" tabindex="-1"></div>
 
 		<!-- Tooltip -->
 		{#if tooltip.visible && tooltip.node}
@@ -507,6 +552,8 @@
 				{/if}
 			</div>
 		{/if}
+
+		<div aria-live="polite" class="sr-only">{liveMessage}</div>
 
 		<!-- Legend -->
 		<div
@@ -580,3 +627,15 @@
 		{/if}
 	</div>
 </div>
+
+<style>
+  :global(.node:focus-visible) {
+    outline: none;
+  }
+  :global(.node:focus-visible circle),
+  :global(.node:focus-visible rect) {
+    stroke: #60a5fa;
+    stroke-width: 3;
+    filter: drop-shadow(0 0 4px rgba(96, 165, 250, 0.5));
+  }
+</style>

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.62.3",
+  "version": "0.62.4",
   "lastUpdated": "2026-03-24T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- Circular arrow key navigation between adjacent graph nodes (#706)
- aria-live region for screen reader node selection announcements (#707)
- focus-visible styling for keyboard-navigated SVG nodes (#708)
- Skip link to bypass graph for keyboard/screen reader users (#709)
- deep-verify caught Svelte scoped CSS issue with D3 elements — fixed with `:global()`
- Docs synced to v0.62.4

## Test plan
- [ ] `bun run test` passes (1511 tests)
- [ ] `bun run lint` clean (1 pre-existing warning only)
- [ ] Keyboard navigation: Tab to nodes, Arrow keys cycle through adjacent nodes circularly
- [ ] Screen reader: node selection announced via aria-live
- [ ] Skip link: visible on focus, jumps past SVG graph
- [ ] Focus indicator: blue ring on keyboard-focused nodes

Closes #706, #707, #708, #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)