### PR TITLE
feat: v0.76.1 — agora multi-LLM adversarial consensus skill

### DIFF
--- a/.claude/skills/agora/SKILL.md
+++ b/.claude/skills/agora/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: agora
+description: "Multi-LLM adversarial consensus loop — 3+ LLMs compete to find flaws in designs/specs until unanimous agreement is reached"
+user-invocable: true
+argument-hint: "<document-path> [--rounds N] [--severity-threshold HIGH]"
+effort: max
+scope: core
+version: 1.0.0
+source:
+  type: external
+  origin: github
+  url: https://github.com/baekenough/baekenough-skills
+  version: 1.0.0
+---
+
+# Agora: Multi-LLM Adversarial Consensus
+
+3개 이상의 LLM(Claude, Codex/GPT, Gemini)이 경쟁적으로 설계/문서의 결함을 찾고, 만장일치 합의에 도달할 때까지 반복하는 적대적 교차 검증 스킬.
+
+## Prerequisites
+
+- `codex-exec` skill (Codex/GPT 호출)
+- `gemini-exec` skill (Gemini 호출)
+- Agent Teams enabled (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) or Agent tool available
+
+## Usage
+
+```
+/agora docs/design.md                          # Default: 3 LLMs, unlimited rounds
+/agora docs/design.md --rounds 10              # Max 10 rounds
+/agora docs/design.md --severity-threshold HIGH # Exit when no HIGH+ findings
+/agora docs/design.md --models claude,codex     # 2 LLMs only
+```
+
+## Workflow
+
+### Phase 1: Setup
+1. Read the target document
+2. Create Agent Team: `TeamCreate("agora-review")`
+3. Create review tasks per focus area
+
+### Phase 2: Spawn Reviewers (parallel)
+Spawn 3 reviewers as Agent Team members:
+
+```
+Agent(name: "claude-critic", model: opus, effort: max)
+  → 20-point deep adversarial review
+  
+Agent(name: "codex-critic", model: opus)
+  → Invoke Skill(codex-exec) for GPT perspective + independent Claude analysis
+  
+Agent(name: "gemini-critic", model: opus)  
+  → Invoke Skill(gemini-exec) for Gemini perspective + independent Claude analysis
+```
+
+### Phase 3: Independent Review
+Each reviewer performs adversarial review with this template:
+
+```
+For EACH review point:
+### Round N: [Topic]
+**Severity**: CRITICAL / HIGH / MEDIUM / LOW
+**Flaw**: [Specific, concrete problem description]
+**Evidence**: [Why this is real, not theoretical]
+**Impact**: [What happens if not addressed]
+**Counter-argument**: [Best case FOR the current design]
+**Verdict**: KEEP / MODIFY / REJECT
+```
+
+Review areas (adapt to document type):
+- Architecture fundamentals
+- Component/service design
+- Data architecture
+- Security & resilience
+- Feasibility & deployment
+- Testing strategy
+- Operational complexity
+
+### Phase 4: Cross-Review (Peer-to-Peer)
+Each reviewer sends findings to the other two via `SendMessage`.
+
+Counter-review template:
+1. Which findings do you **AGREE** with? (and why)
+2. Which findings do you **DISAGREE** with? (evidence-based rebuttal)
+3. What did they **MISS** that you caught?
+4. What did they catch that you **MISSED**?
+5. **SEVERITY** adjustments — upgrade or downgrade with justification
+
+### Phase 5: Synthesis
+Team lead aggregates all findings:
+
+```
+UNANIMOUS CRITICAL: [findings all 3 agreed on]
+STRONG AGREEMENT:   [findings 2/3 agreed on]
+SPLIT DECISIONS:    [findings with disagreement + resolution]
+```
+
+Determine verdict:
+- **BUILD**: No CRITICAL, no unresolved HIGH
+- **BUILD WITH CHANGES**: No CRITICAL, HIGH findings have accepted mitigations
+- **REDESIGN**: Any unresolved CRITICAL findings
+- **ABANDON**: Fundamental concept is flawed
+
+### Phase 6: Loop (if REDESIGN)
+1. Team lead produces/delegates redesign addressing ALL critical findings
+2. New version sent to ALL reviewers: `SendMessage(to: "*")`
+3. Reviewers re-review → GOTO Phase 4
+4. Repeat until EXIT criteria met
+
+### Phase 7: Exit (consensus reached)
+When ALL reviewers agree BUILD or BUILD WITH CHANGES:
+1. Produce final consensus report
+2. Write to `.claude/outputs/sessions/{date}/agora-{topic}-{time}.md`
+3. Shut down team: `SendMessage(to: "*", message: {type: "shutdown_request"})`
+
+## Reviewer Principles
+
+1. **NEUTRAL** — no reviewer has home team advantage
+2. **COMPETITIVE** — find flaws others missed
+3. **CRITICAL** — "fewer than 5 CRITICAL flaws = not looking hard enough"
+4. **EVIDENCE-BASED** — every finding cites specific evidence
+5. **CONSTRUCTIVE** — every flaw includes recommended fix
+6. **CONVERGENT** — goal is consensus, not endless disagreement
+
+## Consensus Criteria
+
+| Condition | Required |
+|-----------|----------|
+| CRITICAL findings resolved | ALL |
+| HIGH findings resolved or accepted | ALL |
+| All reviewers rate BUILD or BUILD WITH CHANGES | YES |
+| Cross-review disagreements resolved | ALL |
+
+## Output Format
+
+```markdown
+# Agora Consensus Report
+
+## Document: [path]
+## Rounds: [N]
+## Reviewers: [list with LLM models used]
+
+## Verdict: [BUILD / BUILD WITH CHANGES / REDESIGN]
+
+## Unanimous Findings
+| # | Finding | Severity | All 3 Agree |
+|---|---------|----------|-------------|
+
+## Required Changes Before Build
+1. [change with source reviewer]
+2. ...
+
+## Accepted Risks
+- [finding accepted with justification]
+
+## Unique Contributions Per Reviewer
+| Reviewer | Findings Others Missed |
+|----------|----------------------|
+
+## Process Metrics
+- Rounds: N
+- Total findings: N
+- Cross-adopted: N
+- Severity upgrades: N
+- Severity downgrades: N
+- Disagreements raised: N
+- Disagreements resolved: N/N
+```
+
+## Configuration
+
+```yaml
+# Default settings
+agora:
+  max_rounds: unlimited       # Set --rounds to limit
+  severity_threshold: HIGH    # EXIT when no findings >= threshold
+  models:
+    - claude (opus, max effort)
+    - codex (via codex-exec skill)
+    - gemini (via gemini-exec skill)
+  review_points: 20           # Per reviewer
+  cross_review: true          # Peer-to-peer sharing
+  auto_redesign: true         # Auto-produce redesign on REDESIGN verdict
+```
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Wrong | Correct |
+|-------------|-----------|---------|
+| Single LLM review | Misses blind spots | 3+ LLMs find complementary flaws |
+| No cross-review | Reviewers don't challenge each other | Peer-to-peer sharing surfaces disagreements |
+| Accepting first BUILD | May miss edge cases | Loop until ALL agree |
+| Ignoring split decisions | Unresolved disagreements fester | Resolve every split with evidence |
+| Push for consensus too fast | Premature agreement | Let reviewers challenge freely |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ oh-my-customcode로 구동됩니다.
 | `/omcustom:improve-report` | eval-core 기반 개선 현황 리포트 |
 | `/omcustom-takeover` | 기존 에이전트/스킬에서 canonical spec 추출 |
 | `/adversarial-review` | 공격자 관점 보안 코드 리뷰 |
+| `/omcustom:agora` | Multi-LLM 적대적 합의 루프 (설계/스펙 교차 검증) |
 | `/ambiguity-gate` | 요청 모호성 분석 및 명확화 질문 (ouroboros 패턴) |
 | `/dev-review` | 코드 베스트 프랙티스 리뷰 |
 | `/dev-refactor` | 코드 리팩토링 |
@@ -152,7 +153,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (46 파일)
-|   +-- skills/                  # 스킬 (100 디렉토리)
+|   +-- skills/                  # 스킬 (101 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R021)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Each agent declares its tools, model, memory scope, and limitations in YAML fron
 
 ---
 
