### PR TITLE
release: v0.84.0 — MemKraft bridge + Multica reference

### DIFF
--- a/.claude/skills/dag-orchestration/SKILL.md
+++ b/.claude/skills/dag-orchestration/SKILL.md
@@ -204,3 +204,22 @@ The orchestrator builds the DAG from this inline format and executes using the s
 - Max 20 nodes per workflow (complexity guard)
 - Nested DAGs not supported (flatten instead)
 - Cross-workflow dependencies not supported
+
+## External References
+
+### Multica — Managed Agent Platform
+
+> Reference: [Multica](https://github.com/multica-ai/multica) — managed agent platform for Claude Code/Codex.
+> Verdict: INTEGRATE (external reference, not internalize)
+
+Multica's task lifecycle pattern (enqueue → claim → start → complete/fail) is a useful reference for DAG node state management:
+
+| Multica State | DAG Equivalent | Notes |
+|---------------|---------------|-------|
+| enqueue | pending | Node waiting for dependencies |
+| claim | ready | Dependencies resolved, ready to execute |
+| start | running | Agent spawned and executing |
+| complete | completed | Node finished successfully |
+| fail | failed | Node execution failed |
+
+Consider this pattern when extending DAG node state tracking or implementing retry logic.

--- a/.claude/skills/memory-management/SKILL.md
+++ b/.claude/skills/memory-management/SKILL.md
@@ -194,3 +194,47 @@ recall_errors:
   - Connection failure: Return empty with warning
   - Invalid query: Help user reformulate
 ```
+
+## MemKraft Bridge (Optional)
+
+> External integration: [MemKraft](https://github.com/seojoonkim/memkraft) — zero-dependency compound memory for AI agents.
+> Install: `pipx install memkraft`
+
+### When to Use
+
+| Capability | claude-mem | MemKraft |
+|-----------|-----------|----------|
+| Session persistence | ✅ (Chroma) | ✅ (Markdown) |
+| Entity tracking | ❌ | ✅ (person/org/concept) |
+| Source attribution | ❌ | ✅ (`[Source: who, when, how]`) |
+| Auto-maintenance | ❌ | ✅ (Dream Cycle) |
+| CJK entity extraction | ❌ | ✅ (Korean/Chinese/Japanese) |
+| Offline search | ❌ | ✅ (stdlib difflib) |
+
+Use MemKraft when entity tracking or source attribution is needed. Use claude-mem for simple session persistence.
+
+### Commands
+
+```bash
+# Extract entities from a document
+memkraft extract <file>
+
+# Get a brief on a topic
+memkraft brief <topic>
+
+# Run maintenance cycle (dedup, prune orphans)
+memkraft dream
+```
+
+### Integration with sys-memory-keeper
+
+At session end, sys-memory-keeper can optionally run MemKraft operations:
+
+1. `memkraft extract` on session summary → builds entity graph
+2. `memkraft dream` → prunes stale entries (run weekly, not every session)
+
+### Prerequisites
+
+- Python 3.9+
+- `pipx install memkraft`
+- No API keys required (offline-only)

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.83.0",
-  "generatedAt": "2026-04-12T14:26:16.397Z",
-  "templateVersion": "0.83.0",
+  "generatorVersion": "0.84.0",
+  "generatedAt": "2026-04-12T14:35:12.786Z",
+  "templateVersion": "0.84.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",
@@ -790,8 +790,8 @@
       "component": "skills"
     },
     ".claude/skills/memory-management/SKILL.md": {
-      "templateHash": "24897f8657bad3963812696cab4058473d6ebdeecadd86ada71d564361e699e1",
-      "size": 3847,
+      "templateHash": "3fc9e09475523831caa74ddcbaeaa5cc3e3bcb58cbe680834e68179d653e0d7d",
+      "size": 5135,
       "component": "skills"
     },
     ".claude/skills/kafka-best-practices/SKILL.md": {
@@ -900,8 +900,8 @@
       "component": "skills"
     },
     ".claude/skills/dag-orchestration/SKILL.md": {
-      "templateHash": "1b3a9a2865a9756944da4a8d7a7e80a510657100d234f41ed310b6490384b9eb",
-      "size": 5847,
+      "templateHash": "e3dbefa46a4b997c9956ce35a3ae377f46f58955f4a778236a474ea72c5621f2",
+      "size": 6655,
       "component": "skills"
     },
     ".claude/skills/wiki-rag/SKILL.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2301,7 +2301,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.83.0",
+    version: "0.84.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1974,7 +1974,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.83.0",
+  version: "0.84.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.83.0",
+  "version": "0.84.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.83.0",
+  "version": "0.84.0",
   "lastUpdated": "2026-04-12T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
# Release v0.84.0

## Highlights
- MemKraft 외부 CLI 통합 브릿지 (memory-management 스킬 확장)
- Multica 태스크 라이프사이클 참조 (dag-orchestration 스킬 확장)

## :rocket: Features
- **MemKraft bridge** (#836): memory-management 스킬에 MemKraft CLI 래퍼 섹션 추가 — 엔티티 추적, source attribution, Dream Cycle, CJK 지원
- **Multica reference** (#834): dag-orchestration 스킬에 Multica 상태 매핑 테이블 추가 — enqueue/claim/start/complete/fail

## Test Results
- 1667 tests passing, 0 failures

Closes #836, #834

---
_Release notes generated with Claude Code_