### PR TITLE
release: v0.85.0

### DIFF
--- a/.claude/rules/MUST-agent-design.md
+++ b/.claude/rules/MUST-agent-design.md
@@ -298,7 +298,7 @@ Default: `core` (when field is omitted)
 
 ### Context Fork Criteria
 
-Use `context: fork` for multi-agent orchestration skills only. Cap: **12 total**. Current: 9/12 (secretary/dev-lead/de-lead/qa-lead-routing, dag-orchestration, task-decomposition, worker-reviewer-pipeline, pipeline-guards, deep-plan).
+Use `context: fork` for multi-agent orchestration skills only. Cap: **12 total**. Current: 12/12 (secretary/dev-lead/de-lead/qa-lead-routing, dag-orchestration, task-decomposition, worker-reviewer-pipeline, pipeline-guards, deep-plan, professor-triage, evaluator-optimizer, sauron-watch).
 
 <!-- DETAIL: Context Fork decision table
 | Use context:fork | Do NOT use context:fork |

--- a/.claude/rules/MUST-parallel-execution.md
+++ b/.claude/rules/MUST-parallel-execution.md
@@ -130,6 +130,26 @@ Must use `[N] {subagent_type}:{model}` format. `[N]` is 1-indexed and MUST match
 
 Single agent spawns do NOT use the `[N]` prefix.
 
