### PR TITLE
feat: v0.63.0 — Chroma Context-1 internalize (#714)

### DIFF
--- a/.claude/rules/SHOULD-ecomode.md
+++ b/.claude/rules/SHOULD-ecomode.md
@@ -36,6 +36,35 @@ Ecomode: `[lang-golang-expert] ✓ src/main.go reviewed: 1 naming issue (handle_
 
 Disable with: "ecomode off", "verbose mode", or "show full details".
 
+## Input Context Pruning
+
+Active removal of irrelevant retrieved content from agent context. Complements output compression by managing the input side of token budget.
+
+> **Terminology**: "Input Context Pruning" (R013) manages retrieved chunks during a task. "Memory Pruning" (R011) manages behavioral memory across sessions. These are distinct concepts.
+
+### Pruning Triggers
+
+| Trigger | Condition | Action |
+|---------|-----------|--------|
+| Search overflow | Retrieved chunks > 10 | Retain top-K by relevance, prune rest |
+| Context pressure | Context usage > 50% | Summarize oldest/lowest-relevance chunks |
+| Multi-hop intermediate | Between retrieval hops | Replace previous hop raw results with summary |
+
+### Pruning Strategy
+
+| Strategy | When | Behavior |
+|----------|------|----------|
+| **Retain** | Directly relevant code/docs | Keep as-is |
+| **Summarize** | Background context, prior hop results | Replace with 1-2 line summary |
+| **Drop** | Search noise, duplicates, already-reflected info | Remove entirely |
+
+### Rules
+
+- Pruning is irreversible — generate summary BEFORE dropping original
+- Prune at document/chunk level, not mid-sentence
+- When in doubt, Summarize rather than Drop
+- Track pruning decisions: `[Pruned] {N} chunks → {M} retained, {K} summarized, {J} dropped`
+
 ## Context Budget Management
 
 Task-type-aware context thresholds that trigger ecomode earlier for context-heavy operations.

--- a/.claude/skills/memory-recall/SKILL.md
+++ b/.claude/skills/memory-recall/SKILL.md
@@ -58,6 +58,24 @@ avoid:
   - Special characters or complex syntax
 ```
 
+## Retrieval Strategy
+
+### Recall-Precision Tradeoff
+
+Default bias: **recall > precision** — it is easier to filter out irrelevant results (false positives) than to recover missed information (false negatives).
+
+| Task Type | Bias | Recommended --limit | Rationale |
+|-----------|------|--------------------:|-----------|
+| Debugging / Investigation | High recall (16:1) | 10-15 | Cast wide net, prune later |
+| Decision reference | Balanced | 5 (default) | Moderate breadth with manageable noise |
+| Specific fact lookup | High precision | 3 | Narrow, targeted retrieval |
+
+### Guidelines
+
+- **Over-retrieve, then filter**: When uncertain, request more results and discard irrelevant ones in post-processing
+- **Narrow progressively**: Start broad, refine query only if results are noisy — avoid starting too narrow
+- **Combine temporal + semantic**: Add date filters (`--date`) to semantic queries for better precision without sacrificing recall
+
 ## Output Format
 
 ### Basic Search

--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -228,6 +228,33 @@ Convergence expected by round 3. Hard stop at round 30.
 | Ecomode | Auto-activate for team result aggregation (R013) |
 | Intent display | Show research plan before execution (R015) |
 
+## Retrieval-Reasoning Separation
+
+Retrieval and reasoning are distinct cognitive operations that benefit from explicit role separation. Mixing them in a single agent degrades both: retrieval becomes biased by premature conclusions, and reasoning gets polluted by search noise.
+
+### Principle
+
+| Role | Phase | Model | Responsibility |
+|------|-------|-------|----------------|
+| Retriever | Phase 1 | sonnet (fast, broad) | Gather, catalog, enumerate — no judgment |
+| Reasoner | Phase 2-3 | opus (deep, precise) | Verify, synthesize, judge — no new retrieval |
+
+### Why Separate
+
+- **Retrieval bias**: A reasoning agent searching for evidence tends to confirm existing hypotheses (confirmation bias)
+- **Context pollution**: Raw search results mixed with analysis obscure both
+- **Cost efficiency**: Retrieval needs speed and breadth (cheaper model); reasoning needs depth (capable model)
+- **Debuggability**: When results are wrong, separated roles make it clear whether the problem was bad retrieval or bad reasoning
+
+### Application in Research Workflow
+
+| Phase | Role | Separation Rule |
+|-------|------|-----------------|
+| Phase 1 (10 teams) | Retriever | Teams gather and catalog only. No ADOPT/AVOID judgments. |
+| Phase 2 (Verification) | Reasoner | Verifiers challenge claims using Phase 1 data. No new searches. |
+| Phase 3 (Synthesis) | Reasoner | Synthesizer produces taxonomy from verified findings only. |
+| Phase 4 (Output) | Reporter | Formats and persists. No new analysis. |
+
 ## Model Selection
 
 | Phase | Model | Rationale |

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.62.3",
-  "generatedAt": "2026-03-28T03:24:31.434Z",
-  "templateVersion": "0.62.3",
+  "generatorVersion": "0.63.0",
+  "generatedAt": "2026-03-28T11:48:25.166Z",
+  "templateVersion": "0.63.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",
@@ -35,8 +35,8 @@
       "component": "rules"
     },
     ".claude/rules/SHOULD-ecomode.md": {
-      "templateHash": "99f682aa45785a9b691b0a5d34c85c37e418820ffae8de5a3fcfbbebcdb2c509",
-      "size": 2425,
+      "templateHash": "30d43c6d08c2edda6c5a71e20a65ad2424918e0b45fa3be3d9c6ddfe3911c92d",
+      "size": 3728,
       "component": "rules"
     },
     ".claude/rules/MUST-language-policy.md": {
@@ -365,8 +365,8 @@
       "component": "skills"
     },
     ".claude/skills/research/SKILL.md": {
-      "templateHash": "b36a495ae7fda67167d1cb09b9e1e4c0cd6ebc2b314278a5e68bd89f8fd892f9",
-      "size": 16151,
+      "templateHash": "426341bb98b09586f908d22a3b629dd540029d04d129ca860bae8d758936d50f",
+      "size": 17653,
       "component": "skills"
     },
     ".claude/skills/audit-agents/SKILL.md": {
@@ -430,8 +430,8 @@
       "component": "skills"
     },
     ".claude/skills/memory-recall/SKILL.md": {
-      "templateHash": "b40223a46b0fa3e75aa3e78d871ad79c5a6c0acf4f837af6cab4e3b4a1a33734",
-      "size": 3370,
+      "templateHash": "22b2d518426b8d6baa0fa61a063491221ad25608b2e5ec67efcd71ea8d0fa08b",
+      "size": 4323,
       "component": "skills"
     },
     ".claude/skills/cve-triage/SKILL.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9307,7 +9307,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.62.5",
