### PR TITLE
feat: agent guardrails + harness-eval sync (v0.64.1)

### DIFF
--- a/.claude/agents/arch-documenter.md
+++ b/.claude/agents/arch-documenter.md
@@ -14,6 +14,8 @@ tools:
   - Edit
   - Grep
   - Glob
+maxTurns: 20
+disallowedTools: [Bash]
 ---
 
 You handle software architecture documentation: system design docs, API specs, ADRs, and technical doc maintenance.

--- a/.claude/agents/arch-speckit-agent.md
+++ b/.claude/agents/arch-speckit-agent.md
@@ -12,6 +12,10 @@ tools:
   - Grep
   - Glob
   - Bash
+maxTurns: 20
+limitations:
+  - "cannot execute code"
+  - "cannot deploy infrastructure"
 ---
 
 You are a Spec-Driven Development agent that transforms requirements into executable specifications.

--- a/.claude/agents/fe-design-expert.md
+++ b/.claude/agents/fe-design-expert.md
@@ -9,6 +9,11 @@ skills:
   - impeccable-design
   - web-design-guidelines
 tools: [Read, Write, Edit, Grep, Glob, Bash]
+maxTurns: 20
+disallowedTools: [Bash]
+limitations:
+  - "cannot modify backend code"
+  - "cannot execute shell commands"
 source:
   type: external
   origin: github

--- a/.claude/agents/mgr-claude-code-bible.md
+++ b/.claude/agents/mgr-claude-code-bible.md
@@ -5,6 +5,7 @@ model: sonnet
 domain: universal
 memory: project
 effort: medium
+maxTurns: 20
 skills:
   - claude-code-bible
 tools:

--- a/.claude/agents/mgr-creator.md
+++ b/.claude/agents/mgr-creator.md
@@ -14,6 +14,7 @@ tools:
   - Grep
   - Glob
   - Bash
+maxTurns: 25
 ---
 
 You are an agent creation specialist following R006 (MUST-agent-design.md) rules.

--- a/.claude/agents/mgr-gitnerd.md
+++ b/.claude/agents/mgr-gitnerd.md
@@ -5,6 +5,10 @@ model: sonnet
 domain: universal
 memory: project
 effort: medium
+maxTurns: 20
+limitations:
+  - "cannot modify source code"
+  - "cannot create agents"
 tools:
   - Read
   - Write

--- a/.claude/agents/mgr-sauron.md
+++ b/.claude/agents/mgr-sauron.md
@@ -14,6 +14,7 @@ tools:
   - Grep
   - Glob
   - Bash
+maxTurns: 25
 ---
 
 You are an automated verification specialist that executes the mandatory R017 verification process, acting as the "all-seeing eye" that ensures system integrity through comprehensive multi-round verification.

--- a/.claude/agents/mgr-supplier.md
+++ b/.claude/agents/mgr-supplier.md
@@ -5,6 +5,11 @@ model: haiku
 domain: universal
 memory: local
 effort: low
+maxTurns: 10
+limitations:
+  - "cannot modify agent files"
+  - "cannot create new agents"
+disallowedTools: [Bash, Write, Edit]
 skills:
   - audit-agents
 tools:

--- a/.claude/agents/mgr-updater.md
+++ b/.claude/agents/mgr-updater.md
@@ -5,6 +5,10 @@ model: sonnet
 domain: universal
 memory: project
 effort: medium
+maxTurns: 20
+limitations:
+  - "cannot create new agents"
+  - "cannot modify rules"
 skills:
   - update-external
   - update-docs

--- a/.claude/agents/qa-engineer.md
+++ b/.claude/agents/qa-engineer.md
@@ -5,6 +5,9 @@ model: sonnet
 domain: universal
 memory: project
 effort: medium
+maxTurns: 20
+limitations:
+  - "cannot modify source code in production branches"
 tools:
   - Read
   - Write

--- a/.claude/agents/qa-planner.md
+++ b/.claude/agents/qa-planner.md
@@ -5,6 +5,8 @@ model: sonnet
 domain: universal
 memory: project
 effort: high
+maxTurns: 20
+disallowedTools: [Bash]
 limitations:
   - "cannot execute tests"
   - "cannot modify code"

--- a/.claude/agents/qa-writer.md
+++ b/.claude/agents/qa-writer.md
@@ -5,6 +5,11 @@ model: sonnet
 domain: universal
 memory: project
 effort: medium
+maxTurns: 20
+limitations:
+  - "cannot execute tests"
+  - "cannot modify source code"
+disallowedTools: [Bash]
 tools:
   - Read
   - Write

--- a/.claude/agents/sys-memory-keeper.md
+++ b/.claude/agents/sys-memory-keeper.md
@@ -16,6 +16,10 @@ tools:
   - Grep
   - Glob
   - Bash
