### PR TITLE
release: v0.87.0 — Claude Code v2.1.105 feature docs

### DIFF
--- a/.claude/rules/MUST-agent-design.md
+++ b/.claude/rules/MUST-agent-design.md
@@ -64,7 +64,7 @@ disableSkillShellExecution: true  # Disable inline shell execution in skills (v2
 
 > **Note**: When `disableSkillShellExecution` is enabled (v2.1.91+), skills that rely on inline shell execution (e.g., `codex-exec`, `gemini-exec`, `rtk-exec`) will have their shell blocks disabled. This is a security hardening option.
 
-> **Note**: `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations` are supported in Claude Code v2.1.63+. Hook types `PostCompact`, `Elicitation`, `ElicitationResult` require v2.1.76+. `CwdChanged`, `FileChanged` hook events and `managed-settings.d/` drop-in directory require v2.1.83+. Conditional `if` field for hooks requires v2.1.85+. `PermissionDenied` hook event requires v2.1.88+. Monitor tool and subprocess sandboxing (`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`, `CLAUDE_CODE_SCRIPT_CAPS`) added in v2.1.98+. Settings resilience (unrecognized hook event names no longer cause settings.json to be ignored) improved in v2.1.101+.
+> **Note**: `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations` are supported in Claude Code v2.1.63+. Hook types `PostCompact`, `Elicitation`, `ElicitationResult` require v2.1.76+. `CwdChanged`, `FileChanged` hook events and `managed-settings.d/` drop-in directory require v2.1.83+. Conditional `if` field for hooks requires v2.1.85+. `PermissionDenied` hook event requires v2.1.88+. Monitor tool and subprocess sandboxing (`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`, `CLAUDE_CODE_SCRIPT_CAPS`) added in v2.1.98+. Settings resilience (unrecognized hook event names no longer cause settings.json to be ignored) improved in v2.1.101+. PreCompact hook block support (exit 2 / `{"decision":"block"}`) added in v2.1.105+. Skill description listing cap raised from 250 to 1,536 characters in v2.1.105+. Plugin `monitors` manifest key for background monitors added in v2.1.105+.
 
 ## Hook Event Types
 
@@ -112,6 +112,16 @@ All supported hook event types in Claude Code. Agents and skills can reference t
 | `{"decision": "defer"}` | Pause execution; resume with `-p --resume` | v2.1.89+ |
 
 The `defer` decision allows headless sessions to pause at a tool call for human review.
+
+### PreCompact Hook Return Values
+
+| Return | Behavior | CC Version |
+|--------|----------|------------|
+| `exit 0` | Allow compaction | All |
+| `exit 2` + stderr | Block compaction with message | v2.1.105+ |
+| `{"decision": "block"}` | Block compaction (JSON response) | v2.1.105+ |
+
+PreCompact hooks can now prevent context compaction, useful for preserving critical context during multi-step workflows.
 
 ### Hook Matcher Syntax
 

--- a/guides/git-worktree-workflow/README.md
+++ b/guides/git-worktree-workflow/README.md
@@ -75,6 +75,10 @@ EnterWorktree(name: "feature-x")
 # Creates .claude/worktrees/feature-x with a new branch based on HEAD
 # Session working directory switches to the worktree
 
+EnterWorktree(path: "/absolute/path/to/existing-worktree")
+# Switches into an existing worktree of the current repository (v2.1.105+)
+# No new branch is created — uses the worktree as-is
+
 ExitWorktree()
 # Returns to the main repository
 # Prompts to keep or remove the worktree

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.86.1",
+  "version": "0.87.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -64,7 +64,7 @@ disableSkillShellExecution: true  # Disable inline shell execution in skills (v2
 
 > **Note**: When `disableSkillShellExecution` is enabled (v2.1.91+), skills that rely on inline shell execution (e.g., `codex-exec`, `gemini-exec`, `rtk-exec`) will have their shell blocks disabled. This is a security hardening option.
 
-> **Note**: `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations` are supported in Claude Code v2.1.63+. Hook types `PostCompact`, `Elicitation`, `ElicitationResult` require v2.1.76+. `CwdChanged`, `FileChanged` hook events and `managed-settings.d/` drop-in directory require v2.1.83+. Conditional `if` field for hooks requires v2.1.85+. `PermissionDenied` hook event requires v2.1.88+. Monitor tool and subprocess sandboxing (`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`, `CLAUDE_CODE_SCRIPT_CAPS`) added in v2.1.98+. Settings resilience (unrecognized hook event names no longer cause settings.json to be ignored) improved in v2.1.101+.
+> **Note**: `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations` are supported in Claude Code v2.1.63+. Hook types `PostCompact`, `Elicitation`, `ElicitationResult` require v2.1.76+. `CwdChanged`, `FileChanged` hook events and `managed-settings.d/` drop-in directory require v2.1.83+. Conditional `if` field for hooks requires v2.1.85+. `PermissionDenied` hook event requires v2.1.88+. Monitor tool and subprocess sandboxing (`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`, `CLAUDE_CODE_SCRIPT_CAPS`) added in v2.1.98+. Settings resilience (unrecognized hook event names no longer cause settings.json to be ignored) improved in v2.1.101+. PreCompact hook block support (exit 2 / `{"decision":"block"}`) added in v2.1.105+. Skill description listing cap raised from 250 to 1,536 characters in v2.1.105+. Plugin `monitors` manifest key for background monitors added in v2.1.105+.
 
 ## Hook Event Types
 
