### PR TITLE
feat: R002 tool modernization (9→30) + R006 frontmatter sync + Fast Mode (#724)

### DIFF
--- a/.claude/rules/MUST-agent-design.md
+++ b/.claude/rules/MUST-agent-design.md
@@ -11,15 +11,26 @@ Location: `.claude/agents/{name}.md` (single file, kebab-case)
 ```yaml
 name: agent-name           # Unique identifier (kebab-case)
 description: Brief desc    # One-line summary
-model: sonnet              # sonnet | opus | haiku (or full ID: claude-sonnet-4-6)
+model: sonnet              # sonnet | opus | haiku | opusplan (or full ID: claude-sonnet-4-6, claude-opus-4-6[1m])
 tools: [Read, Write, ...]  # Allowed tools
 ```
+
+### Model Aliases
+
+| Alias | Full ID | Use Case |
+|-------|---------|----------|
+| `haiku` | claude-haiku-4-5 | Fast, cheap tasks (search, simple edits) |
+| `sonnet` | claude-sonnet-4-6 | General tasks, code generation (default) |
+| `opus` | claude-opus-4-6 | Complex reasoning, architecture |
+| `opusplan` | claude-opus-4-6 + plan mode | Architecture planning with approval gates |
+
+Extended context suffix: `[1m]` (e.g., `claude-opus-4-6[1m]`) — enables 1M token context window.
 
 ### Optional Frontmatter
 
 ```yaml
 memory: project            # user | project | local
-effort: high               # low | medium | high
+effort: high               # low | medium | high | default | max
 skills: [skill-1, ...]     # Skill name references
 source:                    # For external agents
   type: external
@@ -144,6 +155,26 @@ Skills persist output to `.claude/outputs/sessions/{YYYY-MM-DD}/{skill-name}-{HH
 
 Agent body: purpose, capabilities overview, workflow. NOT detailed instructions or reference docs.
 
+## Fast Mode
+
+Fast Mode uses the same model with faster output. Activated via `/fast` toggle or `fastMode` setting. Does NOT switch to a different model.
+
+| Aspect | Normal | Fast Mode |
+|--------|--------|-----------|
+| Model | As configured | Same model |
+| Output speed | Standard | ~2.5x faster |
+| Reasoning depth | Full | Reduced |
+
+### Activation
+
+- `/fast` — toggle in current session
+- `fastMode: true` in settings.json
+- `CLAUDE_CODE_DISABLE_FAST_MODE=1` — env var to disable
+
+### Interaction with Effort
+
+When Fast Mode is active, it reduces effective reasoning depth but does NOT override the `effort` frontmatter field. The effort field controls task complexity allocation; Fast Mode controls output generation speed.
+
 ## Skill Frontmatter
 
 Location: `.claude/skills/{name}/SKILL.md`
@@ -163,7 +194,17 @@ context: fork              # Forked context for isolated execution
 version: 1.0.0             # Semantic version
 user-invocable: false      # Whether user can invoke directly
 disable-model-invocation: true  # Prevent model from auto-invoking
-effort: medium              # low | medium | high — overrides model effort level when invoked
+effort: medium              # low | medium | high | default | max — overrides model effort level when invoked
+argument-hint: "<arg> [--flag]"  # CLI-style usage hint displayed in /help and command listings
+model: sonnet                      # Override spawned model when skill is invoked via Agent
+agent: mgr-creator                 # Preferred agent to execute this skill
+hooks:                             # Skill-specific hooks (same syntax as agent hooks)
+  PreToolUse:
+    - matcher: "Bash"
+      command: "echo hook"
+paths: ["src/**/*.ts"]             # Conditional loading — skill auto-injected when matching files are open
+shell: "bash"                      # Shell for embedded script execution
+allowed-tools: [Read, Write, Bash] # Restrict tools available during skill execution
 ```
 
 When both an agent and its invoked skill specify `effort`, the skill's value takes precedence (more specific invocation-time setting).

--- a/.claude/rules/MUST-permissions.md
+++ b/.claude/rules/MUST-permissions.md
@@ -6,10 +6,12 @@
 
 | Tier | Tools | Policy |
 |------|-------|--------|
-| 1: Always | Read, Glob, Grep | Free use |
-| 2: Default | Write, Edit | State changes explicitly, notify before modifying important files |
-| 3: Approval | Bash, WebFetch, WebSearch | Request user approval on first use |
-| 4: Explicit | Task | Only when user explicitly requests |
+| 1: Always | Read, Glob, Grep, ToolSearch | Free use, read-only |
+| 2: Default | Write, Edit, NotebookEdit | State changes explicitly, notify before modifying important files |
+| 3: Context | Agent, Skill, EnterPlanMode, ExitPlanMode, EnterWorktree, ExitWorktree, LSP, TodoWrite, AskUserQuestion | Context-dependent, no user approval needed |
+| 4: Approval | Bash, WebFetch, WebSearch | Request user approval on first use |
+| 5: Conditional | TeamCreate, TeamDelete, SendMessage, TaskCreate, TaskGet, TaskList, TaskUpdate, TaskStop, TaskOutput | Available when Agent Teams enabled |
+| 6: MCP | ListMcpResourcesTool, ReadMcpResourceTool, CronCreate, CronDelete, CronList, RemoteTrigger | MCP/extension tools, available when servers configured |
 
 ## File Access
 

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9307,7 +9307,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.63.1",
+    version: "0.64.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1685,7 +1685,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.63.1",
+  version: "0.64.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.63.1",
+  "version": "0.64.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -11,15 +11,26 @@ Location: `.claude/agents/{name}.md` (single file, kebab-case)
 ```yaml
 name: agent-name           # Unique identifier (kebab-case)
 description: Brief desc    # One-line summary
-model: sonnet              # sonnet | opus | haiku (or full ID: claude-sonnet-4-6)
+model: sonnet              # sonnet | opus | haiku | opusplan (or full ID: claude-sonnet-4-6, claude-opus-4-6[1m])
 tools: [Read, Write, ...]  # Allowed tools
 ```
+
+### Model Aliases
+
+| Alias | Full ID | Use Case |
+|-------|---------|----------|
+| `haiku` | claude-haiku-4-5 | Fast, cheap tasks (search, simple edits) |
+| `sonnet` | claude-sonnet-4-6 | General tasks, code generation (default) |
+| `opus` | claude-opus-4-6 | Complex reasoning, architecture |
+| `opusplan` | claude-opus-4-6 + plan mode | Architecture planning with approval gates |
+
+Extended context suffix: `[1m]` (e.g., `claude-opus-4-6[1m]`) — enables 1M token context window.
 
 ### Optional Frontmatter
 
 ```yaml
 memory: project            # user | project | local
-effort: high               # low | medium | high
+effort: high               # low | medium | high | default | max
 skills: [skill-1, ...]     # Skill name references
 source:                    # For external agents
   type: external
@@ -144,6 +155,26 @@ Skills persist output to `.claude/outputs/sessions/{YYYY-MM-DD}/{skill-name}-{HH
 
 Agent body: purpose, capabilities overview, workflow. NOT detailed instructions or reference docs.
 
+## Fast Mode
+
+Fast Mode uses the same model with faster output. Activated via `/fast` toggle or `fastMode` setting. Does NOT switch to a different model.
+
+| Aspect | Normal | Fast Mode |
+|--------|--------|-----------|
+| Model | As configured | Same model |
+| Output speed | Standard | ~2.5x faster |
+| Reasoning depth | Full | Reduced |
+
+### Activation
+
+- `/fast` — toggle in current session
+- `fastMode: true` in settings.json
+- `CLAUDE_CODE_DISABLE_FAST_MODE=1` — env var to disable
+
+### Interaction with Effort
+
+When Fast Mode is active, it reduces effective reasoning depth but does NOT override the `effort` frontmatter field. The effort field controls task complexity allocation; Fast Mode controls output generation speed.
+
 ## Skill Frontmatter
 
 Location: `.claude/skills/{name}/SKILL.md`
@@ -163,7 +194,17 @@ context: fork              # Forked context for isolated execution
 version: 1.0.0             # Semantic version
 user-invocable: false      # Whether user can invoke directly
 disable-model-invocation: true  # Prevent model from auto-invoking
-effort: medium              # low | medium | high — overrides model effort level when invoked
+effort: medium              # low | medium | high | default | max — overrides model effort level when invoked
+argument-hint: "<arg> [--flag]"  # CLI-style usage hint displayed in /help and command listings
+model: sonnet                      # Override spawned model when skill is invoked via Agent
+agent: mgr-creator                 # Preferred agent to execute this skill
+hooks:                             # Skill-specific hooks (same syntax as agent hooks)
+  PreToolUse:
+    - matcher: "Bash"
+      command: "echo hook"
+paths: ["src/**/*.ts"]             # Conditional loading — skill auto-injected when matching files are open
+shell: "bash"                      # Shell for embedded script execution
+allowed-tools: [Read, Write, Bash] # Restrict tools available during skill execution
 ```
 
 When both an agent and its invoked skill specify `effort`, the skill's value takes precedence (more specific invocation-time setting).

--- a/templates/.claude/rules/MUST-permissions.md
+++ b/templates/.claude/rules/MUST-permissions.md
@@ -6,10 +6,12 @@
 
 | Tier | Tools | Policy |
 |------|-------|--------|
-| 1: Always | Read, Glob, Grep | Free use |
-| 2: Default | Write, Edit | State changes explicitly, notify before modifying important files |
-| 3: Approval | Bash, WebFetch, WebSearch | Request user approval on first use |
-| 4: Explicit | Task | Only when user explicitly requests |
+| 1: Always | Read, Glob, Grep, ToolSearch | Free use, read-only |
+| 2: Default | Write, Edit, NotebookEdit | State changes explicitly, notify before modifying important files |
+| 3: Context | Agent, Skill, EnterPlanMode, ExitPlanMode, EnterWorktree, ExitWorktree, LSP, TodoWrite, AskUserQuestion | Context-dependent, no user approval needed |
+| 4: Approval | Bash, WebFetch, WebSearch | Request user approval on first use |
+| 5: Conditional | TeamCreate, TeamDelete, SendMessage, TaskCreate, TaskGet, TaskList, TaskUpdate, TaskStop, TaskOutput | Available when Agent Teams enabled |
+| 6: MCP | ListMcpResourcesTool, ReadMcpResourceTool, CronCreate, CronDelete, CronList, RemoteTrigger | MCP/extension tools, available when servers configured |
 
 ## File Access
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.63.1",
+  "version": "0.64.0",
   "lastUpdated": "2026-03-24T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- R002 tool tier list modernized from 9 tools (4 tiers) to 30 tools (6 tiers)
- R006 skill frontmatter expanded with 7 new optional fields
- Model aliases documented (opusplan, [1m] extended context)
- Fast Mode section added to R006
- All templates synced

## Issues
Closes #724
Part of #723

## Test plan
- [x] Template sync verified (diff = empty)
- [x] 1511 unit tests pass, 0 fail
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)