### PR TITLE
fix: auto-close issues + delete release branch on merge (#776)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -57,3 +58,28 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
+
+      - name: Close linked issues
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          ISSUES=$(echo "$PR_BODY" | grep -oE '(Closes|Fixes|Resolves) #[0-9]+' | grep -oE '[0-9]+' | sort -u)
+          for ISSUE in $ISSUES; do
+            echo "Closing issue #$ISSUE"
+            gh issue close "$ISSUE" \
+              -c "Closed by ${TAG} release (PR #${PR_NUMBER})" \
+              --repo "$REPO" || echo "⚠ Failed to close #$ISSUE"
+          done
+
+      - name: Delete merged release branch
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          echo "Deleting branch: $BRANCH"
+          git push origin --delete "$BRANCH" || echo "⚠ Branch $BRANCH already deleted or not found"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,28 +329,3 @@ jobs:
           echo "| GitHub Release | ${GHR} |" >> $GITHUB_STEP_SUMMARY
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  cleanup:
-    name: Cleanup Release Branch
-    needs: [publish]
-    if: success()
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - name: Delete release branch
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-
-          # Try both naming patterns
-          for BRANCH in "release/v${VERSION}" "release/${VERSION}"; do
-            echo "Checking branch: $BRANCH"
-            if gh api "repos/${{ github.repository }}/git/refs/heads/${BRANCH}" --silent 2>/dev/null; then
-              gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${BRANCH}" && \
-                echo "✓ Deleted branch: $BRANCH" || \
-                echo "⚠ Failed to delete branch: $BRANCH"
-            else
-              echo "Branch $BRANCH not found, skipping"
-            fi
-          done
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- **auto-tag.yml**: Add 2 post-merge cleanup steps after tag creation
  - Close all issues referenced in PR body (`Closes/Fixes/Resolves #N`)
  - Delete the merged `release/*` branch
- **release.yml**: Remove broken `Cleanup Release Branch` job (was failing with "Branch not found" on every release)

## Details
The release.yml cleanup job tried to infer branch names from `GITHUB_REF` (tag refs) but consistently failed. Moving cleanup to auto-tag.yml is correct because it fires on PR merge where `github.event.pull_request.head.ref` provides the exact branch name.

## Test plan
- [x] Both YAML files pass syntax validation
- [x] 1592/1592 tests passing
- [x] No version bump needed (CI-only change)
- [ ] Verify on next release PR merge

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)