### PR TITLE
release/v0.80.0

### DIFF
--- a/.claude/hooks/scripts/feedback-collector.sh
+++ b/.claude/hooks/scripts/feedback-collector.sh
@@ -5,19 +5,19 @@
 set -euo pipefail
 
 # Pass through stdin (Stop hook protocol)
-cat > /dev/null
+input=$(cat)
 
 # Dependencies check
-command -v jq >/dev/null 2>&1 || exit 0
-command -v sqlite3 >/dev/null 2>&1 || exit 0
+command -v jq >/dev/null 2>&1 || { echo "$input"; exit 0; }
+command -v sqlite3 >/dev/null 2>&1 || { echo "$input"; exit 0; }
 
 # PID scoping
 OUTCOMES_FILE="/tmp/.claude-task-outcomes-${PPID}"
-[ -f "$OUTCOMES_FILE" ] || exit 0
+[ -f "$OUTCOMES_FILE" ] || { echo "$input"; exit 0; }
 
 # DB path
 DB_PATH="${HOME}/.config/oh-my-customcode/eval-core.sqlite"
-[ -f "$DB_PATH" ] || exit 0
+[ -f "$DB_PATH" ] || { echo "$input"; exit 0; }
 
 # Log file for error diagnostics
 LOG_FILE="/tmp/.claude-feedback-collector-${PPID}.log"
@@ -65,7 +65,7 @@ for agent_type in "${!FAILURE_COUNTS[@]}"; do
     action_type="augment"
   fi
 
-  failure_rate=$(awk "BEGIN {printf \"%.2f\", $count/$total}")
+  failure_rate=$(awk "BEGIN {printf \"%.2f\", $count/$total}" 2>/dev/null || echo "0.00")
   description="Agent '${agent_type}' failed ${count}/${total} times (${failure_rate} failure rate) in session"
 
   escaped_agent_type=$(_sql_escape "$agent_type")
@@ -86,4 +86,7 @@ if [ "$INSERTED" -gt 0 ]; then
   echo "[feedback-collector] Extracted ${INSERTED} failure pattern(s) from session outcomes" >&2
 fi
 
+# CRITICAL: Always pass through input and exit 0
+# This hook MUST NEVER block session termination
+echo "$input"
 exit 0

--- a/.claude/hooks/scripts/skill-extractor-analyzer.sh
+++ b/.claude/hooks/scripts/skill-extractor-analyzer.sh
@@ -4,11 +4,15 @@
 
 set -euo pipefail
 
+# Pass through stdin (Stop hook protocol)
+input=$(cat)
+
 OUTCOMES_FILE="/tmp/.claude-task-outcomes-${PPID}"
 PROPOSALS_FILE="/tmp/.claude-skill-proposals-${PPID}"
 
 # Early exit if no outcomes
 if [ ! -f "$OUTCOMES_FILE" ] || [ ! -s "$OUTCOMES_FILE" ]; then
+  echo "$input"
   exit 0
 fi
 
@@ -36,7 +40,10 @@ if [ "$CANDIDATES" -gt 0 ] 2>/dev/null; then
   echo "[skill-extractor] Run /skill-extractor to review and create" >&2
 
   # Save proposal count for Stop prompt hook to pick up
-  echo "{\"candidates\": $CANDIDATES, \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$PROPOSALS_FILE"
+  echo "{\"candidates\": $CANDIDATES, \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$PROPOSALS_FILE" || true
 fi
 
+# CRITICAL: Always pass through input and exit 0
+# This hook MUST NEVER block session termination
+echo "$input"
 exit 0

--- a/.claude/rules/MUST-agent-design.md
+++ b/.claude/rules/MUST-agent-design.md
@@ -64,7 +64,7 @@ disableSkillShellExecution: true  # Disable inline shell execution in skills (v2
 
 > **Note**: When `disableSkillShellExecution` is enabled (v2.1.91+), skills that rely on inline shell execution (e.g., `codex-exec`, `gemini-exec`, `rtk-exec`) will have their shell blocks disabled. This is a security hardening option.
 
-> **Note**: `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations` are supported in Claude Code v2.1.63+. Hook types `PostCompact`, `Elicitation`, `ElicitationResult` require v2.1.76+. `CwdChanged`, `FileChanged` hook events and `managed-settings.d/` drop-in directory require v2.1.83+. Conditional `if` field for hooks requires v2.1.85+.
+> **Note**: `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations` are supported in Claude Code v2.1.63+. Hook types `PostCompact`, `Elicitation`, `ElicitationResult` require v2.1.76+. `CwdChanged`, `FileChanged` hook events and `managed-settings.d/` drop-in directory require v2.1.83+. Conditional `if` field for hooks requires v2.1.85+. `PermissionDenied` hook event requires v2.1.88+. Monitor tool and subprocess sandboxing (`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`, `CLAUDE_CODE_SCRIPT_CAPS`) added in v2.1.98+. Settings resilience (unrecognized hook event names no longer cause settings.json to be ignored) improved in v2.1.101+.
 
 ## Hook Event Types
 

