### PR TITLE
feat: v0.78.0 — stall detection hook + task-decomposition granularity integration

### DIFF
--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -166,9 +166,13 @@
           {
             "type": "command",
             "command": "#!/bin/bash\ninput=$(cat)\nagent_type=$(echo \"$input\" | jq -r '.agent_type // \"unknown\"')\nmodel=$(echo \"$input\" | jq -r '.model // \"inherit\"')\ndesc=$(echo \"$input\" | jq -r '.description // \"\"' | head -c 40)\necho \"─── [SubagentStart] ${agent_type}:${model} | ${desc} ───\" >&2\necho \"$input\""
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/scripts/agent-start-recorder.sh"
           }
         ],
-        "description": "HUD display when a subagent starts (complements PreToolUse Agent matcher)"
+        "description": "HUD display + agent start time recording for stall detection (R009)"
       }
     ],
     "SubagentStop": [
@@ -178,6 +182,10 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/scripts/task-outcome-recorder.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/scripts/stall-detection-advisor.sh"
           },
           {
             "type": "command",

--- a/.claude/hooks/scripts/agent-start-recorder.sh
+++ b/.claude/hooks/scripts/agent-start-recorder.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+# Agent Start Recorder
+# Trigger: SubagentStart
+# Purpose: Record agent spawn time for stall detection duration calculations
+# Protocol: stdin JSON -> record start time -> stdout pass-through, exit 0 always (R021 advisory)
+
+command -v jq >/dev/null 2>&1 || { cat; exit 0; }
+
+input=$(cat)
+
+agent_type=$(echo "$input" | jq -r '.agent_type // "unknown"')
+model=$(echo "$input" | jq -r '.model // "inherit"')
+description=$(echo "$input" | jq -r '.description // ""' | head -c 80)
+
+AGENT_START_FILE="/tmp/.claude-agent-starts-${PPID}"
+
+timestamp=$(date +%s)
+
+entry=$(jq -cn \
+  --arg ts "$timestamp" \
+  --arg agent "$agent_type" \
+  --arg model "$model" \
+  --arg desc "$description" \
+  '{start_epoch: $ts, agent_type: $agent, model: $model, description: $desc}')
+
+echo "$entry" >> "$AGENT_START_FILE"
+
+# Ring buffer: 50 max
+if [ -f "$AGENT_START_FILE" ]; then
+  line_count=$(wc -l < "$AGENT_START_FILE" | tr -d ' ')
+  if [ "$line_count" -gt 50 ]; then
+    tail -50 "$AGENT_START_FILE" > "${AGENT_START_FILE}.tmp"
+    mv "${AGENT_START_FILE}.tmp" "$AGENT_START_FILE"
+  fi
+fi
+
+echo "$input"
+exit 0

--- a/.claude/hooks/scripts/stall-detection-advisor.sh
+++ b/.claude/hooks/scripts/stall-detection-advisor.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+set -euo pipefail
+
+# Stall Detection Advisor
+# Trigger: SubagentStop
+# Purpose: Detect stalled parallel agents and advise adaptive splitting (R009)
+# Protocol: stdin JSON -> analyze durations -> stderr advisory, stdout pass-through, exit 0 always (R021)
+
+# ORDERING: This hook MUST run AFTER task-outcome-recorder.sh in hooks.json SubagentStop array.
+# Reason: This script removes consumed entries from AGENT_START_FILE; task-outcome-recorder reads them first.
+
+command -v jq >/dev/null 2>&1 || { cat; exit 0; }
+
+input=$(cat)
+
+AGENT_START_FILE="/tmp/.claude-agent-starts-${PPID}"
+DURATION_FILE="/tmp/.claude-agent-durations-${PPID}"
+
+# Skip if no start records exist
+[ -f "$AGENT_START_FILE" ] || { echo "$input"; exit 0; }
+
+# --- 1. Extract completed agent info ---
+agent_type=$(echo "$input" | jq -r '.agent_type // "unknown"')
+model=$(echo "$input" | jq -r '.model // "inherit"')
+description=$(echo "$input" | jq -r '.description // ""' | head -c 80)
+
+# --- 2. Calculate duration from start record ---
+start_epoch=$(grep -F "\"agent_type\":\"${agent_type}\"" "$AGENT_START_FILE" 2>/dev/null | tail -1 | jq -r '.start_epoch // "0"' 2>/dev/null || echo "0")
+
+if [ "$start_epoch" = "0" ] || [ "$start_epoch" = "null" ]; then
+  echo "$input"
+  exit 0
+fi
+
+now_epoch=$(date +%s)
+duration_seconds=$((now_epoch - start_epoch))
+
+# Guard against negative duration (NTP adjustment, clock skew)
+if [ "$duration_seconds" -lt 0 ]; then duration_seconds=0; fi
+
+# --- 3. Stall detection (BEFORE recording this agent's duration, so self is excluded from average) ---
+# Need at least 1 completed peer to calculate average
+if [ -f "$DURATION_FILE" ]; then
+  completed_count=$(wc -l < "$DURATION_FILE" | tr -d ' ')
+else
+  completed_count=0
+fi
+
+if [ "$completed_count" -ge 1 ]; then
+  # Calculate average duration of completed agents (null-safe)
+  avg_duration=$(jq -s '[.[].duration_seconds | numbers] | if length == 0 then 0 else add / length | floor end' "$DURATION_FILE" 2>/dev/null || echo "0")
+
+  if [ "$avg_duration" -gt 0 ]; then
+    stall_threshold=$((avg_duration * 2))
+
+    # Check for still-running agents (in start file but not in duration file)
+    if [ -f "$AGENT_START_FILE" ] && [ -s "$AGENT_START_FILE" ]; then
+      while IFS= read -r line; do
+        running_agent=$(echo "$line" | jq -r '.agent_type // ""' 2>/dev/null || true)
+        running_start=$(echo "$line" | jq -r '.start_epoch // "0"' 2>/dev/null || echo "0")
+        running_desc=$(echo "$line" | jq -r '.description // ""' 2>/dev/null || true)
+        running_model=$(echo "$line" | jq -r '.model // "inherit"' 2>/dev/null || true)
+
+        if [ "$running_start" = "0" ] || [ "$running_start" = "null" ]; then continue; fi
+
+        elapsed=$((now_epoch - running_start))
+
+        if [ "$elapsed" -gt "$stall_threshold" ]; then
+          # --- Emit advisory (stderr) ---
+          echo "" >&2
+          echo "─── [Stall Detection Advisory] ───────────────────────────" >&2
+          echo "  Stalled: ${running_agent}:${running_model} (${elapsed}s elapsed, 2x avg ${avg_duration}s)" >&2
+          echo "  Description: ${running_desc}" >&2
+          echo "  ⚡ Consider spawning independent pending tasks immediately" >&2
+          echo "  R009 Adaptive Parallel Splitting applies" >&2
+          echo "──────────────────────────────────────────────────────────" >&2
+          echo "" >&2
+        fi
+      done < "$AGENT_START_FILE"
+    fi
+  fi
+fi
+
+# --- 4. Record duration (AFTER stall detection so self is excluded from average) ---
+duration_entry=$(jq -cn \
+  --arg agent "$agent_type" \
+  --arg model "$model" \
+  --arg desc "$description" \
+  --arg dur "$duration_seconds" \
+  --arg ts "$now_epoch" \
+  '{agent_type: $agent, model: $model, description: $desc, duration_seconds: ($dur | tonumber), timestamp: $ts}')
+
+echo "$duration_entry" >> "$DURATION_FILE"
+
+# Remove only first consumed start entry (preserve siblings for parallel same-type agents)
+if [ -f "$AGENT_START_FILE" ]; then
+  awk -v pat="\"agent_type\":\"${agent_type}\"" 'found || $0 !~ pat { print; next } { found=1 }' "$AGENT_START_FILE" > "${AGENT_START_FILE}.tmp" 2>/dev/null || true
+  mv "${AGENT_START_FILE}.tmp" "$AGENT_START_FILE" 2>/dev/null || true
+fi
+
+# Ring buffer: 50 max
+if [ -f "$DURATION_FILE" ]; then
+  line_count=$(wc -l < "$DURATION_FILE" | tr -d ' ')
+  if [ "$line_count" -gt 50 ]; then
+    tail -50 "$DURATION_FILE" > "${DURATION_FILE}.tmp"
+    mv "${DURATION_FILE}.tmp" "$DURATION_FILE"
+  fi
+fi
+
+# Pass through
+echo "$input"
+exit 0

--- a/.claude/hooks/scripts/task-outcome-recorder.sh
+++ b/.claude/hooks/scripts/task-outcome-recorder.sh
@@ -67,6 +67,19 @@ else
   fi
 fi
 
+# Duration calculation from start recorder
+# ORDERING: This script MUST run BEFORE stall-detection-advisor.sh in hooks.json SubagentStop array.
+# Reason: stall-detection-advisor removes consumed entries from AGENT_START_FILE after reading.
+AGENT_START_FILE="/tmp/.claude-agent-starts-${PPID}"
+duration_seconds=0
+if [ -f "$AGENT_START_FILE" ]; then
+  start_epoch=$(grep -F "\"agent_type\":\"${agent_type}\"" "$AGENT_START_FILE" 2>/dev/null | tail -1 | jq -r '.start_epoch // "0"' 2>/dev/null || echo "0")
+  if [ "$start_epoch" != "0" ] && [ "$start_epoch" != "null" ]; then
+    now_epoch=$(date +%s)
+    duration_seconds=$((now_epoch - start_epoch))
+  fi
+fi
+
 # Append JSON line entry
 timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 entry=$(jq -n \
@@ -78,7 +91,8 @@ entry=$(jq -n \
   --arg skill "$skill_name" \
   --arg desc "$description" \
   --arg err "$error_summary" \
-  '{timestamp: $ts, agent_type: $agent, model: $model, outcome: $outcome, pattern_used: $pattern, skill: $skill, description: $desc, error_summary: $err}')
+  --arg dur "$duration_seconds" \
+  '{timestamp: $ts, agent_type: $agent, model: $model, outcome: $outcome, pattern_used: $pattern, skill: $skill, description: $desc, error_summary: $err, duration_seconds: ($dur | tonumber)}')
 
 echo "$entry" >> "$OUTCOME_FILE"
 

--- a/.claude/skills/pipeline-guards/SKILL.md
+++ b/.claude/skills/pipeline-guards/SKILL.md
@@ -176,6 +176,7 @@ Guard warnings appear inline:
 | omcustom-auto-improve | Auto-improve item count limits |
 | stuck-recovery | Guard triggers feed into stuck detection |
 | model-escalation | Repeated failures trigger escalation advisory |
+| task-decomposition | Subtask file counts validated against granularity guard thresholds |
 
 ## Override Policy
 

--- a/.claude/skills/task-decomposition/SKILL.md
+++ b/.claude/skills/task-decomposition/SKILL.md
@@ -48,6 +48,12 @@ Before decomposing, select the appropriate workflow pattern:
    ├── Map subtasks to agents (use routing skills)
    └── Generate DAG workflow spec
 
+2.5. Validate granularity against pipeline-guards limits:
+     ├── For each subtask, estimate file count
+     ├── If files > 10 → emit advisory: [Guard] ⚠ Subtask "{id}" assigned {n} files (> 10) — splitting by layer
+     ├── If files > 15 → emit hard warning: [Guard] 🛑 Subtask "{id}" assigned {n} files (> 15) — must split
+     └── Auto-split oversized subtasks by layer/domain until all ≤ 10
+
 3. Present plan to user (R015 transparency)
    ├── Show decomposed subtasks with agents
    ├── Show dependency graph
@@ -172,9 +178,42 @@ A subtask is **atomic** when it meets ALL of:
 - Single concern (one logical change)
 - Independently testable outcome
 - < 15 minutes estimated duration
-- < 3 files affected
+- < 3 files affected (ideal atomic size)
+- MUST NOT exceed 10 files (pipeline-guards advisory threshold)
+- If > 10 files unavoidable → emit [Guard] warning and split by layer/domain
+- > 15 files is a hard violation — always split further (pipeline-guards hard cap)
 
 If a subtask is not atomic → decompose further (max 2 levels deep).
+
+## Granularity Validation
+
+After decomposition, validate each subtask against pipeline-guards file limits:
+
+| Subtask Files | Action |
+|---------------|--------|
+| ≤ 3 | Ideal atomic size — no action |
+| 4-10 | Acceptable — proceed without warning |
+| 11-15 | Advisory warning, attempt further split |
+| > 15 | Hard warning, MUST split before execution |
+
+### Validation Process
+
+For each decomposed subtask:
+1. Count estimated files
+2. If > 10:
+   a. Emit: `[Guard] ⚠ Subtask "{id}" assigned {n} files (> 10) — splitting by layer`
+   b. Attempt split by: layer (domain → adapter → handler) or domain separation
+   c. Re-validate split results
+3. If > 15 after split attempt:
+   a. Emit: `[Guard] 🛑 Subtask "{id}" still has {n} files (> 15) — requires user override`
+   b. Pause for user confirmation before proceeding
+
+### Generated DAG Adjustment
+
+When granularity validation triggers a split, update the DAG spec:
+- Original node is replaced by 2+ child nodes
+- Dependencies are preserved (children inherit parent's deps)
+- `max_parallel` in config respects R009 limits (soft: 4, hard: 5)
 
 ## Skip Decomposition When
 
@@ -195,3 +234,4 @@ If a subtask is not atomic → decompose further (max 2 levels deep).
 | R010 | Decomposition happens in orchestrator only |
 | R015 | Plan displayed before execution for user approval |
 | R018 | 3+ agents in plan → check Agent Teams eligibility |
+| pipeline-guards | Validates subtask file count against 10/15 granularity limits |

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,7 +1,7 @@
 {
   "lockfileVersion": 1,
   "generatorVersion": "0.78.0",
-  "generatedAt": "2026-04-06T08:43:30.858Z",
+  "generatedAt": "2026-04-06T08:47:50.554Z",
   "templateVersion": "0.78.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.76.2",
-  "generatedAt": "2026-04-06T05:36:55.517Z",
-  "templateVersion": "0.76.2",
+  "generatorVersion": "0.78.0",
+  "generatedAt": "2026-04-06T08:43:30.858Z",
+  "templateVersion": "0.78.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",
@@ -30,8 +30,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-parallel-execution.md": {
-      "templateHash": "0c233fbb202d8018356d919ee341ef381a03dd49a6e35580565029072f0a8808",
-      "size": 3981,
+      "templateHash": "0789f7463b10384a2d63a9d35bccd9c88f7b0253cdd4bfaed86173335fa27f03",
+      "size": 5703,
       "component": "rules"
     },
     ".claude/rules/SHOULD-ecomode.md": {
@@ -880,8 +880,8 @@
       "component": "skills"
     },
     ".claude/skills/dag-orchestration/SKILL.md": {
-      "templateHash": "477fe1b67f4743cb1de8aa356e3c396781d11ca73de59f09720f8998285412da",
-      "size": 5499,
+      "templateHash": "1b3a9a2865a9756944da4a8d7a7e80a510657100d234f41ed310b6490384b9eb",
+      "size": 5847,
       "component": "skills"
     },
     ".claude/skills/codex-exec/scripts/codex-wrapper.cjs": {
@@ -935,8 +935,8 @@
       "component": "skills"
     },
     ".claude/skills/task-decomposition/SKILL.md": {
-      "templateHash": "1ea81db093867e25ebbdb096f6abf857d151dc09811c6be73f3440328cef35d2",
-      "size": 6399,
+      "templateHash": "da598dd5f57c4d20cdd1a1849e7c8a473805570931978216a2ffab3e7325f829",
+      "size": 8278,
       "component": "skills"
     },
     ".claude/skills/test-new-skill-ci-test.md": {
@@ -955,8 +955,8 @@
       "component": "skills"
     },
     ".claude/skills/pipeline-guards/SKILL.md": {
-      "templateHash": "6da89cef52a157ca0458cb12ed9b8d5795802d85d6fb42ca9a19bafe930e2432",
-      "size": 5284,
+      "templateHash": "c959d41cd627eb63bd8145eb757614134823aaf47d3fbd5eca8f20bb7d40790f",
+      "size": 6145,
       "component": "skills"
     },
     ".claude/skills/help/SKILL.md": {
@@ -1034,6 +1034,11 @@
       "size": 7463,
       "component": "hooks"
     },
+    ".claude/hooks/scripts/agent-start-recorder.sh": {
+      "templateHash": "b6d706295a97939539e67361d76cb82417b7d8dd42548f5d6d9a8908f7f72e34",
+      "size": 1125,
+      "component": "hooks"
+    },
     ".claude/hooks/scripts/file-change-validator.sh": {
       "templateHash": "85c4f67dcef49c60534fcc4c3b4f698c9f8e8830c9a8af28483abf19b785524c",
       "size": 749,
@@ -1055,8 +1060,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/task-outcome-recorder.sh": {
-      "templateHash": "5933b4e4ec5c0918cb11e032c3219f82e9550ad148689200f7dc61cd2460978b",
-      "size": 3951,
+      "templateHash": "12ff3bf4c791ba8e77b33fb574f52fbcf56f81238e2762c2640d2f4d1af3c71d",
+      "size": 4680,
       "component": "hooks"
     },
     ".claude/hooks/scripts/cwd-change-detector.sh": {
@@ -1079,14 +1084,19 @@
       "size": 3244,
       "component": "hooks"
     },
+    ".claude/hooks/scripts/stall-detection-advisor.sh": {
+      "templateHash": "7949bdaf5942700efde75bdb1d2b21d7c7ba66a1f33500216012267e7459ad30",
+      "size": 4673,
+      "component": "hooks"
+    },
     ".claude/hooks/scripts/cost-cap-advisor.sh": {
       "templateHash": "6dc04f0291fda7d2bfca05709b7a9a9b633369e90b43092f6248cb94f00e5da5",
       "size": 2506,
       "component": "hooks"
     },
     ".claude/hooks/hooks.json": {
-      "templateHash": "809d059941cb0c9231cd517fe3c9792fab8c0dff8f30bac9589426c2a47f4ea7",
-      "size": 23379,
+      "templateHash": "66abf6ec4f8131e14014890733b3ba30409656be7ac979599b98775f247f854e",
+      "size": 23640,
       "component": "hooks"
     },
     ".claude/contexts/ecomode.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -9307,7 +9307,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.76.2",
+    version: "0.78.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1831,7 +1831,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.76.2",
+  version: "0.78.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/docs/superpowers/plans/2026-04-06-v0.78.0-release.md
+++ b/docs/superpowers/plans/2026-04-06-v0.78.0-release.md
@@ -1,0 +1,28 @@
+# 릴리즈 계획 — 2026-04-06 생성
+
+> 출처: 2026-04-06 기준 `verify-done` 라벨 오픈 이슈
+> 제외된 이슈: 없음 (오픈 PR 없음)
+
+## v0.78.0 릴리즈 계획
+
+**예상 범위**: M+S | **이슈**: 2 | **병렬 가능**: 2
+
+| # | 우선순위 | 규모 | 제목 | 의존성 |
+|---|----------|------|------|--------|
+| #788 | P2 | M | feat: implement stall detection automation hook for Adaptive Parallel Splitting | 없음 |
+| #789 | P3 | S | feat: integrate task-decomposition with pipeline-guards granularity limits | 없음 |
+
+### 구현 순서
+1. #788 — Stall detection SubagentStop hook 스크립트 생성 및 hooks.json 등록 (권장 에이전트: general-purpose)
+2. #789 — task-decomposition SKILL.md에 pipeline-guards granularity 교차 참조 추가 (권장 에이전트: mgr-updater)
+
+### 참고 사항
+- 두 이슈 모두 독립적 — 병렬 구현 가능
+- #788은 새 hook 스크립트 + hooks.json 수정 필요 (advisory-only, R021 준수)
+- #789는 단일 스킬 파일 수정으로 낮은 리스크
+- 두 이슈 모두 v0.77.0 Adaptive Parallel Splitting 후속 작업
+
+## 요약
+| 릴리즈 | 이슈 수 | 규모 | P1 | P2 | P3 |
+|--------|---------|------|----|----|-----|
+| v0.78.0 | 2 | M+S | 0 | 1 | 1 |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.77.0",
+  "version": "0.78.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/hooks/hooks.json
+++ b/templates/.claude/hooks/hooks.json
@@ -166,9 +166,13 @@
           {
             "type": "command",
             "command": "#!/bin/bash\ninput=$(cat)\nagent_type=$(echo \"$input\" | jq -r '.agent_type // \"unknown\"')\nmodel=$(echo \"$input\" | jq -r '.model // \"inherit\"')\ndesc=$(echo \"$input\" | jq -r '.description // \"\"' | head -c 40)\necho \"─── [SubagentStart] ${agent_type}:${model} | ${desc} ───\" >&2\necho \"$input\""
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/scripts/agent-start-recorder.sh"
           }
         ],
-        "description": "HUD display when a subagent starts (complements PreToolUse Agent matcher)"
+        "description": "HUD display + agent start time recording for stall detection (R009)"
       }
     ],
     "SubagentStop": [
@@ -178,6 +182,10 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/scripts/task-outcome-recorder.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/scripts/stall-detection-advisor.sh"
           },
           {
             "type": "command",

--- a/templates/.claude/hooks/scripts/agent-start-recorder.sh
+++ b/templates/.claude/hooks/scripts/agent-start-recorder.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+# Agent Start Recorder
+# Trigger: SubagentStart
+# Purpose: Record agent spawn time for stall detection duration calculations
+# Protocol: stdin JSON -> record start time -> stdout pass-through, exit 0 always (R021 advisory)
+
+command -v jq >/dev/null 2>&1 || { cat; exit 0; }
+
+input=$(cat)
+
+agent_type=$(echo "$input" | jq -r '.agent_type // "unknown"')
+model=$(echo "$input" | jq -r '.model // "inherit"')
+description=$(echo "$input" | jq -r '.description // ""' | head -c 80)
+
+AGENT_START_FILE="/tmp/.claude-agent-starts-${PPID}"
+
+timestamp=$(date +%s)
+
+entry=$(jq -cn \
+  --arg ts "$timestamp" \
+  --arg agent "$agent_type" \
+  --arg model "$model" \
+  --arg desc "$description" \
+  '{start_epoch: $ts, agent_type: $agent, model: $model, description: $desc}')
+
+echo "$entry" >> "$AGENT_START_FILE"
+
+# Ring buffer: 50 max
+if [ -f "$AGENT_START_FILE" ]; then
+  line_count=$(wc -l < "$AGENT_START_FILE" | tr -d ' ')
+  if [ "$line_count" -gt 50 ]; then
+    tail -50 "$AGENT_START_FILE" > "${AGENT_START_FILE}.tmp"
+    mv "${AGENT_START_FILE}.tmp" "$AGENT_START_FILE"
+  fi
+fi
+
+echo "$input"
+exit 0

--- a/templates/.claude/hooks/scripts/stall-detection-advisor.sh
+++ b/templates/.claude/hooks/scripts/stall-detection-advisor.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+set -euo pipefail
+
+# Stall Detection Advisor
+# Trigger: SubagentStop
+# Purpose: Detect stalled parallel agents and advise adaptive splitting (R009)
+# Protocol: stdin JSON -> analyze durations -> stderr advisory, stdout pass-through, exit 0 always (R021)
+
+# ORDERING: This hook MUST run AFTER task-outcome-recorder.sh in hooks.json SubagentStop array.
+# Reason: This script removes consumed entries from AGENT_START_FILE; task-outcome-recorder reads them first.
+
+command -v jq >/dev/null 2>&1 || { cat; exit 0; }
+
+input=$(cat)
+
+AGENT_START_FILE="/tmp/.claude-agent-starts-${PPID}"
+DURATION_FILE="/tmp/.claude-agent-durations-${PPID}"
+
+# Skip if no start records exist
+[ -f "$AGENT_START_FILE" ] || { echo "$input"; exit 0; }
+
+# --- 1. Extract completed agent info ---
+agent_type=$(echo "$input" | jq -r '.agent_type // "unknown"')
+model=$(echo "$input" | jq -r '.model // "inherit"')
+description=$(echo "$input" | jq -r '.description // ""' | head -c 80)
+
+# --- 2. Calculate duration from start record ---
+start_epoch=$(grep -F "\"agent_type\":\"${agent_type}\"" "$AGENT_START_FILE" 2>/dev/null | tail -1 | jq -r '.start_epoch // "0"' 2>/dev/null || echo "0")
+
+if [ "$start_epoch" = "0" ] || [ "$start_epoch" = "null" ]; then
+  echo "$input"
+  exit 0
+fi
+
+now_epoch=$(date +%s)
+duration_seconds=$((now_epoch - start_epoch))
+
+# Guard against negative duration (NTP adjustment, clock skew)
+if [ "$duration_seconds" -lt 0 ]; then duration_seconds=0; fi
+
+# --- 3. Stall detection (BEFORE recording this agent's duration, so self is excluded from average) ---
+# Need at least 1 completed peer to calculate average
+if [ -f "$DURATION_FILE" ]; then
+  completed_count=$(wc -l < "$DURATION_FILE" | tr -d ' ')
+else
+  completed_count=0
+fi
+
+if [ "$completed_count" -ge 1 ]; then
+  # Calculate average duration of completed agents (null-safe)
+  avg_duration=$(jq -s '[.[].duration_seconds | numbers] | if length == 0 then 0 else add / length | floor end' "$DURATION_FILE" 2>/dev/null || echo "0")
+
+  if [ "$avg_duration" -gt 0 ]; then
+    stall_threshold=$((avg_duration * 2))
+
+    # Check for still-running agents (in start file but not in duration file)
+    if [ -f "$AGENT_START_FILE" ] && [ -s "$AGENT_START_FILE" ]; then
+      while IFS= read -r line; do
+        running_agent=$(echo "$line" | jq -r '.agent_type // ""' 2>/dev/null || true)
+        running_start=$(echo "$line" | jq -r '.start_epoch // "0"' 2>/dev/null || echo "0")
+        running_desc=$(echo "$line" | jq -r '.description // ""' 2>/dev/null || true)
+        running_model=$(echo "$line" | jq -r '.model // "inherit"' 2>/dev/null || true)
+
+        if [ "$running_start" = "0" ] || [ "$running_start" = "null" ]; then continue; fi
+
+        elapsed=$((now_epoch - running_start))
+
+        if [ "$elapsed" -gt "$stall_threshold" ]; then
+          # --- Emit advisory (stderr) ---
+          echo "" >&2
+          echo "─── [Stall Detection Advisory] ───────────────────────────" >&2
+          echo "  Stalled: ${running_agent}:${running_model} (${elapsed}s elapsed, 2x avg ${avg_duration}s)" >&2
+          echo "  Description: ${running_desc}" >&2
+          echo "  ⚡ Consider spawning independent pending tasks immediately" >&2
+          echo "  R009 Adaptive Parallel Splitting applies" >&2
+          echo "──────────────────────────────────────────────────────────" >&2
+          echo "" >&2
+        fi
+      done < "$AGENT_START_FILE"
+    fi
+  fi
+fi
+
+# --- 4. Record duration (AFTER stall detection so self is excluded from average) ---
+duration_entry=$(jq -cn \
+  --arg agent "$agent_type" \
+  --arg model "$model" \
+  --arg desc "$description" \
+  --arg dur "$duration_seconds" \
+  --arg ts "$now_epoch" \
+  '{agent_type: $agent, model: $model, description: $desc, duration_seconds: ($dur | tonumber), timestamp: $ts}')
+
+echo "$duration_entry" >> "$DURATION_FILE"
+
+# Remove only first consumed start entry (preserve siblings for parallel same-type agents)
+if [ -f "$AGENT_START_FILE" ]; then
+  awk -v pat="\"agent_type\":\"${agent_type}\"" 'found || $0 !~ pat { print; next } { found=1 }' "$AGENT_START_FILE" > "${AGENT_START_FILE}.tmp" 2>/dev/null || true
+  mv "${AGENT_START_FILE}.tmp" "$AGENT_START_FILE" 2>/dev/null || true
+fi
+
+# Ring buffer: 50 max
+if [ -f "$DURATION_FILE" ]; then
+  line_count=$(wc -l < "$DURATION_FILE" | tr -d ' ')
+  if [ "$line_count" -gt 50 ]; then
+    tail -50 "$DURATION_FILE" > "${DURATION_FILE}.tmp"
+    mv "${DURATION_FILE}.tmp" "$DURATION_FILE"
+  fi
+fi
+
+# Pass through
+echo "$input"
+exit 0

--- a/templates/.claude/hooks/scripts/task-outcome-recorder.sh
+++ b/templates/.claude/hooks/scripts/task-outcome-recorder.sh
@@ -67,6 +67,19 @@ else
   fi
 fi
 
+# Duration calculation from start recorder
+# ORDERING: This script MUST run BEFORE stall-detection-advisor.sh in hooks.json SubagentStop array.
+# Reason: stall-detection-advisor removes consumed entries from AGENT_START_FILE after reading.
+AGENT_START_FILE="/tmp/.claude-agent-starts-${PPID}"
+duration_seconds=0
+if [ -f "$AGENT_START_FILE" ]; then
+  start_epoch=$(grep -F "\"agent_type\":\"${agent_type}\"" "$AGENT_START_FILE" 2>/dev/null | tail -1 | jq -r '.start_epoch // "0"' 2>/dev/null || echo "0")
+  if [ "$start_epoch" != "0" ] && [ "$start_epoch" != "null" ]; then
+    now_epoch=$(date +%s)
+    duration_seconds=$((now_epoch - start_epoch))
+  fi
+fi
+
 # Append JSON line entry
 timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 entry=$(jq -n \
@@ -78,7 +91,8 @@ entry=$(jq -n \
   --arg skill "$skill_name" \
   --arg desc "$description" \
   --arg err "$error_summary" \
-  '{timestamp: $ts, agent_type: $agent, model: $model, outcome: $outcome, pattern_used: $pattern, skill: $skill, description: $desc, error_summary: $err}')
+  --arg dur "$duration_seconds" \
+  '{timestamp: $ts, agent_type: $agent, model: $model, outcome: $outcome, pattern_used: $pattern, skill: $skill, description: $desc, error_summary: $err, duration_seconds: ($dur | tonumber)}')
 
 echo "$entry" >> "$OUTCOME_FILE"
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.77.0",
+  "version": "0.78.0",
   "lastUpdated": "2026-03-24T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- Implement stall detection automation hook for Adaptive Parallel Splitting (#788)
- Integrate task-decomposition with pipeline-guards granularity limits (#789)

## Changes

### #788 — Stall Detection Hook (M/P2)
- **NEW** `.claude/hooks/scripts/agent-start-recorder.sh` — SubagentStart hook records spawn timestamps to `/tmp/.claude-agent-starts-$PPID`
- **NEW** `.claude/hooks/scripts/stall-detection-advisor.sh` — SubagentStop hook detects stalled parallel agents (2x avg duration) and emits advisory
- **MODIFIED** `.claude/hooks/hooks.json` — Registers new hooks in SubagentStart/SubagentStop arrays
- **MODIFIED** `.claude/hooks/scripts/task-outcome-recorder.sh` — Adds `duration_seconds` field from start recorder

### #789 — Task-Decomposition Granularity Integration (S/P3)
- **MODIFIED** `.claude/skills/task-decomposition/SKILL.md` — Added step 2.5 (granularity validation), Granularity Validation section, updated Atomic Task Criteria
- **MODIFIED** `.claude/skills/pipeline-guards/SKILL.md` — Added task-decomposition cross-reference

## Design Decisions
- All hooks are **advisory-only** (exit 0 always) per R021
- Duration tracking uses `date +%s` (macOS/Linux compatible)
- Agent matching uses `grep -F` (fixed-string) to avoid regex metacharacter issues
- Ring buffer capped at 50 entries per temp file
- Stall detection excludes self from average calculation

## Deep Verification
- 4 HIGH + 4 MEDIUM findings discovered and fixed during deep-verify
- 1620/1620 tests passing
- All shell scripts pass `bash -n` syntax validation
- hooks.json validates as valid JSON

## Test plan
- [ ] Verify hooks.json is valid JSON after deployment
- [ ] Verify agent-start-recorder.sh creates start file on SubagentStart
- [ ] Verify stall-detection-advisor.sh emits advisory for stalled agents
- [ ] Verify task-outcome-recorder.sh includes duration_seconds field
- [ ] Verify task-decomposition SKILL.md references pipeline-guards correctly
- [ ] Verify pipeline-guards SKILL.md references task-decomposition correctly

Closes #788, Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)