@@ -112,6 +112,16 @@ All supported hook event types in Claude Code. Agents and skills can reference t
 | `{"decision": "defer"}` | Pause execution; resume with `-p --resume` | v2.1.89+ |
 
 The `defer` decision allows headless sessions to pause at a tool call for human review.
+
+### PreCompact Hook Return Values
+
+| Return | Behavior | CC Version |
+|--------|----------|------------|
+| `exit 0` | Allow compaction | All |
+| `exit 2` + stderr | Block compaction with message | v2.1.105+ |
+| `{"decision": "block"}` | Block compaction (JSON response) | v2.1.105+ |
+
+PreCompact hooks can now prevent context compaction, useful for preserving critical context during multi-step workflows.
 
 ### Hook Matcher Syntax
 
@@ -298,7 +308,7 @@ Default: `core` (when field is omitted)
 
 ### Context Fork Criteria
 
-Use `context: fork` for multi-agent orchestration skills only. Cap: **12 total**. Current: 9/12 (secretary/dev-lead/de-lead/qa-lead-routing, dag-orchestration, task-decomposition, worker-reviewer-pipeline, pipeline-guards, deep-plan).
+Use `context: fork` for multi-agent orchestration skills only. Cap: **12 total**. Current: 12/12 (secretary/dev-lead/de-lead/qa-lead-routing, dag-orchestration, task-decomposition, worker-reviewer-pipeline, pipeline-guards, deep-plan, professor-triage, evaluator-optimizer, sauron-watch).
 
 <!-- DETAIL: Context Fork decision table
 | Use context:fork | Do NOT use context:fork |

--- a/templates/guides/git-worktree-workflow/README.md
+++ b/templates/guides/git-worktree-workflow/README.md
@@ -75,6 +75,10 @@ EnterWorktree(name: "feature-x")
 # Creates .claude/worktrees/feature-x with a new branch based on HEAD
 # Session working directory switches to the worktree
 
+EnterWorktree(path: "/absolute/path/to/existing-worktree")
+# Switches into an existing worktree of the current repository (v2.1.105+)
+# No new branch is created — uses the worktree as-is
+
 ExitWorktree()
 # Returns to the main repository
 # Prompts to keep or remove the worktree

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.86.1",
-  "lastUpdated": "2026-04-13T00:00:00.000Z",
+  "version": "0.87.0",
+  "lastUpdated": "2026-04-14T00:00:00.000Z",
   "components": [
     {
       "name": "rules",


### PR DESCRIPTION
## Summary
- Claude Code v2.1.105 신규 기능 문서 반영 (#854)
- PreCompact hook block 지원 (R006), EnterWorktree path 파라미터 (가이드), templates/ 동기화

## Changes
- **R006** (`MUST-agent-design.md`): PreCompact Hook Return Values 섹션 추가 + v2.1.105 버전 노트
- **Worktree 가이드**: `EnterWorktree(path:)` 파라미터 문서화
- **templates/**: 소스 파일 동기화

## Release Notes

# Release v0.87.0

## Highlights
- Claude Code v2.1.105 신규 기능 반영: PreCompact hook block, EnterWorktree path 파라미터

## :books: Documentation
- **PreCompact hook block** (#854): R006에 PreCompact Hook Return Values 섹션 추가 (exit 2 + {"decision":"block"} 지원)
- **EnterWorktree path param** (#854): 기존 worktree에 진입하는 `path` 파라미터 문서화
- **v2.1.105 version notes**: skill description cap 250→1536, plugin monitors manifest 추가

## Resource Changes
| Resource | Before | After | Delta |
|----------|--------|-------|-------|
| Rules | 23 | 23 | 0 |
| Skills | 105 | 105 | 0 |
| Agents | 48 | 48 | 0 |

---
_Release notes generated with Claude Code_

## Test Plan
- [x] 테스트 전체 통과 (1667/1667)
- [x] deep-verify READY 판정
- [x] R017 sauron 검증 통과
- [x] templates/ 소스 동기화 확인

Closes #854