### PR TITLE
release: v0.87.1 — wiki sync for EnterWorktree path (#857)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.87.0",
+  "version": "0.87.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.87.0",
+  "version": "0.87.1",
   "lastUpdated": "2026-04-14T00:00:00.000Z",
   "components": [
     {

--- a/wiki/guides/git-worktree-workflow.md
+++ b/wiki/guides/git-worktree-workflow.md
@@ -1,7 +1,7 @@
 ---
 title: "Git Worktree Workflow Guide"
 type: guide
-updated: 2026-04-12
+updated: 2026-04-14
 sources:
   - guides/git-worktree-workflow/README.md
 related:
@@ -21,7 +21,7 @@ Git worktrees allow checking out multiple branches in separate sibling directori
 - Creating worktrees for existing and new branches
 - Recommended directory structure as siblings to the main repo
 - Listing and removing worktrees, pruning stale references
-- Claude Code `EnterWorktree`/`ExitWorktree` tool integration
+- Claude Code `EnterWorktree`/`ExitWorktree` tool integration (v2.1.105+: `path` parameter for entering existing worktrees)
 - Worktree isolation and its agent isolation use case (R006)
 
 ## Relationships

--- a/wiki/guides/worktree-lifecycle.md
+++ b/wiki/guides/worktree-lifecycle.md
@@ -1,7 +1,7 @@
 ---
 title: "Worktree Lifecycle Automation Guide"
 type: guide
-updated: 2026-04-12
+updated: 2026-04-14
 sources:
   - guides/worktree-lifecycle/README.md
 related:
@@ -40,7 +40,8 @@ agent-spin feature/x develop
 
 | Method | Use Case |
 |--------|----------|
-| `EnterWorktree` tool | Agent-managed isolation (automatic) |
+| `EnterWorktree(name:)` tool | Agent-managed isolation — create new worktree (automatic) |
+| `EnterWorktree(path:)` tool | Enter existing worktree without creating a new branch (v2.1.105+) |
 | `agent-spin` alias | Manual or hook-triggered creation |
 | `isolation: worktree` frontmatter | Declarative per-agent isolation (R006) |
 


### PR DESCRIPTION
## Summary
- Wiki 페이지 동기화: EnterWorktree `path` 파라미터 반영 (#857)

## Changes
- `wiki/guides/git-worktree-workflow.md` — Key Topics에 path param 추가
- `wiki/guides/worktree-lifecycle.md` — Claude Code Integration 테이블에 path/name 분리

## Release Notes

# Release v0.87.1

## :books: Documentation
- **Wiki sync** (#857): git-worktree-workflow, worktree-lifecycle 위키 페이지에 EnterWorktree path 파라미터 반영

## Resource Changes
| Resource | Before | After | Delta |
|----------|--------|-------|-------|
| Rules | 23 | 23 | 0 |
| Skills | 105 | 105 | 0 |
| Agents | 48 | 48 | 0 |

---
_Release notes generated with Claude Code_

## Test Plan
- [x] Wiki 페이지 path 파라미터 반영 확인
- [x] Wiki updated 날짜 갱신 확인
- [x] 카운트 변경 없음 확인

Closes #857