--- a/.claude/rules/MUST-language-policy.md
+++ b/.claude/rules/MUST-language-policy.md
@@ -9,6 +9,7 @@
 | User communication | Korean |
 | Code, file contents, commits | English |
 | Error messages to user | Korean |
+| PR title/body, GitHub issues | Korean (default, overridable in project CLAUDE.md) |
 
 ## Delegation Model
 

--- a/.claude/rules/MUST-permissions.md
+++ b/.claude/rules/MUST-permissions.md
@@ -8,7 +8,7 @@
 |------|-------|--------|
 | 1: Always | Read, Glob, Grep, ToolSearch | Free use, read-only |
 | 2: Default | Write, Edit, NotebookEdit | State changes explicitly, notify before modifying important files |
-| 3: Context | Agent, Skill, EnterPlanMode, ExitPlanMode, EnterWorktree, ExitWorktree, LSP, TodoWrite, AskUserQuestion | Context-dependent, no user approval needed |
+| 3: Context | Agent, Skill, EnterPlanMode, ExitPlanMode, EnterWorktree, ExitWorktree, LSP, Monitor, TodoWrite, AskUserQuestion | Context-dependent, no user approval needed |
 | 4: Approval | Bash, WebFetch, WebSearch | Request user approval on first use |
 | 5: Conditional | TeamCreate, TeamDelete, SendMessage, TaskCreate, TaskGet, TaskList, TaskUpdate, TaskStop, TaskOutput | Available when Agent Teams enabled |
 | 6: MCP | ListMcpResourcesTool, ReadMcpResourceTool, CronCreate, CronDelete, CronList, RemoteTrigger | MCP/extension tools, available when servers configured |

--- a/.claude/rules/SHOULD-hud-statusline.md
+++ b/.claude/rules/SHOULD-hud-statusline.md
@@ -27,7 +27,7 @@ Format: `─── [Spawn] {subagent_type}:{model} | {description} ───` �
 
 Format: `{Cost} | {project} | {branch} | RL:{rate_limit}% {countdown} | WL:{weekly_limit}% {countdown} | CTX:{usage}%`
 
