### PR TITLE
fix: omcustom update --all --hard 핫픽스 v0.87.2 (#860)

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.84.0",
-  "generatedAt": "2026-04-12T14:35:12.786Z",
-  "templateVersion": "0.84.0",
+  "generatorVersion": "0.87.2",
+  "generatedAt": "2026-04-14T12:39:09.315Z",
+  "templateVersion": "0.87.1",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",
@@ -35,8 +35,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-parallel-execution.md": {
-      "templateHash": "0789f7463b10384a2d63a9d35bccd9c88f7b0253cdd4bfaed86173335fa27f03",
-      "size": 5703,
+      "templateHash": "67ebdd6a63ad693d5cda51e3e3a5e542b3e87aba69c5095ff83d50abc7f4a089",
+      "size": 6188,
       "component": "rules"
     },
     ".claude/rules/SHOULD-ecomode.md": {
@@ -50,8 +50,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
-      "templateHash": "2d6ed28b487f57820327a66349e96d367e89989bd69986104e304816664ead81",
-      "size": 15356,
+      "templateHash": "21c7c849165fa0eabb9e549c246703a9515db49f326c4a1fbe45c82b147ca6b2",
+      "size": 16056,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
@@ -379,6 +379,11 @@
       "size": 17653,
       "component": "skills"
     },
+    ".claude/skills/hada-scout/SKILL.md": {
+      "templateHash": "f488805805ace9a0c9b06023d0d04a3730ed5c89030fe75cde84619c5c5fa160",
+      "size": 3261,
+      "component": "skills"
+    },
     ".claude/skills/audit-agents/SKILL.md": {
       "templateHash": "6acc8dc2142e180e1c2689b2c47a96f58c11c43f0ecf44ef19fe75667e2ce13f",
       "size": 2360,
@@ -530,8 +535,8 @@
       "component": "skills"
     },
     ".claude/skills/systematic-debugging/SKILL.md": {
-      "templateHash": "3bfa7e39f6f450652b2f62dfd34c2dd838bf3d7d87cfc6108f1570f74ff85d2b",
-      "size": 9018,
+      "templateHash": "d8e9bbf677a9559a55de476e3b4458193313de239b8b9f0fa85f2e7cbfeab49a",
+      "size": 10417,
       "component": "skills"
     },
     ".claude/skills/systematic-debugging/root-cause-tracing.md": {
@@ -989,6 +994,11 @@
       "size": 9222,
       "component": "hooks"
     },
+    ".claude/hooks/skill-count-reminder.sh": {
+      "templateHash": "3d2f3908c497d26cb1c0bf408f17a8302fa2b724cdc455797f16016e44f95c03",
+      "size": 1461,
+      "component": "hooks"
+    },
     ".claude/hooks/scripts/eval-core-batch-save.sh": {
       "templateHash": "4f5bcba16122eff79461166e88204a03dddd8a31a1e4bfe927252c8f1526b26f",
       "size": 1347,
@@ -1140,8 +1150,8 @@
       "component": "hooks"
     },
     ".claude/hooks/hooks.json": {
-      "templateHash": "165c66e0d751dbdb6764be28362696594577a1eb385bf68014b936c38e6d1938",
-      "size": 24468,
+      "templateHash": "5c1e0519b019b40c1f729e5924d888a6ea1efdcfeb3b3c2c86ab203b56dd6881",
+      "size": 24820,
       "component": "hooks"
     },
     ".claude/ontology/agents.yaml": {
@@ -1480,8 +1490,8 @@
       "component": "guides"
     },
     "guides/git-worktree-workflow/README.md": {
-      "templateHash": "701bfaf51161dd3c03079fe0ed2e354e756c297ac2e3e985f88d991c03272e6e",
-      "size": 3769,
+      "templateHash": "6445c5e39696f40063180b08b51953602ebb58c30377f4c7a88404fc9912f2e5",
+      "size": 3959,
       "component": "guides"
     },
     "guides/aws/well-architected.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2301,7 +2301,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.84.0",
