### PR TITLE
feat: CC v2.1.88 compat + RTK auto-intercept — v0.68.0

### DIFF
--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -83,6 +83,16 @@
         "description": "Schema-based tool input validation — Phase 1 advisory only"
       },
       {
+        "matcher": "tool == \"Bash\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/scripts/rtk-intercept.sh"
+          }
+        ],
+        "description": "RTK auto-intercept — transparently rewrites CLI commands through RTK proxy when available (R015 advisory)"
+      },
+      {
         "matcher": "tool == \"Task\" || tool == \"Agent\"",
         "hooks": [
           {

--- a/.claude/hooks/scripts/rtk-intercept.sh
+++ b/.claude/hooks/scripts/rtk-intercept.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# RTK Auto-Intercept Hook
+# Trigger: PreToolUse (Bash matcher)
+# Purpose: Transparently rewrite CLI commands through RTK proxy
+# Protocol: stdin JSON → stdout modified JSON, exit 0 always
+
+set -euo pipefail
+
+input=$(cat)
+
+# Only intercept Bash tool calls
+tool_name=$(echo "$input" | jq -r '.tool // empty' 2>/dev/null || echo "")
+if [ "$tool_name" != "Bash" ]; then
+  echo "$input"
+  exit 0
+fi
+
+# Check RTK availability
+RTK_AVAILABLE=false
+STATUS_FILE="/tmp/.claude-env-status-${PPID}"
+if [ -f "$STATUS_FILE" ] && grep -q "rtk=available" "$STATUS_FILE" 2>/dev/null; then
+  RTK_AVAILABLE=true
+elif command -v rtk >/dev/null 2>&1; then
+  RTK_AVAILABLE=true
+fi
+
+if [ "$RTK_AVAILABLE" != "true" ]; then
+  echo "$input"
+  exit 0
+fi
+
+# Extract command
+cmd=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+if [ -z "$cmd" ]; then
+  echo "$input"
+  exit 0
+fi
+
+# Skip if already using rtk
+if echo "$cmd" | grep -qE '^rtk\b'; then
+  echo "$input"
+  exit 0
+fi
+
+# Skip complex commands (pipes, redirections, background, subshells, semicolons with multiple commands)
+if echo "$cmd" | grep -qE '[|><&]|;\s*\w'; then
+  echo "$input"
+  exit 0
+fi
+
+# RTK-supported command prefixes
+RTK_CMDS="ls find tree du cat head tail wc grep rg git cargo npm pnpm bun pip pytest vitest jest rspec eslint tsc ruff docker kubectl"
+
+# Extract first word of command (skip env var assignments like FOO=bar)
+first_word=$(echo "$cmd" | sed 's/^[A-Z_]*=[^ ]* //' | awk '{print $1}')
+
+# Check if command is RTK-supported
+SUPPORTED=false
+for rtk_cmd in $RTK_CMDS; do
+  if [ "$first_word" = "$rtk_cmd" ]; then
+    SUPPORTED=true
+    break
+  fi
+done
+
+if [ "$SUPPORTED" != "true" ]; then
+  echo "$input"
+  exit 0
+fi
+
+# Rewrite command with rtk prefix
+new_cmd="rtk $cmd"
+echo "[RTK] Intercepted: $cmd → $new_cmd" >&2
+
+# Output modified JSON
+echo "$input" | jq --arg new_cmd "$new_cmd" '.tool_input.command = $new_cmd'
+exit 0

--- a/.claude/hooks/scripts/session-env-check.sh
+++ b/.claude/hooks/scripts/session-env-check.sh
@@ -60,6 +60,15 @@ if [ "$CLAUDE_VERSION" != "unknown" ]; then
   fi
 fi
 
+# v2.1.88+ features notice
+if [ "$CLAUDE_VERSION" != "unknown" ]; then
+  if printf '%s\n' "2.1.88" "$CLAUDE_VERSION" | sort -V | head -1 | grep -q "^2\.1\.88$"; then
+    if [ -z "${CLAUDE_CODE_NO_FLICKER:-}" ]; then
+      echo "  [v2.1.88] Tip: CLAUDE_CODE_NO_FLICKER=1 for flicker-free rendering" >&2
+    fi
+  fi
+fi
+
 # Git workflow reminder
 CURRENT_BRANCH="unknown"
 if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then

--- a/.claude/rules/MUST-agent-design.md
+++ b/.claude/rules/MUST-agent-design.md
@@ -85,6 +85,7 @@ All supported hook event types in Claude Code. Agents and skills can reference t
 | `Elicitation` | Agent requests user input | question | command, prompt | v2.1.76+ |
 | `ElicitationResult` | User responds to elicitation | answer | command, prompt | v2.1.76+ |
 | `PostMessage` | After message sent | message_type | command | v2.1.76+ |
+| `PermissionDenied` | Auto mode classifier denial | tool, tool_input, denial_reason | command, prompt | v2.1.88+ |
 | `TeammateIdle` | Agent Teams member idle | teammate_id | command | v2.1.83+ |
 | `TaskCreated` | Task created | task_id, description | command | v2.1.83+ |
 | `TaskCompleted` | Task completed | task_id, result | command | v2.1.83+ |
@@ -109,6 +110,8 @@ hooks:
     - matcher: "*"                       # Match all
       command: "echo hook"
 ```
+
+> **v2.1.85+**: `if` field supports permission rule syntax for conditional hook execution. **v2.1.88** extended `if` matching to support compound commands (`ls && git push`) and commands with env-var prefixes (`FOO=bar git push`).
 
 ## Permission Mode Guidance
 

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,7 +1,7 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.67.0",
-  "generatedAt": "2026-03-31T01:20:11.046Z",
+  "generatorVersion": "0.68.0",
+  "generatedAt": "2026-03-31T01:57:26.572Z",
   "templateVersion": "0.67.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
@@ -45,8 +45,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
-      "templateHash": "7008395c2f4651b4254d9c86ca575df820f26d7db6013565cf7fcf619bda5b34",
-      "size": 13439,
+      "templateHash": "e0c41dbb9426364d054ff52423d895ca855679091f0deff53ac9b70d8d324f83",
+      "size": 13787,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
@@ -979,6 +979,11 @@
       "size": 843,
       "component": "hooks"
     },
+    ".claude/hooks/scripts/rtk-intercept.sh": {
+      "templateHash": "5e936074a2dcc6e17ce05992778c72ed2fac5edc3cfd8ce63a480ea5a6a95947",
+      "size": 1926,
+      "component": "hooks"
+    },
     ".claude/hooks/scripts/stale-todo-scanner.sh": {
       "templateHash": "d2f47fdfff22243a4d5cbbbb09f176e019235decf603fac17407ea17d114d17d",
       "size": 2306,
@@ -1020,8 +1025,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/session-env-check.sh": {
-      "templateHash": "9c72a5229b422cd4fc59c206ea10b2ef9f1c0a5458f0a67c42d3a83757332711",
-      "size": 8347,
+      "templateHash": "c309410499ca66d6a4a7ebe588b8faf4fa6f2a1e5e5190d8f3ccd3feab749e31",
+      "size": 8665,
       "component": "hooks"
     },
     ".claude/hooks/scripts/feedback-collector.sh": {
@@ -1065,8 +1070,8 @@
       "component": "hooks"
     },
     ".claude/hooks/hooks.json": {
-      "templateHash": "5ae70b2c53fe8a4496fd57bdeda6bd1096b2ecb801938b8b6b42045e4fe187a6",
-      "size": 22438,
+      "templateHash": "523511050e94b18bcec66d40d1ef1cad42b3c1a3bd00a88e0d5afba51f77f438",
+      "size": 22781,
       "component": "hooks"
     },
     ".claude/contexts/ecomode.md": {

--- a/README.md
+++ b/README.md
@@ -294,6 +294,20 @@ your-project/
 
 ---
 
+## Optional External Tools
+
+oh-my-customcode works fully without any external tools. These optional integrations provide additional capabilities when installed:
+
+| Tool | Purpose | Install | Skill |
+|------|---------|---------|-------|
+| [RTK](https://github.com/rtk-ai/rtk) | 60-90% token savings on CLI output | `brew install rtk` | `/rtk-exec` |
+| [Codex CLI](https://github.com/openai/codex) | OpenAI Codex hybrid workflows | `npm i -g @openai/codex` | `/codex-exec` |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Google Gemini hybrid workflows | `npm i -g @anthropic-ai/gemini-cli` | `/gemini-exec` |
+
+When installed, each tool is **auto-detected** at session start and its features become available. When not installed, all commands gracefully fall back to Claude-native alternatives.
+
+---
+
 ## Development
 
 ```bash

--- a/README_ko.md
+++ b/README_ko.md
@@ -283,6 +283,20 @@ your-project/
 
 ---
 
+## 선택적 외부 도구
+
+oh-my-customcode는 외부 도구 없이도 완전하게 동작합니다. 설치 시 추가 기능을 제공하는 선택적 통합입니다:
+
+| 도구 | 용도 | 설치 | 스킬 |
+|------|------|------|------|
+| [RTK](https://github.com/rtk-ai/rtk) | CLI 출력 토큰 60-90% 절감 | `brew install rtk` | `/rtk-exec` |
+| [Codex CLI](https://github.com/openai/codex) | OpenAI Codex 하이브리드 워크플로우 | `npm i -g @openai/codex` | `/codex-exec` |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Google Gemini 하이브리드 워크플로우 | `npm i -g @anthropic-ai/gemini-cli` | `/gemini-exec` |
+
+설치된 도구는 세션 시작 시 **자동 감지**되며 관련 기능이 활성화됩니다. 미설치 시 모든 명령어는 Claude 네이티브 대안으로 자연스럽게 폴백됩니다.
+
+---
+
 ## 개발
 
 ```bash

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9307,7 +9307,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.67.0",
+    version: "0.68.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1685,7 +1685,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.67.0",
+  version: "0.68.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.67.0",
+  "version": "0.68.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/hooks/hooks.json
+++ b/templates/.claude/hooks/hooks.json
@@ -83,6 +83,16 @@
         "description": "Schema-based tool input validation — Phase 1 advisory only"
       },
       {
+        "matcher": "tool == \"Bash\"",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/scripts/rtk-intercept.sh"
+          }
+        ],
+        "description": "RTK auto-intercept — transparently rewrites CLI commands through RTK proxy when available (R015 advisory)"
+      },
+      {
         "matcher": "tool == \"Task\" || tool == \"Agent\"",
         "hooks": [
           {

--- a/templates/.claude/hooks/scripts/rtk-intercept.sh
+++ b/templates/.claude/hooks/scripts/rtk-intercept.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# RTK Auto-Intercept Hook
+# Trigger: PreToolUse (Bash matcher)
+# Purpose: Transparently rewrite CLI commands through RTK proxy
+# Protocol: stdin JSON → stdout modified JSON, exit 0 always
+
+set -euo pipefail
+
+input=$(cat)
+
+# Only intercept Bash tool calls
+tool_name=$(echo "$input" | jq -r '.tool // empty' 2>/dev/null || echo "")
+if [ "$tool_name" != "Bash" ]; then
+  echo "$input"
+  exit 0
+fi
+
+# Check RTK availability
+RTK_AVAILABLE=false
+STATUS_FILE="/tmp/.claude-env-status-${PPID}"
+if [ -f "$STATUS_FILE" ] && grep -q "rtk=available" "$STATUS_FILE" 2>/dev/null; then
+  RTK_AVAILABLE=true
+elif command -v rtk >/dev/null 2>&1; then
+  RTK_AVAILABLE=true
+fi
+
+if [ "$RTK_AVAILABLE" != "true" ]; then
+  echo "$input"
+  exit 0
+fi
+
+# Extract command
+cmd=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+if [ -z "$cmd" ]; then
+  echo "$input"
+  exit 0
+fi
+
+# Skip if already using rtk
+if echo "$cmd" | grep -qE '^rtk\b'; then
+  echo "$input"
+  exit 0
+fi
+
+# Skip complex commands (pipes, redirections, background, subshells, semicolons with multiple commands)
+if echo "$cmd" | grep -qE '[|><&]|;\s*\w'; then
+  echo "$input"
+  exit 0
+fi
+
+# RTK-supported command prefixes
+RTK_CMDS="ls find tree du cat head tail wc grep rg git cargo npm pnpm bun pip pytest vitest jest rspec eslint tsc ruff docker kubectl"
+
+# Extract first word of command (skip env var assignments like FOO=bar)
+first_word=$(echo "$cmd" | sed 's/^[A-Z_]*=[^ ]* //' | awk '{print $1}')
+
+# Check if command is RTK-supported
+SUPPORTED=false
+for rtk_cmd in $RTK_CMDS; do
+  if [ "$first_word" = "$rtk_cmd" ]; then
+    SUPPORTED=true
+    break
+  fi
+done
+
+if [ "$SUPPORTED" != "true" ]; then
+  echo "$input"
+  exit 0
+fi
+
+# Rewrite command with rtk prefix
+new_cmd="rtk $cmd"
+echo "[RTK] Intercepted: $cmd → $new_cmd" >&2
+
+# Output modified JSON
+echo "$input" | jq --arg new_cmd "$new_cmd" '.tool_input.command = $new_cmd'
+exit 0

--- a/templates/.claude/hooks/scripts/session-env-check.sh
+++ b/templates/.claude/hooks/scripts/session-env-check.sh
@@ -60,6 +60,15 @@ if [ "$CLAUDE_VERSION" != "unknown" ]; then
   fi
 fi
 
+# v2.1.88+ features notice
+if [ "$CLAUDE_VERSION" != "unknown" ]; then
+  if printf '%s\n' "2.1.88" "$CLAUDE_VERSION" | sort -V | head -1 | grep -q "^2\.1\.88$"; then
+    if [ -z "${CLAUDE_CODE_NO_FLICKER:-}" ]; then
+      echo "  [v2.1.88] Tip: CLAUDE_CODE_NO_FLICKER=1 for flicker-free rendering" >&2
+    fi
+  fi
+fi
+
 # Git workflow reminder
 CURRENT_BRANCH="unknown"
 if command -v git >/dev/null 2>&1 && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -85,6 +85,7 @@ All supported hook event types in Claude Code. Agents and skills can reference t
 | `Elicitation` | Agent requests user input | question | command, prompt | v2.1.76+ |
 | `ElicitationResult` | User responds to elicitation | answer | command, prompt | v2.1.76+ |
 | `PostMessage` | After message sent | message_type | command | v2.1.76+ |
+| `PermissionDenied` | Auto mode classifier denial | tool, tool_input, denial_reason | command, prompt | v2.1.88+ |
 | `TeammateIdle` | Agent Teams member idle | teammate_id | command | v2.1.83+ |
 | `TaskCreated` | Task created | task_id, description | command | v2.1.83+ |
 | `TaskCompleted` | Task completed | task_id, result | command | v2.1.83+ |
@@ -109,6 +110,8 @@ hooks:
     - matcher: "*"                       # Match all
       command: "echo hook"
 ```
+
+> **v2.1.85+**: `if` field supports permission rule syntax for conditional hook execution. **v2.1.88** extended `if` matching to support compound commands (`ls && git push`) and commands with env-var prefixes (`FOO=bar git push`).
 
 ## Permission Mode Guidance
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.67.0",
+  "version": "0.68.0",
   "lastUpdated": "2026-03-24T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- CC v2.1.88 호환: PermissionDenied hook event (R006 20번째), compound command `if` matching 문서화
- RTK PreToolUse auto-intercept: Bash 명령어 자동 RTK 프록시 (`rtk-intercept.sh`)
- Optional External Tools 섹션 README 추가 (RTK/Codex/Gemini opt-in 명시)
- v2.1.88 NO_FLICKER 팁 session-env-check 추가

## Changes
- `.claude/rules/MUST-agent-design.md` — PermissionDenied hook event + v2.1.88 if matching note
- `.claude/hooks/hooks.json` — RTK PreToolUse Bash matcher
- `.claude/hooks/scripts/rtk-intercept.sh` — NEW auto-intercept script
- `.claude/hooks/scripts/session-env-check.sh` — v2.1.88 feature notice
- `README.md`, `README_ko.md` — Optional External Tools section
- `templates/` — all synced
- `package.json` — 0.67.0 → 0.68.0

## Test plan
- [x] 1534 unit tests pass
- [x] Build success
- [x] Template sync verified
- [x] Pre-commit hooks pass (type check + lint + coverage)

Closes #741, closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)