+    version: "0.63.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1685,7 +1685,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.62.5",
+  version: "0.63.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.62.5",
+  "version": "0.63.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/SHOULD-ecomode.md
+++ b/templates/.claude/rules/SHOULD-ecomode.md
@@ -36,6 +36,35 @@ Ecomode: `[lang-golang-expert] ✓ src/main.go reviewed: 1 naming issue (handle_
 
 Disable with: "ecomode off", "verbose mode", or "show full details".
 
+## Input Context Pruning
+
+Active removal of irrelevant retrieved content from agent context. Complements output compression by managing the input side of token budget.
+
+> **Terminology**: "Input Context Pruning" (R013) manages retrieved chunks during a task. "Memory Pruning" (R011) manages behavioral memory across sessions. These are distinct concepts.
+
+### Pruning Triggers
+
+| Trigger | Condition | Action |
+|---------|-----------|--------|
+| Search overflow | Retrieved chunks > 10 | Retain top-K by relevance, prune rest |
+| Context pressure | Context usage > 50% | Summarize oldest/lowest-relevance chunks |
+| Multi-hop intermediate | Between retrieval hops | Replace previous hop raw results with summary |
+
+### Pruning Strategy
+
+| Strategy | When | Behavior |
+|----------|------|----------|
+| **Retain** | Directly relevant code/docs | Keep as-is |
+| **Summarize** | Background context, prior hop results | Replace with 1-2 line summary |
+| **Drop** | Search noise, duplicates, already-reflected info | Remove entirely |
+
+### Rules
+
+- Pruning is irreversible — generate summary BEFORE dropping original
+- Prune at document/chunk level, not mid-sentence
+- When in doubt, Summarize rather than Drop
+- Track pruning decisions: `[Pruned] {N} chunks → {M} retained, {K} summarized, {J} dropped`
+
 ## Context Budget Management
 
 Task-type-aware context thresholds that trigger ecomode earlier for context-heavy operations.

--- a/templates/.claude/skills/memory-recall/SKILL.md
+++ b/templates/.claude/skills/memory-recall/SKILL.md
@@ -58,6 +58,24 @@ avoid:
   - Special characters or complex syntax
 ```
 