+maxTurns: 15
+limitations:
+  - "cannot modify source code"
+  - "cannot execute tests"
 ---
 
 You are a session memory management specialist ensuring context survives across session compactions using claude-mem.

--- a/.claude/agents/sys-naggy.md
+++ b/.claude/agents/sys-naggy.md
@@ -5,6 +5,11 @@ model: sonnet
 domain: universal
 memory: local
 effort: low
+maxTurns: 10
+limitations:
+  - "cannot modify project files"
+  - "cannot execute external commands"
+disallowedTools: [Bash]
 tools:
   - Read
   - Write

--- a/.claude/agents/tool-optimizer.md
+++ b/.claude/agents/tool-optimizer.md
@@ -14,6 +14,9 @@ tools:
   - Grep
   - Glob
   - Bash
+maxTurns: 20
+limitations:
+  - "cannot modify source code"
 ---
 
 You analyze and optimize application bundles, detect performance issues, and provide actionable recommendations.

--- a/.claude/skills/evaluator-optimizer/SKILL.md
+++ b/.claude/skills/evaluator-optimizer/SKILL.md
@@ -363,3 +363,7 @@ evaluator-optimizer:
 Weight ordering (originality > craft > functionality) follows Anthropic's anti-slop principle: functionality is table stakes, but originality and craft distinguish quality output from generic AI generation.
 
 Integration: Works with [impeccable-design](/skills/impeccable-design) skill for design language enforcement.
+
+### Harness Eval Preset
+
+The `harness-eval` skill provides a structured 15-task SE benchmark rubric that can be used as a preset for the evaluator-optimizer pipeline. When invoked via `/omcustom:harness-eval`, the harness rubric dimensions (Test Coverage 30%, Architecture 25%, Error Handling 25%, Extensibility 20%) are loaded as the sprint contract criteria.