-### Skills (100)
+### Skills (101)
 
 | Category | Count | Includes |
 |----------|-------|----------|

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9307,7 +9307,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.76.0",
+    version: "0.76.1",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {
@@ -22248,7 +22248,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { createInterface } from "node:readline/promises";
 
-// node_modules/.bun/i18next@25.8.0+8e24a2f921b8d7be/node_modules/i18next/dist/esm/i18next.js
+// node_modules/.bun/i18next@26.0.2+8e24a2f921b8d7be/node_modules/i18next/dist/esm/i18next.js
 var isString = (obj) => typeof obj === "string";
 var defer = () => {
   let res;
@@ -22264,7 +22264,7 @@ var defer = () => {
 var makeString = (object) => {
   if (object == null)
     return "";
-  return "" + object;
+  return String(object);
 };
 var copy = (a, s, t) => {
   a.forEach((m) => {
@@ -22273,7 +22273,7 @@ var copy = (a, s, t) => {
   });
 };
 var lastOfPathSeparatorRegExp = /###/g;
-var cleanKey = (key) => key && key.indexOf("###") > -1 ? key.replace(lastOfPathSeparatorRegExp, ".") : key;
+var cleanKey = (key) => key && key.includes("###") ? key.replace(lastOfPathSeparatorRegExp, ".") : key;
 var canNotTraverseDeeper = (object) => !object || isString(object);
 var getLastOfPath = (object, path, Empty) => {
   const stack = !isString(path) ? path : path.split(".");
@@ -22404,7 +22404,7 @@ var looksLikeObjectPathRegExpCache = new RegExpCache(20);
 var looksLikeObjectPath = (key, nsSeparator, keySeparator) => {
   nsSeparator = nsSeparator || "";
   keySeparator = keySeparator || "";
-  const possibleChars = chars.filter((c) => nsSeparator.indexOf(c) < 0 && keySeparator.indexOf(c) < 0);
+  const possibleChars = chars.filter((c) => !nsSeparator.includes(c) && !keySeparator.includes(c));
   if (possibleChars.length === 0)
     return true;
   const r = looksLikeObjectPathRegExpCache.getRegExp(`(${possibleChars.map((c) => c === "?" ? "\\?" : c).join("|")})`);
@@ -22440,7 +22440,7 @@ var deepFind = (obj, path, keySeparator = ".") => {
       nextPath += tokens[j];
       next = current[nextPath];
       if (next !== undefined) {
-        if (["string", "number", "boolean"].indexOf(typeof next) > -1 && j < tokens.length - 1) {
+        if (["string", "number", "boolean"].includes(typeof next) && j < tokens.length - 1) {
           continue;
         }
         i += j - i + 1;
@@ -22451,7 +22451,7 @@ var deepFind = (obj, path, keySeparator = ".") => {
   }
   return current;
 };
-var getCleanedCode = (code) => code?.replace("_", "-");
+var getCleanedCode = (code) => code?.replace(/_/g, "-");
 var consoleLogger = {
   type: "logger",
   log(args) {
@@ -22535,6 +22535,14 @@ class EventEmitter {
     }
     this.observers[event].delete(listener);
   }
+  once(event, listener) {
+    const wrapper = (...args) => {
+      listener(...args);
+      this.off(event, wrapper);
+    };
+    this.on(event, wrapper);
+    return this;
+  }
   emit(event, ...args) {
     if (this.observers[event]) {
       const cloned = Array.from(this.observers[event].entries());
@@ -22548,7 +22556,7 @@ class EventEmitter {
       const cloned = Array.from(this.observers["*"].entries());
       cloned.forEach(([observer, numTimesAdded]) => {
         for (let i = 0;i < numTimesAdded; i++) {
-          observer.apply(observer, [event, ...args]);
+          observer(event, ...args);
         }
       });
     }
@@ -22571,7 +22579,7 @@ class ResourceStore extends EventEmitter {
     }
   }
   addNamespaces(ns) {
-    if (this.options.ns.indexOf(ns) < 0) {
+    if (!this.options.ns.includes(ns)) {
       this.options.ns.push(ns);
     }
   }
@@ -22585,7 +22593,7 @@ class ResourceStore extends EventEmitter {
     const keySeparator = options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;
     const ignoreJSONStructure = options.ignoreJSONStructure !== undefined ? options.ignoreJSONStructure : this.options.ignoreJSONStructure;
     let path;
-    if (lng.indexOf(".") > -1) {
+    if (lng.includes(".")) {
       path = lng.split(".");
     } else {
       path = [lng, ns];
@@ -22600,7 +22608,7 @@ class ResourceStore extends EventEmitter {
       }
     }
     const result = getPath(this.data, path);
-    if (!result && !ns && !key && lng.indexOf(".") > -1) {
+    if (!result && !ns && !key && lng.includes(".")) {
       lng = path[0];
       ns = path[1];
       key = path.slice(2).join(".");
@@ -22616,7 +22624,7 @@ class ResourceStore extends EventEmitter {
     let path = [lng, ns];
     if (key)
       path = path.concat(keySeparator ? key.split(keySeparator) : key);
-    if (lng.indexOf(".") > -1) {
+    if (lng.includes(".")) {
       path = lng.split(".");
       value = ns;
       ns = path[1];
@@ -22643,7 +22651,7 @@ class ResourceStore extends EventEmitter {
     skipCopy: false
   }) {
     let path = [lng, ns];
-    if (lng.indexOf(".") > -1) {
+    if (lng.includes(".")) {
       path = lng.split(".");
       deep = resources;
       resources = ns;
@@ -22723,9 +22731,17 @@ function keysFromSelector(selector, opts) {
   const {
     [PATH_KEY]: path
   } = selector(createProxy());
-  return path.join(opts?.keySeparator ?? ".");
+  const keySeparator = opts?.keySeparator ?? ".";
+  const nsSeparator = opts?.nsSeparator ?? ":";
+  if (path.length > 1 && nsSeparator) {
+    const ns = opts?.ns;
+    const nsArray = Array.isArray(ns) ? ns : null;
+    if (nsArray && nsArray.length > 1 && nsArray.slice(1).includes(path[0])) {
+      return `${path[0]}${nsSeparator}${path.slice(1).join(keySeparator)}`;
+    }
+  }
+  return path.join(keySeparator);
 }
-var checkedLoadedFor = {};
 var shouldHandleAsObject = (res) => !isString(res) && typeof res !== "boolean" && typeof res !== "number";
 
 class Translator extends EventEmitter {
@@ -22737,6 +22753,7 @@ class Translator extends EventEmitter {
       this.options.keySeparator = ".";
     }
     this.logger = baseLogger.create("translator");
+    this.checkedLoadedFor = {};
   }
   changeLanguage(lng) {
     if (lng)
@@ -22765,7 +22782,7 @@ class Translator extends EventEmitter {
       nsSeparator = ":";
     const keySeparator = opt.keySeparator !== undefined ? opt.keySeparator : this.options.keySeparator;
     let namespaces = opt.ns || this.options.defaultNS || [];
-    const wouldCheckForNsInKey = nsSeparator && key.indexOf(nsSeparator) > -1;
+    const wouldCheckForNsInKey = nsSeparator && key.includes(nsSeparator);
     const seemsNaturalLanguage = !this.options.userDefinedKeySeparator && !opt.keySeparator && !this.options.userDefinedNsSeparator && !opt.nsSeparator && !looksLikeObjectPath(key, nsSeparator, keySeparator);
     if (wouldCheckForNsInKey && !seemsNaturalLanguage) {
       const m = key.match(this.interpolator.nestingRegexp);
@@ -22776,7 +22793,7 @@ class Translator extends EventEmitter {
         };
       }
       const parts = key.split(nsSeparator);
-      if (nsSeparator !== keySeparator || nsSeparator === keySeparator && this.options.ns.indexOf(parts[0]) > -1)
+      if (nsSeparator !== keySeparator || nsSeparator === keySeparator && this.options.ns.includes(parts[0]))
         namespaces = parts.shift();
       key = parts.join(keySeparator);
     }
@@ -22807,6 +22824,10 @@ class Translator extends EventEmitter {
       });
     if (!Array.isArray(keys))
       keys = [String(keys)];
+    keys = keys.map((k) => typeof k === "function" ? keysFromSelector(k, {
+      ...this.options,
+      ...opt
+    }) : String(k));
     const returnDetails = opt.returnDetails !== undefined ? opt.returnDetails : this.options.returnDetails;
     const keySeparator = opt.keySeparator !== undefined ? opt.keySeparator : this.options.keySeparator;
     const {
@@ -22866,7 +22887,7 @@ class Translator extends EventEmitter {
     }
     const handleAsObject = shouldHandleAsObject(resForObjHndl);
     const resType = Object.prototype.toString.apply(resForObjHndl);
-    if (handleAsObjectInI18nFormat && resForObjHndl && handleAsObject && noObject.indexOf(resType) < 0 && !(isString(joinArrays) && Array.isArray(resForObjHndl))) {
+    if (handleAsObjectInI18nFormat && resForObjHndl && handleAsObject && !noObject.includes(resType) && !(isString(joinArrays) && Array.isArray(resForObjHndl))) {
       if (!opt.returnObjects && !this.options.returnObjects) {
         if (!this.options.returnedObjectHandler) {
           this.logger.warn("accessing an object - but returnObjects options is not enabled!");
@@ -22965,7 +22986,7 @@ class Translator extends EventEmitter {
           if (this.options.saveMissingPlurals && needsPluralHandling) {
             lngs.forEach((language) => {
               const suffixes = this.pluralResolver.getSuffixes(language, opt);
-              if (needsZeroSuffixLookup && opt[`defaultValue${this.options.pluralSeparator}zero`] && suffixes.indexOf(`${this.options.pluralSeparator}zero`) < 0) {
+              if (needsZeroSuffixLookup && opt[`defaultValue${this.options.pluralSeparator}zero`] && !suffixes.includes(`${this.options.pluralSeparator}zero`)) {
                 suffixes.push(`${this.options.pluralSeparator}zero`);
               }
               suffixes.forEach((suffix) => {
@@ -23064,6 +23085,11 @@ class Translator extends EventEmitter {
     let usedNS;
     if (isString(keys))
       keys = [keys];
+    if (Array.isArray(keys))
+      keys = keys.map((k) => typeof k === "function" ? keysFromSelector(k, {
+        ...this.options,
+        ...opt
+      }) : k);
     keys.forEach((k) => {
       if (this.isValidLookup(found))
         return;
@@ -23081,8 +23107,8 @@ class Translator extends EventEmitter {
         if (this.isValidLookup(found))
           return;
         usedNS = ns;
-        if (!checkedLoadedFor[`${codes[0]}-${ns}`] && this.utils?.hasLoadedNamespace && !this.utils?.hasLoadedNamespace(usedNS)) {
-          checkedLoadedFor[`${codes[0]}-${ns}`] = true;
+        if (!this.checkedLoadedFor[`${codes[0]}-${ns}`] && this.utils?.hasLoadedNamespace && !this.utils?.hasLoadedNamespace(usedNS)) {
+          this.checkedLoadedFor[`${codes[0]}-${ns}`] = true;
           this.logger.warn(`key "${usedKey}" for languages "${codes.join(", ")}" won't get resolved as namespace "${usedNS}" was not yet loaded`, "This means something IS WRONG in your setup. You access the t function before i18next.init / i18next.loadNamespace / i18next.changeLanguage was done. Wait for the callback or Promise to resolve before accessing it!!!");
         }
         codes.forEach((code) => {
@@ -23099,7 +23125,7 @@ class Translator extends EventEmitter {
             const zeroSuffix = `${this.options.pluralSeparator}zero`;
             const ordinalPrefix = `${this.options.pluralSeparator}ordinal${this.options.pluralSeparator}`;
             if (needsPluralHandling) {
-              if (opt.ordinal && pluralSuffix.indexOf(ordinalPrefix) === 0) {
+              if (opt.ordinal && pluralSuffix.startsWith(ordinalPrefix)) {
                 finalKeys.push(key + pluralSuffix.replace(ordinalPrefix, this.options.pluralSeparator));
               }
               finalKeys.push(key + pluralSuffix);
@@ -23111,7 +23137,7 @@ class Translator extends EventEmitter {
               const contextKey = `${key}${this.options.contextSeparator || "_"}${opt.context}`;
               finalKeys.push(contextKey);
               if (needsPluralHandling) {
-                if (opt.ordinal && pluralSuffix.indexOf(ordinalPrefix) === 0) {
+                if (opt.ordinal && pluralSuffix.startsWith(ordinalPrefix)) {
                   finalKeys.push(contextKey + pluralSuffix.replace(ordinalPrefix, this.options.pluralSeparator));
                 }
                 finalKeys.push(contextKey + pluralSuffix);
@@ -23173,7 +23199,7 @@ class Translator extends EventEmitter {
   static hasDefaultValue(options) {
     const prefix = "defaultValue";
     for (const option in options) {
-      if (Object.prototype.hasOwnProperty.call(options, option) && prefix === option.substring(0, prefix.length) && options[option] !== undefined) {
+      if (Object.prototype.hasOwnProperty.call(options, option) && option.startsWith(prefix) && options[option] !== undefined) {
         return true;
       }
     }
@@ -23189,7 +23215,7 @@ class LanguageUtil {
   }
   getScriptPartFromCode(code) {
     code = getCleanedCode(code);
-    if (!code || code.indexOf("-") < 0)
+    if (!code || !code.includes("-"))
       return null;
     const p = code.split("-");
     if (p.length === 2)
@@ -23201,13 +23227,13 @@ class LanguageUtil {
   }
   getLanguagePartFromCode(code) {
     code = getCleanedCode(code);
-    if (!code || code.indexOf("-") < 0)
+    if (!code || !code.includes("-"))
       return code;
     const p = code.split("-");
     return this.formatLanguageCode(p[0]);
   }
   formatLanguageCode(code) {
-    if (isString(code) && code.indexOf("-") > -1) {
+    if (isString(code) && code.includes("-")) {
       let formattedCode;
       try {
         formattedCode = Intl.getCanonicalLocales(code)[0];
@@ -23228,7 +23254,7 @@ class LanguageUtil {
     if (this.options.load === "languageOnly" || this.options.nonExplicitSupportedLngs) {
       code = this.getLanguagePartFromCode(code);
     }
-    return !this.supportedLngs || !this.supportedLngs.length || this.supportedLngs.indexOf(code) > -1;
+    return !this.supportedLngs || !this.supportedLngs.length || this.supportedLngs.includes(code);
   }
   getBestMatchFromCodes(codes) {
     if (!codes)
@@ -23253,13 +23279,14 @@ class LanguageUtil {
           return found = lngOnly;
         found = this.options.supportedLngs.find((supportedLng) => {
           if (supportedLng === lngOnly)
-            return supportedLng;
-          if (supportedLng.indexOf("-") < 0 && lngOnly.indexOf("-") < 0)
-            return;
-          if (supportedLng.indexOf("-") > 0 && lngOnly.indexOf("-") < 0 && supportedLng.substring(0, supportedLng.indexOf("-")) === lngOnly)
-            return supportedLng;
-          if (supportedLng.indexOf(lngOnly) === 0 && lngOnly.length > 1)
-            return supportedLng;
+            return true;
+          if (!supportedLng.includes("-") && !lngOnly.includes("-"))
+            return false;
+          if (supportedLng.includes("-") && !lngOnly.includes("-") && supportedLng.slice(0, supportedLng.indexOf("-")) === lngOnly)
+            return true;
+          if (supportedLng.startsWith(lngOnly) && lngOnly.length > 1)
+            return true;
+          return false;
         });
       });
     }
@@ -23301,7 +23328,7 @@ class LanguageUtil {
         this.logger.warn(`rejecting language code not found in supportedLngs: ${c}`);
       }
     };
-    if (isString(code) && (code.indexOf("-") > -1 || code.indexOf("_") > -1)) {
+    if (isString(code) && (code.includes("-") || code.includes("_"))) {
       if (this.options.load !== "languageOnly")
         addCode(this.formatLanguageCode(code));
       if (this.options.load !== "languageOnly" && this.options.load !== "currentOnly")
@@ -23312,7 +23339,7 @@ class LanguageUtil {
       addCode(this.formatLanguageCode(code));
     }
     fallbackCodes.forEach((fc) => {
-      if (codes.indexOf(fc) < 0)
+      if (!codes.includes(fc))
         addCode(this.formatLanguageCode(fc));
     });
     return codes;
@@ -23359,7 +23386,7 @@ class PluralResolver {
         type
       });
     } catch (err) {
-      if (!Intl) {
+      if (typeof Intl === "undefined") {
         this.logger.error("No Intl support, please use an Intl polyfill!");
         return dummyRule;
       }
@@ -23476,7 +23503,7 @@ class Interpolator {
     let replaces;
     const defaultData = this.options && this.options.interpolation && this.options.interpolation.defaultVariables || {};
     const handleFormat = (key) => {
-      if (key.indexOf(this.formatSeparator) < 0) {
+      if (!key.includes(this.formatSeparator)) {
         const path = deepFindWithDefaults(data, defaultData, key, this.options.keySeparator, this.options.ignoreJSONStructure);
         return this.alwaysFormat ? this.format(path, undefined, lng, {
           ...options,
@@ -23546,15 +23573,15 @@ class Interpolator {
     let clonedOptions;
     const handleHasOptions = (key, inheritedOptions) => {
       const sep = this.nestingOptionsSeparator;
-      if (key.indexOf(sep) < 0)
+      if (!key.includes(sep))
         return key;
-      const c = key.split(new RegExp(`${sep}[ ]*{`));
+      const c = key.split(new RegExp(`${regexEscape(sep)}[ ]*{`));
       let optionsString = `{${c[1]}`;
       key = c[0];
       optionsString = this.interpolate(optionsString, clonedOptions);
       const matchedSingleQuotes = optionsString.match(/'/g);
       const matchedDoubleQuotes = optionsString.match(/"/g);
-      if ((matchedSingleQuotes?.length ?? 0) % 2 === 0 && !matchedDoubleQuotes || matchedDoubleQuotes.length % 2 !== 0) {
+      if ((matchedSingleQuotes?.length ?? 0) % 2 === 0 && !matchedDoubleQuotes || (matchedDoubleQuotes?.length ?? 0) % 2 !== 0) {
         optionsString = optionsString.replace(/'/g, '"');
       }
       try {
@@ -23568,7 +23595,7 @@ class Interpolator {
         this.logger.warn(`failed parsing options string in nesting for key ${key}`, e);
         return `${key}${sep}${optionsString}`;
       }
-      if (clonedOptions.defaultValue && clonedOptions.defaultValue.indexOf(this.prefix) > -1)
+      if (clonedOptions.defaultValue && clonedOptions.defaultValue.includes(this.prefix))
         delete clonedOptions.defaultValue;
       return key;
     };
@@ -23609,14 +23636,14 @@ class Interpolator {
 var parseFormatStr = (formatStr) => {
   let formatName = formatStr.toLowerCase().trim();
   const formatOptions = {};
-  if (formatStr.indexOf("(") > -1) {
+  if (formatStr.includes("(")) {
     const p = formatStr.split("(");
     formatName = p[0].toLowerCase().trim();
-    const optStr = p[1].substring(0, p[1].length - 1);
-    if (formatName === "currency" && optStr.indexOf(":") < 0) {
+    const optStr = p[1].slice(0, -1);
+    if (formatName === "currency" && !optStr.includes(":")) {
       if (!formatOptions.currency)
         formatOptions.currency = optStr.trim();
-    } else if (formatName === "relativetime" && optStr.indexOf(":") < 0) {
+    } else if (formatName === "relativetime" && !optStr.includes(":")) {
       if (!formatOptions.range)
         formatOptions.range = optStr.trim();
     } else {
@@ -23716,9 +23743,13 @@ class Formatter {
     this.formats[name.toLowerCase().trim()] = createCachedFormatter(fc);
   }
   format(value, format, lng, options = {}) {
+    if (!format)
+      return value;
+    if (value == null)
+      return value;
     const formats = format.split(this.formatSeparator);
-    if (formats.length > 1 && formats[0].indexOf("(") > 1 && formats[0].indexOf(")") < 0 && formats.find((f) => f.indexOf(")") > -1)) {
-      const lastIndex = formats.findIndex((f) => f.indexOf(")") > -1);
+    if (formats.length > 1 && formats[0].indexOf("(") > 1 && !formats[0].includes(")") && formats.find((f) => f.includes(")"))) {
+      const lastIndex = formats.findIndex((f) => f.includes(")"));
       formats[0] = [formats[0], ...formats.splice(1, lastIndex)].join(this.formatSeparator);
     }
     const result = formats.reduce((mem, f) => {
@@ -23885,7 +23916,7 @@ class Connector extends EventEmitter {
       }
       if (err && data && tried < this.maxRetries) {
         setTimeout(() => {
-          this.read.call(this, lng, ns, fcName, tried + 1, wait * 2, callback);
+          this.read(lng, ns, fcName, tried + 1, wait * 2, callback);
         }, wait);
         return;
       }
@@ -23995,7 +24026,6 @@ var get = () => ({
   nonExplicitSupportedLngs: false,
   load: "all",
   preload: false,
-  simplifyPluralSuffix: true,
   keySeparator: ".",
   nsSeparator: ":",
   pluralSeparator: "_",
@@ -24035,7 +24065,6 @@ var get = () => ({
   },
   interpolation: {
     escapeValue: true,
-    format: (value) => value,
     prefix: "{{",
     suffix: "}}",
     formatSeparator: ",",
@@ -24055,11 +24084,9 @@ var transformOptions = (options) => {
     options.fallbackLng = [options.fallbackLng];
   if (isString(options.fallbackNS))
     options.fallbackNS = [options.fallbackNS];
-  if (options.supportedLngs?.indexOf?.("cimode") < 0) {
+  if (options.supportedLngs && !options.supportedLngs.includes("cimode")) {
     options.supportedLngs = options.supportedLngs.concat(["cimode"]);
   }
-  if (typeof options.initImmediate === "boolean")
-    options.initAsync = options.initImmediate;
   return options;
 };
 var noop = () => {};
@@ -24101,7 +24128,7 @@ class I18n extends EventEmitter {
     if (options.defaultNS == null && options.ns) {
       if (isString(options.ns)) {
         options.defaultNS = options.ns;
-      } else if (options.ns.indexOf("translation") < 0) {
+      } else if (!options.ns.includes("translation")) {
         options.defaultNS = options.ns[0];
       }
     }
@@ -24123,10 +24150,6 @@ class I18n extends EventEmitter {
     }
     if (typeof this.options.overloadTranslationOptionHandler !== "function") {
       this.options.overloadTranslationOptionHandler = defOpts.overloadTranslationOptionHandler;
-    }
-    if (this.options.debug === true) {
-      if (typeof console !== "undefined")
-        console.warn("i18next is maintained with support from locize.com — consider powering your project with managed localization (AI, CDN, integrations): https://locize.com");
     }
     const createClassOnDemand = (ClassOrObject) => {
       if (!ClassOrObject)
@@ -24154,14 +24177,9 @@ class I18n extends EventEmitter {
       s.resourceStore = this.store;
       s.languageUtils = lu;
       s.pluralResolver = new PluralResolver(lu, {
-        prepend: this.options.pluralSeparator,
-        simplifyPluralSuffix: this.options.simplifyPluralSuffix
+        prepend: this.options.pluralSeparator
       });
-      const usingLegacyFormatFunction = this.options.interpolation.format && this.options.interpolation.format !== defOpts.interpolation.format;
-      if (usingLegacyFormatFunction) {
-        this.logger.deprecate(`init: you are still using the legacy format function, please use the new approach: https://www.i18next.com/translation-function/formatting`);
-      }
-      if (formatter && (!this.options.interpolation.format || this.options.interpolation.format === defOpts.interpolation.format)) {
+      if (formatter) {
         s.formatter = createClassOnDemand(formatter);
         if (s.formatter.init)
           s.formatter.init(s, this.options);
@@ -24258,7 +24276,7 @@ class I18n extends EventEmitter {
         lngs.forEach((l) => {
           if (l === "cimode")
             return;
-          if (toLoad.indexOf(l) < 0)
+          if (!toLoad.includes(l))
             toLoad.push(l);
         });
       };
@@ -24331,18 +24349,18 @@ class I18n extends EventEmitter {
   setResolvedLanguage(l) {
     if (!l || !this.languages)
       return;
-    if (["cimode", "dev"].indexOf(l) > -1)
+    if (["cimode", "dev"].includes(l))
       return;
     for (let li = 0;li < this.languages.length; li++) {
       const lngInLngs = this.languages[li];
-      if (["cimode", "dev"].indexOf(lngInLngs) > -1)
+      if (["cimode", "dev"].includes(lngInLngs))
         continue;
       if (this.store.hasLanguageSomeTranslations(lngInLngs)) {
         this.resolvedLanguage = lngInLngs;
         break;
       }
     }
-    if (!this.resolvedLanguage && this.languages.indexOf(l) < 0 && this.store.hasLanguageSomeTranslations(l)) {
+    if (!this.resolvedLanguage && !this.languages.includes(l) && this.store.hasLanguageSomeTranslations(l)) {
       this.resolvedLanguage = l;
       this.languages.unshift(l);
     }
@@ -24418,23 +24436,23 @@ class I18n extends EventEmitter {
       o.ns = o.ns || fixedT.ns;
       if (o.keyPrefix !== "")
         o.keyPrefix = o.keyPrefix || keyPrefix || fixedT.keyPrefix;
+      const selectorOpts = {
+        ...this.options,
+        ...o
+      };
+      if (typeof o.keyPrefix === "function")
+        o.keyPrefix = keysFromSelector(o.keyPrefix, selectorOpts);
       const keySeparator = this.options.keySeparator || ".";
       let resultKey;
       if (o.keyPrefix && Array.isArray(key)) {
         resultKey = key.map((k) => {
           if (typeof k === "function")
-            k = keysFromSelector(k, {
-              ...this.options,
-              ...opts
-            });
+            k = keysFromSelector(k, selectorOpts);
           return `${o.keyPrefix}${keySeparator}${k}`;
         });
       } else {
         if (typeof key === "function")
-          key = keysFromSelector(key, {
-            ...this.options,
-            ...opts
-          });
+          key = keysFromSelector(key, selectorOpts);
         resultKey = o.keyPrefix ? `${o.keyPrefix}${keySeparator}${key}` : key;
       }
       return this.t(resultKey, o);
@@ -24498,7 +24516,7 @@ class I18n extends EventEmitter {
     if (isString(ns))
       ns = [ns];
     ns.forEach((n) => {
-      if (this.options.ns.indexOf(n) < 0)
+      if (!this.options.ns.includes(n))
         this.options.ns.push(n);
     });
     this.loadResources((err) => {
@@ -24513,7 +24531,7 @@ class I18n extends EventEmitter {
     if (isString(lngs))
       lngs = [lngs];
     const preloaded = this.options.preload || [];
-    const newLngs = lngs.filter((lng) => preloaded.indexOf(lng) < 0 && this.services.languageUtils.isSupportedCode(lng));
+    const newLngs = lngs.filter((lng) => !preloaded.includes(lng) && this.services.languageUtils.isSupportedCode(lng));
     if (!newLngs.length) {
       if (callback)
         callback();
@@ -24544,7 +24562,7 @@ class I18n extends EventEmitter {
     const languageUtils = this.services?.languageUtils || new LanguageUtil(get());
     if (lng.toLowerCase().indexOf("-latn") > 1)
       return "ltr";
-    return rtlLngs.indexOf(languageUtils.getLanguagePartFromCode(lng)) > -1 || lng.toLowerCase().indexOf("-arab") > 1 ? "rtl" : "ltr";
+    return rtlLngs.includes(languageUtils.getLanguagePartFromCode(lng)) || lng.toLowerCase().indexOf("-arab") > 1 ? "rtl" : "ltr";
   }
   static createInstance(options = {}, callback) {
     const instance = new I18n(options, callback);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1831,7 +1831,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.76.0",
+  version: "0.76.1",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {
@@ -1916,7 +1916,7 @@ var package_default = {
   }
 };
 
-// node_modules/.bun/i18next@25.8.0+8e24a2f921b8d7be/node_modules/i18next/dist/esm/i18next.js
+// node_modules/.bun/i18next@26.0.2+8e24a2f921b8d7be/node_modules/i18next/dist/esm/i18next.js
 var isString = (obj) => typeof obj === "string";
 var defer = () => {
   let res;
@@ -1932,7 +1932,7 @@ var defer = () => {
 var makeString = (object) => {
   if (object == null)
     return "";
-  return "" + object;
+  return String(object);
 };
 var copy = (a, s, t) => {
   a.forEach((m) => {
@@ -1941,7 +1941,7 @@ var copy = (a, s, t) => {
   });
 };
 var lastOfPathSeparatorRegExp = /###/g;
-var cleanKey = (key) => key && key.indexOf("###") > -1 ? key.replace(lastOfPathSeparatorRegExp, ".") : key;
+var cleanKey = (key) => key && key.includes("###") ? key.replace(lastOfPathSeparatorRegExp, ".") : key;
 var canNotTraverseDeeper = (object) => !object || isString(object);
 var getLastOfPath = (object, path, Empty) => {
   const stack = !isString(path) ? path : path.split(".");
@@ -2072,7 +2072,7 @@ var looksLikeObjectPathRegExpCache = new RegExpCache(20);
 var looksLikeObjectPath = (key, nsSeparator, keySeparator) => {
   nsSeparator = nsSeparator || "";
   keySeparator = keySeparator || "";
-  const possibleChars = chars.filter((c) => nsSeparator.indexOf(c) < 0 && keySeparator.indexOf(c) < 0);
+  const possibleChars = chars.filter((c) => !nsSeparator.includes(c) && !keySeparator.includes(c));
   if (possibleChars.length === 0)
     return true;
   const r = looksLikeObjectPathRegExpCache.getRegExp(`(${possibleChars.map((c) => c === "?" ? "\\?" : c).join("|")})`);
@@ -2108,7 +2108,7 @@ var deepFind = (obj, path, keySeparator = ".") => {
       nextPath += tokens[j];
       next = current[nextPath];
       if (next !== undefined) {
-        if (["string", "number", "boolean"].indexOf(typeof next) > -1 && j < tokens.length - 1) {
+        if (["string", "number", "boolean"].includes(typeof next) && j < tokens.length - 1) {
           continue;
         }
         i += j - i + 1;
@@ -2119,7 +2119,7 @@ var deepFind = (obj, path, keySeparator = ".") => {
   }
   return current;
 };
-var getCleanedCode = (code) => code?.replace("_", "-");
+var getCleanedCode = (code) => code?.replace(/_/g, "-");
 var consoleLogger = {
   type: "logger",
   log(args) {
@@ -2203,6 +2203,14 @@ class EventEmitter {
     }
     this.observers[event].delete(listener);
   }
+  once(event, listener) {
+    const wrapper = (...args) => {
+      listener(...args);
+      this.off(event, wrapper);
+    };
+    this.on(event, wrapper);
+    return this;
+  }
   emit(event, ...args) {
     if (this.observers[event]) {
       const cloned = Array.from(this.observers[event].entries());
@@ -2216,7 +2224,7 @@ class EventEmitter {
       const cloned = Array.from(this.observers["*"].entries());
       cloned.forEach(([observer, numTimesAdded]) => {
         for (let i = 0;i < numTimesAdded; i++) {
-          observer.apply(observer, [event, ...args]);
+          observer(event, ...args);
         }
       });
     }
@@ -2239,7 +2247,7 @@ class ResourceStore extends EventEmitter {
     }
   }
   addNamespaces(ns) {
-    if (this.options.ns.indexOf(ns) < 0) {
+    if (!this.options.ns.includes(ns)) {
       this.options.ns.push(ns);
     }
   }
@@ -2253,7 +2261,7 @@ class ResourceStore extends EventEmitter {
     const keySeparator = options.keySeparator !== undefined ? options.keySeparator : this.options.keySeparator;
     const ignoreJSONStructure = options.ignoreJSONStructure !== undefined ? options.ignoreJSONStructure : this.options.ignoreJSONStructure;
     let path;
-    if (lng.indexOf(".") > -1) {
+    if (lng.includes(".")) {
       path = lng.split(".");
     } else {
       path = [lng, ns];
@@ -2268,7 +2276,7 @@ class ResourceStore extends EventEmitter {
       }
     }
     const result = getPath(this.data, path);
-    if (!result && !ns && !key && lng.indexOf(".") > -1) {
+    if (!result && !ns && !key && lng.includes(".")) {
       lng = path[0];
       ns = path[1];
       key = path.slice(2).join(".");
@@ -2284,7 +2292,7 @@ class ResourceStore extends EventEmitter {
     let path = [lng, ns];
     if (key)
       path = path.concat(keySeparator ? key.split(keySeparator) : key);
-    if (lng.indexOf(".") > -1) {
+    if (lng.includes(".")) {
       path = lng.split(".");
       value = ns;
       ns = path[1];
@@ -2311,7 +2319,7 @@ class ResourceStore extends EventEmitter {
     skipCopy: false
   }) {
     let path = [lng, ns];
-    if (lng.indexOf(".") > -1) {
+    if (lng.includes(".")) {
       path = lng.split(".");
       deep = resources;
       resources = ns;
@@ -2391,9 +2399,17 @@ function keysFromSelector(selector, opts) {
   const {
     [PATH_KEY]: path
   } = selector(createProxy());
-  return path.join(opts?.keySeparator ?? ".");
+  const keySeparator = opts?.keySeparator ?? ".";
+  const nsSeparator = opts?.nsSeparator ?? ":";
+  if (path.length > 1 && nsSeparator) {
+    const ns = opts?.ns;
+    const nsArray = Array.isArray(ns) ? ns : null;
+    if (nsArray && nsArray.length > 1 && nsArray.slice(1).includes(path[0])) {
+      return `${path[0]}${nsSeparator}${path.slice(1).join(keySeparator)}`;
+    }
+  }
+  return path.join(keySeparator);
 }
-var checkedLoadedFor = {};
 var shouldHandleAsObject = (res) => !isString(res) && typeof res !== "boolean" && typeof res !== "number";
 
 class Translator extends EventEmitter {
@@ -2405,6 +2421,7 @@ class Translator extends EventEmitter {
       this.options.keySeparator = ".";
     }
     this.logger = baseLogger.create("translator");
+    this.checkedLoadedFor = {};
   }
   changeLanguage(lng) {
     if (lng)
@@ -2433,7 +2450,7 @@ class Translator extends EventEmitter {
       nsSeparator = ":";
     const keySeparator = opt.keySeparator !== undefined ? opt.keySeparator : this.options.keySeparator;
     let namespaces = opt.ns || this.options.defaultNS || [];
-    const wouldCheckForNsInKey = nsSeparator && key.indexOf(nsSeparator) > -1;
+    const wouldCheckForNsInKey = nsSeparator && key.includes(nsSeparator);
     const seemsNaturalLanguage = !this.options.userDefinedKeySeparator && !opt.keySeparator && !this.options.userDefinedNsSeparator && !opt.nsSeparator && !looksLikeObjectPath(key, nsSeparator, keySeparator);
     if (wouldCheckForNsInKey && !seemsNaturalLanguage) {
       const m = key.match(this.interpolator.nestingRegexp);
@@ -2444,7 +2461,7 @@ class Translator extends EventEmitter {
         };
       }
       const parts = key.split(nsSeparator);
-      if (nsSeparator !== keySeparator || nsSeparator === keySeparator && this.options.ns.indexOf(parts[0]) > -1)
+      if (nsSeparator !== keySeparator || nsSeparator === keySeparator && this.options.ns.includes(parts[0]))
         namespaces = parts.shift();
       key = parts.join(keySeparator);
     }
@@ -2475,6 +2492,10 @@ class Translator extends EventEmitter {
       });
     if (!Array.isArray(keys))
       keys = [String(keys)];
+    keys = keys.map((k) => typeof k === "function" ? keysFromSelector(k, {
+      ...this.options,
+      ...opt
+    }) : String(k));
     const returnDetails = opt.returnDetails !== undefined ? opt.returnDetails : this.options.returnDetails;
     const keySeparator = opt.keySeparator !== undefined ? opt.keySeparator : this.options.keySeparator;
     const {
@@ -2534,7 +2555,7 @@ class Translator extends EventEmitter {
     }
     const handleAsObject = shouldHandleAsObject(resForObjHndl);
     const resType = Object.prototype.toString.apply(resForObjHndl);
-    if (handleAsObjectInI18nFormat && resForObjHndl && handleAsObject && noObject.indexOf(resType) < 0 && !(isString(joinArrays) && Array.isArray(resForObjHndl))) {
+    if (handleAsObjectInI18nFormat && resForObjHndl && handleAsObject && !noObject.includes(resType) && !(isString(joinArrays) && Array.isArray(resForObjHndl))) {
       if (!opt.returnObjects && !this.options.returnObjects) {
         if (!this.options.returnedObjectHandler) {
           this.logger.warn("accessing an object - but returnObjects options is not enabled!");
@@ -2633,7 +2654,7 @@ class Translator extends EventEmitter {
           if (this.options.saveMissingPlurals && needsPluralHandling) {
             lngs.forEach((language) => {
               const suffixes = this.pluralResolver.getSuffixes(language, opt);
-              if (needsZeroSuffixLookup && opt[`defaultValue${this.options.pluralSeparator}zero`] && suffixes.indexOf(`${this.options.pluralSeparator}zero`) < 0) {
+              if (needsZeroSuffixLookup && opt[`defaultValue${this.options.pluralSeparator}zero`] && !suffixes.includes(`${this.options.pluralSeparator}zero`)) {
                 suffixes.push(`${this.options.pluralSeparator}zero`);
               }
               suffixes.forEach((suffix) => {
@@ -2732,6 +2753,11 @@ class Translator extends EventEmitter {
     let usedNS;
     if (isString(keys))
       keys = [keys];
+    if (Array.isArray(keys))
+      keys = keys.map((k) => typeof k === "function" ? keysFromSelector(k, {
+        ...this.options,
+        ...opt
+      }) : k);
     keys.forEach((k) => {
       if (this.isValidLookup(found))
         return;
@@ -2749,8 +2775,8 @@ class Translator extends EventEmitter {
         if (this.isValidLookup(found))
           return;
         usedNS = ns;
-        if (!checkedLoadedFor[`${codes[0]}-${ns}`] && this.utils?.hasLoadedNamespace && !this.utils?.hasLoadedNamespace(usedNS)) {
-          checkedLoadedFor[`${codes[0]}-${ns}`] = true;
+        if (!this.checkedLoadedFor[`${codes[0]}-${ns}`] && this.utils?.hasLoadedNamespace && !this.utils?.hasLoadedNamespace(usedNS)) {
+          this.checkedLoadedFor[`${codes[0]}-${ns}`] = true;
           this.logger.warn(`key "${usedKey}" for languages "${codes.join(", ")}" won't get resolved as namespace "${usedNS}" was not yet loaded`, "This means something IS WRONG in your setup. You access the t function before i18next.init / i18next.loadNamespace / i18next.changeLanguage was done. Wait for the callback or Promise to resolve before accessing it!!!");
         }
         codes.forEach((code) => {
@@ -2767,7 +2793,7 @@ class Translator extends EventEmitter {
             const zeroSuffix = `${this.options.pluralSeparator}zero`;
             const ordinalPrefix = `${this.options.pluralSeparator}ordinal${this.options.pluralSeparator}`;
             if (needsPluralHandling) {
-              if (opt.ordinal && pluralSuffix.indexOf(ordinalPrefix) === 0) {
+              if (opt.ordinal && pluralSuffix.startsWith(ordinalPrefix)) {
                 finalKeys.push(key + pluralSuffix.replace(ordinalPrefix, this.options.pluralSeparator));
               }
               finalKeys.push(key + pluralSuffix);
@@ -2779,7 +2805,7 @@ class Translator extends EventEmitter {
               const contextKey = `${key}${this.options.contextSeparator || "_"}${opt.context}`;
               finalKeys.push(contextKey);
               if (needsPluralHandling) {
-                if (opt.ordinal && pluralSuffix.indexOf(ordinalPrefix) === 0) {
+                if (opt.ordinal && pluralSuffix.startsWith(ordinalPrefix)) {
                   finalKeys.push(contextKey + pluralSuffix.replace(ordinalPrefix, this.options.pluralSeparator));
                 }
                 finalKeys.push(contextKey + pluralSuffix);
@@ -2841,7 +2867,7 @@ class Translator extends EventEmitter {
   static hasDefaultValue(options) {
     const prefix = "defaultValue";
     for (const option in options) {
-      if (Object.prototype.hasOwnProperty.call(options, option) && prefix === option.substring(0, prefix.length) && options[option] !== undefined) {
+      if (Object.prototype.hasOwnProperty.call(options, option) && option.startsWith(prefix) && options[option] !== undefined) {
         return true;
       }
     }
@@ -2857,7 +2883,7 @@ class LanguageUtil {
   }
   getScriptPartFromCode(code) {
     code = getCleanedCode(code);
-    if (!code || code.indexOf("-") < 0)
+    if (!code || !code.includes("-"))
       return null;
     const p = code.split("-");
     if (p.length === 2)
@@ -2869,13 +2895,13 @@ class LanguageUtil {
   }
   getLanguagePartFromCode(code) {
     code = getCleanedCode(code);
-    if (!code || code.indexOf("-") < 0)
+    if (!code || !code.includes("-"))
       return code;
     const p = code.split("-");
     return this.formatLanguageCode(p[0]);
   }
   formatLanguageCode(code) {
-    if (isString(code) && code.indexOf("-") > -1) {
+    if (isString(code) && code.includes("-")) {
       let formattedCode;
       try {
         formattedCode = Intl.getCanonicalLocales(code)[0];
@@ -2896,7 +2922,7 @@ class LanguageUtil {
     if (this.options.load === "languageOnly" || this.options.nonExplicitSupportedLngs) {
       code = this.getLanguagePartFromCode(code);
     }
-    return !this.supportedLngs || !this.supportedLngs.length || this.supportedLngs.indexOf(code) > -1;
+    return !this.supportedLngs || !this.supportedLngs.length || this.supportedLngs.includes(code);
   }
   getBestMatchFromCodes(codes) {
     if (!codes)
@@ -2921,13 +2947,14 @@ class LanguageUtil {
           return found = lngOnly;
         found = this.options.supportedLngs.find((supportedLng) => {
           if (supportedLng === lngOnly)
-            return supportedLng;
-          if (supportedLng.indexOf("-") < 0 && lngOnly.indexOf("-") < 0)
-            return;
-          if (supportedLng.indexOf("-") > 0 && lngOnly.indexOf("-") < 0 && supportedLng.substring(0, supportedLng.indexOf("-")) === lngOnly)
-            return supportedLng;
-          if (supportedLng.indexOf(lngOnly) === 0 && lngOnly.length > 1)
-            return supportedLng;
+            return true;
+          if (!supportedLng.includes("-") && !lngOnly.includes("-"))
+            return false;
+          if (supportedLng.includes("-") && !lngOnly.includes("-") && supportedLng.slice(0, supportedLng.indexOf("-")) === lngOnly)
+            return true;
+          if (supportedLng.startsWith(lngOnly) && lngOnly.length > 1)
+            return true;
+          return false;
         });
       });
     }
@@ -2969,7 +2996,7 @@ class LanguageUtil {
         this.logger.warn(`rejecting language code not found in supportedLngs: ${c}`);
       }
     };
-    if (isString(code) && (code.indexOf("-") > -1 || code.indexOf("_") > -1)) {
+    if (isString(code) && (code.includes("-") || code.includes("_"))) {
       if (this.options.load !== "languageOnly")
         addCode(this.formatLanguageCode(code));
       if (this.options.load !== "languageOnly" && this.options.load !== "currentOnly")
@@ -2980,7 +3007,7 @@ class LanguageUtil {
       addCode(this.formatLanguageCode(code));
     }
     fallbackCodes.forEach((fc) => {
-      if (codes.indexOf(fc) < 0)
+      if (!codes.includes(fc))
         addCode(this.formatLanguageCode(fc));
     });
     return codes;
@@ -3027,7 +3054,7 @@ class PluralResolver {
         type
       });
     } catch (err) {
-      if (!Intl) {
+      if (typeof Intl === "undefined") {
         this.logger.error("No Intl support, please use an Intl polyfill!");
         return dummyRule;
       }
@@ -3144,7 +3171,7 @@ class Interpolator {
     let replaces;
     const defaultData = this.options && this.options.interpolation && this.options.interpolation.defaultVariables || {};
     const handleFormat = (key) => {
-      if (key.indexOf(this.formatSeparator) < 0) {
+      if (!key.includes(this.formatSeparator)) {
         const path = deepFindWithDefaults(data, defaultData, key, this.options.keySeparator, this.options.ignoreJSONStructure);
         return this.alwaysFormat ? this.format(path, undefined, lng, {
           ...options,
@@ -3214,15 +3241,15 @@ class Interpolator {
     let clonedOptions;
     const handleHasOptions = (key, inheritedOptions) => {
       const sep2 = this.nestingOptionsSeparator;
-      if (key.indexOf(sep2) < 0)
+      if (!key.includes(sep2))
         return key;
-      const c = key.split(new RegExp(`${sep2}[ ]*{`));
+      const c = key.split(new RegExp(`${regexEscape(sep2)}[ ]*{`));
       let optionsString = `{${c[1]}`;
       key = c[0];
       optionsString = this.interpolate(optionsString, clonedOptions);
       const matchedSingleQuotes = optionsString.match(/'/g);
       const matchedDoubleQuotes = optionsString.match(/"/g);
-      if ((matchedSingleQuotes?.length ?? 0) % 2 === 0 && !matchedDoubleQuotes || matchedDoubleQuotes.length % 2 !== 0) {
+      if ((matchedSingleQuotes?.length ?? 0) % 2 === 0 && !matchedDoubleQuotes || (matchedDoubleQuotes?.length ?? 0) % 2 !== 0) {
         optionsString = optionsString.replace(/'/g, '"');
       }
       try {
@@ -3236,7 +3263,7 @@ class Interpolator {
         this.logger.warn(`failed parsing options string in nesting for key ${key}`, e);
         return `${key}${sep2}${optionsString}`;
       }
-      if (clonedOptions.defaultValue && clonedOptions.defaultValue.indexOf(this.prefix) > -1)
+      if (clonedOptions.defaultValue && clonedOptions.defaultValue.includes(this.prefix))
         delete clonedOptions.defaultValue;
       return key;
     };
@@ -3277,14 +3304,14 @@ class Interpolator {
 var parseFormatStr = (formatStr) => {
   let formatName = formatStr.toLowerCase().trim();
   const formatOptions = {};
-  if (formatStr.indexOf("(") > -1) {
+  if (formatStr.includes("(")) {
     const p = formatStr.split("(");
     formatName = p[0].toLowerCase().trim();
-    const optStr = p[1].substring(0, p[1].length - 1);
-    if (formatName === "currency" && optStr.indexOf(":") < 0) {
+    const optStr = p[1].slice(0, -1);
+    if (formatName === "currency" && !optStr.includes(":")) {
       if (!formatOptions.currency)
         formatOptions.currency = optStr.trim();
-    } else if (formatName === "relativetime" && optStr.indexOf(":") < 0) {
+    } else if (formatName === "relativetime" && !optStr.includes(":")) {
       if (!formatOptions.range)
         formatOptions.range = optStr.trim();
     } else {
@@ -3384,9 +3411,13 @@ class Formatter {
     this.formats[name.toLowerCase().trim()] = createCachedFormatter(fc);
   }
   format(value, format, lng, options = {}) {
+    if (!format)
+      return value;
+    if (value == null)
+      return value;
     const formats = format.split(this.formatSeparator);
-    if (formats.length > 1 && formats[0].indexOf("(") > 1 && formats[0].indexOf(")") < 0 && formats.find((f) => f.indexOf(")") > -1)) {
-      const lastIndex = formats.findIndex((f) => f.indexOf(")") > -1);
+    if (formats.length > 1 && formats[0].indexOf("(") > 1 && !formats[0].includes(")") && formats.find((f) => f.includes(")"))) {
+      const lastIndex = formats.findIndex((f) => f.includes(")"));
       formats[0] = [formats[0], ...formats.splice(1, lastIndex)].join(this.formatSeparator);
     }
     const result = formats.reduce((mem, f) => {
@@ -3553,7 +3584,7 @@ class Connector extends EventEmitter {
       }
       if (err && data && tried < this.maxRetries) {
         setTimeout(() => {
-          this.read.call(this, lng, ns, fcName, tried + 1, wait * 2, callback);
+          this.read(lng, ns, fcName, tried + 1, wait * 2, callback);
         }, wait);
         return;
       }
@@ -3663,7 +3694,6 @@ var get = () => ({
   nonExplicitSupportedLngs: false,
   load: "all",
   preload: false,
-  simplifyPluralSuffix: true,
   keySeparator: ".",
   nsSeparator: ":",
   pluralSeparator: "_",
@@ -3703,7 +3733,6 @@ var get = () => ({
   },
   interpolation: {
     escapeValue: true,
-    format: (value) => value,
     prefix: "{{",
     suffix: "}}",
     formatSeparator: ",",
@@ -3723,11 +3752,9 @@ var transformOptions = (options) => {
     options.fallbackLng = [options.fallbackLng];
   if (isString(options.fallbackNS))
     options.fallbackNS = [options.fallbackNS];
-  if (options.supportedLngs?.indexOf?.("cimode") < 0) {
+  if (options.supportedLngs && !options.supportedLngs.includes("cimode")) {
     options.supportedLngs = options.supportedLngs.concat(["cimode"]);
   }
-  if (typeof options.initImmediate === "boolean")
-    options.initAsync = options.initImmediate;
   return options;
 };
 var noop = () => {};
@@ -3769,7 +3796,7 @@ class I18n extends EventEmitter {
     if (options.defaultNS == null && options.ns) {
       if (isString(options.ns)) {
         options.defaultNS = options.ns;
-      } else if (options.ns.indexOf("translation") < 0) {
+      } else if (!options.ns.includes("translation")) {
         options.defaultNS = options.ns[0];
       }
     }
@@ -3791,10 +3818,6 @@ class I18n extends EventEmitter {
     }
     if (typeof this.options.overloadTranslationOptionHandler !== "function") {
       this.options.overloadTranslationOptionHandler = defOpts.overloadTranslationOptionHandler;
-    }
-    if (this.options.debug === true) {
-      if (typeof console !== "undefined")
-        console.warn("i18next is maintained with support from locize.com — consider powering your project with managed localization (AI, CDN, integrations): https://locize.com");
     }
     const createClassOnDemand = (ClassOrObject) => {
       if (!ClassOrObject)
@@ -3822,14 +3845,9 @@ class I18n extends EventEmitter {
       s.resourceStore = this.store;
       s.languageUtils = lu;
       s.pluralResolver = new PluralResolver(lu, {
-        prepend: this.options.pluralSeparator,
-        simplifyPluralSuffix: this.options.simplifyPluralSuffix
+        prepend: this.options.pluralSeparator
       });
-      const usingLegacyFormatFunction = this.options.interpolation.format && this.options.interpolation.format !== defOpts.interpolation.format;
-      if (usingLegacyFormatFunction) {
-        this.logger.deprecate(`init: you are still using the legacy format function, please use the new approach: https://www.i18next.com/translation-function/formatting`);
-      }
-      if (formatter && (!this.options.interpolation.format || this.options.interpolation.format === defOpts.interpolation.format)) {
+      if (formatter) {
         s.formatter = createClassOnDemand(formatter);
         if (s.formatter.init)
           s.formatter.init(s, this.options);
@@ -3926,7 +3944,7 @@ class I18n extends EventEmitter {
         lngs.forEach((l) => {
           if (l === "cimode")
             return;
-          if (toLoad.indexOf(l) < 0)
+          if (!toLoad.includes(l))
             toLoad.push(l);
         });
       };
@@ -3999,18 +4017,18 @@ class I18n extends EventEmitter {
   setResolvedLanguage(l) {
     if (!l || !this.languages)
       return;
-    if (["cimode", "dev"].indexOf(l) > -1)
+    if (["cimode", "dev"].includes(l))
       return;
     for (let li = 0;li < this.languages.length; li++) {
       const lngInLngs = this.languages[li];
-      if (["cimode", "dev"].indexOf(lngInLngs) > -1)
+      if (["cimode", "dev"].includes(lngInLngs))
         continue;
       if (this.store.hasLanguageSomeTranslations(lngInLngs)) {
         this.resolvedLanguage = lngInLngs;
         break;
       }
     }
-    if (!this.resolvedLanguage && this.languages.indexOf(l) < 0 && this.store.hasLanguageSomeTranslations(l)) {
+    if (!this.resolvedLanguage && !this.languages.includes(l) && this.store.hasLanguageSomeTranslations(l)) {
       this.resolvedLanguage = l;
       this.languages.unshift(l);
     }
@@ -4086,23 +4104,23 @@ class I18n extends EventEmitter {
       o.ns = o.ns || fixedT.ns;
       if (o.keyPrefix !== "")
         o.keyPrefix = o.keyPrefix || keyPrefix || fixedT.keyPrefix;
+      const selectorOpts = {
+        ...this.options,
+        ...o
+      };
+      if (typeof o.keyPrefix === "function")
+        o.keyPrefix = keysFromSelector(o.keyPrefix, selectorOpts);
       const keySeparator = this.options.keySeparator || ".";
       let resultKey;
       if (o.keyPrefix && Array.isArray(key)) {
         resultKey = key.map((k) => {
           if (typeof k === "function")
-            k = keysFromSelector(k, {
-              ...this.options,
-              ...opts
-            });
+            k = keysFromSelector(k, selectorOpts);
           return `${o.keyPrefix}${keySeparator}${k}`;
         });
       } else {
         if (typeof key === "function")
-          key = keysFromSelector(key, {
-            ...this.options,
-            ...opts
-          });
+          key = keysFromSelector(key, selectorOpts);
         resultKey = o.keyPrefix ? `${o.keyPrefix}${keySeparator}${key}` : key;
       }
       return this.t(resultKey, o);
@@ -4166,7 +4184,7 @@ class I18n extends EventEmitter {
     if (isString(ns))
       ns = [ns];
     ns.forEach((n) => {
-      if (this.options.ns.indexOf(n) < 0)
+      if (!this.options.ns.includes(n))
         this.options.ns.push(n);
     });
     this.loadResources((err) => {
@@ -4181,7 +4199,7 @@ class I18n extends EventEmitter {
     if (isString(lngs))
       lngs = [lngs];
     const preloaded = this.options.preload || [];
-    const newLngs = lngs.filter((lng) => preloaded.indexOf(lng) < 0 && this.services.languageUtils.isSupportedCode(lng));
+    const newLngs = lngs.filter((lng) => !preloaded.includes(lng) && this.services.languageUtils.isSupportedCode(lng));
     if (!newLngs.length) {
       if (callback)
         callback();
@@ -4212,7 +4230,7 @@ class I18n extends EventEmitter {
     const languageUtils = this.services?.languageUtils || new LanguageUtil(get());
     if (lng.toLowerCase().indexOf("-latn") > 1)
       return "ltr";
-    return rtlLngs.indexOf(languageUtils.getLanguagePartFromCode(lng)) > -1 || lng.toLowerCase().indexOf("-arab") > 1 ? "rtl" : "ltr";
+    return rtlLngs.includes(languageUtils.getLanguagePartFromCode(lng)) || lng.toLowerCase().indexOf("-arab") > 1 ? "rtl" : "ltr";
   }
   static createInstance(options = {}, callback) {
     const instance = new I18n(options, callback);

--- a/docs/superpowers/plans/2026-04-06-agora-skill-internalization.md
+++ b/docs/superpowers/plans/2026-04-06-agora-skill-internalization.md
@@ -1,0 +1,451 @@
+# Agora Skill Internalization Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Internalize agora skill from baekenough-skills into oh-my-customcode as /omcustom:agora (v0.76.1)
+
+**Architecture:** Direct skill copy with source frontmatter tracking, following the established pipeline/scout internalization pattern.
+
+**Tech Stack:** Markdown, YAML frontmatter, bun (build/lockfile)
+
+---
+
+## Task 1: Create agora skill directory
+
+**Files:**
+- CREATE: `.claude/skills/agora/SKILL.md`
+- CREATE: `templates/.claude/skills/agora/SKILL.md`
+
+Both files have identical content. The content is the original `../baekenough-skills/agora/SKILL.md` with the `source:` frontmatter block already included in the frontmatter.
+
+- [ ] Create directory `.claude/skills/agora/`
+- [ ] Create directory `templates/.claude/skills/agora/`
+- [ ] Write `.claude/skills/agora/SKILL.md` with the full content below
+- [ ] Write `templates/.claude/skills/agora/SKILL.md` with identical content
+- [ ] Verify both files are identical: `diff .claude/skills/agora/SKILL.md templates/.claude/skills/agora/SKILL.md`
+
+### Full SKILL.md content (write verbatim to both paths):
+
+````markdown
+---
+name: agora
+description: "Multi-LLM adversarial consensus loop — 3+ LLMs compete to find flaws in designs/specs until unanimous agreement is reached"
+user-invocable: true
+argument-hint: "<document-path> [--rounds N] [--severity-threshold HIGH]"
+effort: max
+scope: core
+version: 1.0.0
+source:
+  type: external
+  origin: github
+  url: https://github.com/baekenough/baekenough-skills
+  version: 1.0.0
+---
+
+# Agora: Multi-LLM Adversarial Consensus
+
+3개 이상의 LLM(Claude, Codex/GPT, Gemini)이 경쟁적으로 설계/문서의 결함을 찾고, 만장일치 합의에 도달할 때까지 반복하는 적대적 교차 검증 스킬.
+
+## Prerequisites
+
+- `codex-exec` skill (Codex/GPT 호출)
+- `gemini-exec` skill (Gemini 호출)
+- Agent Teams enabled (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) or Agent tool available
+
+## Usage
+
+```
+/agora docs/design.md                          # Default: 3 LLMs, unlimited rounds
+/agora docs/design.md --rounds 10              # Max 10 rounds
+/agora docs/design.md --severity-threshold HIGH # Exit when no HIGH+ findings
+/agora docs/design.md --models claude,codex     # 2 LLMs only
+```
+
+## Workflow
+
+### Phase 1: Setup
+1. Read the target document
+2. Create Agent Team: `TeamCreate("agora-review")`
+3. Create review tasks per focus area
+
+### Phase 2: Spawn Reviewers (parallel)
+Spawn 3 reviewers as Agent Team members:
+
+```
+Agent(name: "claude-critic", model: opus, effort: max)
+  → 20-point deep adversarial review
+  
+Agent(name: "codex-critic", model: opus)
+  → Invoke Skill(codex-exec) for GPT perspective + independent Claude analysis
+  
+Agent(name: "gemini-critic", model: opus)  
+  → Invoke Skill(gemini-exec) for Gemini perspective + independent Claude analysis
+```
+
+### Phase 3: Independent Review
+Each reviewer performs adversarial review with this template:
+
+```
+For EACH review point:
+### Round N: [Topic]
+**Severity**: CRITICAL / HIGH / MEDIUM / LOW
+**Flaw**: [Specific, concrete problem description]
+**Evidence**: [Why this is real, not theoretical]
+**Impact**: [What happens if not addressed]
+**Counter-argument**: [Best case FOR the current design]
+**Verdict**: KEEP / MODIFY / REJECT
+```
+
+Review areas (adapt to document type):
+- Architecture fundamentals
+- Component/service design
+- Data architecture
+- Security & resilience
+- Feasibility & deployment
+- Testing strategy
+- Operational complexity
+
+### Phase 4: Cross-Review (Peer-to-Peer)
+Each reviewer sends findings to the other two via `SendMessage`.
+
+Counter-review template:
+1. Which findings do you **AGREE** with? (and why)
+2. Which findings do you **DISAGREE** with? (evidence-based rebuttal)
+3. What did they **MISS** that you caught?
+4. What did they catch that you **MISSED**?
+5. **SEVERITY** adjustments — upgrade or downgrade with justification
+
+### Phase 5: Synthesis
+Team lead aggregates all findings:
+
+```
+UNANIMOUS CRITICAL: [findings all 3 agreed on]
+STRONG AGREEMENT:   [findings 2/3 agreed on]
+SPLIT DECISIONS:    [findings with disagreement + resolution]
+```
+
+Determine verdict:
+- **BUILD**: No CRITICAL, no unresolved HIGH
+- **BUILD WITH CHANGES**: No CRITICAL, HIGH findings have accepted mitigations
+- **REDESIGN**: Any unresolved CRITICAL findings
+- **ABANDON**: Fundamental concept is flawed
+
+### Phase 6: Loop (if REDESIGN)
+1. Team lead produces/delegates redesign addressing ALL critical findings
+2. New version sent to ALL reviewers: `SendMessage(to: "*")`
+3. Reviewers re-review → GOTO Phase 4
+4. Repeat until EXIT criteria met
+
+### Phase 7: Exit (consensus reached)
+When ALL reviewers agree BUILD or BUILD WITH CHANGES:
+1. Produce final consensus report
+2. Write to `.claude/outputs/sessions/{date}/agora-{topic}-{time}.md`
+3. Shut down team: `SendMessage(to: "*", message: {type: "shutdown_request"})`
+
+## Reviewer Principles
+
+1. **NEUTRAL** — no reviewer has home team advantage
+2. **COMPETITIVE** — find flaws others missed
+3. **CRITICAL** — "fewer than 5 CRITICAL flaws = not looking hard enough"
+4. **EVIDENCE-BASED** — every finding cites specific evidence
+5. **CONSTRUCTIVE** — every flaw includes recommended fix
+6. **CONVERGENT** — goal is consensus, not endless disagreement
+
+## Consensus Criteria
+
+| Condition | Required |
+|-----------|----------|
+| CRITICAL findings resolved | ALL |
+| HIGH findings resolved or accepted | ALL |
+| All reviewers rate BUILD or BUILD WITH CHANGES | YES |
+| Cross-review disagreements resolved | ALL |
+
+## Output Format
+
+```markdown
+# Agora Consensus Report
+
+## Document: [path]
+## Rounds: [N]
+## Reviewers: [list with LLM models used]
+
+## Verdict: [BUILD / BUILD WITH CHANGES / REDESIGN]
+
+## Unanimous Findings
+| # | Finding | Severity | All 3 Agree |
+|---|---------|----------|-------------|
+
+## Required Changes Before Build
+1. [change with source reviewer]
+2. ...
+
+## Accepted Risks
+- [finding accepted with justification]
+
+## Unique Contributions Per Reviewer
+| Reviewer | Findings Others Missed |
+|----------|----------------------|
+
+## Process Metrics
+- Rounds: N
+- Total findings: N
+- Cross-adopted: N
+- Severity upgrades: N
+- Severity downgrades: N
+- Disagreements raised: N
+- Disagreements resolved: N/N
+```
+
+## Configuration
+
+```yaml
+# Default settings
+agora:
+  max_rounds: unlimited       # Set --rounds to limit
+  severity_threshold: HIGH    # EXIT when no findings >= threshold
+  models:
+    - claude (opus, max effort)
+    - codex (via codex-exec skill)
+    - gemini (via gemini-exec skill)
+  review_points: 20           # Per reviewer
+  cross_review: true          # Peer-to-peer sharing
+  auto_redesign: true         # Auto-produce redesign on REDESIGN verdict
+```
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Wrong | Correct |
+|-------------|-----------|---------|
+| Single LLM review | Misses blind spots | 3+ LLMs find complementary flaws |
+| No cross-review | Reviewers don't challenge each other | Peer-to-peer sharing surfaces disagreements |
+| Accepting first BUILD | May miss edge cases | Loop until ALL agree |
+| Ignoring split decisions | Unresolved disagreements fester | Resolve every split with evidence |
+| Push for consensus too fast | Premature agreement | Let reviewers challenge freely |
+````
+
+---
+
+## Task 2: Update CLAUDE.md command tables
+
+**Files:**
+- EDIT: `CLAUDE.md`
+- EDIT: `templates/CLAUDE.md`
+
+### 2a. Add command row to `CLAUDE.md`
+
+- [ ] Add `/omcustom:agora` row after `/adversarial-review` row
+
+**Edit tool parameters:**
+
+```
+file: CLAUDE.md
+old_string: | `/adversarial-review` | 공격자 관점 보안 코드 리뷰 |
+new_string: | `/adversarial-review` | 공격자 관점 보안 코드 리뷰 |
+| `/omcustom:agora` | Multi-LLM 적대적 합의 루프 (설계/스펙 교차 검증) |
+```
+
+### 2b. Add command row to `templates/CLAUDE.md`
+
+- [ ] Add `/omcustom:agora` row after `/adversarial-review` row
+
+**Edit tool parameters:**
+
+```
+file: templates/CLAUDE.md
+old_string: | `/adversarial-review` | 공격자 관점 보안 코드 리뷰 |
+new_string: | `/adversarial-review` | 공격자 관점 보안 코드 리뷰 |
+| `/omcustom:agora` | Multi-LLM 적대적 합의 루프 (설계/스펙 교차 검증) |
+```
+
+### 2c. Update skill count in `CLAUDE.md` project structure
+
+- [ ] Update skill directory count from 100 to 101
+
+**Edit tool parameters:**
+
+```
+file: CLAUDE.md
+old_string: |   +-- skills/                  # 스킬 (100 디렉토리)
+new_string: |   +-- skills/                  # 스킬 (101 디렉토리)
+```
+
+### 2d. Update skill count in `templates/CLAUDE.md` project structure
+
+- [ ] Update skill directory count from 99 to 100
+
+**Edit tool parameters:**
+
+```
+file: templates/CLAUDE.md
+old_string: |   +-- skills/                  # 스킬 (99 디렉토리)
+new_string: |   +-- skills/                  # 스킬 (100 디렉토리)
+```
+
+### 2e. Verify command tables
+
+- [ ] Run: `grep -n "omcustom:agora" CLAUDE.md templates/CLAUDE.md` — expect 2 matches
+- [ ] Run: `grep -n "스킬 (" CLAUDE.md templates/CLAUDE.md` — expect 101 and 100 respectively
+
+---
+
+## Task 3: Update manifest.json
+
+**Files:**
+- EDIT: `templates/manifest.json`
+
+Note: There is only one manifest.json at `templates/manifest.json`. No root-level manifest.json exists.
+
+### 3a. Bump version
+
+- [ ] Update version from 0.76.0 to 0.76.1
+
+**Edit tool parameters:**
+
+```
+file: templates/manifest.json
+old_string: "version": "0.76.0",
+new_string: "version": "0.76.1",
+```
+
+### 3b. Update skills count
+
+- [ ] Update skills files count from 100 to 101
+
+**Edit tool parameters:**
+
+```
+file: templates/manifest.json
+old_string: "files": 100
+new_string: "files": 101
+```
+
+Note: The `"files": 100` string appears only once in manifest.json (in the skills component block), so this edit is unambiguous.
+
+### 3c. Verify manifest.json
+
+- [ ] Run: `cat templates/manifest.json | grep -E '"version"|"files": 101'` — expect version 0.76.1 and files 101
+
+---
+
+## Task 4: Version bump and build
+
+**Files:**
+- EDIT: `package.json`
+- REGENERATE: `bun.lock`
+- REGENERATE: `dist/`
+
+### 4a. Bump package.json version
+
+- [ ] Update version from 0.76.0 to 0.76.1
+
+**Edit tool parameters:**
+
+```
+file: package.json
+old_string: "version": "0.76.0",
+new_string: "version": "0.76.1",
+```
+
+### 4b. Sync lockfile
+
+- [ ] Run: `bun install`
+- [ ] Expected: lockfile updated, exit code 0
+
+### 4c. Build dist
+
+- [ ] Run: `bun run build`
+- [ ] Expected: dist/ regenerated, exit code 0
+
+### 4d. Verify versions match
+
+- [ ] Run: `grep '"version"' package.json templates/manifest.json` — both should show 0.76.1
+
+---
+
+## Task 5: Git operations
+
+**Files:** All changes from Tasks 1-4
+
+### 5a. Create release branch
+
+- [ ] Run: `git checkout -b release/v0.76.1`
+- [ ] Expected: new branch created from current `release/v0.76.0`
+
+### 5b. Stage all changes
+
+- [ ] Run: `git add -f .claude/skills/agora/SKILL.md` (gitignored, needs -f)
+- [ ] Run: `git add templates/.claude/skills/agora/SKILL.md` (templates not gitignored)
+- [ ] Run: `git add CLAUDE.md templates/CLAUDE.md`
+- [ ] Run: `git add templates/manifest.json`
+- [ ] Run: `git add package.json bun.lock`
+- [ ] Run: `git add dist/`
+- [ ] Verify: `git status` shows all expected files staged, nothing unexpected
+
+### 5c. Commit
+
+- [ ] Run:
+```bash
+git commit -m "feat: v0.76.1 — agora multi-LLM adversarial consensus skill (#TBD)"
+```
+- [ ] Expected: commit succeeds, pre-commit hooks pass (coverage >= 98%, README counts match)
+
+### 5d. Push and create PR
+
+- [ ] Run: `git push -u origin release/v0.76.1`
+- [ ] Run:
+```bash
+gh pr create --base develop --title "feat: v0.76.1 — agora multi-LLM adversarial consensus skill" --body "$(cat <<'EOF'
+## Summary
+- Internalize agora skill from baekenough-skills into oh-my-customcode
+- agora: Multi-LLM adversarial consensus loop — 3+ LLMs (Claude, Codex/GPT, Gemini) compete to find flaws in designs/specs until unanimous agreement
+- Skills count: 100 → 101
+
+## Changes
+- NEW: `.claude/skills/agora/SKILL.md` + template mirror
+- EDIT: CLAUDE.md + templates/CLAUDE.md (command table + skill count)
+- EDIT: templates/manifest.json (version + skills count)
+- EDIT: package.json (version bump 0.76.0 → 0.76.1)
+- REBUILD: bun.lock, dist/
+
+## Test plan
+- [ ] Pre-commit hooks pass (coverage, README count sync)
+- [ ] CI 7/7 green
+- [ ] Skill count verification: `find .claude/skills -name "SKILL.md" | wc -l` = 101
+- [ ] `/omcustom:agora` appears in command listings
+EOF
+)"
+```
+- [ ] Expected: PR created, CI starts, record PR number
+
+### 5e. Post-PR
+
+- [ ] Wait for CI 7/7 green
+- [ ] Replace `#TBD` in commit message with actual issue number if applicable (or leave as-is if no issue)
+- [ ] Merge PR to develop
+- [ ] Verify auto-tag.yml creates v0.76.1 tag
+- [ ] Verify release.yml publishes npm 0.76.1
+
+---
+
+## Parallelization Notes
+
+Tasks 1, 2, 3, and 4a can execute in parallel (4 independent agents per R009):
+- Agent 1: Task 1 (create skill files)
+- Agent 2: Task 2 (update CLAUDE.md files)
+- Agent 3: Task 3 (update manifest.json)
+- Agent 4: Task 4a (bump package.json)
+
+Tasks 4b-4c (bun install, bun run build) must run after 4a completes.
+Task 5 must run after all other tasks complete.
+
+---
+
+## Estimated Duration
+
+| Task | Time |
+|------|------|
+| Tasks 1-4a (parallel) | ~2 min |
+| Tasks 4b-4c (sequential) | ~1 min |
+| Task 5 (git + PR) | ~3 min |
+| CI wait | ~5 min |
+| **Total** | **~11 min** |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.76.0",
+  "version": "0.76.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/agora/SKILL.md
+++ b/templates/.claude/skills/agora/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: agora
+description: "Multi-LLM adversarial consensus loop — 3+ LLMs compete to find flaws in designs/specs until unanimous agreement is reached"
+user-invocable: true
+argument-hint: "<document-path> [--rounds N] [--severity-threshold HIGH]"
+effort: max
+scope: core
+version: 1.0.0
+source:
+  type: external
+  origin: github
+  url: https://github.com/baekenough/baekenough-skills
+  version: 1.0.0
+---
+
+# Agora: Multi-LLM Adversarial Consensus
+
+3개 이상의 LLM(Claude, Codex/GPT, Gemini)이 경쟁적으로 설계/문서의 결함을 찾고, 만장일치 합의에 도달할 때까지 반복하는 적대적 교차 검증 스킬.
+
+## Prerequisites
+
+- `codex-exec` skill (Codex/GPT 호출)
+- `gemini-exec` skill (Gemini 호출)
+- Agent Teams enabled (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) or Agent tool available
+
+## Usage
+
+```
+/agora docs/design.md                          # Default: 3 LLMs, unlimited rounds
+/agora docs/design.md --rounds 10              # Max 10 rounds
+/agora docs/design.md --severity-threshold HIGH # Exit when no HIGH+ findings
+/agora docs/design.md --models claude,codex     # 2 LLMs only
+```
+
+## Workflow
+
+### Phase 1: Setup
+1. Read the target document
+2. Create Agent Team: `TeamCreate("agora-review")`
+3. Create review tasks per focus area
+
+### Phase 2: Spawn Reviewers (parallel)
+Spawn 3 reviewers as Agent Team members:
+
+```
+Agent(name: "claude-critic", model: opus, effort: max)
+  → 20-point deep adversarial review
+  
+Agent(name: "codex-critic", model: opus)
+  → Invoke Skill(codex-exec) for GPT perspective + independent Claude analysis
+  
+Agent(name: "gemini-critic", model: opus)  
+  → Invoke Skill(gemini-exec) for Gemini perspective + independent Claude analysis
+```
+
+### Phase 3: Independent Review
+Each reviewer performs adversarial review with this template:
+
+```
+For EACH review point:
+### Round N: [Topic]
+**Severity**: CRITICAL / HIGH / MEDIUM / LOW
+**Flaw**: [Specific, concrete problem description]
+**Evidence**: [Why this is real, not theoretical]
+**Impact**: [What happens if not addressed]
+**Counter-argument**: [Best case FOR the current design]
+**Verdict**: KEEP / MODIFY / REJECT
+```
+
+Review areas (adapt to document type):
+- Architecture fundamentals
+- Component/service design
+- Data architecture
+- Security & resilience
+- Feasibility & deployment
+- Testing strategy
+- Operational complexity
+
+### Phase 4: Cross-Review (Peer-to-Peer)
+Each reviewer sends findings to the other two via `SendMessage`.
+
+Counter-review template:
+1. Which findings do you **AGREE** with? (and why)
+2. Which findings do you **DISAGREE** with? (evidence-based rebuttal)
+3. What did they **MISS** that you caught?
+4. What did they catch that you **MISSED**?
+5. **SEVERITY** adjustments — upgrade or downgrade with justification
+
+### Phase 5: Synthesis
+Team lead aggregates all findings:
+
+```
+UNANIMOUS CRITICAL: [findings all 3 agreed on]
+STRONG AGREEMENT:   [findings 2/3 agreed on]
+SPLIT DECISIONS:    [findings with disagreement + resolution]
+```
+
+Determine verdict:
+- **BUILD**: No CRITICAL, no unresolved HIGH
+- **BUILD WITH CHANGES**: No CRITICAL, HIGH findings have accepted mitigations
+- **REDESIGN**: Any unresolved CRITICAL findings
+- **ABANDON**: Fundamental concept is flawed
+
+### Phase 6: Loop (if REDESIGN)
+1. Team lead produces/delegates redesign addressing ALL critical findings
+2. New version sent to ALL reviewers: `SendMessage(to: "*")`
+3. Reviewers re-review → GOTO Phase 4
+4. Repeat until EXIT criteria met
+
+### Phase 7: Exit (consensus reached)
+When ALL reviewers agree BUILD or BUILD WITH CHANGES:
+1. Produce final consensus report
+2. Write to `.claude/outputs/sessions/{date}/agora-{topic}-{time}.md`
+3. Shut down team: `SendMessage(to: "*", message: {type: "shutdown_request"})`
+
+## Reviewer Principles
+
+1. **NEUTRAL** — no reviewer has home team advantage
+2. **COMPETITIVE** — find flaws others missed
+3. **CRITICAL** — "fewer than 5 CRITICAL flaws = not looking hard enough"
+4. **EVIDENCE-BASED** — every finding cites specific evidence
+5. **CONSTRUCTIVE** — every flaw includes recommended fix
+6. **CONVERGENT** — goal is consensus, not endless disagreement
+
+## Consensus Criteria
+
+| Condition | Required |
+|-----------|----------|
+| CRITICAL findings resolved | ALL |
+| HIGH findings resolved or accepted | ALL |
+| All reviewers rate BUILD or BUILD WITH CHANGES | YES |
+| Cross-review disagreements resolved | ALL |
+
+## Output Format
+
+```markdown
+# Agora Consensus Report
+
+## Document: [path]
+## Rounds: [N]
+## Reviewers: [list with LLM models used]
+
+## Verdict: [BUILD / BUILD WITH CHANGES / REDESIGN]
+
+## Unanimous Findings
+| # | Finding | Severity | All 3 Agree |
+|---|---------|----------|-------------|
+
+## Required Changes Before Build
+1. [change with source reviewer]
+2. ...
+
+## Accepted Risks
+- [finding accepted with justification]
+
+## Unique Contributions Per Reviewer
+| Reviewer | Findings Others Missed |
+|----------|----------------------|
+
+## Process Metrics
+- Rounds: N
+- Total findings: N
+- Cross-adopted: N
+- Severity upgrades: N
+- Severity downgrades: N
+- Disagreements raised: N
+- Disagreements resolved: N/N
+```
+
+## Configuration
+
+```yaml
+# Default settings
+agora:
+  max_rounds: unlimited       # Set --rounds to limit
+  severity_threshold: HIGH    # EXIT when no findings >= threshold
+  models:
+    - claude (opus, max effort)
+    - codex (via codex-exec skill)
+    - gemini (via gemini-exec skill)
+  review_points: 20           # Per reviewer
+  cross_review: true          # Peer-to-peer sharing
+  auto_redesign: true         # Auto-produce redesign on REDESIGN verdict
+```
+
+## Anti-Patterns
+
+| Anti-Pattern | Why Wrong | Correct |
+|-------------|-----------|---------|
+| Single LLM review | Misses blind spots | 3+ LLMs find complementary flaws |
+| No cross-review | Reviewers don't challenge each other | Peer-to-peer sharing surfaces disagreements |
+| Accepting first BUILD | May miss edge cases | Loop until ALL agree |
+| Ignoring split decisions | Unresolved disagreements fester | Resolve every split with evidence |
+| Push for consensus too fast | Premature agreement | Let reviewers challenge freely |

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -108,6 +108,7 @@ oh-my-customcode로 구동됩니다.
 | `/omcustom:improve-report` | eval-core 기반 개선 현황 리포트 |
 | `/omcustom-takeover` | 기존 에이전트/스킬에서 canonical spec 추출 |
 | `/adversarial-review` | 공격자 관점 보안 코드 리뷰 |
+| `/omcustom:agora` | Multi-LLM 적대적 합의 루프 (설계/스펙 교차 검증) |
 | `/ambiguity-gate` | 요청 모호성 분석 및 명확화 질문 (ouroboros 패턴) |
 | `/dev-review` | 코드 베스트 프랙티스 리뷰 |
 | `/dev-refactor` | 코드 리팩토링 |
@@ -151,7 +152,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (46 파일)
-|   +-- skills/                  # 스킬 (99 디렉토리)
+|   +-- skills/                  # 스킬 (100 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R021)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.76.0",
+  "version": "0.76.1",
   "lastUpdated": "2026-03-24T00:00:00.000Z",
   "components": [
     {
@@ -18,7 +18,7 @@
       "name": "skills",
       "path": ".claude/skills",
       "description": "Reusable skill modules (includes slash commands)",
-      "files": 100
+      "files": 101
     },
     {
       "name": "guides",


### PR DESCRIPTION
## Summary
- Internalize agora skill from baekenough-skills into oh-my-customcode
- agora: Multi-LLM adversarial consensus loop — 3+ LLMs (Claude, Codex/GPT, Gemini) compete to find flaws in designs/specs until unanimous agreement
- Skills count: 100 → 101

## Changes
- NEW: `.claude/skills/agora/SKILL.md` + template mirror
- EDIT: CLAUDE.md + templates/CLAUDE.md (command table + skill count)
- EDIT: README.md + templates/manifest.json (version + skills count)
- EDIT: package.json (version bump 0.76.0 → 0.76.1)
- REBUILD: dist/

## Test plan
- [ ] Pre-commit hooks pass (coverage, README count sync)
- [ ] CI 7/7 green
- [ ] Skill count verification: `find .claude/skills -name "SKILL.md" | wc -l` = 101
- [ ] `/omcustom:agora` appears in command listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)