+## Retrieval Strategy
+
+### Recall-Precision Tradeoff
+
+Default bias: **recall > precision** — it is easier to filter out irrelevant results (false positives) than to recover missed information (false negatives).
+
+| Task Type | Bias | Recommended --limit | Rationale |
+|-----------|------|--------------------:|-----------|
+| Debugging / Investigation | High recall (16:1) | 10-15 | Cast wide net, prune later |
+| Decision reference | Balanced | 5 (default) | Moderate breadth with manageable noise |
+| Specific fact lookup | High precision | 3 | Narrow, targeted retrieval |
+
+### Guidelines
+
+- **Over-retrieve, then filter**: When uncertain, request more results and discard irrelevant ones in post-processing
+- **Narrow progressively**: Start broad, refine query only if results are noisy — avoid starting too narrow
+- **Combine temporal + semantic**: Add date filters (`--date`) to semantic queries for better precision without sacrificing recall
+
 ## Output Format
 
 ### Basic Search

--- a/templates/.claude/skills/research/SKILL.md
+++ b/templates/.claude/skills/research/SKILL.md
@@ -228,6 +228,33 @@ Convergence expected by round 3. Hard stop at round 30.
 | Ecomode | Auto-activate for team result aggregation (R013) |
 | Intent display | Show research plan before execution (R015) |
 
+## Retrieval-Reasoning Separation
+
+Retrieval and reasoning are distinct cognitive operations that benefit from explicit role separation. Mixing them in a single agent degrades both: retrieval becomes biased by premature conclusions, and reasoning gets polluted by search noise.
+
+### Principle
+
+| Role | Phase | Model | Responsibility |
+|------|-------|-------|----------------|
+| Retriever | Phase 1 | sonnet (fast, broad) | Gather, catalog, enumerate — no judgment |
+| Reasoner | Phase 2-3 | opus (deep, precise) | Verify, synthesize, judge — no new retrieval |
+
+### Why Separate
+
+- **Retrieval bias**: A reasoning agent searching for evidence tends to confirm existing hypotheses (confirmation bias)
+- **Context pollution**: Raw search results mixed with analysis obscure both
+- **Cost efficiency**: Retrieval needs speed and breadth (cheaper model); reasoning needs depth (capable model)
+- **Debuggability**: When results are wrong, separated roles make it clear whether the problem was bad retrieval or bad reasoning
+
+### Application in Research Workflow
+
+| Phase | Role | Separation Rule |
+|-------|------|-----------------|
+| Phase 1 (10 teams) | Retriever | Teams gather and catalog only. No ADOPT/AVOID judgments. |
+| Phase 2 (Verification) | Reasoner | Verifiers challenge claims using Phase 1 data. No new searches. |
+| Phase 3 (Synthesis) | Reasoner | Synthesizer produces taxonomy from verified findings only. |
+| Phase 4 (Output) | Reporter | Formats and persists. No new analysis. |
+
 ## Model Selection
 
 | Phase | Model | Rationale |

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.62.5",
+  "version": "0.63.0",
   "lastUpdated": "2026-03-24T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- R013 Ecomode: Input Context Pruning section (Retain/Summarize/Drop strategy for active input context management)
- research SKILL.md: Retrieval-Reasoning Separation principle (Phase 1 retrieval vs Phase 2-3 reasoning explicit separation)
- memory-recall SKILL.md: Recall Bias tradeoff guide (16:1 default, task-type-specific --limit recommendations)
- All 3 template files synced

Closes #714

## Test plan
- [x] Template sync verified (diff shows identical)
- [x] Section placement verified (R013:39, research:231, memory-recall:61)
- [x] 1511 tests pass, 0 fail
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)