### PR TITLE
feat: gemini-exec skill v0.66.0 (#739)

### DIFF
--- a/.claude/hooks/scripts/session-env-check.sh
+++ b/.claude/hooks/scripts/session-env-check.sh
@@ -21,6 +21,16 @@ if command -v codex >/dev/null 2>&1; then
   fi
 fi
 
+# Check Gemini CLI availability
+GEMINI_STATUS="unavailable"
+if command -v gemini >/dev/null 2>&1; then
+  if [ -n "${GOOGLE_API_KEY:-}" ] || [ -n "${GEMINI_API_KEY:-}" ]; then
+    GEMINI_STATUS="available (authenticated)"
+  else
+    GEMINI_STATUS="installed (gcloud auth may be available)"
+  fi
+fi
+
 # Check Agent Teams availability
 AGENT_TEAMS_STATUS="disabled"
 if [ "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}" = "1" ]; then
@@ -134,6 +144,7 @@ fi
 STATUS_FILE="/tmp/.claude-env-status-${PPID}"
 cat > "$STATUS_FILE" << ENVEOF
 codex=${CODEX_STATUS}
+gemini=${GEMINI_STATUS}
 agent_teams=${AGENT_TEAMS_STATUS}
 git_branch=${CURRENT_BRANCH}
 claude_version=${CLAUDE_VERSION}
@@ -144,6 +155,7 @@ ENVEOF
 
 # Report to stderr (visible in conversation)
 echo "  codex CLI: ${CODEX_STATUS}" >&2
+echo "  gemini CLI: ${GEMINI_STATUS}" >&2
 echo "  Agent Teams: ${AGENT_TEAMS_STATUS}" >&2
 echo "  Claude Code: v${CLAUDE_VERSION} (${COMPAT_STATUS})" >&2
 if [ "$COMPAT_STATUS" = "outdated" ]; then

--- a/.claude/skills/de-lead-routing/SKILL.md
+++ b/.claude/skills/de-lead-routing/SKILL.md
@@ -64,12 +64,16 @@ Check if Agent Teams is available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or T
 ### Step 2: Codex-Exec Hybrid (Code Generation)
 For **new pipeline code**, **DAG scaffolding**, or **SQL model generation**:
 
-1. Check `/tmp/.claude-env-status-*` for codex availability
+1. Check `/tmp/.claude-env-status-*` for codex and gemini availability
 2. If codex available AND task involves new file creation → automatically delegate to `/codex-exec` for scaffolding:
    - Display: `[Codex Hybrid] Delegating to codex-exec...`
    - codex-exec generates initial code (strength: fast generation)
    - Selected DE expert reviews and refines codex output (strength: reasoning, quality)
-3. If codex unavailable → display `[Codex] Unavailable — proceeding with {expert} directly` and use DE expert directly
+3. If codex unavailable but gemini available → delegate to `/gemini-exec` for scaffolding:
+   - Display: `[Gemini Hybrid] Delegating to gemini-exec...`
+   - gemini-exec generates initial code
+   - Selected DE expert reviews and refines output
+4. If neither available → display `[External CLI] Unavailable — proceeding with {expert} directly` and use DE expert directly
 
 **Suitable**: New DAG files, dbt model scaffolding, SQL template generation
 **Unsuitable**: Existing pipeline modification, architecture decisions, data quality analysis

--- a/.claude/skills/dev-lead-routing/SKILL.md
+++ b/.claude/skills/dev-lead-routing/SKILL.md
@@ -99,12 +99,16 @@ Check if Agent Teams is available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or T
 ### Step 2: Codex-Exec Hybrid (Implementation Tasks)
 For **new file creation**, **boilerplate**, or **test code generation**:
 
-1. Check `/tmp/.claude-env-status-*` for codex availability
+1. Check `/tmp/.claude-env-status-*` for codex and gemini availability
 2. If codex available AND task involves new file creation → automatically delegate to `/codex-exec` for scaffolding:
    - Display: `[Codex Hybrid] Delegating to codex-exec...`
    - codex-exec generates initial code (strength: fast generation)
    - Selected Claude expert reviews and refines codex output (strength: reasoning, quality)
-3. If codex unavailable → display `[Codex] Unavailable — proceeding with {expert} directly` and use Claude expert directly
+3. If codex unavailable but gemini available → delegate to `/gemini-exec` for scaffolding:
+   - Display: `[Gemini Hybrid] Delegating to gemini-exec...`
+   - gemini-exec generates initial code
+   - Selected Claude expert reviews and refines output
+4. If neither available → display `[External CLI] Unavailable — proceeding with {expert} directly` and use Claude expert directly
 
 **Suitable**: New file creation, boilerplate, scaffolding, test code
 **Unsuitable**: Existing code modification, architecture decisions, bug fixes

--- a/.claude/skills/gemini-exec/SKILL.md
+++ b/.claude/skills/gemini-exec/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: gemini-exec
+description: Execute Gemini CLI prompts and return results
+scope: core
+argument-hint: "<prompt> [--json] [--stream-json] [--output <path>] [--model <name>] [--timeout <ms>] [--sandbox] [--plan]"
+user-invocable: true
+---
+
+# Gemini Exec Skill
+
+Execute Google Gemini CLI prompts in non-interactive mode and return structured results. Enables Claude + Gemini hybrid workflows.
+
+## Options
+
+```
+<prompt>          Required. The prompt to send to Gemini CLI
+--json            Return structured JSON output (-o json)
+--stream-json     Return streaming JSON events (-o stream-json)
+--output <path>   Save response to file
+--model <name>    Model override (default: Gemini CLI default)
+--timeout <ms>    Execution timeout (default: 120000, max: 600000)
+--yolo            Enable auto-approval mode (gemini -y)
+--sandbox         Run in sandbox mode (gemini -s)
+--plan            Use plan approval mode (--approval-mode plan)
+--working-dir     Working directory for Gemini execution
+```
+
+## Workflow
+
+```
+1. Pre-checks
+   - Verify `gemini` binary is installed (which gemini)
+   - Verify authentication (GOOGLE_API_KEY, GEMINI_API_KEY, or gcloud auth)
+2. Build command
+   - Base: gemini -p "<prompt>"
+   - Apply options: -o json, -m <model>, -y, -s, --approval-mode plan
+3. Execute
+   - Run via Bash tool with timeout (default 2min, max 10min)
+   - Or use helper script: node .claude/skills/gemini-exec/scripts/gemini-wrapper.cjs
+4. Parse output
+   - Text mode: return raw stdout
+   - JSON mode: parse single JSON object, extract response field
+   - Stream-JSON mode: parse event stream, extract final assistant message
+5. Report results
+   - Format output with execution metadata
+```
+
+## Safety Defaults
+
+- `-p` flag: Non-interactive prompt mode (no session persistence)
+- Default mode: Normal approval (Gemini prompts for confirmation)
+- Override with `--yolo` only when explicitly requested
+- Sandbox mode (`-s`) available for isolated execution
+
+## Output Format
+
+### Success (Text Mode)
+```
+[Gemini Exec] Completed
+
+Model: (default)
+Duration: 23.4s
+Working Dir: /path/to/project
+
+--- Output ---
+{gemini response text}
+```
+
+### Success (JSON Mode)
+```
+[Gemini Exec] Completed (JSON)
+
+Model: (default)
+Duration: 23.4s
+
+--- Response ---
+{extracted response from JSON}
+
+--- Stats ---
+{token usage and other stats}
+```
+
+### Success (Stream-JSON Mode)
+```
+[Gemini Exec] Completed (Stream-JSON)
+
+Model: (default)
+Duration: 23.4s
+Events: 12
+
+--- Final Message ---
+{extracted final assistant message}
+```
+
+### Failure
+```
+[Gemini Exec] Failed
+
+Error: {error_message}
+Exit Code: {code}
+Suggested Fix: {suggestion}
+```
+
+## Helper Script
+
+For complex executions, use the wrapper script:
+```bash
+node .claude/skills/gemini-exec/scripts/gemini-wrapper.cjs --prompt "your prompt" [options]
+```
+
+The wrapper provides:
+- Environment validation (binary + auth checks)
+- Safe command construction
+- JSON and stream-JSON parsing with response extraction
+- Structured JSON output
+- Timeout handling with graceful termination
+
+## Examples
+
+```bash
+# Simple text prompt
+gemini-exec "explain what this project does"
+
+# JSON output with model override
+gemini-exec "list all TODO items" --json --model gemini-2.5-pro
+
+# Stream-JSON for detailed event tracking
+gemini-exec "analyze the codebase" --stream-json
+
+# Save output to file
+gemini-exec "generate a README" --output ./README.md
+
+# Sandbox mode with auto-approval
+gemini-exec "fix the failing tests" --yolo --sandbox
+
+# Plan mode for careful execution
+gemini-exec "refactor the auth module" --plan
+
+# Specify working directory
+gemini-exec "analyze the codebase" --working-dir /path/to/project
+```
+
+## Integration
+
+Works with the orchestrator pattern:
+- Main conversation delegates Gemini execution via this skill
+- Results are returned to the main conversation for further processing
+- Can be chained with other skills (e.g., dev-review after Gemini generates code)
+
+## Availability Check
+
+gemini-exec requires the Gemini CLI binary to be installed and authenticated. The skill is only usable when:
+
+1. `gemini` binary is found in PATH (`which gemini` succeeds)
+2. Authentication is valid (GOOGLE_API_KEY, GEMINI_API_KEY set, or gcloud auth active)
+
+If either check fails, this skill cannot be used. Fall back to Claude agents for the task.
+
+> **Note**: This skill is invoked via `/gemini-exec` command, delegated by the orchestrator, or suggested by routing skills when gemini is available. The intent-detection system can trigger it for research and code generation hybrid workflows.
+
+## Agent Teams Integration
+
+When used within Agent Teams (requires explicit invocation):
+
+1. **As delegated task**: orchestrator explicitly delegates gemini-exec for code generation
+2. **Hybrid workflow**: Claude team member analyzes → orchestrator invokes gemini-exec → Claude reviews
+3. **Iteration**: Team messaging enables review-fix cycles between Claude and Gemini outputs
+
+```
+Orchestrator delegates generation task
+  → /gemini-exec invoked explicitly
+  → Output returned to orchestrator
+  → Reviewer validates quality
+  → Iterate if needed
+```
+
+## Research Workflow
+
+When the orchestrator or intent-detection detects a research request:
+
+1. **Check Gemini availability**: Verify `gemini` binary and auth
+2. **If available**: Execute prompt for research
+3. **If unavailable**: Fall back to Claude's WebFetch/WebSearch
+
+### Research Command Pattern
+```
+/gemini-exec "Research and analyze: {topic}. Provide structured findings with sources." --json
+```
+
+## Code Generation Workflow
+
+When routing skills detect a code generation task and gemini is available:
+
+1. **Check availability**: Verify gemini CLI via `/tmp/.claude-env-status-*`
+2. **If available + new file creation**: Suggest hybrid workflow
+3. **Hybrid pattern**:
+   - gemini-exec generates initial code (fast, broad generation)
+   - Claude expert reviews for quality, patterns, best practices
+   - Iterate if needed
+
+### Suitable Tasks
+- New file scaffolding
+- Boilerplate generation
+- Test stub creation
+- Documentation generation
+
+### Unsuitable Tasks
+- Modifying existing code (Claude expert better at understanding context)
+- Architecture decisions (requires reasoning, not generation)
+- Bug fixes (requires deep code understanding)
+
+### Code Generation Command Pattern
+```
+/gemini-exec "Generate {description} following {framework} best practices" --yolo
+```

--- a/.claude/skills/gemini-exec/scripts/gemini-wrapper.cjs
+++ b/.claude/skills/gemini-exec/scripts/gemini-wrapper.cjs
@@ -1,0 +1,485 @@
+#!/usr/bin/env node
+
+/**
+ * gemini-wrapper.cjs
+ *
+ * Node.js wrapper for Google Gemini CLI (non-interactive execution).
+ * Executes gemini in prompt mode with structured JSON output.
+ *
+ * Usage:
+ *   node gemini-wrapper.cjs --prompt "your prompt" [options]
+ *
+ * Options:
+ *   --prompt <text>       Required: prompt to execute
+ *   --json                Enable JSON output from gemini (-o json)
+ *   --stream-json         Enable stream-JSON output (-o stream-json)
+ *   --output <path>       Save response to file
+ *   --model <name>        Specify model (default: gemini CLI default)
+ *   --timeout <ms>        Execution timeout in milliseconds (default: 120000, max: 600000)
+ *   --yolo                Use yolo approval mode (auto-approve all actions)
+ *   --sandbox             Run in sandbox mode
+ *   --plan                Use plan approval mode
+ *   --working-dir <dir>   Set working directory for execution
+ *
+ * Output (JSON to stdout):
+ *   Success: { "success": true, "output": "...", "duration_ms": 1234, ... }
+ *   Failure: { "success": false, "error": "...", "stderr": "...", ... }
+ *
+ * Exit codes:
+ *   0 = success
+ *   1 = execution error
+ *   2 = validation error (missing binary/auth)
+ */
+
+const { spawn, execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Configuration
+const DEFAULT_TIMEOUT_MS = 120000; // 2 minutes
+const MAX_TIMEOUT_MS = 600000; // 10 minutes
+const KILL_GRACE_PERIOD_MS = 5000; // 5 seconds for graceful shutdown
+
+/**
+ * Parse command line arguments
+ * @returns {Object} Parsed arguments
+ */
+function parseArgs() {
+  const args = {
+    prompt: null,
+    json: false,
+    streamJson: false,
+    output: null,
+    model: null,
+    timeout: DEFAULT_TIMEOUT_MS,
+    yolo: false,
+    sandbox: false,
+    plan: false,
+    workingDir: null,
+  };
+
+  for (let i = 2; i < process.argv.length; i++) {
+    const arg = process.argv[i];
+
+    switch (arg) {
+      case '--prompt':
+        if (i + 1 < process.argv.length) {
+          args.prompt = process.argv[++i];
+        }
+        break;
+      case '--json':
+        args.json = true;
+        break;
+      case '--stream-json':
+        args.streamJson = true;
+        break;
+      case '--output':
+        if (i + 1 < process.argv.length) {
+          args.output = process.argv[++i];
+        }
+        break;
+      case '--model':
+        if (i + 1 < process.argv.length) {
+          args.model = process.argv[++i];
+        }
+        break;
+      case '--timeout':
+        if (i + 1 < process.argv.length) {
+          const timeoutValue = parseInt(process.argv[++i], 10);
+          if (!isNaN(timeoutValue)) {
+            args.timeout = Math.min(timeoutValue, MAX_TIMEOUT_MS);
+          }
+        }
+        break;
+      case '--yolo':
+        args.yolo = true;
+        break;
+      case '--sandbox':
+        args.sandbox = true;
+        break;
+      case '--plan':
+        args.plan = true;
+        break;
+      case '--working-dir':
+        if (i + 1 < process.argv.length) {
+          args.workingDir = process.argv[++i];
+        }
+        break;
+    }
+  }
+
+  return args;
+}
+
+/**
+ * Validate environment for gemini execution
+ * @returns {Object} Validation result { valid: boolean, errors: string[] }
+ */
+function validateEnvironment() {
+  const errors = [];
+
+  // Check for gemini binary
+  try {
+    execFileSync('which', ['gemini'], { stdio: 'pipe' });
+  } catch (error) {
+    // Try common installation paths
+    const commonPaths = [
+      '/usr/local/bin/gemini',
+      path.join(os.homedir(), '.local', 'bin', 'gemini'),
+      path.join(os.homedir(), 'bin', 'gemini'),
+      path.join(os.homedir(), '.npm-global', 'bin', 'gemini'),
+    ];
+
+    const geminiExists = commonPaths.some(p => fs.existsSync(p));
+    if (!geminiExists) {
+      errors.push('gemini binary not found in PATH or common locations');
+    }
+  }
+
+  // Check authentication (multiple methods supported)
+  const hasGoogleApiKey = !!process.env.GOOGLE_API_KEY;
+  const hasGeminiApiKey = !!process.env.GEMINI_API_KEY;
+
+  if (!hasGoogleApiKey && !hasGeminiApiKey) {
+    console.error('[gemini-wrapper] Note: GOOGLE_API_KEY/GEMINI_API_KEY not set, relying on gcloud auth');
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Build gemini command array
+ * @param {Object} options - Command options
+ * @returns {Object} Command structure { binary: string, args: string[] }
+ */
+function buildCommand(options) {
+  const args = [];
+
+  // Prompt mode (non-interactive, ephemeral)
+  args.push('-p', options.prompt);
+
+  // Output format
+  if (options.streamJson) {
+    args.push('-o', 'stream-json');
+  } else if (options.json) {
+    args.push('-o', 'json');
+  }
+
+  // Model selection
+  if (options.model) {
+    args.push('-m', options.model);
+  }
+
+  // Approval mode
+  if (options.yolo) {
+    args.push('-y');
+  } else if (options.plan) {
+    args.push('--approval-mode', 'plan');
+  }
+
+  // Sandbox mode
+  if (options.sandbox) {
+    args.push('-s');
+  }
+
+  return {
+    binary: 'gemini',
+    args,
+  };
+}
+
+/**
+ * Execute gemini command
+ * @param {string} binary - Binary to execute
+ * @param {string[]} args - Command arguments
+ * @param {number} timeout - Timeout in milliseconds
+ * @param {string|null} workingDir - Working directory
+ * @returns {Promise<Object>} Execution result
+ */
+function executeGemini(binary, args, timeout, workingDir = null) {
+  return new Promise((resolve) => {
+    const startTime = Date.now();
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+
+    const spawnOptions = {
+      cwd: workingDir || process.cwd(),
+      env: process.env,
+    };
+
+    const child = spawn(binary, args, spawnOptions);
+
+    // Collect output
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    // Set timeout
+    const timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      console.error('[gemini-wrapper] Timeout reached, terminating process...');
+
+      // Graceful termination attempt
+      child.kill('SIGTERM');
+
+      // Force kill after grace period
+      setTimeout(() => {
+        if (!child.killed) {
+          console.error('[gemini-wrapper] Force killing process...');
+          child.kill('SIGKILL');
+        }
+      }, KILL_GRACE_PERIOD_MS);
+    }, timeout);
+
+    // Handle process exit
+    child.on('close', (exitCode) => {
+      clearTimeout(timeoutHandle);
+      const durationMs = Date.now() - startTime;
+
+      resolve({
+        exitCode: exitCode !== null ? exitCode : 1,
+        stdout,
+        stderr,
+        timedOut,
+        durationMs,
+      });
+    });
+
+    // Handle spawn errors
+    child.on('error', (error) => {
+      clearTimeout(timeoutHandle);
+      const durationMs = Date.now() - startTime;
+
+      resolve({
+        exitCode: 1,
+        stdout,
+        stderr: stderr + '\nSpawn error: ' + error.message,
+        timedOut: false,
+        durationMs,
+      });
+    });
+  });
+}
+
+/**
+ * Parse JSON output from gemini (-o json)
+ * Gemini JSON output is a single JSON object: { session_id, response, stats }
+ * @param {string} output - Raw output string
+ * @returns {Object} Parsed result { response: string|null, stats: object|null, parseError: string|null }
+ */
+function parseJson(output) {
+  try {
+    const data = JSON.parse(output.trim());
+    return {
+      response: data.response || null,
+      stats: data.stats || null,
+      sessionId: data.session_id || null,
+      parseError: null,
+    };
+  } catch (error) {
+    return {
+      response: null,
+      stats: null,
+      sessionId: null,
+      parseError: `Failed to parse JSON: ${error.message}`,
+    };
+  }
+}
+
+/**
+ * Parse stream-JSON output from gemini (-o stream-json)
+ * Stream format: newline-delimited JSON events
+ *   { type: "init", ... }
+ *   { type: "message", role: "user"|"assistant", content: "..." }
+ *   { type: "result", stats: {...} }
+ * @param {string} output - Raw output string
+ * @returns {Object} Parsed result { events: object[], finalMessage: string|null, stats: object|null, parseErrors: string[] }
+ */
+function parseStreamJson(output) {
+  const lines = output.split('\n').filter(line => line.trim().length > 0);
+  const events = [];
+  const parseErrors = [];
+  let finalMessage = null;
+  let stats = null;
+
+  for (const line of lines) {
+    try {
+      const event = JSON.parse(line);
+      events.push(event);
+
+      // Extract final assistant message
+      if (event.type === 'message' && event.role === 'assistant') {
+        finalMessage = event.content || event.text || finalMessage;
+      }
+
+      // Extract stats from result event
+      if (event.type === 'result') {
+        stats = event.stats || null;
+        if (event.response) {
+          finalMessage = event.response;
+        }
+      }
+
+      // Fallback: look for common response patterns
+      if (!finalMessage && event.content && event.role === 'model') {
+        finalMessage = event.content;
+      }
+    } catch (error) {
+      parseErrors.push(`Failed to parse line: ${error.message}`);
+    }
+  }
+
+  return {
+    events,
+    finalMessage,
+    stats,
+    parseErrors,
+  };
+}
+
+/**
+ * Main execution function
+ */
+async function main() {
+  const args = parseArgs();
+
+  // Validate required arguments
+  if (!args.prompt) {
+    const result = {
+      success: false,
+      error: 'Missing required argument: --prompt',
+      exit_code: 2,
+    };
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(2);
+  }
+
+  // Validate environment
+  const validation = validateEnvironment();
+  if (!validation.valid) {
+    const result = {
+      success: false,
+      error: 'Environment validation failed',
+      validation_errors: validation.errors,
+      exit_code: 2,
+    };
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(2);
+  }
+
+  console.error(`[gemini-wrapper] Executing gemini with timeout: ${args.timeout}ms`);
+  if (args.workingDir) {
+    console.error(`[gemini-wrapper] Working directory: ${args.workingDir}`);
+  }
+
+  // Build command
+  const command = buildCommand(args);
+  console.error(`[gemini-wrapper] Command: ${command.binary} ${command.args.join(' ')}`);
+
+  // Execute
+  const execResult = await executeGemini(
+    command.binary,
+    command.args,
+    args.timeout,
+    args.workingDir
+  );
+
+  // Process result
+  let output = null;
+  let eventsCount = 0;
+  let stats = null;
+
+  if (args.streamJson && execResult.stdout) {
+    const parsed = parseStreamJson(execResult.stdout);
+    eventsCount = parsed.events.length;
+    output = parsed.finalMessage;
+    stats = parsed.stats;
+
+    if (parsed.parseErrors.length > 0) {
+      console.error('[gemini-wrapper] Stream-JSON parse errors:', parsed.parseErrors.join('; '));
+    }
+  } else if (args.json && execResult.stdout) {
+    const parsed = parseJson(execResult.stdout);
+    output = parsed.response;
+    stats = parsed.stats;
+
+    if (parsed.parseError) {
+      console.error('[gemini-wrapper] JSON parse error:', parsed.parseError);
+      // Fallback to raw output
+      output = execResult.stdout.trim();
+    }
+  } else {
+    output = execResult.stdout.trim();
+  }
+
+  // Determine success
+  const success = execResult.exitCode === 0 && !execResult.timedOut;
+
+  // Build result object
+  const result = {
+    success,
+    duration_ms: execResult.durationMs,
+    exit_code: execResult.exitCode,
+  };
+
+  if (success) {
+    result.output = output || execResult.stdout;
+    result.model = args.model || '(default)';
+    if (args.streamJson) {
+      result.events_count = eventsCount;
+    }
+    if (stats) {
+      result.stats = stats;
+    }
+  } else {
+    if (execResult.timedOut) {
+      result.error = `Execution timed out after ${args.timeout}ms`;
+    } else {
+      result.error = 'Execution failed';
+    }
+    if (execResult.stderr) {
+      result.stderr = execResult.stderr.trim();
+    }
+  }
+
+  // Write output file if requested
+  if (args.output && output) {
+    try {
+      const outputDir = path.dirname(args.output);
+      if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+      }
+      fs.writeFileSync(args.output, output, 'utf-8');
+      console.error(`[gemini-wrapper] Output written to: ${args.output}`);
+    } catch (error) {
+      console.error(`[gemini-wrapper] Failed to write output file: ${error.message}`);
+      result.output_file_error = error.message;
+    }
+  }
+
+  // Output JSON result to stdout
+  console.log(JSON.stringify(result, null, 2));
+
+  process.exit(result.exit_code);
+}
+
+// Run
+main().catch(error => {
+  const result = {
+    success: false,
+    error: 'Unexpected error: ' + error.message,
+    stack: error.stack,
+    exit_code: 1,
+  };
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(1);
+});

--- a/.claude/skills/intent-detection/patterns/agent-triggers.yaml
+++ b/.claude/skills/intent-detection/patterns/agent-triggers.yaml
@@ -338,7 +338,7 @@ agents:
       - gather
     base_confidence: 50
     action_weight: 30
-    routing_rule: "MUST use codex-exec --effort xhigh when codex available, fallback to WebFetch/WebSearch"
+    routing_rule: "MUST use codex-exec --effort xhigh when codex available, or gemini-exec when gemini available, fallback to WebFetch/WebSearch"
 
   # ---------------------------------------------------------------------------
   # Code Generation (hybrid workflow, skill-based)
@@ -367,7 +367,7 @@ agents:
       - scaffold
     base_confidence: 30
     action_weight: 25
-    routing_rule: "Suggest codex-exec hybrid when codex available and task is new file creation"
+    routing_rule: "Suggest codex-exec hybrid when codex available, or gemini-exec hybrid when gemini available, for new file creation tasks"
 
   # Managers (continued)
   mgr-gitnerd:

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.65.2",
-  "generatedAt": "2026-03-30T10:54:04.185Z",
-  "templateVersion": "0.65.2",
+  "generatorVersion": "0.66.0",
+  "generatedAt": "2026-03-30T12:08:06.700Z",
+  "templateVersion": "0.66.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",
@@ -535,8 +535,8 @@
       "component": "skills"
     },
     ".claude/skills/intent-detection/patterns/agent-triggers.yaml": {
-      "templateHash": "de4813600e4159b0d9c767a3a3ff5d09b1b3319db7c51b311dea36e0cd61b34e",
-      "size": 13636,
+      "templateHash": "1dd7e03b7e46d6473379f90eec4dadb58de9565ab09db26f9b7848d596077de8",
+      "size": 13718,
       "component": "skills"
     },
     ".claude/skills/intent-detection/SKILL.md": {
@@ -640,8 +640,8 @@
       "component": "skills"
     },
     ".claude/skills/dev-lead-routing/SKILL.md": {
-      "templateHash": "6ea42f82b21b25ed6ba6bbdc3d0b44123cffcf1591e719d35be2a0960edf8384",
-      "size": 6216,
+      "templateHash": "425289dc7dd031c9185b3fde3e85a2087d13fc3144ba304a873d33dd8149c822",
+      "size": 6483,
       "component": "skills"
     },
     ".claude/skills/scout/SKILL.md": {
@@ -712,6 +712,16 @@
     ".claude/skills/omcustom-takeover/SKILL.md": {
       "templateHash": "8e4005df217634663e6942c7f8435ad00fb992270621fc98ddb43a1344322dfe",
       "size": 2909,
+      "component": "skills"
+    },
+    ".claude/skills/gemini-exec/scripts/gemini-wrapper.cjs": {
+      "templateHash": "15eb89f1d7a360e7d53f92796b75c10115eccf76ff70e7ec950d7629235f05b0",
+      "size": 12751,
+      "component": "skills"
+    },
+    ".claude/skills/gemini-exec/SKILL.md": {
+      "templateHash": "f66595a61e69442c1738ff83c4ed5020eb98ccd4c68f0b7792bd0a36dfbd135c",
+      "size": 6372,
       "component": "skills"
     },
     ".claude/skills/flutter-best-practices/SKILL.md": {
@@ -900,8 +910,8 @@
       "component": "skills"
     },
     ".claude/skills/de-lead-routing/SKILL.md": {
-      "templateHash": "0918d2b25f137907ee64ad0eae5a554aca9efd3df5754f0834939041f94984cb",
-      "size": 8127,
+      "templateHash": "7dba8a70f56a17c82bd9fde7baae59ef248b62711a01c74feae94b06a97adf02",
+      "size": 8390,
       "component": "skills"
     },
     ".claude/skills/stuck-recovery/SKILL.md": {
@@ -1000,8 +1010,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/session-env-check.sh": {
-      "templateHash": "48d5d92d9a715f559c412437b9d9638eb4004a7e4e2ca4e542ed3a722c6bf4d7",
-      "size": 7801,
+      "templateHash": "8a63b9d04a14d777f24d8d72d34ce0b545683cdeab76b00fb6690b9f0254b997",
+      "size": 8165,
       "component": "hooks"
     },
     ".claude/hooks/scripts/feedback-collector.sh": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ oh-my-customcode로 구동됩니다.
 | `/omcustom-release-notes` | 릴리즈 노트 생성 (git 히스토리 기반) |
 | `/omcustom-feedback` | 사용자 피드백을 GitHub Issue로 등록 |
 | `/codex-exec` | Codex CLI 프롬프트 실행 |
+| `/gemini-exec` | Gemini CLI 프롬프트 실행 |
 | `/optimize-analyze` | 번들 및 성능 분석 |
 | `/optimize-bundle` | 번들 크기 최적화 |
 | `/optimize-report` | 최적화 리포트 생성 |
@@ -148,7 +149,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (46 파일)
-|   +-- skills/                  # 스킬 (98 디렉토리)
+|   +-- skills/                  # 스킬 (99 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R021)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **[한국어 문서 (Korean)](./README_ko.md)**
 
-46 agents. 98 skills. 21 rules. One command.
+46 agents. 99 skills. 21 rules. One command.
 
 ```bash
 npm install -g oh-my-customcode && cd your-project && omcustom init
@@ -146,7 +146,7 @@ Each agent declares its tools, model, memory scope, and limitations in YAML fron
 
 ---
 
-### Skills (98)
+### Skills (99)
 
 | Category | Count | Includes |
 |----------|-------|----------|
@@ -282,7 +282,7 @@ your-project/
 ├── CLAUDE.md                   # Entry point
 ├── .claude/
 │   ├── agents/                 # 46 agent definitions
-│   ├── skills/                 # 98 skill modules
+│   ├── skills/                 # 99 skill modules
 │   ├── rules/                  # 21 governance rules (R000-R021)
 │   ├── hooks/                  # 15 lifecycle hook scripts
 │   ├── schemas/                # Tool input validation schemas

--- a/README_ko.md
+++ b/README_ko.md
@@ -13,7 +13,7 @@
 
 **[English Documentation](./README.md)**
 
-46개 에이전트. 98개 스킬. 21개 규칙. 명령어 하나.
+46개 에이전트. 99개 스킬. 21개 규칙. 명령어 하나.
 
 > **v0.62.5** — D3 의존성 그래프, Playwright 접근성 E2E 테스트, 키보드 접근성, CI lockfile-sync 게이트
 
@@ -136,7 +136,7 @@ Agent(arch-documenter):haiku      ┘
 
 ---
 
-## 스킬 (98개)
+## 스킬 (99개)
 
 | 카테고리 | 수 | 포함 |
 |---------|-----|------|
@@ -269,7 +269,7 @@ your-project/
 ├── CLAUDE.md                   # 진입점
 ├── .claude/
 │   ├── agents/                 # 46개 에이전트 정의
-│   ├── skills/                 # 98개 스킬 모듈
+│   ├── skills/                 # 99개 스킬 모듈
 │   ├── rules/                  # 21개 거버넌스 규칙 (R000-R021)
 │   ├── hooks/                  # 15개 라이프사이클 훅 스크립트
 │   ├── schemas/                # 도구 입력 검증 스키마

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9307,7 +9307,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.65.2",
+    version: "0.66.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1685,7 +1685,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.65.2",
+  version: "0.66.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.65.2",
+  "version": "0.66.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/hooks/scripts/session-env-check.sh
+++ b/templates/.claude/hooks/scripts/session-env-check.sh
@@ -21,6 +21,16 @@ if command -v codex >/dev/null 2>&1; then
   fi
 fi
 
+# Check Gemini CLI availability
+GEMINI_STATUS="unavailable"
+if command -v gemini >/dev/null 2>&1; then
+  if [ -n "${GOOGLE_API_KEY:-}" ] || [ -n "${GEMINI_API_KEY:-}" ]; then
+    GEMINI_STATUS="available (authenticated)"
+  else
+    GEMINI_STATUS="installed (gcloud auth may be available)"
+  fi
+fi
+
 # Check Agent Teams availability
 AGENT_TEAMS_STATUS="disabled"
 if [ "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-0}" = "1" ]; then
@@ -134,6 +144,7 @@ fi
 STATUS_FILE="/tmp/.claude-env-status-${PPID}"
 cat > "$STATUS_FILE" << ENVEOF
 codex=${CODEX_STATUS}
+gemini=${GEMINI_STATUS}
 agent_teams=${AGENT_TEAMS_STATUS}
 git_branch=${CURRENT_BRANCH}
 claude_version=${CLAUDE_VERSION}
@@ -144,6 +155,7 @@ ENVEOF
 
 # Report to stderr (visible in conversation)
 echo "  codex CLI: ${CODEX_STATUS}" >&2
+echo "  gemini CLI: ${GEMINI_STATUS}" >&2
 echo "  Agent Teams: ${AGENT_TEAMS_STATUS}" >&2
 echo "  Claude Code: v${CLAUDE_VERSION} (${COMPAT_STATUS})" >&2
 if [ "$COMPAT_STATUS" = "outdated" ]; then

--- a/templates/.claude/skills/de-lead-routing/SKILL.md
+++ b/templates/.claude/skills/de-lead-routing/SKILL.md
@@ -64,12 +64,16 @@ Check if Agent Teams is available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or T
 ### Step 2: Codex-Exec Hybrid (Code Generation)
 For **new pipeline code**, **DAG scaffolding**, or **SQL model generation**:
 
-1. Check `/tmp/.claude-env-status-*` for codex availability
+1. Check `/tmp/.claude-env-status-*` for codex and gemini availability
 2. If codex available AND task involves new file creation → automatically delegate to `/codex-exec` for scaffolding:
    - Display: `[Codex Hybrid] Delegating to codex-exec...`
    - codex-exec generates initial code (strength: fast generation)
    - Selected DE expert reviews and refines codex output (strength: reasoning, quality)
-3. If codex unavailable → display `[Codex] Unavailable — proceeding with {expert} directly` and use DE expert directly
+3. If codex unavailable but gemini available → delegate to `/gemini-exec` for scaffolding:
+   - Display: `[Gemini Hybrid] Delegating to gemini-exec...`
+   - gemini-exec generates initial code
+   - Selected DE expert reviews and refines output
+4. If neither available → display `[External CLI] Unavailable — proceeding with {expert} directly` and use DE expert directly
 
 **Suitable**: New DAG files, dbt model scaffolding, SQL template generation
 **Unsuitable**: Existing pipeline modification, architecture decisions, data quality analysis

--- a/templates/.claude/skills/dev-lead-routing/SKILL.md
+++ b/templates/.claude/skills/dev-lead-routing/SKILL.md
@@ -99,12 +99,16 @@ Check if Agent Teams is available (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or T
 ### Step 2: Codex-Exec Hybrid (Implementation Tasks)
 For **new file creation**, **boilerplate**, or **test code generation**:
 
-1. Check `/tmp/.claude-env-status-*` for codex availability
+1. Check `/tmp/.claude-env-status-*` for codex and gemini availability
 2. If codex available AND task involves new file creation → automatically delegate to `/codex-exec` for scaffolding:
    - Display: `[Codex Hybrid] Delegating to codex-exec...`
    - codex-exec generates initial code (strength: fast generation)
    - Selected Claude expert reviews and refines codex output (strength: reasoning, quality)
-3. If codex unavailable → display `[Codex] Unavailable — proceeding with {expert} directly` and use Claude expert directly
+3. If codex unavailable but gemini available → delegate to `/gemini-exec` for scaffolding:
+   - Display: `[Gemini Hybrid] Delegating to gemini-exec...`
+   - gemini-exec generates initial code
+   - Selected Claude expert reviews and refines output
+4. If neither available → display `[External CLI] Unavailable — proceeding with {expert} directly` and use Claude expert directly
 
 **Suitable**: New file creation, boilerplate, scaffolding, test code
 **Unsuitable**: Existing code modification, architecture decisions, bug fixes

--- a/templates/.claude/skills/gemini-exec/SKILL.md
+++ b/templates/.claude/skills/gemini-exec/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: gemini-exec
+description: Execute Gemini CLI prompts and return results
+scope: core
+argument-hint: "<prompt> [--json] [--stream-json] [--output <path>] [--model <name>] [--timeout <ms>] [--sandbox] [--plan]"
+user-invocable: true
+---
+
+# Gemini Exec Skill
+
+Execute Google Gemini CLI prompts in non-interactive mode and return structured results. Enables Claude + Gemini hybrid workflows.
+
+## Options
+
+```
+<prompt>          Required. The prompt to send to Gemini CLI
+--json            Return structured JSON output (-o json)
+--stream-json     Return streaming JSON events (-o stream-json)
+--output <path>   Save response to file
+--model <name>    Model override (default: Gemini CLI default)
+--timeout <ms>    Execution timeout (default: 120000, max: 600000)
+--yolo            Enable auto-approval mode (gemini -y)
+--sandbox         Run in sandbox mode (gemini -s)
+--plan            Use plan approval mode (--approval-mode plan)
+--working-dir     Working directory for Gemini execution
+```
+
+## Workflow
+
+```
+1. Pre-checks
+   - Verify `gemini` binary is installed (which gemini)
+   - Verify authentication (GOOGLE_API_KEY, GEMINI_API_KEY, or gcloud auth)
+2. Build command
+   - Base: gemini -p "<prompt>"
+   - Apply options: -o json, -m <model>, -y, -s, --approval-mode plan
+3. Execute
+   - Run via Bash tool with timeout (default 2min, max 10min)
+   - Or use helper script: node .claude/skills/gemini-exec/scripts/gemini-wrapper.cjs
+4. Parse output
+   - Text mode: return raw stdout
+   - JSON mode: parse single JSON object, extract response field
+   - Stream-JSON mode: parse event stream, extract final assistant message
+5. Report results
+   - Format output with execution metadata
+```
+
+## Safety Defaults
+
+- `-p` flag: Non-interactive prompt mode (no session persistence)
+- Default mode: Normal approval (Gemini prompts for confirmation)
+- Override with `--yolo` only when explicitly requested
+- Sandbox mode (`-s`) available for isolated execution
+
+## Output Format
+
+### Success (Text Mode)
+```
+[Gemini Exec] Completed
+
+Model: (default)
+Duration: 23.4s
+Working Dir: /path/to/project
+
+--- Output ---
+{gemini response text}
+```
+
+### Success (JSON Mode)
+```
+[Gemini Exec] Completed (JSON)
+
+Model: (default)
+Duration: 23.4s
+
+--- Response ---
+{extracted response from JSON}
+
+--- Stats ---
+{token usage and other stats}
+```
+
+### Success (Stream-JSON Mode)
+```
+[Gemini Exec] Completed (Stream-JSON)
+
+Model: (default)
+Duration: 23.4s
+Events: 12
+
+--- Final Message ---
+{extracted final assistant message}
+```
+
+### Failure
+```
+[Gemini Exec] Failed
+
+Error: {error_message}
+Exit Code: {code}
+Suggested Fix: {suggestion}
+```
+
+## Helper Script
+
+For complex executions, use the wrapper script:
+```bash
+node .claude/skills/gemini-exec/scripts/gemini-wrapper.cjs --prompt "your prompt" [options]
+```
+
+The wrapper provides:
+- Environment validation (binary + auth checks)
+- Safe command construction
+- JSON and stream-JSON parsing with response extraction
+- Structured JSON output
+- Timeout handling with graceful termination
+
+## Examples
+
+```bash
+# Simple text prompt
+gemini-exec "explain what this project does"
+
+# JSON output with model override
+gemini-exec "list all TODO items" --json --model gemini-2.5-pro
+
+# Stream-JSON for detailed event tracking
+gemini-exec "analyze the codebase" --stream-json
+
+# Save output to file
+gemini-exec "generate a README" --output ./README.md
+
+# Sandbox mode with auto-approval
+gemini-exec "fix the failing tests" --yolo --sandbox
+
+# Plan mode for careful execution
+gemini-exec "refactor the auth module" --plan
+
+# Specify working directory
+gemini-exec "analyze the codebase" --working-dir /path/to/project
+```
+
+## Integration
+
+Works with the orchestrator pattern:
+- Main conversation delegates Gemini execution via this skill
+- Results are returned to the main conversation for further processing
+- Can be chained with other skills (e.g., dev-review after Gemini generates code)
+
+## Availability Check
+
+gemini-exec requires the Gemini CLI binary to be installed and authenticated. The skill is only usable when:
+
+1. `gemini` binary is found in PATH (`which gemini` succeeds)
+2. Authentication is valid (GOOGLE_API_KEY, GEMINI_API_KEY set, or gcloud auth active)
+
+If either check fails, this skill cannot be used. Fall back to Claude agents for the task.
+
+> **Note**: This skill is invoked via `/gemini-exec` command, delegated by the orchestrator, or suggested by routing skills when gemini is available. The intent-detection system can trigger it for research and code generation hybrid workflows.
+
+## Agent Teams Integration
+
+When used within Agent Teams (requires explicit invocation):
+
+1. **As delegated task**: orchestrator explicitly delegates gemini-exec for code generation
+2. **Hybrid workflow**: Claude team member analyzes → orchestrator invokes gemini-exec → Claude reviews
+3. **Iteration**: Team messaging enables review-fix cycles between Claude and Gemini outputs
+
+```
+Orchestrator delegates generation task
+  → /gemini-exec invoked explicitly
+  → Output returned to orchestrator
+  → Reviewer validates quality
+  → Iterate if needed
+```
+
+## Research Workflow
+
+When the orchestrator or intent-detection detects a research request:
+
+1. **Check Gemini availability**: Verify `gemini` binary and auth
+2. **If available**: Execute prompt for research
+3. **If unavailable**: Fall back to Claude's WebFetch/WebSearch
+
+### Research Command Pattern
+```
+/gemini-exec "Research and analyze: {topic}. Provide structured findings with sources." --json
+```
+
+## Code Generation Workflow
+
+When routing skills detect a code generation task and gemini is available:
+
+1. **Check availability**: Verify gemini CLI via `/tmp/.claude-env-status-*`
+2. **If available + new file creation**: Suggest hybrid workflow
+3. **Hybrid pattern**:
+   - gemini-exec generates initial code (fast, broad generation)
+   - Claude expert reviews for quality, patterns, best practices
+   - Iterate if needed
+
+### Suitable Tasks
+- New file scaffolding
+- Boilerplate generation
+- Test stub creation
+- Documentation generation
+
+### Unsuitable Tasks
+- Modifying existing code (Claude expert better at understanding context)
+- Architecture decisions (requires reasoning, not generation)
+- Bug fixes (requires deep code understanding)
+
+### Code Generation Command Pattern
+```
+/gemini-exec "Generate {description} following {framework} best practices" --yolo
+```

--- a/templates/.claude/skills/gemini-exec/scripts/gemini-wrapper.cjs
+++ b/templates/.claude/skills/gemini-exec/scripts/gemini-wrapper.cjs
@@ -1,0 +1,485 @@
+#!/usr/bin/env node
+
+/**
+ * gemini-wrapper.cjs
+ *
+ * Node.js wrapper for Google Gemini CLI (non-interactive execution).
+ * Executes gemini in prompt mode with structured JSON output.
+ *
+ * Usage:
+ *   node gemini-wrapper.cjs --prompt "your prompt" [options]
+ *
+ * Options:
+ *   --prompt <text>       Required: prompt to execute
+ *   --json                Enable JSON output from gemini (-o json)
+ *   --stream-json         Enable stream-JSON output (-o stream-json)
+ *   --output <path>       Save response to file
+ *   --model <name>        Specify model (default: gemini CLI default)
+ *   --timeout <ms>        Execution timeout in milliseconds (default: 120000, max: 600000)
+ *   --yolo                Use yolo approval mode (auto-approve all actions)
+ *   --sandbox             Run in sandbox mode
+ *   --plan                Use plan approval mode
+ *   --working-dir <dir>   Set working directory for execution
+ *
+ * Output (JSON to stdout):
+ *   Success: { "success": true, "output": "...", "duration_ms": 1234, ... }
+ *   Failure: { "success": false, "error": "...", "stderr": "...", ... }
+ *
+ * Exit codes:
+ *   0 = success
+ *   1 = execution error
+ *   2 = validation error (missing binary/auth)
+ */
+
+const { spawn, execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Configuration
+const DEFAULT_TIMEOUT_MS = 120000; // 2 minutes
+const MAX_TIMEOUT_MS = 600000; // 10 minutes
+const KILL_GRACE_PERIOD_MS = 5000; // 5 seconds for graceful shutdown
+
+/**
+ * Parse command line arguments
+ * @returns {Object} Parsed arguments
+ */
+function parseArgs() {
+  const args = {
+    prompt: null,
+    json: false,
+    streamJson: false,
+    output: null,
+    model: null,
+    timeout: DEFAULT_TIMEOUT_MS,
+    yolo: false,
+    sandbox: false,
+    plan: false,
+    workingDir: null,
+  };
+
+  for (let i = 2; i < process.argv.length; i++) {
+    const arg = process.argv[i];
+
+    switch (arg) {
+      case '--prompt':
+        if (i + 1 < process.argv.length) {
+          args.prompt = process.argv[++i];
+        }
+        break;
+      case '--json':
+        args.json = true;
+        break;
+      case '--stream-json':
+        args.streamJson = true;
+        break;
+      case '--output':
+        if (i + 1 < process.argv.length) {
+          args.output = process.argv[++i];
+        }
+        break;
+      case '--model':
+        if (i + 1 < process.argv.length) {
+          args.model = process.argv[++i];
+        }
+        break;
+      case '--timeout':
+        if (i + 1 < process.argv.length) {
+          const timeoutValue = parseInt(process.argv[++i], 10);
+          if (!isNaN(timeoutValue)) {
+            args.timeout = Math.min(timeoutValue, MAX_TIMEOUT_MS);
+          }
+        }
+        break;
+      case '--yolo':
+        args.yolo = true;
+        break;
+      case '--sandbox':
+        args.sandbox = true;
+        break;
+      case '--plan':
+        args.plan = true;
+        break;
+      case '--working-dir':
+        if (i + 1 < process.argv.length) {
+          args.workingDir = process.argv[++i];
+        }
+        break;
+    }
+  }
+
+  return args;
+}
+
+/**
+ * Validate environment for gemini execution
+ * @returns {Object} Validation result { valid: boolean, errors: string[] }
+ */
+function validateEnvironment() {
+  const errors = [];
+
+  // Check for gemini binary
+  try {
+    execFileSync('which', ['gemini'], { stdio: 'pipe' });
+  } catch (error) {
+    // Try common installation paths
+    const commonPaths = [
+      '/usr/local/bin/gemini',
+      path.join(os.homedir(), '.local', 'bin', 'gemini'),
+      path.join(os.homedir(), 'bin', 'gemini'),
+      path.join(os.homedir(), '.npm-global', 'bin', 'gemini'),
+    ];
+
+    const geminiExists = commonPaths.some(p => fs.existsSync(p));
+    if (!geminiExists) {
+      errors.push('gemini binary not found in PATH or common locations');
+    }
+  }
+
+  // Check authentication (multiple methods supported)
+  const hasGoogleApiKey = !!process.env.GOOGLE_API_KEY;
+  const hasGeminiApiKey = !!process.env.GEMINI_API_KEY;
+
+  if (!hasGoogleApiKey && !hasGeminiApiKey) {
+    console.error('[gemini-wrapper] Note: GOOGLE_API_KEY/GEMINI_API_KEY not set, relying on gcloud auth');
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Build gemini command array
+ * @param {Object} options - Command options
+ * @returns {Object} Command structure { binary: string, args: string[] }
+ */
+function buildCommand(options) {
+  const args = [];
+
+  // Prompt mode (non-interactive, ephemeral)
+  args.push('-p', options.prompt);
+
+  // Output format
+  if (options.streamJson) {
+    args.push('-o', 'stream-json');
+  } else if (options.json) {
+    args.push('-o', 'json');
+  }
+
+  // Model selection
+  if (options.model) {
+    args.push('-m', options.model);
+  }
+
+  // Approval mode
+  if (options.yolo) {
+    args.push('-y');
+  } else if (options.plan) {
+    args.push('--approval-mode', 'plan');
+  }
+
+  // Sandbox mode
+  if (options.sandbox) {
+    args.push('-s');
+  }
+
+  return {
+    binary: 'gemini',
+    args,
+  };
+}
+
+/**
+ * Execute gemini command
+ * @param {string} binary - Binary to execute
+ * @param {string[]} args - Command arguments
+ * @param {number} timeout - Timeout in milliseconds
+ * @param {string|null} workingDir - Working directory
+ * @returns {Promise<Object>} Execution result
+ */
+function executeGemini(binary, args, timeout, workingDir = null) {
+  return new Promise((resolve) => {
+    const startTime = Date.now();
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+
+    const spawnOptions = {
+      cwd: workingDir || process.cwd(),
+      env: process.env,
+    };
+
+    const child = spawn(binary, args, spawnOptions);
+
+    // Collect output
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    // Set timeout
+    const timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      console.error('[gemini-wrapper] Timeout reached, terminating process...');
+
+      // Graceful termination attempt
+      child.kill('SIGTERM');
+
+      // Force kill after grace period
+      setTimeout(() => {
+        if (!child.killed) {
+          console.error('[gemini-wrapper] Force killing process...');
+          child.kill('SIGKILL');
+        }
+      }, KILL_GRACE_PERIOD_MS);
+    }, timeout);
+
+    // Handle process exit
+    child.on('close', (exitCode) => {
+      clearTimeout(timeoutHandle);
+      const durationMs = Date.now() - startTime;
+
+      resolve({
+        exitCode: exitCode !== null ? exitCode : 1,
+        stdout,
+        stderr,
+        timedOut,
+        durationMs,
+      });
+    });
+
+    // Handle spawn errors
+    child.on('error', (error) => {
+      clearTimeout(timeoutHandle);
+      const durationMs = Date.now() - startTime;
+
+      resolve({
+        exitCode: 1,
+        stdout,
+        stderr: stderr + '\nSpawn error: ' + error.message,
+        timedOut: false,
+        durationMs,
+      });
+    });
+  });
+}
+
+/**
+ * Parse JSON output from gemini (-o json)
+ * Gemini JSON output is a single JSON object: { session_id, response, stats }
+ * @param {string} output - Raw output string
+ * @returns {Object} Parsed result { response: string|null, stats: object|null, parseError: string|null }
+ */
+function parseJson(output) {
+  try {
+    const data = JSON.parse(output.trim());
+    return {
+      response: data.response || null,
+      stats: data.stats || null,
+      sessionId: data.session_id || null,
+      parseError: null,
+    };
+  } catch (error) {
+    return {
+      response: null,
+      stats: null,
+      sessionId: null,
+      parseError: `Failed to parse JSON: ${error.message}`,
+    };
+  }
+}
+
+/**
+ * Parse stream-JSON output from gemini (-o stream-json)
+ * Stream format: newline-delimited JSON events
+ *   { type: "init", ... }
+ *   { type: "message", role: "user"|"assistant", content: "..." }
+ *   { type: "result", stats: {...} }
+ * @param {string} output - Raw output string
+ * @returns {Object} Parsed result { events: object[], finalMessage: string|null, stats: object|null, parseErrors: string[] }
+ */
+function parseStreamJson(output) {
+  const lines = output.split('\n').filter(line => line.trim().length > 0);
+  const events = [];
+  const parseErrors = [];
+  let finalMessage = null;
+  let stats = null;
+
+  for (const line of lines) {
+    try {
+      const event = JSON.parse(line);
+      events.push(event);
+
+      // Extract final assistant message
+      if (event.type === 'message' && event.role === 'assistant') {
+        finalMessage = event.content || event.text || finalMessage;
+      }
+
+      // Extract stats from result event
+      if (event.type === 'result') {
+        stats = event.stats || null;
+        if (event.response) {
+          finalMessage = event.response;
+        }
+      }
+
+      // Fallback: look for common response patterns
+      if (!finalMessage && event.content && event.role === 'model') {
+        finalMessage = event.content;
+      }
+    } catch (error) {
+      parseErrors.push(`Failed to parse line: ${error.message}`);
+    }
+  }
+
+  return {
+    events,
+    finalMessage,
+    stats,
+    parseErrors,
+  };
+}
+
+/**
+ * Main execution function
+ */
+async function main() {
+  const args = parseArgs();
+
+  // Validate required arguments
+  if (!args.prompt) {
+    const result = {
+      success: false,
+      error: 'Missing required argument: --prompt',
+      exit_code: 2,
+    };
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(2);
+  }
+
+  // Validate environment
+  const validation = validateEnvironment();
+  if (!validation.valid) {
+    const result = {
+      success: false,
+      error: 'Environment validation failed',
+      validation_errors: validation.errors,
+      exit_code: 2,
+    };
+    console.log(JSON.stringify(result, null, 2));
+    process.exit(2);
+  }
+
+  console.error(`[gemini-wrapper] Executing gemini with timeout: ${args.timeout}ms`);
+  if (args.workingDir) {
+    console.error(`[gemini-wrapper] Working directory: ${args.workingDir}`);
+  }
+
+  // Build command
+  const command = buildCommand(args);
+  console.error(`[gemini-wrapper] Command: ${command.binary} ${command.args.join(' ')}`);
+
+  // Execute
+  const execResult = await executeGemini(
+    command.binary,
+    command.args,
+    args.timeout,
+    args.workingDir
+  );
+
+  // Process result
+  let output = null;
+  let eventsCount = 0;
+  let stats = null;
+
+  if (args.streamJson && execResult.stdout) {
+    const parsed = parseStreamJson(execResult.stdout);
+    eventsCount = parsed.events.length;
+    output = parsed.finalMessage;
+    stats = parsed.stats;
+
+    if (parsed.parseErrors.length > 0) {
+      console.error('[gemini-wrapper] Stream-JSON parse errors:', parsed.parseErrors.join('; '));
+    }
+  } else if (args.json && execResult.stdout) {
+    const parsed = parseJson(execResult.stdout);
+    output = parsed.response;
+    stats = parsed.stats;
+
+    if (parsed.parseError) {
+      console.error('[gemini-wrapper] JSON parse error:', parsed.parseError);
+      // Fallback to raw output
+      output = execResult.stdout.trim();
+    }
+  } else {
+    output = execResult.stdout.trim();
+  }
+
+  // Determine success
+  const success = execResult.exitCode === 0 && !execResult.timedOut;
+
+  // Build result object
+  const result = {
+    success,
+    duration_ms: execResult.durationMs,
+    exit_code: execResult.exitCode,
+  };
+
+  if (success) {
+    result.output = output || execResult.stdout;
+    result.model = args.model || '(default)';
+    if (args.streamJson) {
+      result.events_count = eventsCount;
+    }
+    if (stats) {
+      result.stats = stats;
+    }
+  } else {
+    if (execResult.timedOut) {
+      result.error = `Execution timed out after ${args.timeout}ms`;
+    } else {
+      result.error = 'Execution failed';
+    }
+    if (execResult.stderr) {
+      result.stderr = execResult.stderr.trim();
+    }
+  }
+
+  // Write output file if requested
+  if (args.output && output) {
+    try {
+      const outputDir = path.dirname(args.output);
+      if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+      }
+      fs.writeFileSync(args.output, output, 'utf-8');
+      console.error(`[gemini-wrapper] Output written to: ${args.output}`);
+    } catch (error) {
+      console.error(`[gemini-wrapper] Failed to write output file: ${error.message}`);
+      result.output_file_error = error.message;
+    }
+  }
+
+  // Output JSON result to stdout
+  console.log(JSON.stringify(result, null, 2));
+
+  process.exit(result.exit_code);
+}
+
+// Run
+main().catch(error => {
+  const result = {
+    success: false,
+    error: 'Unexpected error: ' + error.message,
+    stack: error.stack,
+    exit_code: 1,
+  };
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(1);
+});

--- a/templates/.claude/skills/intent-detection/patterns/agent-triggers.yaml
+++ b/templates/.claude/skills/intent-detection/patterns/agent-triggers.yaml
@@ -110,6 +110,14 @@ agents:
     supported_actions: [review, create, fix, refactor, test]
     base_confidence: 40
 
+  fe-design-expert:
+    keywords:
+      korean: [디자인, 타이포그래피, 색상, 모션, UX라이팅, 디자인시스템, 디자인리뷰]
+      english: [design, typography, color, motion, "ux writing", "design system", "design review", impeccable, "design audit", "ai slop"]
+    file_patterns: ["*.css", "*.scss", "*.less", "tailwind.config.*"]
+    supported_actions: [review, audit, critique, polish, normalize]
+    base_confidence: 40
+
   # SW Engineers - Backend
   be-fastapi-expert:
     keywords:
@@ -330,7 +338,7 @@ agents:
       - gather
     base_confidence: 50
     action_weight: 30
-    routing_rule: "MUST use codex-exec --effort xhigh when codex available, fallback to WebFetch/WebSearch"
+    routing_rule: "MUST use codex-exec --effort xhigh when codex available, or gemini-exec when gemini available, fallback to WebFetch/WebSearch"
 
   # ---------------------------------------------------------------------------
   # Code Generation (hybrid workflow, skill-based)
@@ -359,7 +367,7 @@ agents:
       - scaffold
     base_confidence: 30
     action_weight: 25
-    routing_rule: "Suggest codex-exec hybrid when codex available and task is new file creation"
+    routing_rule: "Suggest codex-exec hybrid when codex available, or gemini-exec hybrid when gemini available, for new file creation tasks"
 
   # Managers (continued)
   mgr-gitnerd:
@@ -411,3 +419,12 @@ agents:
     file_patterns: []
     supported_actions: [manage, create, coordinate]
     base_confidence: 40
+
+  professor-triage:
+    keywords:
+      korean: [트리아지, 이슈분석, 교차분석, 프로페서]
+      english: [triage, cross-analyze, professor, issue-analysis]
+    file_patterns: []
+    actions: [review, analyze]
+    base_confidence: 85
+    routing_rule: "MUST use professor-triage skill for cross-analyzing GitHub issues with omc_issue_analyzer comments"

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1,3 +1,4 @@
+<!-- omcustom:start -->
 # AI 에이전트 시스템
 
 oh-my-customcode로 구동됩니다.
@@ -118,6 +119,7 @@ oh-my-customcode로 구동됩니다.
 | `/omcustom-release-notes` | 릴리즈 노트 생성 (git 히스토리 기반) |
 | `/omcustom-feedback` | 사용자 피드백을 GitHub Issue로 등록 |
 | `/codex-exec` | Codex CLI 프롬프트 실행 |
+| `/gemini-exec` | Gemini CLI 프롬프트 실행 |
 | `/optimize-analyze` | 번들 및 성능 분석 |
 | `/optimize-bundle` | 번들 크기 최적화 |
 | `/optimize-report` | 최적화 리포트 생성 |
@@ -125,11 +127,19 @@ oh-my-customcode로 구동됩니다.
 | `/scout` | 외부 URL 분석 및 프로젝트 적합성 평가 |
 | `/deep-plan` | 연구 검증 기반 계획 수립 (research → plan → verify) |
 | `/deep-verify` | 다중 관점 릴리즈 품질 검증 |
+| `/professor-triage` | 이슈 교차 분석 트리아지 (omc_issue_analyzer 댓글 기반) |
+| `/release-plan` | verify-done 이슈 릴리즈 유닛 계획 생성 |
+| `/omcustom:workflow` | YAML 워크플로우 실행 (예: /omcustom:workflow auto-dev) |
+| `/omcustom:workflow:resume` | 중단된 워크플로우 재개 |
 | `/omcustom:sauron-watch` | 전체 R017 검증 |
+| `/sdd-dev` | Spec-Driven Development 워크플로우 (sdd/ 폴더 기반) |
 | `/structured-dev-cycle` | 6단계 구조적 개발 사이클 (Plan → Verify → Implement → Verify → Compound → Done) |
 | `/omcustom:loop` | 백그라운드 에이전트 자동 계속 실행 |
 | `/omcustom:lists` | 모든 사용 가능한 커맨드 표시 |
 | `/omcustom:status` | 시스템 상태 표시 |
+| `/omcustom-web` | 내장 Web UI 제어 및 검사 |
+| `/skills-sh-search` | skills.sh 마켓플레이스 스킬 검색 및 설치 |
+| `/vercel-deploy` | Vercel 배포 자동화 |
 | `/omcustom:help` | 도움말 표시 |
 
 ## 프로젝트 구조
@@ -139,7 +149,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (46 파일)
-|   +-- skills/                  # 스킬 (98 디렉토리)
+|   +-- skills/                  # 스킬 (99 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R021)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)
@@ -278,3 +288,5 @@ claude-mem setup
 ```
 
 <!-- omcustom:git-workflow -->
+
+<!-- omcustom:end -->

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.65.2",
+  "version": "0.66.0",
   "lastUpdated": "2026-03-24T00:00:00.000Z",
   "components": [
     {
@@ -18,7 +18,7 @@
       "name": "skills",
       "path": ".claude/skills",
       "description": "Reusable skill modules (includes slash commands)",
-      "files": 98
+      "files": 99
     },
     {
       "name": "guides",


### PR DESCRIPTION
## Summary
- Add `gemini-exec` skill for native Gemini CLI execution within Claude Code sessions
- Pattern-based on `codex-exec`: 5-phase workflow + Node.js wrapper script
- Supports `-p` prompt, `-o json/stream-json`, `-y` yolo, `-s` sandbox, `--approval-mode plan`
- Session env-check extended with Gemini CLI availability detection
- Intent-detection and routing skills updated for Gemini hybrid workflows
- Version bump: 0.65.2 → 0.66.0

## Changes
- **New**: `.claude/skills/gemini-exec/SKILL.md` — skill definition
- **New**: `.claude/skills/gemini-exec/scripts/gemini-wrapper.cjs` — Node.js wrapper
- **Modified**: `session-env-check.sh` — Gemini CLI availability check
- **Modified**: `agent-triggers.yaml` — routing rules for gemini-exec
- **Modified**: `dev-lead-routing/SKILL.md` — Gemini hybrid fallback
- **Modified**: `de-lead-routing/SKILL.md` — Gemini hybrid fallback
- **Modified**: `CLAUDE.md` — `/gemini-exec` command added
- **Modified**: `README.md`, `README_ko.md` — skill count 98 → 99
- Templates synced, dist rebuilt

## Test plan
- [x] 1534 unit tests pass, 0 fail
- [x] `gemini-wrapper.cjs` syntax validated (node execution check)
- [x] Template validation tests pass (skill count, manifest, README)
- [ ] CI: test, lint, template-sync, version-sync, dependency-audit, rust-tests

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)