### PR TITLE
release: v0.79.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.79.2",
+  "version": "0.79.3",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -177,7 +177,7 @@ export function createProgram(): Command {
       await serveStopCommand();
     });
 
-  // omcustom projects [--format table|json|simple] [--path <dir>] [--migrate]
+  // omcustom projects [--format table|json|simple] [--path <dir>] [--migrate] [--clean]
   program
     .command('projects')
     .description('List all projects on this machine where oh-my-customcode is installed')
@@ -192,11 +192,13 @@ export function createProgram(): Command {
       '--migrate',
       'Scan for existing projects with lock files and import them into the registry'
     )
+    .option('--clean', 'Remove registry entries whose project paths no longer exist on disk')
     .action(async (options) => {
       await projectsCommand({
         format: options.format,
         paths: options.path,
         migrate: options.migrate,
+        clean: options.clean,
       });
     });
 

--- a/src/cli/projects.ts
+++ b/src/cli/projects.ts
@@ -412,7 +412,9 @@ export async function projectsCommand(options: ProjectsOptions = {}): Promise<Pr
     const { cleanRegistry } = await import('../core/registry.js');
     const removed = await cleanRegistry();
     if (removed > 0) {
-      console.log(`  정리 완료: ${removed}개 존재하지 않는 프로젝트가 레지스트리에서 제거되었습니다.`);
+      console.log(
+        `  정리 완료: ${removed}개 존재하지 않는 프로젝트가 레지스트리에서 제거되었습니다.`
+      );
     } else {
       console.log('  정리할 항목이 없습니다.');
     }

--- a/src/cli/projects.ts
+++ b/src/cli/projects.ts
@@ -68,6 +68,8 @@ export interface ProjectsOptions {
   format?: 'table' | 'json' | 'simple';
   /** Run migration from lock files to registry */
   migrate?: boolean;
+  /** Remove registry entries whose paths no longer exist */
+  clean?: boolean;
 }
 
 /**
@@ -402,6 +404,17 @@ export async function projectsCommand(options: ProjectsOptions = {}): Promise<Pr
     if (migrationError) {
       console.error('  마이그레이션 실패:', migrationError);
       return { success: false, projects: [], currentVersion, errors: [migrationError] };
+    }
+  }
+
+  // Clean mode: remove stale entries whose paths no longer exist
+  if (options.clean) {
+    const { cleanRegistry } = await import('../core/registry.js');
+    const removed = await cleanRegistry();
+    if (removed > 0) {
+      console.log(`  정리 완료: ${removed}개 존재하지 않는 프로젝트가 레지스트리에서 제거되었습니다.`);
+    } else {
+      console.log('  정리할 항목이 없습니다.');
     }
   }
 

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -144,6 +144,34 @@ export async function unregisterProject(projectPath: string): Promise<void> {
   await writeRegistry(registry);
 }
 
+/**
+ * Remove registry entries whose project paths no longer exist on disk.
+ *
+ * @returns Number of stale entries removed
+ */
+export async function cleanRegistry(): Promise<number> {
+  const { access: fsAccess } = await import('node:fs/promises');
+  const registry = await readRegistryRaw();
+  const paths = Object.keys(registry.projects);
+  let removed = 0;
+
+  for (const projectPath of paths) {
+    try {
+      await fsAccess(projectPath);
+    } catch {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete registry.projects[projectPath];
+      removed++;
+    }
+  }
+
+  if (removed > 0) {
+    await writeRegistry(registry);
+  }
+
+  return removed;
+}
+
 /** Names of directories to skip when scanning for lock files. */
 const SCAN_SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.git']);
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.79.2",
+  "version": "0.79.3",
   "lastUpdated": "2026-03-24T00:00:00.000Z",
   "components": [
     {

--- a/tests/e2e/doctor.test.ts
+++ b/tests/e2e/doctor.test.ts
@@ -8,6 +8,7 @@ import { access, mkdir, mkdtemp, readdir, rm, symlink, writeFile } from 'node:fs
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'bun';
+import { unregisterProject } from '../../src/core/registry.js';
 
 // Set 30s timeout for E2E tests (CI environments are slower)
 describe('E2E: omcustom doctor', { timeout: 30000 }, () => {
@@ -30,6 +31,7 @@ describe('E2E: omcustom doctor', { timeout: 30000 }, () => {
   afterEach(async () => {
     // Reset to a safe directory before cleanup
     process.chdir(tmpdir());
+    await unregisterProject(tempDir);
     await rm(tempDir, { recursive: true, force: true });
   });
 

--- a/tests/e2e/list.test.ts
+++ b/tests/e2e/list.test.ts
@@ -8,6 +8,7 @@ import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from 'bun';
+import { unregisterProject } from '../../src/core/registry.js';
 
 describe('E2E: omcustom list', () => {
   let tempDir: string;
@@ -29,6 +30,7 @@ describe('E2E: omcustom list', () => {
   afterEach(async () => {
     // Reset to a safe directory before cleanup
     process.chdir(tmpdir());
+    await unregisterProject(tempDir);
     await rm(tempDir, { recursive: true, force: true });
   });
 

--- a/tests/unit/core/registry.test.ts
+++ b/tests/unit/core/registry.test.ts
@@ -305,3 +305,46 @@ describe('registryToList()', () => {
     expect(list).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// cleanRegistry
+// ---------------------------------------------------------------------------
+
+describe('cleanRegistry()', () => {
+  it('removes entries whose paths do not exist on disk', async () => {
+    const { registerProject, cleanRegistry, readRegistry } = await import(
+      '../../../src/core/registry.js'
+    );
+
+    // Register two projects: one real, one non-existent
+    const realDir = await mkDir(tempRoot, 'real-project');
+    const ghostDir = join(tempRoot, 'ghost-project');
+
+    await registerProject(realDir, '0.79.0');
+    await registerProject(ghostDir, '0.79.0');
+
+    const removed = await cleanRegistry();
+
+    expect(removed).toBe(1);
+    const registry = await readRegistry();
+    expect(registry.projects[realDir]).toBeDefined();
+    expect(registry.projects[ghostDir]).toBeUndefined();
+  });
+
+  it('returns 0 when all entries are valid', async () => {
+    const { registerProject, cleanRegistry } = await import('../../../src/core/registry.js');
+
+    const realDir = await mkDir(tempRoot, 'valid-project');
+    await registerProject(realDir, '0.79.0');
+
+    const removed = await cleanRegistry();
+    expect(removed).toBe(0);
+  });
+
+  it('returns 0 on empty registry', async () => {
+    const { cleanRegistry } = await import('../../../src/core/registry.js');
+
+    const removed = await cleanRegistry();
+    expect(removed).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- fix: E2E 테스트 레지스트리 cleanup 누락으로 인한 stale 항목 대량 축적 수정
- feat: `omcustom projects --clean` 커맨드 추가 (존재하지 않는 경로 자동 정리)

## Changes
- `tests/e2e/doctor.test.ts` — afterEach에 `unregisterProject()` 추가
- `tests/e2e/list.test.ts` — afterEach에 `unregisterProject()` 추가  
- `src/core/registry.ts` — `cleanRegistry()` 함수 추가
- `src/cli/projects.ts` — `--clean` 옵션 지원
- `src/cli/index.ts` — `--clean` CLI 플래그 연결