### PR TITLE
fix: omcustom update self-update + re-exec 클러스터 v0.87.3 (#862, #863, #864, #865)

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.87.2",
-  "generatedAt": "2026-04-14T12:39:09.315Z",
-  "templateVersion": "0.87.1",
+  "generatorVersion": "0.87.3",
+  "generatedAt": "2026-04-14T13:57:45.433Z",
+  "templateVersion": "0.87.3",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2301,7 +2301,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.87.2",
+    version: "0.87.3",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {
@@ -25032,6 +25032,7 @@ var en_default = {
       selfUpdateDone: "✓ oh-my-customcode updated ({{from}} → {{to}})",
       selfUpdateFailed: "⚠ Self-update check failed — continuing with external updates",
       selfUpdateReexec: "↻ Re-executing with updated CLI (v{{version}})...",
+      reexecArgvMissing: "⚠ Cannot re-exec: process.argv[1] is empty — continuing without re-exec",
       allProjectSkippedSource: "  ℹ Skipped: {{name}} (source project cannot self-update)",
       rtkMissing: "[RTK] RTK is not installed. Attempting installation...",
       rtkInstalled: "[RTK] ✓ RTK installed — 60-90% token savings activated",
@@ -25449,6 +25450,7 @@ var ko_default = {
       selfUpdateDone: "✓ oh-my-customcode 업데이트 완료 ({{from}} → {{to}})",
       selfUpdateFailed: "⚠ 자체 업데이트 확인 실패 — 외부 업데이트를 계속 진행합니다",
       selfUpdateReexec: "↻ 새 CLI(v{{version}})로 재실행 중...",
+      reexecArgvMissing: "⚠ 재실행 불가: process.argv[1]이 비어있습니다 — 재실행 없이 계속합니다",
       allProjectSkippedSource: "  ℹ 스킵: {{name}} (소스 프로젝트는 자체 업데이트할 수 없음)",
       rtkMissing: "[RTK] RTK가 설치되지 않았습니다. 설치를 시도합니다...",
       rtkInstalled: "[RTK] ✓ RTK 설치 완료 — 토큰 60-90% 절감 활성화",
@@ -25934,7 +25936,7 @@ function executeSelfUpdate(options = {}) {
     currentVersion,
     packageName,
     cachePath: options.cachePath,
-    cacheTtlMs: options.cacheTtlMs,
+    cacheTtlMs: options.forceRefresh ? 0 : options.cacheTtlMs,
     fetchLatestVersion: options.fetchLatestVersion,
     now: options.now,
     argv,
@@ -30681,6 +30683,7 @@ function syncCommand(program2) {
 
 // src/cli/update.ts
 init_package();
+import { constants as osConstants } from "node:os";
 
 // src/core/updater.ts
 init_package();
@@ -31460,34 +31463,46 @@ async function checkCliVersion(checkFn) {
     }
   } catch {}
 }
-async function reexecUpdatedCli(toVersion) {
+function exitWithChildStatus(child) {
+  if (child.signal) {
+    const signalNumber = osConstants.signals[child.signal] ?? 0;
+    process.exit(128 + signalNumber);
+  }
+  process.exit(child.status ?? 1);
+}
+async function reexecUpdatedCli(toVersion, spawnFn) {
+  const cliEntry = process.argv[1];
+  if (!cliEntry) {
+    console.warn(i18n.t("cli.update.reexecArgvMissing"));
+    return;
+  }
   console.log(i18n.t("cli.update.selfUpdateReexec", { version: toVersion }));
   const { spawnSync: spawnSync4 } = await import("node:child_process");
-  const child = spawnSync4(process.execPath, [process.argv[1] ?? "", ...process.argv.slice(2)], {
+  const child = (spawnFn ?? spawnSync4)(process.execPath, [cliEntry, ...process.argv.slice(2)], {
     stdio: "inherit",
     env: { ...process.env, OMCUSTOM_SKIP_SELF_UPDATE: "true" }
   });
-  process.exit(child.status ?? 1);
+  exitWithChildStatus(child);
 }
-async function handleSelfUpdate() {
+async function handleSelfUpdate(spawnFn) {
   try {
-    const selfUpdateResult = executeSelfUpdate();
+    const selfUpdateResult = executeSelfUpdate({ forceRefresh: true });
     if (selfUpdateResult.updated) {
       console.log(i18n.t("cli.update.selfUpdateDone", {
         from: selfUpdateResult.fromVersion,
         to: selfUpdateResult.toVersion
       }));
       if (process.env.OMCUSTOM_SKIP_SELF_UPDATE !== "true") {
-        await reexecUpdatedCli(selfUpdateResult.toVersion);
+        await reexecUpdatedCli(selfUpdateResult.toVersion, spawnFn);
       }
     }
   } catch {
     console.warn(i18n.t("cli.update.selfUpdateFailed"));
   }
 }
-async function updateCommand(options = {}, cliVersionCheck = checkSelfUpdate) {
+async function updateCommand(options = {}, cliVersionCheck = checkSelfUpdate, spawnFn) {
   if (!options.skipSelf) {
-    await handleSelfUpdate();
+    await handleSelfUpdate(spawnFn);
   } else {
     await checkCliVersion(cliVersionCheck);
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1974,7 +1974,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.87.2",
+  version: "0.87.3",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/docs/superpowers/plans/2026-04-14-v0.87.3-release.md
+++ b/docs/superpowers/plans/2026-04-14-v0.87.3-release.md
@@ -1,0 +1,50 @@
+# 릴리즈 계획 — 2026-04-14 생성 (v0.87.3 cycle)
+
+> 출처: 2026-04-14 기준 `verify-done` 라벨 오픈 이슈 5건
+> 제외된 이슈 (이미 오픈 PR에 포함): 없음
+
+## v0.87.3 릴리즈 계획 (self-update + re-exec 클러스터 핫픽스)
+
+**예상 범위**: M (S + 3×XS) | **이슈**: 4 | **병렬 가능**: 3
+
+| # | 우선순위 | 규모 | 제목 | 의존성 |
+|---|----------|------|------|--------|
+| #862 | P2 | S | omcustom update --hard 가 latest 대신 구버전 설치 (#860 버그 1 분리) | 없음 |
+| #863 | P3 | XS | re-exec 테스트 커버리지 보강 — non-zero exit 전파 + spawnSync throw | 없음 |
+| #864 | P3 | XS | re-exec 자식이 signal 로 종료 시 signal 정보 손실 (UNIX 관례 128+signal 미사용) | 없음 |
+| #865 | P3 | XS | re-exec: process.argv[1] 미정의 시 silent failure — loud-fail 으로 전환 | 없음 |
+
+### 구현 순서
+1. #862 — `ExecuteSelfUpdateOptions.forceRefresh` 플래그 추가, `executeSelfUpdate` 가 npm view 캐시 우회 (권장 에이전트: lang-typescript-expert)
+2. #864 — `os.constants.signals` 매핑으로 `128+signal` UNIX 관례 적용 (권장 에이전트: lang-typescript-expert)
+3. #865 — `process.argv[1]` 누락 시 early return + i18n 경고 (권장 에이전트: lang-typescript-expert)
+4. #863 — `tests/unit/cli/update.test.ts` 에 non-zero exit 전파 + spawnSync throw 테스트 추가 (권장 에이전트: lang-typescript-expert)
+
+### 참고 사항
+- #862 는 #860 버그 1 의 정식 수정 — PR #861 (v0.87.2) 가 self-update.ts 를 건드리지 않아 미해결로 남음
+- #863/#864/#865 는 모두 `src/cli/update.ts:75-83` `reexecUpdatedCli()` 9줄 함수 대상 — 단일 파일 편집으로 충돌 없음
+- #863 은 코드 로직 변경 없이 테스트만 추가 (다른 항목과 의존성 0)
+- 단일 lang-typescript-expert 에이전트가 4개 deliverable 순차 처리 권장 (병렬 분해는 같은 파일 충돌 위험)
+- **`templates/manifest.json` 도 0.87.3 으로 동시 bump 필요** (Version Sync CI 반복 패턴, mgr-gitnerd memory feedback_ci_version_sync 참고)
+
+## v0.87.4 릴리즈 계획
+
+**예상 범위**: S | **이슈**: 1 | **병렬 가능**: 0
+
+| # | 우선순위 | 규모 | 제목 | 의존성 |
+|---|----------|------|------|--------|
+| #859 | P2 | S | E2E 테스트 임시폴더가 레지스트리에 등록되어 projects 출력을 오염시킴 | 없음 |
+
+### 구현 순서
+1. #859 — 3레이어 방어: `registerProject()` temp path 가드 + `cleanRegistry()` temp 패턴 자동 정리 + 테스트 격리 헬퍼 (권장 에이전트: lang-typescript-expert)
+
+### 참고 사항
+- v0.85.0 `bfcddf9` 가 표시 증상(`isUnderHome()` 필터)만 부분 해결 — 이 릴리즈는 근본 원인 해결
+- 3레이어 단일 PR
+- `templates/manifest.json` 도 0.87.4 로 동시 bump 필요
+
+## 요약
+| 릴리즈 | 이슈 수 | 규모 | P1 | P2 | P3 |
+|--------|---------|------|----|----|-----|
+| v0.87.3 | 4 | M | 0 | 1 | 3 |
+| v0.87.4 | 1 | S | 0 | 1 | 0 |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.87.2",
+  "version": "0.87.3",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -8,6 +8,8 @@
  * 3. Interactive (TTY, no --all): checkbox UI to select which projects to update
  */
 
+import { constants as osConstants } from 'node:os';
+
 import packageJson from '../../package.json';
 import { checkSelfUpdate, executeSelfUpdate } from '../core/self-update.js';
 import { type UpdateComponent, type UpdateOptions, update } from '../core/updater.js';
@@ -67,28 +69,60 @@ async function checkCliVersion(checkFn: typeof checkSelfUpdate): Promise<void> {
 }
 
 /**
+ * Exit with a status that reflects the child process result, mapping signal
+ * termination to the conventional 128 + signal-number exit code.
+ */
+function exitWithChildStatus(child: {
+  status: number | null;
+  signal: NodeJS.Signals | null;
+}): never {
+  if (child.signal) {
+    const signalNumber = osConstants.signals[child.signal] ?? 0;
+    process.exit(128 + signalNumber);
+  }
+  process.exit(child.status ?? 1);
+}
+
+/** Minimal spawnSync signature used by reexecUpdatedCli — injectable for tests. */
+type SpawnSyncFn = (
+  command: string,
+  args: string[],
+  options: { stdio: 'inherit'; env: NodeJS.ProcessEnv }
+) => { status: number | null; signal: NodeJS.Signals | null };
+
+/**
  * Re-exec the current process with OMCUSTOM_SKIP_SELF_UPDATE=true so the child
  * process loads the newly-installed package version. Without this, the running
  * process retains stale top-level imports and downstream project updates fail
  * with "Downgrade prevented" (#860).
  */
-async function reexecUpdatedCli(toVersion: string): Promise<void> {
+async function reexecUpdatedCli(toVersion: string, spawnFn?: SpawnSyncFn): Promise<void> {
+  const cliEntry = process.argv[1];
+  if (!cliEntry) {
+    console.warn(i18n.t('cli.update.reexecArgvMissing'));
+    return;
+  }
   console.log(i18n.t('cli.update.selfUpdateReexec', { version: toVersion }));
+  // Dynamic import used intentionally: avoids static binding to node:child_process,
+  // which allows mock.module('node:child_process') in tests to work correctly.
   const { spawnSync } = await import('node:child_process');
-  const child = spawnSync(process.execPath, [process.argv[1] ?? '', ...process.argv.slice(2)], {
+  const child = (spawnFn ?? spawnSync)(process.execPath, [cliEntry, ...process.argv.slice(2)], {
     stdio: 'inherit',
     env: { ...process.env, OMCUSTOM_SKIP_SELF_UPDATE: 'true' },
   });
-  process.exit(child.status ?? 1);
+  exitWithChildStatus(child); // helper added in D3
 }
 
 /**
  * Handle self-update of the oh-my-customcode package.
  * Performs re-exec if an update was installed and the guard env var is not set.
  */
-async function handleSelfUpdate(): Promise<void> {
+async function handleSelfUpdate(spawnFn?: SpawnSyncFn): Promise<void> {
   try {
-    const selfUpdateResult = executeSelfUpdate();
+    // forceRefresh: always query npm view fresh to avoid installing a stale
+    // cached latest version (#862). Cache is intended for the init prompt path,
+    // not for explicit `omcustom update`.
+    const selfUpdateResult = executeSelfUpdate({ forceRefresh: true });
     if (selfUpdateResult.updated) {
       console.log(
         i18n.t('cli.update.selfUpdateDone', {
@@ -97,7 +131,7 @@ async function handleSelfUpdate(): Promise<void> {
         })
       );
       if (process.env.OMCUSTOM_SKIP_SELF_UPDATE !== 'true') {
-        await reexecUpdatedCli(selfUpdateResult.toVersion);
+        await reexecUpdatedCli(selfUpdateResult.toVersion, spawnFn);
       }
     }
   } catch {
@@ -111,11 +145,12 @@ async function handleSelfUpdate(): Promise<void> {
  */
 export async function updateCommand(
   options: UpdateCommandOptions = {},
-  cliVersionCheck: typeof checkSelfUpdate = checkSelfUpdate
+  cliVersionCheck: typeof checkSelfUpdate = checkSelfUpdate,
+  spawnFn?: SpawnSyncFn
 ): Promise<void> {
   // Step 0: Self-update oh-my-customcode package before external updates
   if (!options.skipSelf) {
-    await handleSelfUpdate();
+    await handleSelfUpdate(spawnFn);
   } else {
     // Fallback: notification-only version check when self-update is skipped
     await checkCliVersion(cliVersionCheck);

--- a/src/core/self-update.ts
+++ b/src/core/self-update.ts
@@ -253,6 +253,8 @@ export interface ExecuteSelfUpdateOptions {
   packageName?: string;
   cachePath?: string;
   cacheTtlMs?: number;
+  /** Bypass self-update-cache.json TTL and always query npm view fresh. */
+  forceRefresh?: boolean;
   fetchLatestVersion?: (packageName: string) => string | null;
   now?: number;
   argv?: string[];
@@ -322,7 +324,7 @@ export function executeSelfUpdate(options: ExecuteSelfUpdateOptions = {}): Execu
     currentVersion,
     packageName,
     cachePath: options.cachePath,
-    cacheTtlMs: options.cacheTtlMs,
+    cacheTtlMs: options.forceRefresh ? 0 : options.cacheTtlMs,
     fetchLatestVersion: options.fetchLatestVersion,
     now: options.now,
     argv,

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -151,6 +151,7 @@
       "selfUpdateDone": "✓ oh-my-customcode updated ({{from}} → {{to}})",
       "selfUpdateFailed": "⚠ Self-update check failed — continuing with external updates",
       "selfUpdateReexec": "↻ Re-executing with updated CLI (v{{version}})...",
+      "reexecArgvMissing": "⚠ Cannot re-exec: process.argv[1] is empty — continuing without re-exec",
       "allProjectSkippedSource": "  ℹ Skipped: {{name}} (source project cannot self-update)",
       "rtkMissing": "[RTK] RTK is not installed. Attempting installation...",
       "rtkInstalled": "[RTK] ✓ RTK installed — 60-90% token savings activated",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -151,6 +151,7 @@
       "selfUpdateDone": "✓ oh-my-customcode 업데이트 완료 ({{from}} → {{to}})",
       "selfUpdateFailed": "⚠ 자체 업데이트 확인 실패 — 외부 업데이트를 계속 진행합니다",
       "selfUpdateReexec": "↻ 새 CLI(v{{version}})로 재실행 중...",
+      "reexecArgvMissing": "⚠ 재실행 불가: process.argv[1]이 비어있습니다 — 재실행 없이 계속합니다",
       "allProjectSkippedSource": "  ℹ 스킵: {{name}} (소스 프로젝트는 자체 업데이트할 수 없음)",
       "rtkMissing": "[RTK] RTK가 설치되지 않았습니다. 설치를 시도합니다...",
       "rtkInstalled": "[RTK] ✓ RTK 설치 완료 — 토큰 60-90% 절감 활성화",

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.87.2",
+  "version": "0.87.3",
   "lastUpdated": "2026-04-14T00:00:00.000Z",
   "components": [
     {

--- a/tests/unit/cli/update.test.ts
+++ b/tests/unit/cli/update.test.ts
@@ -1859,4 +1859,114 @@ describe('update command', () => {
       expect(exitCode).toBeUndefined();
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // D2: exit-code propagation and error swallowing (#863)
+  //
+  // These tests use injectable spawnFn to avoid mock.module('node:child_process')
+  // leakage. They are placed LAST in the file so that any mock.module leakage
+  // from this describe block does not affect the earlier tests.
+  // Bun 1.3.x mock.restore() does not reliably undo module mocks for modules
+  // that have already been cached via dynamic import.
+  // ---------------------------------------------------------------------------
+  // ⚠ DO NOT ADD TESTS BELOW THIS BLOCK ⚠
+  // This describe block uses mock.module() patterns that leak across files
+  // in Bun 1.3.x. Placing it as the LAST block in this file ensures no
+  // downstream tests are affected. New tests in this file MUST be added
+  // ABOVE this block, not below.
+  // ---------------------------------------------------------------------------
+  describe('reexecUpdatedCli exit-code and error swallowing (#863)', () => {
+    let originalEnv: NodeJS.ProcessEnv;
+    let spawnSyncMock: ReturnType<typeof mock>;
+
+    beforeEach(() => {
+      originalEnv = { ...process.env };
+      delete process.env.OMCUSTOM_SKIP_SELF_UPDATE;
+    });
+
+    afterEach(() => {
+      for (const key of Object.keys(process.env)) {
+        if (!(key in originalEnv)) {
+          delete process.env[key];
+        }
+      }
+      Object.assign(process.env, originalEnv);
+    });
+
+    it('should propagate non-zero child exit code via process.exit (#863)', async () => {
+      // Use injectable spawnFn instead of mock.module('node:child_process') to
+      // avoid leaking the replacement into other test files. Bun 1.3.x does not
+      // reliably restore node: built-in module mocks via mock.restore().
+      spawnSyncMock = mock(() => ({ status: 42, pid: 999, signal: null }));
+
+      mock.module('../../../src/core/self-update.js', () => ({
+        executeSelfUpdate: mock(() => ({
+          updated: true,
+          fromVersion: '0.87.2',
+          toVersion: '0.87.3',
+        })),
+        checkSelfUpdate: mock(() => ({ updateAvailable: false })),
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mock(async () => ({
+          success: true,
+          updatedComponents: [],
+          skippedComponents: [],
+          preservedFiles: [],
+          backedUpPaths: [],
+          previousVersion: '0.87.2',
+          newVersion: '0.87.3',
+          warnings: [],
+        })),
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      await updateCommand({ skipSelf: false }, undefined, spawnSyncMock as never);
+
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+      expect(exitCode).toBe(42);
+    });
+
+    it('should catch spawnSync thrown errors in outer try/catch and warn (#863)', async () => {
+      // Use injectable spawnFn instead of mock.module('node:child_process') to
+      // avoid leaking the replacement into other test files. Bun 1.3.x does not
+      // reliably restore node: built-in module mocks via mock.restore().
+      spawnSyncMock = mock(() => {
+        throw new Error('spawn EACCES');
+      });
+
+      mock.module('../../../src/core/self-update.js', () => ({
+        executeSelfUpdate: mock(() => ({
+          updated: true,
+          fromVersion: '0.87.2',
+          toVersion: '0.87.3',
+        })),
+        checkSelfUpdate: mock(() => ({ updateAvailable: false })),
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mock(async () => ({
+          success: true,
+          updatedComponents: [],
+          skippedComponents: [],
+          preservedFiles: [],
+          backedUpPaths: [],
+          previousVersion: '0.87.2',
+          newVersion: '0.87.3',
+          warnings: [],
+        })),
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+
+      // Must NOT throw — outer try/catch in handleSelfUpdate must swallow
+      await updateCommand({ skipSelf: false }, undefined, spawnSyncMock as never);
+
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+      expect(consoleWarnSpy).toHaveBeenCalled();
+    });
+  });
 });
+// END OF FILE — see warning above. Do not add tests below this point.


### PR DESCRIPTION
## Summary

- self-update + re-exec 클러스터 4개 이슈 번들 (v0.87.3)
- #862 핫픽스: `--hard` 가 stale 캐시 latest 설치 → forceRefresh 플래그
- #864/#865: signal 종료 UX + argv 가드
- #863: re-exec 테스트 커버리지 보강

## 관련 이슈

Closes #862, #863, #864, #865

## 변경 사항

| 파일 | 변경 |
|------|------|
| `src/core/self-update.ts` | `ExecuteSelfUpdateOptions.forceRefresh` 추가, `cacheTtlMs:0` 로 캐시 우회 |
| `src/cli/update.ts` | `handleSelfUpdate(forceRefresh:true)`, `exitWithChildStatus`, argv 가드, `SpawnSyncFn` DI |
| `src/i18n/locales/{ko,en}.json` | `reexecArgvMissing` 키 추가 |
| `tests/unit/cli/update.test.ts` | D2 테스트 2건 (#863) + DI 채택, mock leak 워크어라운드 |
| `package.json` + `templates/manifest.json` | `0.87.2` → `0.87.3` |

## 구현 노트

### #862 forceRefresh 설계

`executeSelfUpdate()` 가 `checkSelfUpdate()` 의 24h TTL 캐시를 공유하여 stale latest 를 `npm install -g pkg@${cached}` 로 설치하는 것이 root cause. `cacheTtlMs:0` 으로 `isCacheFresh` 를 false 로 만들어 기존 fresh-fetch 경로를 재사용 (새 코드 경로 추가 없음). `omcustom update` 는 explicit user action 이므로 `forceRefresh:true` 를 무조건 적용.

### Bun mock.module 누수 워크어라운드

새 D2 테스트가 추가되며 `mock.module('node:child_process', ...)` 의 잔존이 `serve-commands.test.ts` 를 깨뜨리는 회귀 발견. 두 가지 방어:

1. **DI 패턴**: `reexecUpdatedCli(toVersion, spawnFn?)` — production 은 dynamic import 사용, test 는 mock 주입
2. **파일 끝 배치**: 새 describe 블록을 파일 마지막에 두고 `DO NOT ADD TESTS BELOW` 경고 코멘트 명시

자세한 원인: Bun 1.3.x 에서 `mock.module()` 이 dynamic import 로 캐시된 모듈에 대해 `mock.restore()` 가 신뢰성 있게 되돌리지 못함.

## Test plan

- [x] `bun run lint` 통과
- [x] `bun run typecheck` 통과
- [x] `bun test` 1675 pass / 0 fail
- [x] `bun run build` 성공
- [x] `deep-verify` READY (10 findings 중 1건만 fix, 나머지 FP/design/deferred)
- [x] mock leak 회귀 수정 검증
- [ ] 수동 검증: `npm install -g oh-my-customcode@0.84.0 && omcustom update --all --hard` 로 #862 재현 시도

## 후속 개선 후보 (별도 이슈 등록 검토)

- D1 (forceRefresh) unit test 추가 — `tests/unit/core/self-update.test.ts`
- D3 (signal path) unit test 추가
- D4 (argv guard) unit test 추가
- signal mapping `?? 0` → `?? (child.status ?? 1)` 폴백 강화

## 릴리즈 계획

`docs/superpowers/plans/2026-04-14-v0.87.3-release.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