+    version: "0.87.2",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {
@@ -2349,7 +2349,7 @@ var init_package = __esm(() => {
       yaml: "^2.8.2"
     },
     devDependencies: {
-      "@anthropic-ai/sdk": "^0.82.0",
+      "@anthropic-ai/sdk": "^0.88.0",
       "@biomejs/biome": "^2.3.12",
       "@types/bun": "^1.3.6",
       "@types/js-yaml": "^4.0.9",
@@ -9608,6 +9608,23 @@ async function getTemplateVersion() {
   }
   return package_default.version;
 }
+function matchesSearchPaths(projectPath, searchPaths) {
+  if (!searchPaths || searchPaths.length === 0)
+    return true;
+  return searchPaths.some((searchPath) => projectPath === searchPath || projectPath.startsWith(searchPath + sep2));
+}
+function isUnderHome(projectPath, home) {
+  return projectPath.startsWith(home + sep2) || projectPath === home;
+}
+function sortProjects(projects) {
+  return projects.sort((a, b) => {
+    if (a.status === "latest" && b.status !== "latest")
+      return -1;
+    if (a.status !== "latest" && b.status === "latest")
+      return 1;
+    return a.name.localeCompare(b.name);
+  });
+}
 async function findProjects(options = {}) {
   const currentVersion = await getTemplateVersion();
   const registry = await readRegistry();
@@ -9619,12 +9636,12 @@ async function findProjects(options = {}) {
     return fallbackResults;
   }
   const results = [];
+  const home = process.env.HOME ?? homedir3();
   for (const [projectPath, entry] of Object.entries(registry.projects)) {
-    if (options.paths && options.paths.length > 0) {
-      const matchesPath = options.paths.some((searchPath) => projectPath === searchPath || projectPath.startsWith(searchPath + sep2));
-      if (!matchesPath)
-        continue;
-    }
+    if (!matchesSearchPaths(projectPath, options.paths))
+      continue;
+    if (!isUnderHome(projectPath, home))
+      continue;
     results.push({
       name: basename4(projectPath),
       path: projectPath,
@@ -9635,31 +9652,21 @@ async function findProjects(options = {}) {
       detectionMethod: "registry"
     });
   }
-  return results.sort((a, b) => {
-    if (a.status === "latest" && b.status !== "latest")
-      return -1;
-    if (a.status !== "latest" && b.status === "latest")
-      return 1;
-    return a.name.localeCompare(b.name);
-  });
+  return sortProjects(results);
 }
-async function _findProjectsFromLockfiles(options, currentVersion) {
-  const { dirname: dirname3 } = await import("node:path");
-  const fs2 = await import("node:fs/promises");
-  const seen = new Set;
-  const results = [];
-  async function scanDir(dir2, depth) {
-    if (depth > 3 || seen.has(dir2))
-      return;
-    seen.add(dir2);
-    let entries;
-    try {
-      entries = await fs2.readdir(dir2, { withFileTypes: true });
-    } catch {
-      return;
-    }
-    const lockFile = await readLockFile(dir2);
-    if (lockFile) {
+async function _scanDirForLockfiles(dir2, depth, seen, results, home, currentVersion, fs2) {
+  if (depth > 3 || seen.has(dir2))
+    return;
+  seen.add(dir2);
+  let entries;
+  try {
+    entries = await fs2.readdir(dir2, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  const lockFile = await readLockFile(dir2);
+  if (lockFile) {
+    if (isUnderHome(dir2, home)) {
       const version = lockFile.version || lockFile.templateVersion || null;
       results.push({
         name: basename4(dir2),
@@ -9670,13 +9677,20 @@ async function _findProjectsFromLockfiles(options, currentVersion) {
         status: computeStatus(version, currentVersion),
         detectionMethod: "lockfile"
       });
-      return;
     }
-    if (depth < 3) {
-      const subdirs = entries.filter((e) => e.isDirectory() && !e.name.startsWith(".") && e.name !== "node_modules" && e.name !== "dist" && e.name !== "build" && e.name !== ".git");
-      await Promise.all(subdirs.map((sub) => scanDir(join10(dir2, sub.name), depth + 1).catch(() => {})));
-    }
+    return;
   }
+  if (depth < 3) {
+    const subdirs = entries.filter((e) => e.isDirectory() && !e.name.startsWith(".") && !SCAN_SKIP_DIRS2.has(e.name));
+    await Promise.all(subdirs.map((sub) => _scanDirForLockfiles(join10(dir2, sub.name), depth + 1, seen, results, home, currentVersion, fs2).catch(() => {})));
+  }
+}
+async function _findProjectsFromLockfiles(options, currentVersion) {
+  const { dirname: dirname3 } = await import("node:path");
+  const fs2 = await import("node:fs/promises");
+  const seen = new Set;
+  const results = [];
+  const home = process.env.HOME ?? homedir3();
   const searchPaths = options.paths ? [...options.paths] : [];
   if (!options.paths) {
     const cwd = process.cwd();
@@ -9686,14 +9700,8 @@ async function _findProjectsFromLockfiles(options, currentVersion) {
     if (parent !== cwd && !searchPaths.includes(parent))
       searchPaths.push(parent);
   }
-  await Promise.all(searchPaths.map((p) => scanDir(p, 0).catch(() => {})));
-  return results.sort((a, b) => {
-    if (a.status === "latest" && b.status !== "latest")
-      return -1;
-    if (a.status !== "latest" && b.status === "latest")
-      return 1;
-    return a.name.localeCompare(b.name);
-  });
+  await Promise.all(searchPaths.map((p) => _scanDirForLockfiles(p, 0, seen, results, home, currentVersion, fs2).catch(() => {})));
+  return sortProjects(results);
 }
 async function writeLockFile(projectDir, version, existing) {
   const fs2 = await import("node:fs/promises");
@@ -9814,11 +9822,12 @@ async function projectsCommand(options = {}) {
     return { success: false, projects: [], currentVersion, errors: [errorMessage] };
   }
 }
-var projects_default;
+var SCAN_SKIP_DIRS2, projects_default;
 var init_projects = __esm(() => {
   init_package();
   init_registry();
   init_fs();
+  SCAN_SKIP_DIRS2 = new Set(["node_modules", "dist", "build", ".git"]);
   projects_default = projectsCommand;
 });
 
@@ -25022,6 +25031,8 @@ var en_default = {
       newVersionAvailable: "[Info] oh-my-customcode v{{latest}} available (current: v{{current}}). Run 'npm i -g oh-my-customcode' to upgrade.",
       selfUpdateDone: "✓ oh-my-customcode updated ({{from}} → {{to}})",
       selfUpdateFailed: "⚠ Self-update check failed — continuing with external updates",
+      selfUpdateReexec: "↻ Re-executing with updated CLI (v{{version}})...",
+      allProjectSkippedSource: "  ℹ Skipped: {{name}} (source project cannot self-update)",
       rtkMissing: "[RTK] RTK is not installed. Attempting installation...",
       rtkInstalled: "[RTK] ✓ RTK installed — 60-90% token savings activated",
       codexMissing: "[Codex] Codex CLI is not installed. Attempting installation...",
@@ -25437,6 +25448,8 @@ var ko_default = {
       newVersionAvailable: "[정보] oh-my-customcode v{{latest}} 사용 가능 (현재: v{{current}}). 'npm i -g oh-my-customcode'를 실행하여 업그레이드하세요.",
       selfUpdateDone: "✓ oh-my-customcode 업데이트 완료 ({{from}} → {{to}})",
       selfUpdateFailed: "⚠ 자체 업데이트 확인 실패 — 외부 업데이트를 계속 진행합니다",
+      selfUpdateReexec: "↻ 새 CLI(v{{version}})로 재실행 중...",
+      allProjectSkippedSource: "  ℹ 스킵: {{name}} (소스 프로젝트는 자체 업데이트할 수 없음)",
       rtkMissing: "[RTK] RTK가 설치되지 않았습니다. 설치를 시도합니다...",
       rtkInstalled: "[RTK] ✓ RTK 설치 완료 — 토큰 60-90% 절감 활성화",
       codexMissing: "[Codex] Codex CLI가 설치되지 않았습니다. 설치를 시도합니다...",
@@ -31029,6 +31042,7 @@ async function shouldSkipSelfUpdate2(targetDir, result) {
     if (targetPkg.name === "oh-my-customcode") {
       warn("update.self_update_skipped");
       result.success = true;
+      result.skippedSource = true;
       result.warnings.push("Skipped: source project cannot update itself");
       return true;
     }
@@ -31446,19 +31460,34 @@ async function checkCliVersion(checkFn) {
     }
   } catch {}
 }
+async function reexecUpdatedCli(toVersion) {
+  console.log(i18n.t("cli.update.selfUpdateReexec", { version: toVersion }));
+  const { spawnSync: spawnSync4 } = await import("node:child_process");
+  const child = spawnSync4(process.execPath, [process.argv[1] ?? "", ...process.argv.slice(2)], {
+    stdio: "inherit",
+    env: { ...process.env, OMCUSTOM_SKIP_SELF_UPDATE: "true" }
+  });
+  process.exit(child.status ?? 1);
+}
+async function handleSelfUpdate() {
+  try {
+    const selfUpdateResult = executeSelfUpdate();
+    if (selfUpdateResult.updated) {
+      console.log(i18n.t("cli.update.selfUpdateDone", {
+        from: selfUpdateResult.fromVersion,
+        to: selfUpdateResult.toVersion
+      }));
+      if (process.env.OMCUSTOM_SKIP_SELF_UPDATE !== "true") {
+        await reexecUpdatedCli(selfUpdateResult.toVersion);
+      }
+    }
+  } catch {
+    console.warn(i18n.t("cli.update.selfUpdateFailed"));
+  }
+}
 async function updateCommand(options = {}, cliVersionCheck = checkSelfUpdate) {
   if (!options.skipSelf) {
-    try {
-      const selfUpdateResult = executeSelfUpdate();
-      if (selfUpdateResult.updated) {
-        console.log(i18n.t("cli.update.selfUpdateDone", {
-          from: selfUpdateResult.fromVersion,
-          to: selfUpdateResult.toVersion
-        }));
-      }
-    } catch {
-      console.warn(i18n.t("cli.update.selfUpdateFailed"));
-    }
+    await handleSelfUpdate();
   } else {
     await checkCliVersion(cliVersionCheck);
   }
@@ -31501,6 +31530,21 @@ async function updateSingleProject(targetDir, options) {
   }
   return true;
 }
+function reportProjectUpdateResult(project, result, currentVersion) {
+  if (result.success) {
+    if (result.skippedSource) {
+      console.log(i18n.t("cli.update.allProjectSkippedSource", { name: project.name }));
+      return "skipped";
+    }
+    const from = result.previousVersion || project.version || "unknown";
+    const to = result.newVersion || currentVersion;
+    console.log(i18n.t("cli.update.allProjectUpdated", { from, to }));
+    return "updated";
+  }
+  const errorMsg = result.error ?? "unknown error";
+  console.log(i18n.t("cli.update.allProjectFailed", { error: errorMsg }));
+  return "failed";
+}
 async function updateAllProjects(options) {
   const { findProjects: findProjects2 } = await Promise.resolve().then(() => (init_projects(), exports_projects));
   const currentVersion = package_default.version;
@@ -31535,14 +31579,10 @@ async function updateAllProjects(options) {
         hard: options.hard
       };
       const result = await update(updateOptions);
-      if (result.success) {
-        const from = result.previousVersion || project.version || "unknown";
-        const to = result.newVersion || currentVersion;
-        console.log(i18n.t("cli.update.allProjectUpdated", { from, to }));
+      const outcome = reportProjectUpdateResult(project, result, currentVersion);
+      if (outcome === "updated") {
         updatedCount++;
-      } else {
-        const errorMsg = result.error ?? "unknown error";
-        console.log(i18n.t("cli.update.allProjectFailed", { error: errorMsg }));
+      } else if (outcome === "failed") {
         failedCount++;
       }
     } catch (error2) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1974,7 +1974,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.84.0",
+  version: "0.87.2",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {
@@ -2022,7 +2022,7 @@ var package_default = {
     yaml: "^2.8.2"
   },
   devDependencies: {
-    "@anthropic-ai/sdk": "^0.82.0",
+    "@anthropic-ai/sdk": "^0.88.0",
     "@biomejs/biome": "^2.3.12",
     "@types/bun": "^1.3.6",
     "@types/js-yaml": "^4.0.9",
@@ -4843,6 +4843,7 @@ async function shouldSkipSelfUpdate(targetDir, result) {
     if (targetPkg.name === "oh-my-customcode") {
       warn("update.self_update_skipped");
       result.success = true;
+      result.skippedSource = true;
       result.warnings.push("Skipped: source project cannot update itself");
       return true;
     }

--- a/docs/superpowers/plans/2026-04-14-v0.87.0-release.md
+++ b/docs/superpowers/plans/2026-04-14-v0.87.0-release.md
@@ -1,0 +1,30 @@
+# 릴리즈 계획 — 2026-04-14 생성
+
+> 출처: 2026-04-14 기준 `verify-done` 라벨 오픈 이슈
+> 제외된 이슈: 없음
+
+## v0.87.0 릴리즈 계획
+
+**예상 범위**: S | **이슈**: 1 | **병렬 가능**: 3 (하위 작업)
+
+| # | 우선순위 | 규모 | 제목 | 의존성 |
+|---|----------|------|------|--------|
+| #854 | P2 | S | Claude Code v2.1.105 — CC 신규 기능 반영 | 없음 |
+
+### 구현 순서
+
+1. #854-a — R006 (`MUST-agent-design.md`) PreCompact hook block 지원 문서화 + v2.1.105 버전 노트 추가 (권장 에이전트: mgr-updater)
+2. #854-b — Worktree 가이드 (`guides/git-worktree-workflow/`) EnterWorktree `path` 파라미터 문서화 (권장 에이전트: arch-documenter)
+3. #854-c — templates/ 동기화 (권장 에이전트: mgr-updater)
+
+### 참고 사항
+
+- CC v2.1.105의 주요 변경: EnterWorktree path param, PreCompact hook block, plugin monitors manifest, skill desc cap 250→1536
+- 3개 하위 작업은 독립적이므로 병렬 실행 가능 (R009)
+- v2.1.107은 triage에서 Not Applicable 판정되어 제외
+
+## 요약
+
+| 릴리즈 | 이슈 수 | 규모 | P1 | P2 | P3 |
+|--------|---------|------|----|----|-----|
+| v0.87.0 | 1 | S | 0 | 1 | 0 |

--- a/docs/superpowers/plans/2026-04-14-v0.87.2-release.md
+++ b/docs/superpowers/plans/2026-04-14-v0.87.2-release.md
@@ -1,0 +1,41 @@
+# 릴리즈 계획 — 2026-04-14 생성
+
+> 출처: 2026-04-14 기준 `verify-done` 라벨 오픈 이슈
+> 제외된 이슈 (이미 오픈 PR에 포함): 없음
+
+## v0.87.2 릴리즈 계획 (hotfix)
+
+**예상 범위**: M | **이슈**: 1 | **병렬 가능**: 0
+
+| # | 우선순위 | 규모 | 제목 | 의존성 |
+|---|----------|------|------|--------|
+| #860 | P1 | M | omcustom update --all --hard: latest 미반영, self-update 후 구버전 참조, 버전 감지 실패 | 없음 |
+
+### 구현 순서
+1. #860 — self-update re-exec via spawnSync + OMCUSTOM_SKIP_SELF_UPDATE env guard, fix version detection in updater.ts:546, fix updatedCount in update.ts:204-208 (권장 에이전트: lang-typescript-expert)
+
+### 참고 사항
+- 버그 2, 3, 4는 단일 핫픽스 PR로 통합
+- 버그 1 (v0.87.1 대신 v0.86.1 설치)은 현재 코드 경로상 명확한 원인 미발견 — 별도 재현/디버깅 이슈로 분리 권장
+- `packageJson.version` 모듈 로드 시점 동결이 근본 원인
+
+## v0.87.3 릴리즈 계획
+
+**예상 범위**: S | **이슈**: 1 | **병렬 가능**: 0
+
+| # | 우선순위 | 규모 | 제목 | 의존성 |
+|---|----------|------|------|--------|
+| #859 | P2 | S | E2E 테스트 임시폴더가 레지스트리에 등록되어 projects 출력을 오염시킴 | 없음 |
+
+### 구현 순서
+1. #859 — registerProject() temp path 가드, cleanRegistry() temp 패턴 자동 정리, 테스트 harness 격리 헬퍼 (권장 에이전트: lang-typescript-expert)
+
+### 참고 사항
+- v0.85.0 `bfcddf9` 커밋이 표시 증상(`isUnderHome()` 필터)만 부분 해결 — 이 릴리즈는 근본 원인 해결
+- 3레이어 방어 단일 PR
+
+## 요약
+| 릴리즈 | 이슈 수 | 규모 | P1 | P2 | P3 |
+|--------|---------|------|----|----|-----|
+| v0.87.2 | 1 | M | 1 | 0 | 0 |
+| v0.87.3 | 1 | S | 0 | 1 | 0 |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.87.1",
+  "version": "0.87.2",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -67,6 +67,46 @@ async function checkCliVersion(checkFn: typeof checkSelfUpdate): Promise<void> {
 }
 
 /**
+ * Re-exec the current process with OMCUSTOM_SKIP_SELF_UPDATE=true so the child
+ * process loads the newly-installed package version. Without this, the running
+ * process retains stale top-level imports and downstream project updates fail
+ * with "Downgrade prevented" (#860).
+ */
+async function reexecUpdatedCli(toVersion: string): Promise<void> {
+  console.log(i18n.t('cli.update.selfUpdateReexec', { version: toVersion }));
+  const { spawnSync } = await import('node:child_process');
+  const child = spawnSync(process.execPath, [process.argv[1] ?? '', ...process.argv.slice(2)], {
+    stdio: 'inherit',
+    env: { ...process.env, OMCUSTOM_SKIP_SELF_UPDATE: 'true' },
+  });
+  process.exit(child.status ?? 1);
+}
+
+/**
+ * Handle self-update of the oh-my-customcode package.
+ * Performs re-exec if an update was installed and the guard env var is not set.
+ */
+async function handleSelfUpdate(): Promise<void> {
+  try {
+    const selfUpdateResult = executeSelfUpdate();
+    if (selfUpdateResult.updated) {
+      console.log(
+        i18n.t('cli.update.selfUpdateDone', {
+          from: selfUpdateResult.fromVersion,
+          to: selfUpdateResult.toVersion,
+        })
+      );
+      if (process.env.OMCUSTOM_SKIP_SELF_UPDATE !== 'true') {
+        await reexecUpdatedCli(selfUpdateResult.toVersion);
+      }
+    }
+  } catch {
+    // Non-blocking: self-update failure must not stop the external update workflow
+    console.warn(i18n.t('cli.update.selfUpdateFailed'));
+  }
+}
+
+/**
  * Execute the update command
  */
 export async function updateCommand(
@@ -75,20 +115,7 @@ export async function updateCommand(
 ): Promise<void> {
   // Step 0: Self-update oh-my-customcode package before external updates
   if (!options.skipSelf) {
-    try {
-      const selfUpdateResult = executeSelfUpdate();
-      if (selfUpdateResult.updated) {
-        console.log(
-          i18n.t('cli.update.selfUpdateDone', {
-            from: selfUpdateResult.fromVersion,
-            to: selfUpdateResult.toVersion,
-          })
-        );
-      }
-    } catch {
-      // Non-blocking: self-update failure must not stop the external update workflow
-      console.warn(i18n.t('cli.update.selfUpdateFailed'));
-    }
+    await handleSelfUpdate();
   } else {
     // Fallback: notification-only version check when self-update is skipped
     await checkCliVersion(cliVersionCheck);
@@ -151,6 +178,32 @@ async function updateSingleProject(
   return true;
 }
 
+type ProjectUpdateOutcome = 'updated' | 'failed' | 'skipped';
+
+/**
+ * Log the result of a single project update and return the outcome.
+ * Extracted to keep updateAllProjects below the complexity limit.
+ */
+function reportProjectUpdateResult(
+  project: { name: string; version: string | null },
+  result: UpdateResult,
+  currentVersion: string
+): ProjectUpdateOutcome {
+  if (result.success) {
+    if (result.skippedSource) {
+      console.log(i18n.t('cli.update.allProjectSkippedSource', { name: project.name }));
+      return 'skipped';
+    }
+    const from = result.previousVersion || project.version || 'unknown';
+    const to = result.newVersion || currentVersion;
+    console.log(i18n.t('cli.update.allProjectUpdated', { from, to }));
+    return 'updated';
+  }
+  const errorMsg = result.error ?? 'unknown error';
+  console.log(i18n.t('cli.update.allProjectFailed', { error: errorMsg }));
+  return 'failed';
+}
+
 /**
  * Batch update all outdated projects found by project discovery.
  * Runs sequentially so progress output is readable.
@@ -200,15 +253,10 @@ async function updateAllProjects(options: UpdateCommandOptions): Promise<void> {
       };
 
       const result = await update(updateOptions);
-
-      if (result.success) {
-        const from = result.previousVersion || project.version || 'unknown';
-        const to = result.newVersion || currentVersion;
-        console.log(i18n.t('cli.update.allProjectUpdated', { from, to }));
+      const outcome = reportProjectUpdateResult(project, result, currentVersion);
+      if (outcome === 'updated') {
         updatedCount++;
-      } else {
-        const errorMsg = result.error ?? 'unknown error';
-        console.log(i18n.t('cli.update.allProjectFailed', { error: errorMsg }));
+      } else if (outcome === 'failed') {
         failedCount++;
       }
     } catch (error: unknown) {

--- a/src/core/updater.ts
+++ b/src/core/updater.ts
@@ -90,6 +90,8 @@ export interface UpdateResult {
   removedDeprecatedFiles: string[];
   /** Files whose frontmatter name: was synced from upstream */
   namespaceSynced: string[];
+  /** True when the target was skipped because it is the source project itself */
+  skippedSource?: boolean;
   /** Error message if failed */
   error?: string;
 }
@@ -544,6 +546,7 @@ async function shouldSkipSelfUpdate(targetDir: string, result: UpdateResult): Pr
     if (targetPkg.name === 'oh-my-customcode') {
       warn('update.self_update_skipped');
       result.success = true;
+      result.skippedSource = true;
       result.warnings.push('Skipped: source project cannot update itself');
       return true;
     }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -150,6 +150,8 @@
       "newVersionAvailable": "[Info] oh-my-customcode v{{latest}} available (current: v{{current}}). Run 'npm i -g oh-my-customcode' to upgrade.",
       "selfUpdateDone": "✓ oh-my-customcode updated ({{from}} → {{to}})",
       "selfUpdateFailed": "⚠ Self-update check failed — continuing with external updates",
+      "selfUpdateReexec": "↻ Re-executing with updated CLI (v{{version}})...",
+      "allProjectSkippedSource": "  ℹ Skipped: {{name}} (source project cannot self-update)",
       "rtkMissing": "[RTK] RTK is not installed. Attempting installation...",
       "rtkInstalled": "[RTK] ✓ RTK installed — 60-90% token savings activated",
       "codexMissing": "[Codex] Codex CLI is not installed. Attempting installation...",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -150,6 +150,8 @@
       "newVersionAvailable": "[정보] oh-my-customcode v{{latest}} 사용 가능 (현재: v{{current}}). 'npm i -g oh-my-customcode'를 실행하여 업그레이드하세요.",
       "selfUpdateDone": "✓ oh-my-customcode 업데이트 완료 ({{from}} → {{to}})",
       "selfUpdateFailed": "⚠ 자체 업데이트 확인 실패 — 외부 업데이트를 계속 진행합니다",
+      "selfUpdateReexec": "↻ 새 CLI(v{{version}})로 재실행 중...",
+      "allProjectSkippedSource": "  ℹ 스킵: {{name}} (소스 프로젝트는 자체 업데이트할 수 없음)",
       "rtkMissing": "[RTK] RTK가 설치되지 않았습니다. 설치를 시도합니다...",
       "rtkInstalled": "[RTK] ✓ RTK 설치 완료 — 토큰 60-90% 절감 활성화",
       "codexMissing": "[Codex] Codex CLI가 설치되지 않았습니다. 설치를 시도합니다...",

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.87.1",
+  "version": "0.87.2",
   "lastUpdated": "2026-04-14T00:00:00.000Z",
   "components": [
     {

--- a/tests/unit/cli/update.test.ts
+++ b/tests/unit/cli/update.test.ts
@@ -1652,4 +1652,211 @@ describe('update command', () => {
       expect(consoleErrorSpy).toHaveBeenCalled();
     });
   });
+
+  describe('updateCommand self-update re-exec (#860)', () => {
+    let originalEnv: NodeJS.ProcessEnv;
+    let spawnSyncMock: ReturnType<typeof mock>;
+
+    beforeEach(() => {
+      originalEnv = { ...process.env };
+      // Ensure re-exec guard is NOT set by default
+      delete process.env.OMCUSTOM_SKIP_SELF_UPDATE;
+    });
+
+    afterEach(() => {
+      // Restore env
+      for (const key of Object.keys(process.env)) {
+        if (!(key in originalEnv)) {
+          delete process.env[key];
+        }
+      }
+      Object.assign(process.env, originalEnv);
+    });
+
+    it('should call spawnSync and exit when executeSelfUpdate returns updated=true and guard is not set', async () => {
+      spawnSyncMock = mock(() => ({ status: 0, pid: 999 }));
+
+      mock.module('node:child_process', () => ({
+        spawnSync: spawnSyncMock,
+      }));
+
+      mock.module('../../../src/core/self-update.js', () => ({
+        executeSelfUpdate: mock(() => ({
+          updated: true,
+          fromVersion: '0.87.1',
+          toVersion: '0.87.2',
+        })),
+        checkSelfUpdate: mock(() => ({ updateAvailable: false })),
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mock(async () => ({
+          success: true,
+          updatedComponents: [],
+          skippedComponents: [],
+          preservedFiles: [],
+          backedUpPaths: [],
+          previousVersion: '0.87.1',
+          newVersion: '0.87.2',
+          warnings: [],
+        })),
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      await updateCommand({ skipSelf: false });
+
+      // spawnSync must have been called with process.execPath and argv re-exec args
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+      const callArgs = (spawnSyncMock.mock.calls as unknown[][])[0] as unknown[];
+      expect(callArgs[0]).toBe(process.execPath);
+      // Third argument is options — env should include the guard
+      const spawnOptions = callArgs[2] as { env?: Record<string, string> };
+      expect(spawnOptions.env?.OMCUSTOM_SKIP_SELF_UPDATE).toBe('true');
+
+      // process.exit must have been called with child.status (0)
+      expect(exitCode).toBe(0);
+    });
+
+    it('should NOT call spawnSync when OMCUSTOM_SKIP_SELF_UPDATE=true is set', async () => {
+      process.env.OMCUSTOM_SKIP_SELF_UPDATE = 'true';
+
+      spawnSyncMock = mock(() => ({ status: 0, pid: 999 }));
+
+      mock.module('node:child_process', () => ({
+        spawnSync: spawnSyncMock,
+      }));
+
+      // executeSelfUpdate itself short-circuits internally when the env guard is set,
+      // so it returns updated=false — spawnSync must not be called
+      mock.module('../../../src/core/self-update.js', () => ({
+        executeSelfUpdate: mock(() => ({
+          updated: false,
+          fromVersion: '0.87.2',
+          toVersion: '0.87.2',
+        })),
+        checkSelfUpdate: mock(() => ({ updateAvailable: false })),
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mock(async () => ({
+          success: true,
+          updatedComponents: [],
+          skippedComponents: [],
+          preservedFiles: [],
+          backedUpPaths: [],
+          previousVersion: '0.87.2',
+          newVersion: '0.87.2',
+          warnings: [],
+        })),
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      await updateCommand({ skipSelf: false });
+
+      expect(spawnSyncMock).not.toHaveBeenCalled();
+      // Should not call process.exit (no re-exec)
+      expect(exitCode).toBeUndefined();
+    });
+
+    it('should NOT call spawnSync when executeSelfUpdate returns updated=false', async () => {
+      spawnSyncMock = mock(() => ({ status: 0, pid: 999 }));
+
+      mock.module('node:child_process', () => ({
+        spawnSync: spawnSyncMock,
+      }));
+
+      mock.module('../../../src/core/self-update.js', () => ({
+        executeSelfUpdate: mock(() => ({
+          updated: false,
+          fromVersion: '0.87.2',
+          toVersion: '0.87.2',
+        })),
+        checkSelfUpdate: mock(() => ({ updateAvailable: false })),
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mock(async () => ({
+          success: true,
+          updatedComponents: [],
+          skippedComponents: [],
+          preservedFiles: [],
+          backedUpPaths: [],
+          previousVersion: '0.87.2',
+          newVersion: '0.87.2',
+          warnings: [],
+        })),
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      await updateCommand({ skipSelf: false });
+
+      expect(spawnSyncMock).not.toHaveBeenCalled();
+      expect(exitCode).toBeUndefined();
+    });
+  });
+
+  describe('updateCommand --all with skippedSource (#860)', () => {
+    it('should print skip message and not increment updatedCount when result.skippedSource is true', async () => {
+      mock.module('../../../src/core/provider.js', () => ({
+        detectProvider: async () => ({
+          provider: 'claude',
+          source: 'override',
+          confidence: 'high',
+          reason: 'test',
+        }),
+      }));
+
+      // One project returns skippedSource=true (the source project itself)
+      const mockUpdate = mock(async () => ({
+        success: true,
+        skippedSource: true,
+        updatedComponents: [],
+        skippedComponents: [],
+        preservedFiles: [],
+        backedUpPaths: [],
+        previousVersion: '0.87.1',
+        newVersion: '0.87.1',
+        warnings: ['Skipped: source project cannot update itself'],
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mockUpdate,
+      }));
+
+      mock.module('../../../src/cli/projects.js', () => ({
+        findProjects: async () => [
+          {
+            name: 'oh-my-customcode',
+            path: '/tmp/oh-my-customcode',
+            version: '0.87.1',
+            installedAt: null,
+            updatedAt: null,
+            status: 'outdated',
+            detectionMethod: 'lockfile',
+          },
+        ],
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      await updateCommand({ all: true });
+
+      // update should have been called once
+      expect(mockUpdate).toHaveBeenCalledTimes(1);
+
+      // The final summary must show 0 updated and 0 failed (skipped source doesn't count)
+      const allLogs = (consoleLogSpy.mock.calls as unknown[][]).flat().join('\n');
+      // "0 updated, 0 failed" in the allDone message
+      expect(allLogs).toContain('0 updated');
+      expect(allLogs).toContain('0 failed');
+
+      // The skip message should have been printed
+      expect(allLogs).toContain('oh-my-customcode');
+
+      expect(exitCode).toBeUndefined();
+    });
+  });
 });

--- a/tests/unit/core/updater.test.ts
+++ b/tests/unit/core/updater.test.ts
@@ -1190,4 +1190,43 @@ describe('updater', () => {
       expect(Array.isArray(result.namespaceSynced)).toBe(true);
     });
   });
+
+  describe('shouldSkipSelfUpdate (via update())', () => {
+    it('should set skippedSource=true when target is the oh-my-customcode source project', async () => {
+      // Write a package.json with name "oh-my-customcode" to tempDir
+      await writeFile(
+        join(tempDir, 'package.json'),
+        JSON.stringify({ name: 'oh-my-customcode', version: '0.1.0' }, null, 2)
+      );
+      await createConfig('0.1.0');
+
+      const result = await update({
+        targetDir: tempDir,
+        components: ['rules'],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.skippedSource).toBe(true);
+    });
+
+    it('should NOT set skippedSource for normal (non-source) projects', async () => {
+      // Write a package.json with a different name
+      await writeFile(
+        join(tempDir, 'package.json'),
+        JSON.stringify({ name: 'my-other-project', version: '0.1.0' }, null, 2)
+      );
+      await createConfig('0.1.0');
+
+      const layout = getProviderLayout();
+      await mkdir(join(tempDir, layout.rootDir), { recursive: true });
+
+      const result = await update({
+        targetDir: tempDir,
+        components: ['rules'],
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.skippedSource).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- `omcustom update --all --hard` 의 3개 버그 핫픽스 (#860)
- self-update 후 CLI re-exec 으로 구버전 `packageJson.version` 참조 문제 해결
- `UpdateResult.skippedSource` 필드 추가로 소스 프로젝트 skip 명시화
- `reportProjectUpdateResult` 헬퍼로 카운팅 정확도 개선

## 관련 이슈

Fixes #860 (버그 2, 3, 4)

**범위 외** — 별도 이슈로 분리:
- 버그 1 (latest v0.87.1 대신 v0.86.1 설치) — npm registry fetch 문제로 재현 필요

## 변경 사항

| 파일 | 변경 |
|------|------|
| `src/core/updater.ts` | `UpdateResult.skippedSource?` 필드, `shouldSkipSelfUpdate` 에서 세팅 |
| `src/cli/update.ts` | `reexecUpdatedCli`, `handleSelfUpdate`, `reportProjectUpdateResult` 헬퍼 추출 |
| `src/i18n/locales/{ko,en}.json` | `selfUpdateReexec`, `allProjectSkippedSource` 키 |
| `tests/unit/cli/update.test.ts` | re-exec 3건 + skippedSource 1건 테스트 |
| `tests/unit/core/updater.test.ts` | skippedSource 2건 테스트 |
| `package.json` | `0.87.1` → `0.87.2` |

## 구현 접근

`packageJson.version` 이 `src/cli/update.ts:11` 과 `src/core/updater.ts:6` 에서 top-level import 로 모듈 로드 시점에 동결되는 것이 근본 원인. `executeSelfUpdate()` 로 패키지를 재설치해도 현재 프로세스의 메모리상 버전은 변하지 않음.

해결: self-update 성공 직후 `spawnSync(process.execPath, [argv[1], ...rest], { env: { OMCUSTOM_SKIP_SELF_UPDATE: 'true' }})` 로 자기 자신을 재실행. 자식 프로세스는 새로 설치된 파일을 로드하여 올바른 버전을 사용. `OMCUSTOM_SKIP_SELF_UPDATE=true` env 가드로 재귀 재실행 방지.

## Test plan

- [x] `bun run lint` 통과
- [x] `bun run typecheck` 통과
- [x] `bun test` 1673 pass / 0 fail
- [x] `bun run build` 성공
- [x] `deep-verify` READY (9 findings 모두 FP/design/deferred, 실제 수정 0건)
- [ ] 수동 검증: `omcustom update --all --hard` 로컬 실행 (리뷰어가 확인)

## 후속 개선 후보 (별도 이슈로 등록 예정)

1. re-exec 테스트 보강 (non-zero exit 전파, spawnSync throw 시나리오)
2. signal 기반 종료 시 `child.signal → 128+signal` 변환
3. 버그 1 (latest version fetch) 재현 및 수정

## 릴리즈 계획

문서: `docs/superpowers/plans/2026-04-14-v0.87.2-release.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