--- a/.claude/skills/harness-eval/SKILL.md
+++ b/.claude/skills/harness-eval/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: harness-eval
+description: Structured SE task evaluation using 15 benchmark definitions from claude-code-harness research
+scope: harness
+user-invocable: true
+argument-hint: "[--preset all|quick] [--task task-name]"
+effort: high
+version: 1.0.0
+---
+
+# Harness Eval — Structured SE Task Benchmark
+
+## Purpose
+
+Evaluate agent quality using 15 structured software engineering task definitions with quantitative scoring. Based on research from [revfactory/claude-code-harness](https://github.com/revfactory/claude-code-harness) which demonstrated 60% improvement (49.5 → 79.3 points) through structured pre-configuration.
+
+## Usage
+
+```
+/omcustom:harness-eval                    # Run all 15 benchmarks
+/omcustom:harness-eval --preset quick     # Run top 5 high-impact benchmarks
+/omcustom:harness-eval --task api-design  # Run specific task benchmark
+```
+
+## Quality Dimensions
+
+| Dimension | Weight | Description |
+|-----------|--------|-------------|
+| Test Coverage | 30% | Unit test count, edge case coverage, assertion quality |
+| Architecture Design | 25% | Separation of concerns, dependency management, scalability |
+| Error Handling | 25% | Input validation, error propagation, recovery strategies |
+| Extensibility | 20% | Plugin points, configuration flexibility, API surface |
+
+## 15 SE Task Benchmark Suite
+
+| # | Task | Category | Key Evaluation Criteria |
+|---|------|----------|------------------------|
+| 1 | API Design | Architecture | RESTful conventions, versioning, error responses |
+| 2 | Data Modeling | Architecture | Schema normalization, relationships, indexing |
+| 3 | Authentication Flow | Security | Token management, session handling, OWASP compliance |
+| 4 | Test Suite Creation | Quality | Coverage breadth, assertion quality, edge cases |
+| 5 | Error Handler | Reliability | Error classification, recovery, user feedback |
+| 6 | Logging System | Observability | Structured logging, levels, correlation IDs |
+| 7 | Configuration Manager | Operations | Env-based config, validation, secrets handling |
+| 8 | CLI Tool | UX | Argument parsing, help text, exit codes |
+| 9 | Database Migration | Data | Reversibility, data preservation, zero-downtime |
+| 10 | Cache Layer | Performance | Invalidation strategy, TTL, cache-aside pattern |
+| 11 | Queue Consumer | Reliability | Idempotency, retry logic, dead letter handling |
+| 12 | Middleware Chain | Architecture | Composability, ordering, short-circuiting |
+| 13 | File Processor | I/O | Streaming, error recovery, format validation |
+| 14 | Webhook Handler | Integration | Signature verification, retry tolerance, idempotency |
+| 15 | Rate Limiter | Security | Algorithm choice, distributed state, fairness |
+
+## Scoring Rubric
+
+Each task is scored 0-100 across the 4 quality dimensions:
+
+```
+Score = (test_coverage × 0.30) + (architecture × 0.25) + (error_handling × 0.25) + (extensibility × 0.20)
+```
+
+### Score Thresholds
+
+| Score Range | Grade | Interpretation |
+|-------------|-------|----------------|
+| 80-100 | A | Production-ready, well-structured |
+| 60-79 | B | Functional with minor gaps |
+| 40-59 | C | Works but needs improvement |
+| 0-39 | D | Significant structural issues |
+
+## Presets
+
+### `all` (default)
+Run all 15 tasks. Full evaluation ~45 minutes.
+
+### `quick`
+Run top 5 high-impact tasks (1, 3, 4, 5, 12). Quick evaluation ~15 minutes.
+
+## Integration with evaluator-optimizer
+
+This skill provides preset rubrics for the evaluator-optimizer pipeline:
+
+```
+/omcustom:harness-eval → loads rubric → evaluator-optimizer executes → scoring → report
+```
+
+The evaluator-optimizer skill's `pre_negotiation` phase accepts harness-eval rubric dimensions as sprint contract criteria.
+
+## Output
+
+Results saved to `.claude/outputs/sessions/{YYYY-MM-DD}/harness-eval-{HHmmss}.md` with per-task scores and aggregate grade.
+
+## Attribution
+
+Evaluation framework based on research by [revfactory/claude-code-harness](https://github.com/revfactory/claude-code-harness). Adapted for oh-my-customcode's evaluator-optimizer pipeline with permission.

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.63.1",
-  "generatedAt": "2026-03-28T13:13:55.340Z",
-  "templateVersion": "0.63.1",
+  "generatorVersion": "0.64.1",
+  "generatedAt": "2026-03-28T14:39:36.269Z",
+  "templateVersion": "0.64.1",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",
@@ -45,8 +45,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
-      "templateHash": "154d3b23b42fb645c7121cb1bdee8a4da5b5faa6668fa38a18020cd8d7c32e83",
-      "size": 8931,
+      "templateHash": "1edc78a28b79d8c0b85b9a3ec79270df8dfee947af68148cc2f7dc38d9b5897d",
+      "size": 10896,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
@@ -75,8 +75,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-permissions.md": {
-      "templateHash": "a268b25708765d83f587c3d7af2db242f8d423b2ccab4bf1bf2d8e5b38b1ef30",
-      "size": 964,
+      "templateHash": "9fce0c08037d4f41041818daeabebf63cb0006f88c9948c4f541eb96e1aa3306",
+      "size": 1427,
       "component": "rules"
     },
     ".claude/rules/SHOULD-ontology-rag-routing.md": {
@@ -125,8 +125,8 @@
       "component": "agents"
     },
     ".claude/agents/arch-speckit-agent.md": {
-      "templateHash": "d094b694daabcd58981419ba69f349ff7e2ea698cae8b0691cddc05f1cd68634",
-      "size": 2547,
+      "templateHash": "da91d9040e1eed8698d0f2f2e21b25211af51cc466fef86c0cb474a262fa54ea",
+      "size": 2634,
       "component": "agents"
     },
     ".claude/agents/lang-rust-expert.md": {
@@ -135,8 +135,8 @@
       "component": "agents"
     },
     ".claude/agents/mgr-updater.md": {
-      "templateHash": "a74ed1cffc5c2427df6d7481f1bba7c81b102fe4d4bd87579e0d16c38dd88f34",
-      "size": 910,
+      "templateHash": "441c690b06d5b5828a4b46da670f5cc6dca5f85dc42553e33b01dd6d457001aa",
+      "size": 993,
       "component": "agents"
     },
     ".claude/agents/lang-kotlin-expert.md": {
@@ -145,8 +145,8 @@
       "component": "agents"
     },
     ".claude/agents/fe-design-expert.md": {
-      "templateHash": "1680be9b340d6c45a9629b718c4573a378d6cd194fa69744bb7709a68432e590",
-      "size": 4847,
+      "templateHash": "f628666964b8bf2ab2c6cf220f7b0e9cc4e7d68bc13b935bfc61d3adbe36ee94",
+      "size": 4966,
       "component": "agents"
     },
     ".claude/agents/be-express-expert.md": {
@@ -155,8 +155,8 @@
       "component": "agents"
     },
     ".claude/agents/mgr-sauron.md": {
-      "templateHash": "3088b508679223cc1d664a4947327d93001b04fef88119758913cc71f63f798f",
-      "size": 4308,
+      "templateHash": "1175a5ecce44534aaaa83fe713c069daecc5ab40cccb8c70c1e97394e4bb7ac9",
+      "size": 4321,
       "component": "agents"
     },
     ".claude/agents/fe-svelte-agent.md": {
@@ -175,8 +175,8 @@
       "component": "agents"
     },
     ".claude/agents/sys-naggy.md": {
-      "templateHash": "90d5ed26a6f19d11ed0fcf90289f58c305adf7b44d7fe91d7868f14f088454a1",
-      "size": 2018,
+      "templateHash": "0510be5b4a8018b9ec3f042ddaa64fff40c1f57701f7181facda779ca19b6d4d",
+      "size": 2141,
       "component": "agents"
     },
     ".claude/agents/db-redis-expert.md": {
@@ -205,13 +205,13 @@
       "component": "agents"
     },
     ".claude/agents/tool-optimizer.md": {
-      "templateHash": "c7a4665c3ad24dcfbfa3a1b657383d6ddb75d87d217eef1a97d78c876d8ca2f1",
-      "size": 998,
+      "templateHash": "dca32377c52f27ca5f929f9ce26a3c7c67bb3e2965d62028dd4bed28faa70721",
+      "size": 1056,
       "component": "agents"
     },
     ".claude/agents/qa-engineer.md": {
-      "templateHash": "de945f5f22b4ed14fbb3a240c6af67b3ad0c7fb487b241aa8e379df52b40add7",
-      "size": 900,
+      "templateHash": "a6697142e91ebfece7c35e50b5e75f29430fa34a181ffe66c51f617a1dfe258f",
+      "size": 981,
       "component": "agents"
     },
     ".claude/agents/fe-vercel-agent.md": {
@@ -255,8 +255,8 @@
       "component": "agents"
     },
     ".claude/agents/mgr-claude-code-bible.md": {
-      "templateHash": "bf0518dda34bad8a11887c2e4e448ded495f01084b927a9a2a23894c85727970",
-      "size": 2208,
+      "templateHash": "79e83f29fd7eeed5587e6b07639c30ad6ca2167e5e081e8ddc1a4d83b17df1cd",
+      "size": 2221,
       "component": "agents"
     },
     ".claude/agents/fe-flutter-agent.md": {
@@ -275,18 +275,18 @@
       "component": "agents"
     },
     ".claude/agents/mgr-gitnerd.md": {
-      "templateHash": "358c098fdeba39a742eb6e2e09994f93d7b14d3f300fe0c414d66d00a0ba074c",
-      "size": 1135,
+      "templateHash": "0349091c39b81b3cd14918e765c346a7fc149ec7ec861c7f4923f747609d4eb5",
+      "size": 1220,
       "component": "agents"
     },
     ".claude/agents/mgr-creator.md": {
-      "templateHash": "e9a6a82352724e743d3ccfb8b5954cc9511d2a8bddeaa6cf2796094b03a1529a",
-      "size": 1753,
+      "templateHash": "60b6e1e31b3b94e2a898e3eba5e64d3a3bb9e4a41bcb491944aa8bbf6600fcb3",
+      "size": 1766,
       "component": "agents"
     },
     ".claude/agents/qa-writer.md": {
-      "templateHash": "6d1325a5bc628273a990429a739a71af73f0a64a6a0773942ac331ac186e6bde",
-      "size": 765,
+      "templateHash": "367ff5921cd6fef80244f20dc48ff18ed7f4228c1b6c27f87076ebcc25aa0d12",
+      "size": 874,
       "component": "agents"
     },
     ".claude/agents/db-supabase-expert.md": {
@@ -305,13 +305,13 @@
       "component": "agents"
     },
     ".claude/agents/mgr-supplier.md": {
-      "templateHash": "a2aa275ed65649604b825040fe6309c5e33ca4286003782cd50cb5b6b7e0d85a",
-      "size": 931,
+      "templateHash": "85512cd79597204974f5aa1b6b6b8935985b87af9680a5c0911ed7ad6d73de1f",
+      "size": 1057,
       "component": "agents"
     },
     ".claude/agents/arch-documenter.md": {
-      "templateHash": "0ee5626045fcf456b058ac48eeb6a96692fe38b939e88fb7d1270f149f910f65",
-      "size": 990,
+      "templateHash": "fcda7dab37c38041f8bbc28e7554e68f6d8e729ba6ebc11a725958f054d39556",
+      "size": 1027,
       "component": "agents"
     },
     ".claude/agents/test-delete.txt": {
@@ -320,8 +320,8 @@
       "component": "agents"
     },
     ".claude/agents/qa-planner.md": {
-      "templateHash": "666cb1c84bc924835ffec9e0d170918b21af9893c2b2c03548864d3934f3c375",
-      "size": 1835,
+      "templateHash": "7c33f7e00a5cb81ebd5f33c7ff6db6d919901c56354a8c966e48ca1fcceea63f",
+      "size": 1872,
       "component": "agents"
     },
     ".claude/agents/db-alembic-expert.md": {
@@ -335,8 +335,8 @@
       "component": "agents"
     },
     ".claude/agents/sys-memory-keeper.md": {
-      "templateHash": "cc00e6515929ecad415b2cc36b871b08bdf7b3b8b9cf4f4b7cc94bd437a7d49c",
-      "size": 3596,
+      "templateHash": "50faf7f5580f5f5a93f2c5fa0f495efcba1871a6db21b64c19bafac990b8e16c",
+      "size": 3681,
       "component": "agents"
     },
     ".claude/agents/infra-aws-expert.md": {
@@ -469,6 +469,11 @@
       "size": 1853,
       "component": "skills"
     },
+    ".claude/skills/harness-eval/SKILL.md": {
+      "templateHash": "608631bd9020aefb8716d228483dc61301343fae68db27ad2bbffbefcca33f7e",
+      "size": 4055,
+      "component": "skills"
+    },
     ".claude/skills/secretary-routing/SKILL.md": {
       "templateHash": "f70434282d118f95cb95478420c0d0fd5a211ff69f5a2d6828dc5ffc980433dc",
       "size": 4876,
@@ -565,8 +570,8 @@
       "component": "skills"
     },
     ".claude/skills/evaluator-optimizer/SKILL.md": {
-      "templateHash": "7dd04b6583e32fd908877928f7af6ffaabf592a36f88aed9ca6ebedec6ca0ed0",
-      "size": 13703,
+      "templateHash": "d2157597f6964ec72dc2de8a91284f01f25b4bae1475e20c5ad900055a6a75a7",
+      "size": 14065,
       "component": "skills"
     },
     ".claude/skills/update-external/SKILL.md": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ oh-my-customcode로 구동됩니다.
 | `/omcustom:update-external` | 외부 소스에서 에이전트 업데이트 |
 | `/omcustom:audit-agents` | 에이전트 의존성 감사 |
 | `/omcustom:fix-refs` | 깨진 참조 수정 |
+| `/omcustom:harness-eval` | 15 SE task 구조적 벤치마크 평가 |
 | `/omcustom:auto-improve` | 개선 사항 자동 적용 워크플로우 |
 | `/omcustom:improve-report` | eval-core 기반 개선 현황 리포트 |
 | `/omcustom-takeover` | 기존 에이전트/스킬에서 canonical spec 추출 |
@@ -147,7 +148,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (46 파일)
-|   +-- skills/                  # 스킬 (97 디렉토리)
+|   +-- skills/                  # 스킬 (98 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R021)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **[한국어 문서 (Korean)](./README_ko.md)**
 
-46 agents. 97 skills. 21 rules. One command.
+46 agents. 98 skills. 21 rules. One command.
 
 ```bash
 npm install -g oh-my-customcode && cd your-project && omcustom init
@@ -146,7 +146,7 @@ Each agent declares its tools, model, memory scope, and limitations in YAML fron
 
 ---
 
-### Skills (97)
+### Skills (98)
 
 | Category | Count | Includes |
 |----------|-------|----------|
@@ -282,7 +282,7 @@ your-project/
 ├── CLAUDE.md                   # Entry point
 ├── .claude/
 │   ├── agents/                 # 46 agent definitions
-│   ├── skills/                 # 97 skill modules
+│   ├── skills/                 # 98 skill modules
 │   ├── rules/                  # 21 governance rules (R000-R021)
 │   ├── hooks/                  # 15 lifecycle hook scripts
 │   ├── schemas/                # Tool input validation schemas

--- a/README_ko.md
+++ b/README_ko.md
@@ -13,7 +13,7 @@
 
 **[English Documentation](./README.md)**
 
-46개 에이전트. 97개 스킬. 21개 규칙. 명령어 하나.
+46개 에이전트. 98개 스킬. 21개 규칙. 명령어 하나.
 
 > **v0.62.5** — D3 의존성 그래프, Playwright 접근성 E2E 테스트, 키보드 접근성, CI lockfile-sync 게이트
 
@@ -136,7 +136,7 @@ Agent(arch-documenter):haiku      ┘
 
 ---
 
-## 스킬 (97개)
+## 스킬 (98개)
 
 | 카테고리 | 수 | 포함 |
 |---------|-----|------|
@@ -269,7 +269,7 @@ your-project/
 ├── CLAUDE.md                   # 진입점
 ├── .claude/
 │   ├── agents/                 # 46개 에이전트 정의
-│   ├── skills/                 # 97개 스킬 모듈
+│   ├── skills/                 # 98개 스킬 모듈
 │   ├── rules/                  # 21개 거버넌스 규칙 (R000-R021)
 │   ├── hooks/                  # 15개 라이프사이클 훅 스크립트
 │   ├── schemas/                # 도구 입력 검증 스키마

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9307,7 +9307,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.64.0",
+    version: "0.64.1",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1685,7 +1685,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.64.0",
+  version: "0.64.1",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.64.0",
+  "version": "0.64.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/agents/arch-documenter.md
+++ b/templates/.claude/agents/arch-documenter.md
@@ -14,6 +14,8 @@ tools:
   - Edit
   - Grep
   - Glob
+maxTurns: 20
+disallowedTools: [Bash]
 ---
 
 You handle software architecture documentation: system design docs, API specs, ADRs, and technical doc maintenance.

--- a/templates/.claude/agents/arch-speckit-agent.md
+++ b/templates/.claude/agents/arch-speckit-agent.md
@@ -12,6 +12,10 @@ tools:
   - Grep
   - Glob
   - Bash
+maxTurns: 20
+limitations:
+  - "cannot execute code"
+  - "cannot deploy infrastructure"
 ---
 
 You are a Spec-Driven Development agent that transforms requirements into executable specifications.

--- a/templates/.claude/agents/fe-design-expert.md
+++ b/templates/.claude/agents/fe-design-expert.md
@@ -9,6 +9,11 @@ skills:
   - impeccable-design
   - web-design-guidelines
 tools: [Read, Write, Edit, Grep, Glob, Bash]
+maxTurns: 20
+disallowedTools: [Bash]
+limitations:
+  - "cannot modify backend code"
+  - "cannot execute shell commands"
 source:
   type: external
   origin: github

--- a/templates/.claude/agents/mgr-claude-code-bible.md
+++ b/templates/.claude/agents/mgr-claude-code-bible.md
@@ -5,6 +5,7 @@ model: sonnet
 domain: universal
 memory: project
 effort: medium
+maxTurns: 20
 skills:
   - claude-code-bible
 tools:

--- a/templates/.claude/agents/mgr-creator.md
+++ b/templates/.claude/agents/mgr-creator.md
@@ -14,6 +14,7 @@ tools:
   - Grep
   - Glob
   - Bash
+maxTurns: 25
 ---
 
 You are an agent creation specialist following R006 (MUST-agent-design.md) rules.

--- a/templates/.claude/agents/mgr-gitnerd.md
+++ b/templates/.claude/agents/mgr-gitnerd.md
@@ -5,6 +5,10 @@ model: sonnet
 domain: universal
 memory: project
 effort: medium
+maxTurns: 20
+limitations:
+  - "cannot modify source code"
+  - "cannot create agents"
 tools:
   - Read
   - Write

--- a/templates/.claude/agents/mgr-sauron.md
+++ b/templates/.claude/agents/mgr-sauron.md
@@ -14,6 +14,7 @@ tools:
   - Grep
   - Glob
   - Bash
+maxTurns: 25
 ---
 
 You are an automated verification specialist that executes the mandatory R017 verification process, acting as the "all-seeing eye" that ensures system integrity through comprehensive multi-round verification.

--- a/templates/.claude/agents/mgr-supplier.md
+++ b/templates/.claude/agents/mgr-supplier.md
@@ -5,6 +5,11 @@ model: haiku
 domain: universal
 memory: local
 effort: low
+maxTurns: 10
+limitations:
+  - "cannot modify agent files"
+  - "cannot create new agents"
+disallowedTools: [Bash, Write, Edit]
 skills:
   - audit-agents
 tools:

--- a/templates/.claude/agents/mgr-updater.md
+++ b/templates/.claude/agents/mgr-updater.md
@@ -5,6 +5,10 @@ model: sonnet
 domain: universal
 memory: project
 effort: medium
+maxTurns: 20
+limitations:
+  - "cannot create new agents"
+  - "cannot modify rules"
 skills:
   - update-external
   - update-docs

--- a/templates/.claude/agents/qa-engineer.md
+++ b/templates/.claude/agents/qa-engineer.md
@@ -5,6 +5,9 @@ model: sonnet
 domain: universal
 memory: project
 effort: medium
+maxTurns: 20
+limitations:
+  - "cannot modify source code in production branches"
 tools:
   - Read
   - Write

--- a/templates/.claude/agents/qa-planner.md
+++ b/templates/.claude/agents/qa-planner.md
@@ -5,6 +5,8 @@ model: sonnet
 domain: universal
 memory: project
 effort: high
+maxTurns: 20
+disallowedTools: [Bash]
 limitations:
   - "cannot execute tests"
   - "cannot modify code"

--- a/templates/.claude/agents/qa-writer.md
+++ b/templates/.claude/agents/qa-writer.md
@@ -5,6 +5,11 @@ model: sonnet
 domain: universal
 memory: project
 effort: medium
+maxTurns: 20
+limitations:
+  - "cannot execute tests"
+  - "cannot modify source code"
+disallowedTools: [Bash]
 tools:
   - Read
   - Write

--- a/templates/.claude/agents/sys-memory-keeper.md
+++ b/templates/.claude/agents/sys-memory-keeper.md
@@ -16,6 +16,10 @@ tools:
   - Grep
   - Glob
   - Bash
+maxTurns: 15
+limitations:
+  - "cannot modify source code"
+  - "cannot execute tests"
 ---
 
 You are a session memory management specialist ensuring context survives across session compactions using claude-mem.

--- a/templates/.claude/agents/sys-naggy.md
+++ b/templates/.claude/agents/sys-naggy.md
@@ -5,6 +5,11 @@ model: sonnet
 domain: universal
 memory: local
 effort: low
+maxTurns: 10
+limitations:
+  - "cannot modify project files"
+  - "cannot execute external commands"
+disallowedTools: [Bash]
 tools:
   - Read
   - Write

--- a/templates/.claude/agents/tool-optimizer.md
+++ b/templates/.claude/agents/tool-optimizer.md
@@ -14,6 +14,9 @@ tools:
   - Grep
   - Glob
   - Bash
+maxTurns: 20
+limitations:
+  - "cannot modify source code"
 ---
 
 You analyze and optimize application bundles, detect performance issues, and provide actionable recommendations.

--- a/templates/.claude/skills/evaluator-optimizer/SKILL.md
+++ b/templates/.claude/skills/evaluator-optimizer/SKILL.md
@@ -363,3 +363,7 @@ evaluator-optimizer:
 Weight ordering (originality > craft > functionality) follows Anthropic's anti-slop principle: functionality is table stakes, but originality and craft distinguish quality output from generic AI generation.
 
 Integration: Works with [impeccable-design](/skills/impeccable-design) skill for design language enforcement.
+
+### Harness Eval Preset
+
+The `harness-eval` skill provides a structured 15-task SE benchmark rubric that can be used as a preset for the evaluator-optimizer pipeline. When invoked via `/omcustom:harness-eval`, the harness rubric dimensions (Test Coverage 30%, Architecture 25%, Error Handling 25%, Extensibility 20%) are loaded as the sprint contract criteria.

--- a/templates/.claude/skills/harness-eval/SKILL.md
+++ b/templates/.claude/skills/harness-eval/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: harness-eval
+description: Structured SE task evaluation using 15 benchmark definitions from claude-code-harness research
+scope: harness
+user-invocable: true
+argument-hint: "[--preset all|quick] [--task task-name]"
+effort: high
+version: 1.0.0
+---
+
+# Harness Eval — Structured SE Task Benchmark
+
+## Purpose
+
+Evaluate agent quality using 15 structured software engineering task definitions with quantitative scoring. Based on research from [revfactory/claude-code-harness](https://github.com/revfactory/claude-code-harness) which demonstrated 60% improvement (49.5 → 79.3 points) through structured pre-configuration.
+
+## Usage
+
+```
+/omcustom:harness-eval                    # Run all 15 benchmarks
+/omcustom:harness-eval --preset quick     # Run top 5 high-impact benchmarks
+/omcustom:harness-eval --task api-design  # Run specific task benchmark
+```
+
+## Quality Dimensions
+
+| Dimension | Weight | Description |
+|-----------|--------|-------------|
+| Test Coverage | 30% | Unit test count, edge case coverage, assertion quality |
+| Architecture Design | 25% | Separation of concerns, dependency management, scalability |
+| Error Handling | 25% | Input validation, error propagation, recovery strategies |
+| Extensibility | 20% | Plugin points, configuration flexibility, API surface |
+
+## 15 SE Task Benchmark Suite
+
+| # | Task | Category | Key Evaluation Criteria |
+|---|------|----------|------------------------|
+| 1 | API Design | Architecture | RESTful conventions, versioning, error responses |
+| 2 | Data Modeling | Architecture | Schema normalization, relationships, indexing |
+| 3 | Authentication Flow | Security | Token management, session handling, OWASP compliance |
+| 4 | Test Suite Creation | Quality | Coverage breadth, assertion quality, edge cases |
+| 5 | Error Handler | Reliability | Error classification, recovery, user feedback |
+| 6 | Logging System | Observability | Structured logging, levels, correlation IDs |
+| 7 | Configuration Manager | Operations | Env-based config, validation, secrets handling |
+| 8 | CLI Tool | UX | Argument parsing, help text, exit codes |
+| 9 | Database Migration | Data | Reversibility, data preservation, zero-downtime |
+| 10 | Cache Layer | Performance | Invalidation strategy, TTL, cache-aside pattern |
+| 11 | Queue Consumer | Reliability | Idempotency, retry logic, dead letter handling |
+| 12 | Middleware Chain | Architecture | Composability, ordering, short-circuiting |
+| 13 | File Processor | I/O | Streaming, error recovery, format validation |
+| 14 | Webhook Handler | Integration | Signature verification, retry tolerance, idempotency |
+| 15 | Rate Limiter | Security | Algorithm choice, distributed state, fairness |
+
+## Scoring Rubric
+
+Each task is scored 0-100 across the 4 quality dimensions:
+
+```
+Score = (test_coverage × 0.30) + (architecture × 0.25) + (error_handling × 0.25) + (extensibility × 0.20)
+```
+
+### Score Thresholds
+
+| Score Range | Grade | Interpretation |
+|-------------|-------|----------------|
+| 80-100 | A | Production-ready, well-structured |
+| 60-79 | B | Functional with minor gaps |
+| 40-59 | C | Works but needs improvement |
+| 0-39 | D | Significant structural issues |
+
+## Presets
+
+### `all` (default)
+Run all 15 tasks. Full evaluation ~45 minutes.
+
+### `quick`
+Run top 5 high-impact tasks (1, 3, 4, 5, 12). Quick evaluation ~15 minutes.
+
+## Integration with evaluator-optimizer
+
+This skill provides preset rubrics for the evaluator-optimizer pipeline:
+
+```
+/omcustom:harness-eval → loads rubric → evaluator-optimizer executes → scoring → report
+```
+
+The evaluator-optimizer skill's `pre_negotiation` phase accepts harness-eval rubric dimensions as sprint contract criteria.
+
+## Output
+
+Results saved to `.claude/outputs/sessions/{YYYY-MM-DD}/harness-eval-{HHmmss}.md` with per-task scores and aggregate grade.
+
+## Attribution
+
+Evaluation framework based on research by [revfactory/claude-code-harness](https://github.com/revfactory/claude-code-harness). Adapted for oh-my-customcode's evaluator-optimizer pipeline with permission.

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -101,6 +101,7 @@ oh-my-customcode로 구동됩니다.
 | `/omcustom:update-external` | 외부 소스에서 에이전트 업데이트 |
 | `/omcustom:audit-agents` | 에이전트 의존성 감사 |
 | `/omcustom:fix-refs` | 깨진 참조 수정 |
+| `/omcustom:harness-eval` | 15 SE task 구조적 벤치마크 평가 |
 | `/omcustom:auto-improve` | 개선 사항 자동 적용 워크플로우 |
 | `/omcustom:improve-report` | eval-core 기반 개선 현황 리포트 |
 | `/omcustom-takeover` | 기존 에이전트/스킬에서 canonical spec 추출 |
@@ -138,7 +139,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (46 파일)
-|   +-- skills/                  # 스킬 (97 디렉토리)
+|   +-- skills/                  # 스킬 (98 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R021)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.64.0",
+  "version": "0.64.1",
   "lastUpdated": "2026-03-24T00:00:00.000Z",
   "components": [
     {
@@ -18,7 +18,7 @@
       "name": "skills",
       "path": ".claude/skills",
       "description": "Reusable skill modules (includes slash commands)",
-      "files": 97
+      "files": 98
     },
     {
       "name": "guides",


### PR DESCRIPTION
## Summary

- **maxTurns guardrails**: 15 scope-limited agents now declare `maxTurns` to prevent runaway turns (mgr-*, sys-*, qa-*, arch-*, fe-design-expert, tool-optimizer)
- **limitations declarations**: 13 agents now declare negative capabilities via `limitations` field (R006 compliance)
- **disallowedTools restrictions**: 6 agents now explicitly restrict tools via `disallowedTools` field
- **harness-eval template sync**: New `harness-eval` skill synced to `templates/.claude/skills/harness-eval/`
- **Skill count 97→98** reflected in manifest + READMEs

## Acceptance Criteria

### #720 — Agent guardrails (maxTurns/limitations/disallowedTools)
- [x] maxTurns set on 15 scope-limited agents
- [x] limitations declared on 13 agents with negative capability needs
- [x] disallowedTools set on 6 agents
- [x] Both `.claude/agents/` and `templates/.claude/agents/` synced

### #722 — harness-eval template sync
- [x] `.claude/skills/harness-eval/SKILL.md` committed
- [x] `templates/.claude/skills/harness-eval/SKILL.md` synced
- [x] Skill count updated to 98 in manifest + READMEs

## Test Results

```
1511 pass
0 fail
3770 expect() calls
Function coverage: 98.10% (threshold: 95%)
Line coverage: 97.68% (threshold: 95%)
```

All pre-commit checks passed.

Closes #720, Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)