-Config in `.claude/settings.local.json`: `statusLine.type: "command"`, `statusLine.command: ".claude/statusline.sh"`. Requires CC v2.1.80+ for RL/WL segments.
+Config in `.claude/settings.local.json`: `statusLine.type: "command"`, `statusLine.command: ".claude/statusline.sh"`. Requires CC v2.1.80+ for RL/WL segments. `refreshInterval` setting (v2.1.97+): Auto-refresh interval in seconds for the status line command. Set in `statusLine.refreshInterval` in settings.json.
 
 <!-- DETAIL: Statusline configuration JSON and color coding
 ```json

--- a/docs/superpowers/plans/2026-04-11-v0.80.0-release.md
+++ b/docs/superpowers/plans/2026-04-11-v0.80.0-release.md
@@ -1,0 +1,66 @@
+# 릴리즈 계획 — 2026-04-11 생성
+
+> 출처: 2026-04-11 기준 `verify-done` 라벨 오픈 이슈
+> 제외된 이슈 (이미 오픈 PR에 포함): 없음
+
+## v0.80.0 릴리즈 계획
+
+**예상 범위**: M (XS×3 + S×3) | **이슈**: 6 | **병렬 가능**: 4
+
+| # | 우선순위 | 규모 | 제목 | 의존성 |
+|---|----------|------|------|--------|
+| #820 | P2 | XS | Stop hook fails with 'non-blocking status code: No stderr output' | 없음 |
+| #821 | P2 | XS | R000 규칙 범위 명확화 — PR/이슈 언어 정책 미포함 | 없음 |
+| #826 | P3 | XS | [Claude Code v2.1.96] Bedrock auth regression fix | 없음 |
+| #827 | P2 | S | Claude Code v2.1.97 — Focus view, refreshInterval, 보안 수정 | 없음 |
+| #828 | P2 | S | Claude Code v2.1.98 — Monitor tool, subprocess sandbox, 보안 수정 | 없음 |
+| #830 | P2 | S | Claude Code v2.1.101 — team-onboarding, settings resilience, 보안 수정 | 없음 |
+
+### 구현 순서
+
+1. **#820** — Stop hook 스크립트 수정 (feedback-collector.sh, skill-extractor-analyzer.sh의 stdin/stdout 프로토콜 수정) (권장 에이전트: general-purpose)
+2. **#821** — R000 규칙에 PR/이슈 언어 정책 행 추가 (권장 에이전트: mgr-creator)
+3. **#826, #827, #828, #830** (병렬) — CC 릴리즈 호환성 업데이트:
+   - R006 에이전트 설계 규칙에 CC v2.1.97-101 신규 기능 반영 (Monitor tool, refreshInterval, settings resilience)
+   - CLAUDE.md에 새 CC 기능 관련 업데이트
+   - (권장 에이전트: mgr-claude-code-bible + mgr-updater)
+
+### 참고 사항
+
+- #820 근본 원인: `feedback-collector.sh`가 `cat > /dev/null`로 stdin을 소비하고 stdout 미출력, `skill-extractor-analyzer.sh`가 stdin 미처리 — Stop hook pass-through 프로토콜 위반
+- CC v2.1.97-101에서 oh-my-customcode에 영향을 주는 주요 변경: Monitor 도구 추가, `refreshInterval` 상태줄 설정, `PermissionDenied` hook 이벤트, settings resilience 개선, compound command 보안 수정
+- CC 릴리즈 이슈 중복 방지를 위한 claude-native 스킬과 CronJob 간 dedup 로직 추가 필요 (별도 이슈 권장)
+
+---
+
+## v0.81.0 릴리즈 계획
+
+**예상 범위**: L | **이슈**: 1 | **병렬 가능**: TBD (deep-plan 필요)
+
+| # | 우선순위 | 규모 | 제목 | 의존성 |
+|---|----------|------|------|--------|
+| #831 | P2 | L | Adaptive Harness Self-Customization: 프로젝트별 omcustom 하네스 자동 커스터마이징 | v0.80.0 선행 |
+
+### 구현 순서
+
+1. **#831** — Adaptive Harness MVP:
+   - adaptive-harness 스킬 설계 및 구현
+   - SessionStart hook 통합
+   - project-profile.yaml 스키마 정의
+   - (권장 에이전트: mgr-creator + arch-speckit-agent)
+
+### 참고 사항
+
+- L 사이즈 이슈로 독립 릴리즈 단위
+- deep-plan 단계에서 상세 구현 계획 수립 필요
+- v0.80.0의 CC 호환성 업데이트 선행 필요 (Monitor tool, settings resilience 등 활용 가능)
+
+---
+
+## 요약
+
+| 릴리즈 | 이슈 수 | 규모 | P1 | P2 | P3 |
+|--------|---------|------|----|----|-----|
+| v0.80.0 | 6 | M | 0 | 5 | 1 |
+| v0.81.0 | 1 | L | 0 | 1 | 0 |
+| **합계** | **7** | | **0** | **6** | **1** |

--- a/infra/cc-release-collector/check-releases.sh
+++ b/infra/cc-release-collector/check-releases.sh
@@ -307,10 +307,10 @@ main() {
         fi
 
         # Fetch release details for this version (try both with and without 'v' prefix)
+        # Use jq first() to avoid SIGPIPE from piping to head -1
         local release_detail
         release_detail=$(echo "$releases_json" | jq --arg ver "$ver" \
-            '.[] | select((.tag_name == $ver) or (.tag_name == ("v" + $ver)))' \
-            | head -1)
+            'first(.[] | select((.tag_name == $ver) or (.tag_name == ("v" + $ver))))')
 
         if [ -z "$release_detail" ]; then
             warn "Could not find release details for v${ver} — skipping"

--- a/infra/cc-release-collector/cronjob.template.yaml
+++ b/infra/cc-release-collector/cronjob.template.yaml
@@ -15,7 +15,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 2
-      activeDeadlineSeconds: 300
+      activeDeadlineSeconds: 600
       template:
         metadata:
           labels:
@@ -49,6 +49,8 @@ spec:
                   value: "${TARGET_REPO}"
                 - name: MIN_VERSION
                   value: "${MIN_VERSION}"
+                - name: GH_CONFIG_DIR
+                  value: "/home/collector"
               resources:
                 requests:
                   memory: "64Mi"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.79.5",
+  "version": "0.80.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -64,7 +64,7 @@ disableSkillShellExecution: true  # Disable inline shell execution in skills (v2
 
 > **Note**: When `disableSkillShellExecution` is enabled (v2.1.91+), skills that rely on inline shell execution (e.g., `codex-exec`, `gemini-exec`, `rtk-exec`) will have their shell blocks disabled. This is a security hardening option.
 
-> **Note**: `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations` are supported in Claude Code v2.1.63+. Hook types `PostCompact`, `Elicitation`, `ElicitationResult` require v2.1.76+. `CwdChanged`, `FileChanged` hook events and `managed-settings.d/` drop-in directory require v2.1.83+. Conditional `if` field for hooks requires v2.1.85+.
+> **Note**: `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations` are supported in Claude Code v2.1.63+. Hook types `PostCompact`, `Elicitation`, `ElicitationResult` require v2.1.76+. `CwdChanged`, `FileChanged` hook events and `managed-settings.d/` drop-in directory require v2.1.83+. Conditional `if` field for hooks requires v2.1.85+. `PermissionDenied` hook event requires v2.1.88+. Monitor tool and subprocess sandboxing (`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`, `CLAUDE_CODE_SCRIPT_CAPS`) added in v2.1.98+. Settings resilience (unrecognized hook event names no longer cause settings.json to be ignored) improved in v2.1.101+.
 
 ## Hook Event Types
 

--- a/templates/.claude/rules/MUST-language-policy.md
+++ b/templates/.claude/rules/MUST-language-policy.md
@@ -9,6 +9,7 @@
 | User communication | Korean |
 | Code, file contents, commits | English |
 | Error messages to user | Korean |
+| PR title/body, GitHub issues | Korean (default, overridable in project CLAUDE.md) |
 
 ## Delegation Model
 

--- a/templates/.claude/rules/MUST-permissions.md
+++ b/templates/.claude/rules/MUST-permissions.md
@@ -8,7 +8,7 @@
 |------|-------|--------|
 | 1: Always | Read, Glob, Grep, ToolSearch | Free use, read-only |
 | 2: Default | Write, Edit, NotebookEdit | State changes explicitly, notify before modifying important files |
-| 3: Context | Agent, Skill, EnterPlanMode, ExitPlanMode, EnterWorktree, ExitWorktree, LSP, TodoWrite, AskUserQuestion | Context-dependent, no user approval needed |
+| 3: Context | Agent, Skill, EnterPlanMode, ExitPlanMode, EnterWorktree, ExitWorktree, LSP, Monitor, TodoWrite, AskUserQuestion | Context-dependent, no user approval needed |
 | 4: Approval | Bash, WebFetch, WebSearch | Request user approval on first use |
 | 5: Conditional | TeamCreate, TeamDelete, SendMessage, TaskCreate, TaskGet, TaskList, TaskUpdate, TaskStop, TaskOutput | Available when Agent Teams enabled |
 | 6: MCP | ListMcpResourcesTool, ReadMcpResourceTool, CronCreate, CronDelete, CronList, RemoteTrigger | MCP/extension tools, available when servers configured |

--- a/templates/.claude/rules/SHOULD-hud-statusline.md
+++ b/templates/.claude/rules/SHOULD-hud-statusline.md
@@ -27,7 +27,7 @@ Format: `─── [Spawn] {subagent_type}:{model} | {description} ───` �
 
 Format: `{Cost} | {project} | {branch} | RL:{rate_limit}% {countdown} | WL:{weekly_limit}% {countdown} | CTX:{usage}%`
 
-Config in `.claude/settings.local.json`: `statusLine.type: "command"`, `statusLine.command: ".claude/statusline.sh"`. Requires CC v2.1.80+ for RL/WL segments.
+Config in `.claude/settings.local.json`: `statusLine.type: "command"`, `statusLine.command: ".claude/statusline.sh"`. Requires CC v2.1.80+ for RL/WL segments. `refreshInterval` setting (v2.1.97+): Auto-refresh interval in seconds for the status line command. Set in `statusLine.refreshInterval` in settings.json.
 
 <!-- DETAIL: Statusline configuration JSON and color coding
 ```json

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.79.5",
+  "version": "0.80.0",
   "lastUpdated": "2026-03-24T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- fix: #820 Stop hook stdin/stdout protocol violation 수정
- feat: #821 R000 PR/이슈 언어 정책 추가
- feat: #827 #828 #830 CC v2.1.97-101 호환성 업데이트 (Monitor, refreshInterval, PermissionDenied, settings resilience)
- fix: cc-release-collector CronJob SIGPIPE 수정 및 GH_CONFIG_DIR 정렬
- close: #826 (no action needed — Bedrock only)

> Note: `.github/workflows/cc-release-monitor.yml` 파일은 `workflow` OAuth scope 필요로 별도 PR로 추가 예정

## Issues
Closes #820, #821, #827, #828, #830

## Test plan
- [x] Stop hook protocol: `echo '{"test":true}' | bash feedback-collector.sh` → passthrough verified
- [x] Tests: 973/995 passing (22 pre-existing failures)
- [x] Lint: CLEAN
- [x] R017 sauron verification: PASS
- [x] Deep verify: READY (2 HIGH findings fixed)
- [x] CronJob test on ubuntu-ext: checked=12, created=4, skipped=8

🤖 Generated with [Claude Code](https://claude.com/claude-code)