+## Narrative Announcement Format (Before Spawn)
+
+When announcing a parallel dispatch in prose text (not the Agent tool call itself), use a markdown list rather than inline comma-separated description:
+
+### Correct
+
+```
+병렬 실행:
+- [1] {agent-a}: {task-a}
+- [2] {agent-b}: {task-b}
+```
+
+### Incorrect
+
+```
+병렬 실행: [1] {agent-a}가 {task-a}, [2] {agent-b}가 {task-b}.
+```
+
+The list form mirrors the tool-call `[N]` prefix pattern and scales better to 3+ concurrent agents.
+
 ## Result Aggregation
 
 ```

--- a/.claude/skills/systematic-debugging/SKILL.md
+++ b/.claude/skills/systematic-debugging/SKILL.md
@@ -64,6 +64,38 @@ user-invocable: false
 
 반드시 아래 순서로 진행한다.
 
+### Phase 0. Blocker Triage (Pre-Debug Gate)
+
+**Trigger**: When any external dependency, tool, or resource appears unavailable.
+
+Before declaring a task blocked or unsolvable, exhaust this checklist:
+
+| # | Workaround Path | Check |
+|---|----------------|-------|
+| 1 | Environment bypass | Can the dependency be bypassed in the current environment? |
+| 2 | Alternative tool | Is there an alternative tool, library, or approach? |
+| 3 | Partial solution | Can the task be partially completed without the dependency? |
+| 4 | Install/configure | Can the dependency be installed or configured now? |
+| 5 | Existing credentials | Are related tokens, auth files, or configs already present? |
+
+**Rules**:
+- Minimum 3 workaround paths MUST be explored before declaring "blocked"
+- Each explored path must be documented with outcome
+- "Session unsolvable" declarations MUST include the list of attempted workaround paths
+- If a workaround is found, proceed with debugging using that workaround
+
+**Output format**:
+```
+[Blocker Triage]
+├── Dependency: {what is unavailable}
+├── Path 1: {attempted} → {outcome}
+├── Path 2: {attempted} → {outcome}
+├── Path 3: {attempted} → {outcome}
+└── Verdict: {proceed with workaround N | genuinely blocked — reason}
+```
+
+If verdict is "genuinely blocked", escalate to user with full triage report. Do NOT silently abandon the task.
+
 ### Phase 1. Define The Problem
 
 먼저 문제를 축약한다.

--- a/README.md
+++ b/README.md
@@ -21,19 +21,6 @@ npm install -g oh-my-customcode && cd your-project && omcustom init
 
 ---
 
-## What's New in v0.74.0
-
-| Feature | Description |
-|---------|-------------|
-| **`omcustom sync`** | Drift detection for `.claude/` configuration — compare against lockfile, export team snapshots |
-| **`omcustom init --from-snapshot`** | Team reproducibility — install from pre-configured snapshot directory |
-| **`analysis --interview`** | Interactive AI architecture interview before file-based project detection |
-| **skill-extractor** | 100th skill — analyze task trajectories to propose reusable SKILL.md candidates |
-| **User Model** | Structured tracking of correction patterns, skill preferences, expertise profile |
-| **Release Cleanup** | Auto-close linked issues and delete release branches on PR merge |
-
----
-
 ## Philosophy
 
 oh-my-customcode is built on two ideas:

--- a/docs/superpowers/plans/2026-04-13-v0.85.0-release.md
+++ b/docs/superpowers/plans/2026-04-13-v0.85.0-release.md
@@ -1,0 +1,48 @@
+# 릴리즈 계획 — 2026-04-13 생성
+
+> 출처: 2026-04-13 기준 `verify-done` 라벨 오픈 이슈
+> 제외된 이슈 (이미 오픈 PR에 포함): 없음
+
+## v0.85.0 릴리즈 계획
+
+**예상 범위**: S (XS+S+XS) | **이슈**: 3 | **병렬 가능**: 3
+
+| # | 우선순위 | 규모 | 제목 | 의존성 |
+|---|----------|------|------|--------|
+| #845 | P1 | XS | findProjects()에서 홈 디렉토리 외부 경로 필터링 필요 | 없음 |
+| #844 | P2 | S | agent가 blocker 선언 전 workaround 탐색을 건너뛰는 문제 | 없음 |
+| #846 | P2 | XS | 병렬 실행 디스패치 표현을 리스트 형식으로 강제 | 없음 |
+
+### 구현 순서
+1. #845 — `findProjects()`에 homedir 필터 추가 + 테스트 수정 (권장 에이전트: lang-typescript-expert)
+2. #846 — `MUST-parallel-execution.md`에 Narrative Announcement Format 섹션 추가 (권장 에이전트: mgr-creator)
+3. #844 — `systematic-debugging` 스킬에 Phase 0 (Blocker Escalation Checklist) 추가 (권장 에이전트: mgr-creator)
+
+### 참고 사항
+- #845는 유일한 P1 버그: `src/cli/projects.ts`의 `findProjects()`와 `_findProjectsFromLockfiles()`에 homedir 필터 추가. 테스트(`tests/unit/cli/projects.test.ts`)에서 HOME 환경변수를 temp 디렉토리로 설정하는 조정 필요
+- #846은 이슈 본문에 제안 텍스트가 거의 완성되어 있어 그대로 적용 가능
+- #844는 `systematic-debugging/SKILL.md`에 Phase 0 추가 + 관련 라우팅 스킬에 blocker 감지 로직 연동
+- 3개 이슈 모두 독립적이므로 전체 병렬 실행 가능
+
+## v0.86.0 릴리즈 계획 (다음 릴리즈)
+
+**예상 범위**: M | **이슈**: 1 | **병렬 가능**: 1
+
+| # | 우선순위 | 규모 | 제목 | 의존성 |
+|---|----------|------|------|--------|
+| #841 | P2 | M | hada-scout 자동화: hada.io AI agent/harness 글 자동 /scout 스케줄링 | 없음 |
+
+### 구현 순서
+1. #841 — hada.io RSS 스크래핑 + 키워드 필터 + /scout 연동 + ubuntu-ext cron 배포 (권장 에이전트: mgr-creator → 신규 hada-scout 스킬)
+
+### 참고 사항
+- 별도 스코프 (외부 서버 배포 포함)로 독립 릴리즈
+- RSS 피드 가용성 사전 확인 필요
+- ubuntu-ext 서버 접근 권한 확인 필요
+
+## 요약
+
+| 릴리즈 | 이슈 수 | 규모 | P1 | P2 | P3 |
+|--------|---------|------|----|----|-----|
+| v0.85.0 | 3 | S | 1 | 2 | 0 |
+| v0.86.0 | 1 | M | 0 | 1 | 0 |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.84.0",
+  "version": "0.85.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/src/cli/projects.ts
+++ b/src/cli/projects.ts
@@ -131,6 +131,34 @@ async function getTemplateVersion(): Promise<string> {
 }
 
 /**
+ * Check whether a project path matches the optional search paths filter.
+ */
+function matchesSearchPaths(projectPath: string, searchPaths: string[] | undefined): boolean {
+  if (!searchPaths || searchPaths.length === 0) return true;
+  return searchPaths.some(
+    (searchPath) => projectPath === searchPath || projectPath.startsWith(searchPath + sep)
+  );
+}
+
+/**
+ * Check whether a project path is under the user's home directory.
+ */
+function isUnderHome(projectPath: string, home: string): boolean {
+  return projectPath.startsWith(home + sep) || projectPath === home;
+}
+
+/**
+ * Sort projects: latest first, then alphabetically by name.
+ */
+function sortProjects(projects: ProjectInfo[]): ProjectInfo[] {
+  return projects.sort((a, b) => {
+    if (a.status === 'latest' && b.status !== 'latest') return -1;
+    if (a.status !== 'latest' && b.status === 'latest') return 1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+/**
  * Find all projects registered in the local registry.
  *
  * When `options.paths` is provided the registry is searched but only entries
@@ -142,7 +170,6 @@ async function getTemplateVersion(): Promise<string> {
  */
 export async function findProjects(options: ProjectsOptions = {}): Promise<ProjectInfo[]> {
   const currentVersion = await getTemplateVersion();
-
   const registry = await readRegistry();
 
   // If registry is empty, fall back to lock-file scan of provided paths (or cwd/parent)
@@ -159,15 +186,11 @@ export async function findProjects(options: ProjectsOptions = {}): Promise<Proje
   }
 
   const results: ProjectInfo[] = [];
+  const home = process.env.HOME ?? homedir();
 
   for (const [projectPath, entry] of Object.entries(registry.projects)) {
-    // Filter by provided paths when options.paths is set
-    if (options.paths && options.paths.length > 0) {
-      const matchesPath = options.paths.some(
-        (searchPath) => projectPath === searchPath || projectPath.startsWith(searchPath + sep)
-      );
-      if (!matchesPath) continue;
-    }
+    if (!matchesSearchPaths(projectPath, options.paths)) continue;
+    if (!isUnderHome(projectPath, home)) continue;
 
     results.push({
       name: basename(projectPath),
@@ -180,12 +203,70 @@ export async function findProjects(options: ProjectsOptions = {}): Promise<Proje
     });
   }
 
-  // Sort: latest first, then by name
-  return results.sort((a, b) => {
-    if (a.status === 'latest' && b.status !== 'latest') return -1;
-    if (a.status !== 'latest' && b.status === 'latest') return 1;
-    return a.name.localeCompare(b.name);
-  });
+  return sortProjects(results);
+}
+
+/** Subdirectory names that should be skipped during lock-file scanning. */
+const SCAN_SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.git']);
+
+/**
+ * Recursively scan a directory for lock files, collecting matching ProjectInfo entries.
+ * @internal
+ */
+async function _scanDirForLockfiles(
+  dir: string,
+  depth: number,
+  seen: Set<string>,
+  results: ProjectInfo[],
+  home: string,
+  currentVersion: string,
+  fs: typeof import('node:fs/promises')
+): Promise<void> {
+  if (depth > 3 || seen.has(dir)) return;
+  seen.add(dir);
+
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  const lockFile = await readLockFile(dir);
+  if (lockFile) {
+    if (isUnderHome(dir, home)) {
+      const version = lockFile.version || lockFile.templateVersion || null;
+      results.push({
+        name: basename(dir),
+        path: dir,
+        version,
+        installedAt: (lockFile.installedAt as string | undefined) || null,
+        updatedAt: (lockFile.updatedAt as string | undefined) || null,
+        status: computeStatus(version, currentVersion),
+        detectionMethod: 'lockfile',
+      });
+    }
+    return;
+  }
+
+  if (depth < 3) {
+    const subdirs = entries.filter(
+      (e) => e.isDirectory() && !e.name.startsWith('.') && !SCAN_SKIP_DIRS.has(e.name)
+    );
+    await Promise.all(
+      subdirs.map((sub) =>
+        _scanDirForLockfiles(
+          join(dir, sub.name),
+          depth + 1,
+          seen,
+          results,
+          home,
+          currentVersion,
+          fs
+        ).catch(() => {})
+      )
+    );
+  }
 }
 
 /**
@@ -204,48 +285,7 @@ async function _findProjectsFromLockfiles(
 
   const seen = new Set<string>();
   const results: ProjectInfo[] = [];
-
-  async function scanDir(dir: string, depth: number): Promise<void> {
-    if (depth > 3 || seen.has(dir)) return;
-    seen.add(dir);
-
-    let entries: import('node:fs').Dirent[];
-    try {
-      entries = await fs.readdir(dir, { withFileTypes: true });
-    } catch {
-      return;
-    }
-
-    const lockFile = await readLockFile(dir);
-    if (lockFile) {
-      const version = lockFile.version || lockFile.templateVersion || null;
-      results.push({
-        name: basename(dir),
-        path: dir,
-        version,
-        installedAt: (lockFile.installedAt as string | undefined) || null,
-        updatedAt: (lockFile.updatedAt as string | undefined) || null,
-        status: computeStatus(version, currentVersion),
-        detectionMethod: 'lockfile',
-      });
-      return;
-    }
-
-    if (depth < 3) {
-      const subdirs = entries.filter(
-        (e) =>
-          e.isDirectory() &&
-          !e.name.startsWith('.') &&
-          e.name !== 'node_modules' &&
-          e.name !== 'dist' &&
-          e.name !== 'build' &&
-          e.name !== '.git'
-      );
-      await Promise.all(
-        subdirs.map((sub) => scanDir(join(dir, sub.name), depth + 1).catch(() => {}))
-      );
-    }
-  }
+  const home = process.env.HOME ?? homedir();
 
   const searchPaths: string[] = options.paths ? [...options.paths] : [];
 
@@ -256,13 +296,13 @@ async function _findProjectsFromLockfiles(
     if (parent !== cwd && !searchPaths.includes(parent)) searchPaths.push(parent);
   }
 
-  await Promise.all(searchPaths.map((p) => scanDir(p, 0).catch(() => {})));
+  await Promise.all(
+    searchPaths.map((p) =>
+      _scanDirForLockfiles(p, 0, seen, results, home, currentVersion, fs).catch(() => {})
+    )
+  );
 
-  return results.sort((a, b) => {
-    if (a.status === 'latest' && b.status !== 'latest') return -1;
-    if (a.status !== 'latest' && b.status === 'latest') return 1;
-    return a.name.localeCompare(b.name);
-  });
+  return sortProjects(results);
 }
 
 /**

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.84.0",
-  "lastUpdated": "2026-04-12T00:00:00.000Z",
+  "version": "0.85.0",
+  "lastUpdated": "2026-04-13T00:00:00.000Z",
   "components": [
     {
       "name": "rules",

--- a/tests/unit/cli/projects.test.ts
+++ b/tests/unit/cli/projects.test.ts
@@ -51,6 +51,7 @@ async function _writeClaudeMarkers(dir: string): Promise<void> {
 
 let tempRoot: string;
 let originalCwd: string;
+let originalHome: string | undefined;
 
 beforeEach(async () => {
   // Create a temp dir that is OUTSIDE DEFAULT_SEARCH_DIRS so default search
@@ -59,6 +60,13 @@ beforeEach(async () => {
   const raw = await mkdtemp(join(tmpdir(), 'omcc-projects-test-'));
   tempRoot = realpathSync(raw);
   originalCwd = process.cwd();
+
+  // Set HOME to tempRoot so the homedir filter in findProjects() treats
+  // tempRoot as the home directory. This is required because tmpdir() resolves
+  // to /private/var/folders/... on macOS, which is outside the real HOME.
+  // The same HOME-override pattern is used in src/core/registry.ts:33.
+  originalHome = process.env.HOME;
+  process.env.HOME = tempRoot;
 
   // Isolate the registry so findProjects() falls back to lock-file scanning.
   // An empty registry causes findProjects() to use _findProjectsFromLockfiles(),
@@ -77,6 +85,7 @@ beforeEach(async () => {
 afterEach(async () => {
   _setRegistryDirForTesting(undefined);
   process.chdir(originalCwd);
+  process.env.HOME = originalHome;
   await rm(tempRoot, { recursive: true, force: true });
 });
 
@@ -922,11 +931,14 @@ describe('projectsCommand() — simple formatting', () => {
 describe('projectsCommand() — shortenPath coverage', () => {
   it('shortens home directory paths to ~ in table output', async () => {
     const { homedir } = await import('node:os');
-    const home = homedir();
+    // Use the real homedir (not tempRoot) so the project path is under ~
+    // and the homedir filter in findProjects() allows it through.
+    const realHome = homedir();
+    process.env.HOME = realHome;
 
     // Create a project path under home dir to trigger the ~ shortening branch
     // We don't actually create the directory — we fake the registry entry instead
-    const projectUnderHome = join(home, '.oh-my-customcode-test-project-coverage');
+    const projectUnderHome = join(realHome, '.oh-my-customcode-test-project-coverage');
     const registryDir = join(tempRoot, '.oh-my-customcode');
     await mkdir(registryDir, { recursive: true });
     await writeFile(
@@ -956,6 +968,8 @@ describe('projectsCommand() — shortenPath coverage', () => {
       expect(output).toContain('~');
     } finally {
       consoleSpy.mockRestore();
+      // Restore HOME to tempRoot for the afterEach cleanup to work correctly
+      process.env.HOME = tempRoot;
     }
   });
 });


### PR DESCRIPTION
## Summary

- **#845** :bug: `findProjects()`에서 홈 디렉토리 외부 경로(임시 테스트 경로) 필터링 — 프로젝트 목록/업데이트에 실제 프로젝트만 표시
- **#846** :rocket: R009에 Narrative Announcement Format 섹션 추가 — 병렬 디스패치 전 리스트 형식 표준화
- **#844** :rocket: systematic-debugging 스킬에 Phase 0 Blocker Triage 추가 — blocker 선언 전 최소 3가지 workaround 탐색 필수
- :wrench: context fork count 정정 (10/12 → 12/12, deep-verify에서 발견)
- :wrench: README에서 outdated "What's New in v0.74.0" 섹션 제거

## Resource Changes

| Resource | Before | After | Delta |
|----------|--------|-------|-------|
| Rules | 22 | 22 | 0 |
| Skills | 104 | 104 | 0 |
| Agents | 48 | 48 | 0 |

## Test plan

- [x] 전체 테스트 1667/1667 pass
- [x] 타입 체크 통과
- [x] deep-verify READY verdict
- [ ] CI green 확인

Closes #845, Closes #846, Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)