### PR TITLE
release: v0.88.0 — registry 격리 (#859) + re-exec 후속 번들 (#867)

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.87.3",
-  "generatedAt": "2026-04-14T13:57:45.433Z",
-  "templateVersion": "0.87.3",
+  "generatorVersion": "0.88.0",
+  "generatedAt": "2026-04-14T14:44:36.089Z",
+  "templateVersion": "0.88.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2148,18 +2148,41 @@ __export(exports_registry, {
   registerProject: () => registerProject,
   readRegistry: () => readRegistry,
   migrateFromLockfiles: () => migrateFromLockfiles,
+  isTempPath: () => isTempPath,
   cleanRegistry: () => cleanRegistry,
   _setRegistryDirForTesting: () => _setRegistryDirForTesting
 });
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { basename, join, resolve } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { basename, join, resolve, sep } from "node:path";
 function _setRegistryDirForTesting(dir) {
   _registryDirOverride = dir;
+}
+function isTempPath(projectPath) {
+  const normalized = resolve(projectPath);
+  const candidates = new Set;
+  candidates.add(resolve(tmpdir()));
+  for (const envKey of ["TMPDIR", "TMP", "TEMP"]) {
+    const value = process.env[envKey];
+    if (value)
+      candidates.add(resolve(value));
+  }
+  candidates.add("/tmp");
+  candidates.add("/var/tmp");
+  candidates.add("/var/folders");
+  for (const candidate of candidates) {
+    if (normalized === candidate || normalized.startsWith(candidate + sep)) {
+      return true;
+    }
+  }
+  return false;
 }
 function registryDir() {
   if (_registryDirOverride !== undefined)
     return _registryDirOverride;
+  const envOverride = process.env.OMCUSTOM_REGISTRY_DIR;
+  if (envOverride)
+    return envOverride;
   const home = process.env.HOME ?? homedir();
   return join(home, ".oh-my-customcode");
 }
@@ -2188,6 +2211,10 @@ async function readRegistry() {
 }
 async function registerProject(projectPath, version) {
   const normalizedPath = resolve(projectPath);
+  if (!process.env.OMCUSTOM_REGISTRY_DIR && _registryDirOverride === undefined) {
+    if (isTempPath(normalizedPath))
+      return;
+  }
   const registry = await readRegistryRaw();
   const existing = registry.projects[normalizedPath];
   const now = new Date().toISOString();
@@ -2211,7 +2238,13 @@ async function cleanRegistry() {
   const registry = await readRegistryRaw();
   const paths = Object.keys(registry.projects);
   let removed = 0;
+  const purgeTempPaths = !process.env.OMCUSTOM_REGISTRY_DIR && _registryDirOverride === undefined;
   for (const projectPath of paths) {
+    if (purgeTempPaths && isTempPath(projectPath)) {
+      delete registry.projects[projectPath];
+      removed++;
+      continue;
+    }
     try {
       await fsAccess(projectPath);
     } catch {
@@ -2301,7 +2334,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.87.3",
+    version: "0.88.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {
@@ -6052,10 +6085,10 @@ var require_resolve_block_map = __commonJS((exports) => {
     let offset = bm.offset;
     let commentEnd = null;
     for (const collItem of bm.items) {
-      const { start, key, sep, value } = collItem;
+      const { start, key, sep: sep2, value } = collItem;
       const keyProps = resolveProps.resolveProps(start, {
         indicator: "explicit-key-ind",
-        next: key ?? sep?.[0],
+        next: key ?? sep2?.[0],
         offset,
         onError,
         parentIndent: bm.indent,
@@ -6069,7 +6102,7 @@ var require_resolve_block_map = __commonJS((exports) => {
           else if ("indent" in key && key.indent !== bm.indent)
             onError(offset, "BAD_INDENT", startColMsg);
         }
-        if (!keyProps.anchor && !keyProps.tag && !sep) {
+        if (!keyProps.anchor && !keyProps.tag && !sep2) {
           commentEnd = keyProps.end;
           if (keyProps.comment) {
             if (map.comment)
@@ -6094,7 +6127,7 @@ var require_resolve_block_map = __commonJS((exports) => {
       ctx.atKey = false;
       if (utilMapIncludes.mapIncludes(ctx, map.items, keyNode))
         onError(keyStart, "DUPLICATE_KEY", "Map keys must be unique");
-      const valueProps = resolveProps.resolveProps(sep ?? [], {
+      const valueProps = resolveProps.resolveProps(sep2 ?? [], {
         indicator: "map-value-ind",
         next: value,
         offset: keyNode.range[2],
@@ -6110,7 +6143,7 @@ var require_resolve_block_map = __commonJS((exports) => {
           if (ctx.options.strict && keyProps.start < valueProps.found.offset - 1024)
             onError(keyNode.range, "KEY_OVER_1024_CHARS", "The : indicator must be at most 1024 chars after the start of an implicit block mapping key");
         }
-        const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep, null, valueProps, onError);
+        const valueNode = value ? composeNode(ctx, value, valueProps, onError) : composeEmptyNode(ctx, offset, sep2, null, valueProps, onError);
         if (ctx.schema.compat)
           utilFlowIndentCheck.flowIndentCheck(bm.indent, value, onError);
         offset = valueNode.range[2];
@@ -6196,7 +6229,7 @@ var require_resolve_end = __commonJS((exports) => {
     let comment = "";
     if (end) {
       let hasSpace = false;
-      let sep = "";
+      let sep2 = "";
       for (const token of end) {
         const { source, type } = token;
         switch (type) {
@@ -6210,13 +6243,13 @@ var require_resolve_end = __commonJS((exports) => {
             if (!comment)
               comment = cb;
             else
-              comment += sep + cb;
-            sep = "";
+              comment += sep2 + cb;
+            sep2 = "";
             break;
           }
           case "newline":
             if (comment)
-              sep += source;
+              sep2 += source;
             hasSpace = true;
             break;
           default:
@@ -6256,18 +6289,18 @@ var require_resolve_flow_collection = __commonJS((exports) => {
     let offset = fc.offset + fc.start.source.length;
     for (let i = 0;i < fc.items.length; ++i) {
       const collItem = fc.items[i];
-      const { start, key, sep, value } = collItem;
+      const { start, key, sep: sep2, value } = collItem;
       const props = resolveProps.resolveProps(start, {
         flow: fcName,
         indicator: "explicit-key-ind",
-        next: key ?? sep?.[0],
+        next: key ?? sep2?.[0],
         offset,
         onError,
         parentIndent: fc.indent,
         startOnNewline: false
       });
       if (!props.found) {
-        if (!props.anchor && !props.tag && !sep && !value) {
+        if (!props.anchor && !props.tag && !sep2 && !value) {
           if (i === 0 && props.comma)
             onError(props.comma, "UNEXPECTED_TOKEN", `Unexpected , in ${fcName}`);
           else if (i < fc.items.length - 1)
@@ -6319,8 +6352,8 @@ var require_resolve_flow_collection = __commonJS((exports) => {
           }
         }
       }
-      if (!isMap && !sep && !props.found) {
-        const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep, null, props, onError);
+      if (!isMap && !sep2 && !props.found) {
+        const valueNode = value ? composeNode(ctx, value, props, onError) : composeEmptyNode(ctx, props.end, sep2, null, props, onError);
         coll.items.push(valueNode);
         offset = valueNode.range[2];
         if (isBlock(value))
@@ -6332,7 +6365,7 @@ var require_resolve_flow_collection = __commonJS((exports) => {
         if (isBlock(key))
           onError(keyNode.range, "BLOCK_IN_FLOW", blockMsg);
         ctx.atKey = false;
-        const valueProps = resolveProps.resolveProps(sep ?? [], {
+        const valueProps = resolveProps.resolveProps(sep2 ?? [], {
           flow: fcName,
           indicator: "map-value-ind",
           next: value,
@@ -6343,8 +6376,8 @@ var require_resolve_flow_collection = __commonJS((exports) => {
         });
         if (valueProps.found) {
           if (!isMap && !props.found && ctx.options.strict) {
-            if (sep)
-              for (const st of sep) {
+            if (sep2)
+              for (const st of sep2) {
                 if (st === valueProps.found)
                   break;
                 if (st.type === "newline") {
@@ -6361,7 +6394,7 @@ var require_resolve_flow_collection = __commonJS((exports) => {
           else
             onError(valueProps.start, "MISSING_CHAR", `Missing , or : between ${fcName} items`);
         }
-        const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep, null, valueProps, onError) : null;
+        const valueNode = value ? composeNode(ctx, value, valueProps, onError) : valueProps.found ? composeEmptyNode(ctx, valueProps.end, sep2, null, valueProps, onError) : null;
         if (valueNode) {
           if (isBlock(value))
             onError(valueNode.range, "BLOCK_IN_FLOW", blockMsg);
@@ -6538,7 +6571,7 @@ var require_resolve_block_scalar = __commonJS((exports) => {
         chompStart = i + 1;
     }
     let value = "";
-    let sep = "";
+    let sep2 = "";
     let prevMoreIndented = false;
     for (let i = 0;i < contentStart; ++i)
       value += lines[i][0].slice(trimIndent) + `
@@ -6556,33 +6589,33 @@ var require_resolve_block_scalar = __commonJS((exports) => {
         indent = "";
       }
       if (type === Scalar.Scalar.BLOCK_LITERAL) {
-        value += sep + indent.slice(trimIndent) + content;
-        sep = `
+        value += sep2 + indent.slice(trimIndent) + content;
+        sep2 = `
 `;
       } else if (indent.length > trimIndent || content[0] === "\t") {
-        if (sep === " ")
-          sep = `
+        if (sep2 === " ")
+          sep2 = `
 `;
-        else if (!prevMoreIndented && sep === `
+        else if (!prevMoreIndented && sep2 === `
 `)
-          sep = `
+          sep2 = `
 
 `;
-        value += sep + indent.slice(trimIndent) + content;
-        sep = `
+        value += sep2 + indent.slice(trimIndent) + content;
+        sep2 = `
 `;
         prevMoreIndented = true;
       } else if (content === "") {
-        if (sep === `
+        if (sep2 === `
 `)
           value += `
 `;
         else
-          sep = `
+          sep2 = `
 `;
       } else {
-        value += sep + content;
-        sep = " ";
+        value += sep2 + content;
+        sep2 = " ";
         prevMoreIndented = false;
       }
     }
@@ -6763,27 +6796,27 @@ var require_resolve_flow_scalar = __commonJS((exports) => {
     if (!match)
       return source;
     let res = match[1];
-    let sep = " ";
+    let sep2 = " ";
     let pos = first.lastIndex;
     line.lastIndex = pos;
     while (match = line.exec(source)) {
       if (match[1] === "") {
-        if (sep === `
+        if (sep2 === `
 `)
-          res += sep;
+          res += sep2;
         else
-          sep = `
+          sep2 = `
 `;
       } else {
-        res += sep + match[1];
-        sep = " ";
+        res += sep2 + match[1];
+        sep2 = " ";
       }
       pos = line.lastIndex;
     }
     const last = /[ \t]*(.*)/sy;
     last.lastIndex = pos;
     match = last.exec(source);
-    return res + sep + (match?.[1] ?? "");
+    return res + sep2 + (match?.[1] ?? "");
   }
   function doubleQuotedValue(source, onError) {
     let res = "";
@@ -7556,14 +7589,14 @@ var require_cst_stringify = __commonJS((exports) => {
       }
     }
   }
-  function stringifyItem({ start, key, sep, value }) {
+  function stringifyItem({ start, key, sep: sep2, value }) {
     let res = "";
     for (const st of start)
       res += st.source;
     if (key)
       res += stringifyToken(key);
-    if (sep)
-      for (const st of sep)
+    if (sep2)
+      for (const st of sep2)
         res += st.source;
     if (value)
       res += stringifyToken(value);
@@ -8693,18 +8726,18 @@ var require_parser = __commonJS((exports) => {
       if (this.type === "map-value-ind") {
         const prev = getPrevProps(this.peek(2));
         const start = getFirstKeyStartProps(prev);
-        let sep;
+        let sep2;
         if (scalar.end) {
-          sep = scalar.end;
-          sep.push(this.sourceToken);
+          sep2 = scalar.end;
+          sep2.push(this.sourceToken);
           delete scalar.end;
         } else
-          sep = [this.sourceToken];
+          sep2 = [this.sourceToken];
         const map = {
           type: "block-map",
           offset: scalar.offset,
           indent: scalar.indent,
-          items: [{ start, key: scalar, sep }]
+          items: [{ start, key: scalar, sep: sep2 }]
         };
         this.onKeyLine = true;
         this.stack[this.stack.length - 1] = map;
@@ -8858,15 +8891,15 @@ var require_parser = __commonJS((exports) => {
               } else if (isFlowToken(it.key) && !includesToken(it.sep, "newline")) {
                 const start2 = getFirstKeyStartProps(it.start);
                 const key = it.key;
-                const sep = it.sep;
-                sep.push(this.sourceToken);
+                const sep2 = it.sep;
+                sep2.push(this.sourceToken);
                 delete it.key;
                 delete it.sep;
                 this.stack.push({
                   type: "block-map",
                   offset: this.offset,
                   indent: this.indent,
-                  items: [{ start: start2, key, sep }]
+                  items: [{ start: start2, key, sep: sep2 }]
                 });
               } else if (start.length > 0) {
                 it.sep = it.sep.concat(start, this.sourceToken);
@@ -9060,13 +9093,13 @@ var require_parser = __commonJS((exports) => {
           const prev = getPrevProps(parent);
           const start = getFirstKeyStartProps(prev);
           fixFlowSeqItems(fc);
-          const sep = fc.end.splice(1, fc.end.length);
-          sep.push(this.sourceToken);
+          const sep2 = fc.end.splice(1, fc.end.length);
+          sep2.push(this.sourceToken);
           const map = {
             type: "block-map",
             offset: fc.offset,
             indent: fc.indent,
-            items: [{ start, key: fc, sep }]
+            items: [{ start, key: fc, sep: sep2 }]
           };
           this.onKeyLine = true;
           this.stack[this.stack.length - 1] = map;
@@ -9315,7 +9348,7 @@ __export(exports_fs, {
   copyDirectory: () => copyDirectory,
   calculateChecksum: () => calculateChecksum
 });
-import { dirname as dirname2, isAbsolute, join as join3, relative, resolve as resolve2, sep } from "node:path";
+import { dirname as dirname2, isAbsolute, join as join3, relative, resolve as resolve2, sep as sep2 } from "node:path";
 import { fileURLToPath } from "node:url";
 function validatePreserveFilePath(filePath, projectRoot) {
   if (!filePath || filePath.trim() === "") {
@@ -9411,7 +9444,7 @@ function shouldSkipPath(destPath, destRoot, skipPaths) {
   for (const skipPath of skipPaths) {
     if (skipPath.endsWith("/")) {
       const dirPath = skipPath.slice(0, -1);
-      if (relativePath === dirPath || relativePath.startsWith(dirPath + sep)) {
+      if (relativePath === dirPath || relativePath.startsWith(dirPath + sep2)) {
         return true;
       }
     } else {
@@ -9574,7 +9607,7 @@ __export(exports_projects, {
   default: () => projects_default
 });
 import { homedir as homedir3 } from "node:os";
-import { basename as basename4, join as join10, sep as sep2 } from "node:path";
+import { basename as basename4, join as join10, sep as sep3 } from "node:path";
 async function readLockFile(projectDir) {
   const lockFilePath = join10(projectDir, ".omcustom.lock.json");
   try {
@@ -9611,10 +9644,10 @@ async function getTemplateVersion() {
 function matchesSearchPaths(projectPath, searchPaths) {
   if (!searchPaths || searchPaths.length === 0)
     return true;
-  return searchPaths.some((searchPath) => projectPath === searchPath || projectPath.startsWith(searchPath + sep2));
+  return searchPaths.some((searchPath) => projectPath === searchPath || projectPath.startsWith(searchPath + sep3));
 }
 function isUnderHome(projectPath, home) {
-  return projectPath.startsWith(home + sep2) || projectPath === home;
+  return projectPath.startsWith(home + sep3) || projectPath === home;
 }
 function sortProjects(projects) {
   return projects.sort((a, b) => {
@@ -23791,10 +23824,10 @@ class Interpolator {
     let value;
     let clonedOptions;
     const handleHasOptions = (key, inheritedOptions) => {
-      const sep = this.nestingOptionsSeparator;
-      if (!key.includes(sep))
+      const sep2 = this.nestingOptionsSeparator;
+      if (!key.includes(sep2))
         return key;
-      const c = key.split(new RegExp(`${regexEscape(sep)}[ ]*{`));
+      const c = key.split(new RegExp(`${regexEscape(sep2)}[ ]*{`));
       let optionsString = `{${c[1]}`;
       key = c[0];
       optionsString = this.interpolate(optionsString, clonedOptions);
@@ -23812,7 +23845,7 @@ class Interpolator {
           };
       } catch (e) {
         this.logger.warn(`failed parsing options string in nesting for key ${key}`, e);
-        return `${key}${sep}${optionsString}`;
+        return `${key}${sep2}${optionsString}`;
       }
       if (clonedOptions.defaultValue && clonedOptions.defaultValue.includes(this.prefix))
         delete clonedOptions.defaultValue;
@@ -31465,8 +31498,10 @@ async function checkCliVersion(checkFn) {
 }
 function exitWithChildStatus(child) {
   if (child.signal) {
-    const signalNumber = osConstants.signals[child.signal] ?? 0;
-    process.exit(128 + signalNumber);
+    const signalNumber = osConstants.signals[child.signal];
+    if (signalNumber !== undefined) {
+      process.exit(128 + signalNumber);
+    }
   }
   process.exit(child.status ?? 1);
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -299,18 +299,41 @@ __export(exports_registry, {
   registerProject: () => registerProject,
   readRegistry: () => readRegistry,
   migrateFromLockfiles: () => migrateFromLockfiles,
+  isTempPath: () => isTempPath,
   cleanRegistry: () => cleanRegistry,
   _setRegistryDirForTesting: () => _setRegistryDirForTesting
 });
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { basename as basename3, join as join6, resolve as resolve2 } from "node:path";
+import { homedir, tmpdir } from "node:os";
+import { basename as basename3, join as join6, resolve as resolve2, sep as sep2 } from "node:path";
 function _setRegistryDirForTesting(dir2) {
   _registryDirOverride = dir2;
+}
+function isTempPath(projectPath) {
+  const normalized = resolve2(projectPath);
+  const candidates = new Set;
+  candidates.add(resolve2(tmpdir()));
+  for (const envKey of ["TMPDIR", "TMP", "TEMP"]) {
+    const value = process.env[envKey];
+    if (value)
+      candidates.add(resolve2(value));
+  }
+  candidates.add("/tmp");
+  candidates.add("/var/tmp");
+  candidates.add("/var/folders");
+  for (const candidate of candidates) {
+    if (normalized === candidate || normalized.startsWith(candidate + sep2)) {
+      return true;
+    }
+  }
+  return false;
 }
 function registryDir() {
   if (_registryDirOverride !== undefined)
     return _registryDirOverride;
+  const envOverride = process.env.OMCUSTOM_REGISTRY_DIR;
+  if (envOverride)
+    return envOverride;
   const home = process.env.HOME ?? homedir();
   return join6(home, ".oh-my-customcode");
 }
@@ -339,6 +362,10 @@ async function readRegistry() {
 }
 async function registerProject(projectPath, version) {
   const normalizedPath = resolve2(projectPath);
+  if (!process.env.OMCUSTOM_REGISTRY_DIR && _registryDirOverride === undefined) {
+    if (isTempPath(normalizedPath))
+      return;
+  }
   const registry = await readRegistryRaw();
   const existing = registry.projects[normalizedPath];
   const now = new Date().toISOString();
@@ -362,7 +389,13 @@ async function cleanRegistry() {
   const registry = await readRegistryRaw();
   const paths = Object.keys(registry.projects);
   let removed = 0;
+  const purgeTempPaths = !process.env.OMCUSTOM_REGISTRY_DIR && _registryDirOverride === undefined;
   for (const projectPath of paths) {
+    if (purgeTempPaths && isTempPath(projectPath)) {
+      delete registry.projects[projectPath];
+      removed++;
+      continue;
+    }
     try {
       await fsAccess(projectPath);
     } catch {
@@ -1974,7 +2007,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.87.3",
+  version: "0.88.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/docs/superpowers/plans/2026-04-14-v0.88.0-release.md
+++ b/docs/superpowers/plans/2026-04-14-v0.88.0-release.md
@@ -1,0 +1,35 @@
+# 릴리즈 계획 — 2026-04-14 생성 (v0.88.0 cycle)
+
+> 출처: 2026-04-14 기준 `verify-done` 라벨 오픈 이슈 2건
+> 제외된 이슈 (이미 오픈 PR에 포함): 없음
+> 사용자 지시: v0.88.0 minor 로 잔존 이슈 일괄 처리
+
+## v0.88.0 릴리즈 계획 (registry 격리 + re-exec 테스트 강화)
+
+**예상 범위**: M (S+S) | **이슈**: 2 | **병렬 가능**: 0 (다른 파일 영역이지만 단일 에이전트 직렬 권장)
+
+| # | 우선순위 | 규모 | 제목 | 의존성 |
+|---|----------|------|------|--------|
+| #859 | P2 | S | E2E 테스트 임시폴더가 레지스트리에 등록되어 projects 출력을 오염시킴 | 없음 |
+| #867 | P3 | S | v0.87.3 후속 개선 4건 통합 — re-exec 테스트 커버리지 + signal mapping 강화 | 없음 |
+
+### 구현 순서
+1. #859 — `registerProject()` 에 temp path 가드 추가, `cleanRegistry()` 에 temp 패턴 자동 정리, 3개 테스트 파일에 `_setRegistryDirForTesting` 격리 헬퍼 적용 (권장 에이전트: lang-typescript-expert)
+2. #867 — 4개 항목 일괄:
+   - `tests/unit/core/self-update.test.ts` 에 forceRefresh cache bypass 테스트 추가
+   - `tests/unit/cli/update.test.ts` 에 signal path 테스트 추가 ({status:null, signal:'SIGTERM'})
+   - `tests/unit/cli/update.test.ts` 에 argv guard 테스트 추가 (empty argv[1])
+   - `src/cli/update.ts` `exitWithChildStatus` 에서 `?? 0` → `?? (child.status ?? 1)` 폴백 강화
+   - **새 테스트는 #863 워크어라운드 박스 위에 추가 (DO NOT ADD TESTS BELOW 경고 준수)**
+3. `package.json` + `templates/manifest.json` 0.87.3 → **0.88.0** 동시 bump (Version Sync CI 필수)
+
+### 참고 사항
+- **버전**: 사용자 명시적 0.88.0 minor 결정 — 표준 semver 로는 patch 가 맞으나 사용자 의도 존중
+- **scope 분리**: #859 는 registry/test-infra, #867 은 update.ts/self-update.ts — 서로 다른 영역이지만 단일 PR 로 묶음
+- **mock leak 워크어라운드**: #867 의 D3/D4 테스트는 #863 describe 블록 ABOVE 에 배치 (블록 아래 는 `DO NOT ADD TESTS BELOW` 경고 영역)
+- **#866 머지로 #862,#863,#864,#865 모두 닫힘** (#864/#865 는 코드만 닫힘, 테스트는 #867 에서 추적)
+
+## 요약
+| 릴리즈 | 이슈 수 | 규모 | P1 | P2 | P3 |
+|--------|---------|------|----|----|-----|
+| v0.88.0 | 2 | M | 0 | 1 | 1 |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.87.3",
+  "version": "0.88.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -77,8 +77,11 @@ function exitWithChildStatus(child: {
   signal: NodeJS.Signals | null;
 }): never {
   if (child.signal) {
-    const signalNumber = osConstants.signals[child.signal] ?? 0;
-    process.exit(128 + signalNumber);
+    const signalNumber = osConstants.signals[child.signal];
+    if (signalNumber !== undefined) {
+      process.exit(128 + signalNumber);
+    }
+    // Unknown signal name — fall through to status-based exit
   }
   process.exit(child.status ?? 1);
 }

--- a/src/core/registry.ts
+++ b/src/core/registry.ts
@@ -6,8 +6,8 @@
  */
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
-import { basename, join, resolve } from 'node:path';
+import { homedir, tmpdir } from 'node:os';
+import { basename, join, resolve, sep } from 'node:path';
 
 /**
  * Override for the registry directory path, used in tests only.
@@ -25,9 +25,39 @@ export function _setRegistryDirForTesting(dir: string | undefined): void {
   _registryDirOverride = dir;
 }
 
+/**
+ * Check whether a path is inside a well-known temporary directory.
+ *
+ * Prevents E2E test runs from polluting the real registry with /tmp or
+ * /var/folders paths (#859).
+ */
+export function isTempPath(projectPath: string): boolean {
+  const normalized = resolve(projectPath);
+  const candidates = new Set<string>();
+
+  candidates.add(resolve(tmpdir()));
+  for (const envKey of ['TMPDIR', 'TMP', 'TEMP'] as const) {
+    const value = process.env[envKey];
+    if (value) candidates.add(resolve(value));
+  }
+  candidates.add('/tmp');
+  candidates.add('/var/tmp');
+  candidates.add('/var/folders');
+
+  for (const candidate of candidates) {
+    if (normalized === candidate || normalized.startsWith(candidate + sep)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** Compute the registry directory path at call-time (respects HOME env changes in tests). */
 function registryDir(): string {
   if (_registryDirOverride !== undefined) return _registryDirOverride;
+  // #859: subprocess test isolation via env var
+  const envOverride = process.env.OMCUSTOM_REGISTRY_DIR;
+  if (envOverride) return envOverride;
   // Use process.env.HOME when available so tests can redirect to a temp directory
   // (Bun's os.homedir() caches the value and ignores runtime HOME changes).
   const home = process.env.HOME ?? homedir();
@@ -115,6 +145,12 @@ export async function readRegistry(): Promise<Registry> {
  */
 export async function registerProject(projectPath: string, version: string): Promise<void> {
   const normalizedPath = resolve(projectPath);
+
+  // #859: reject temp paths unless test isolation is active
+  if (!process.env.OMCUSTOM_REGISTRY_DIR && _registryDirOverride === undefined) {
+    if (isTempPath(normalizedPath)) return;
+  }
+
   const registry = await readRegistryRaw();
   const existing = registry.projects[normalizedPath];
   const now = new Date().toISOString();
@@ -155,7 +191,17 @@ export async function cleanRegistry(): Promise<number> {
   const paths = Object.keys(registry.projects);
   let removed = 0;
 
+  // Only purge temp paths when running in production (not test isolation mode)
+  const purgeTempPaths = !process.env.OMCUSTOM_REGISTRY_DIR && _registryDirOverride === undefined;
+
   for (const projectPath of paths) {
+    // #859: drop temp paths that slipped in via pre-0.88.0 writes
+    if (purgeTempPaths && isTempPath(projectPath)) {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete registry.projects[projectPath];
+      removed++;
+      continue;
+    }
     try {
       await fsAccess(projectPath);
     } catch {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.87.3",
+  "version": "0.88.0",
   "lastUpdated": "2026-04-14T00:00:00.000Z",
   "components": [
     {

--- a/tests/e2e/doctor.test.ts
+++ b/tests/e2e/doctor.test.ts
@@ -46,6 +46,7 @@ describe('E2E: omcustom doctor', { timeout: 30000 }, () => {
       cwd: tempDir,
       stdout: 'pipe',
       stderr: 'pipe',
+      env: { ...process.env, OMCUSTOM_REGISTRY_DIR: join(tempDir, '.omcustom-registry') },
     });
 
     // Add timeout to prevent hanging in CI

--- a/tests/e2e/list.test.ts
+++ b/tests/e2e/list.test.ts
@@ -45,6 +45,7 @@ describe('E2E: omcustom list', () => {
       cwd: tempDir,
       stdout: 'pipe',
       stderr: 'pipe',
+      env: { ...process.env, OMCUSTOM_REGISTRY_DIR: join(tempDir, '.omcustom-registry') },
     });
 
     // Add timeout to prevent hanging in CI

--- a/tests/unit/cli/update.test.ts
+++ b/tests/unit/cli/update.test.ts
@@ -1860,6 +1860,99 @@ describe('update command', () => {
     });
   });
 
+  describe('exitWithChildStatus signal handling (#867)', () => {
+    it('should exit 128+15 (143) when child terminated by SIGTERM (#867)', async () => {
+      const spawnSyncMock = mock(() => ({
+        status: null,
+        signal: 'SIGTERM' as NodeJS.Signals,
+        pid: 999,
+      }));
+
+      // Capture only the FIRST process.exit call. After exitWithChildStatus calls
+      // process.exit(143), the mock returns (doesn't actually exit), and the
+      // fallthrough path calls process.exit(null ?? 1). We record only the first.
+      let firstExitCode: number | undefined;
+      process.exit = ((code?: number) => {
+        if (firstExitCode === undefined) firstExitCode = code ?? 0;
+        exitCode = code ?? 0;
+      }) as typeof process.exit;
+
+      mock.module('../../../src/core/self-update.js', () => ({
+        executeSelfUpdate: mock(() => ({
+          updated: true,
+          fromVersion: '0.87.3',
+          toVersion: '0.88.0',
+        })),
+        checkSelfUpdate: mock(() => ({ updateAvailable: false })),
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mock(async () => ({
+          success: true,
+          updatedComponents: [],
+          skippedComponents: [],
+          preservedFiles: [],
+          backedUpPaths: [],
+          previousVersion: '0.87.3',
+          newVersion: '0.88.0',
+          warnings: [],
+        })),
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+      await updateCommand({ skipSelf: false }, undefined, spawnSyncMock as never);
+
+      expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+      expect(firstExitCode).toBe(143);
+    });
+  });
+
+  describe('reexecUpdatedCli argv guard (#867)', () => {
+    let originalArgv: string[];
+
+    beforeEach(() => {
+      originalArgv = process.argv;
+    });
+
+    afterEach(() => {
+      process.argv = originalArgv;
+    });
+
+    it('should warn and skip re-exec when process.argv[1] is empty (#867)', async () => {
+      process.argv = ['node'];
+
+      const spawnSyncMock = mock(() => ({ status: 0, pid: 999, signal: null }));
+
+      mock.module('../../../src/core/self-update.js', () => ({
+        executeSelfUpdate: mock(() => ({
+          updated: true,
+          fromVersion: '0.87.3',
+          toVersion: '0.88.0',
+        })),
+        checkSelfUpdate: mock(() => ({ updateAvailable: false })),
+      }));
+
+      mock.module('../../../src/core/updater.js', () => ({
+        update: mock(async () => ({
+          success: true,
+          updatedComponents: [],
+          skippedComponents: [],
+          preservedFiles: [],
+          backedUpPaths: [],
+          previousVersion: '0.87.3',
+          newVersion: '0.88.0',
+          warnings: [],
+        })),
+      }));
+
+      const { updateCommand } = await import('../../../src/cli/update.js');
+      await updateCommand({ skipSelf: false }, undefined, spawnSyncMock as never);
+
+      expect(spawnSyncMock).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalled();
+    });
+  });
+
   // ---------------------------------------------------------------------------
   // D2: exit-code propagation and error swallowing (#863)
   //

--- a/tests/unit/core/self-update.test.ts
+++ b/tests/unit/core/self-update.test.ts
@@ -636,6 +636,66 @@ describe('self-update module', () => {
 
       expect(result.updated).toBe(false);
     });
+
+    it('should bypass cache when forceRefresh=true (#867)', () => {
+      const cachePath = createCachePath('exec-cache-force-refresh.json');
+      const now = Date.now();
+
+      writeFileSync(
+        cachePath,
+        JSON.stringify({
+          checkedAt: new Date(now - 1000).toISOString(),
+          latestVersion: '1.0.0',
+        }),
+        'utf-8'
+      );
+
+      let fetchCalls = 0;
+      const result = executeSelfUpdate({
+        currentVersion: '1.0.0',
+        cachePath,
+        fetchLatestVersion: () => {
+          fetchCalls++;
+          return '1.0.0';
+        },
+        forceRefresh: true,
+        now,
+        argv: ['node', '/usr/local/bin/omcustom'],
+        env: {},
+      });
+
+      expect(fetchCalls).toBe(1);
+      expect(result.updated).toBe(false);
+    });
+
+    it('should use cached version when forceRefresh is not set (#867)', () => {
+      const cachePath = createCachePath('exec-cache-no-force.json');
+      const now = Date.now();
+
+      writeFileSync(
+        cachePath,
+        JSON.stringify({
+          checkedAt: new Date(now - 1000).toISOString(),
+          latestVersion: '1.0.0',
+        }),
+        'utf-8'
+      );
+
+      let fetchCalls = 0;
+      executeSelfUpdate({
+        currentVersion: '1.0.0',
+        cachePath,
+        fetchLatestVersion: () => {
+          fetchCalls++;
+          return '1.0.0';
+        },
+        now,
+        argv: ['node', '/usr/local/bin/omcustom'],
+        env: {},
+      });
+
+      expect(fetchCalls).toBe(0);
+    });
   });
 
   describe('maybeHandleSelfUpdateForInit', () => {


### PR DESCRIPTION
## Summary

- v0.88.0 minor: 2개 verify-done 이슈 일괄 처리
- #859 핫픽스: E2E 테스트 registry pollution 3레이어 방어
- #867 후속 번들: forceRefresh 테스트 + signal path 테스트 + argv 가드 테스트 + signal mapping fallback 강화

## 관련 이슈

Closes #859, #867

## 변경 사항

| 파일 | 변경 |
|------|------|
| `src/core/registry.ts` | `isTempPath()` 헬퍼, `registerProject` temp 가드, `cleanRegistry` temp 자동 정리, `OMCUSTOM_REGISTRY_DIR` env 인식 |
| `src/cli/update.ts` | `exitWithChildStatus` signal mapping fallback 강화 |
| `tests/e2e/{doctor,list}.test.ts` | `OMCUSTOM_REGISTRY_DIR` env injection으로 subprocess 격리 |
| `tests/unit/core/self-update.test.ts` | forceRefresh cache bypass 테스트 2건 |
| `tests/unit/cli/update.test.ts` | SIGTERM signal path + argv guard 테스트 (#867) |
| `package.json` + `templates/manifest.json` | `0.87.3` → `0.88.0` |

## 구현 노트

### #859 3레이어 방어

1. **Write-side guard**: `registerProject()`에서 isTempPath 거부 — registry 오염의 root cause 차단
2. **Cleanup**: `cleanRegistry()`가 기존 temp 항목 자동 정리 — 마이그레이션 효과
3. **Test isolation**: `OMCUSTOM_REGISTRY_DIR` env var로 E2E subprocess가 자체 registry 사용 (E2E 테스트 정상 동작 보장)

### Implementation deviations

**D3 (updater.test.ts isolation) 스킵**:
- 원래 계획은 `_setRegistryDirForTesting`을 updater.test.ts에 적용
- Bun 1.3.x의 module-state 공유 문제로 registry.test.ts와 충돌
- 대안: D1의 `registerProject` 가드가 단일 진입점에서 차단하므로 동일한 보호 효과
- 검증: 테스트 실행 후 `~/.oh-my-customcode/projects.json`에 0개의 새 temp 항목 추가

**D7 SIGTERM 테스트 firstExitCode 캡처**:
- 테스트 환경에서 `process.exit`이 no-op 모킹되어 코드가 fall-through
- production에서는 `process.exit: never` 타입으로 즉시 종료, 문제 없음
- 테스트는 `firstExitCode === 143`을 검증하여 production 동작을 정확히 반영

### #867 signal mapping fallback

기존: `osConstants.signals[child.signal] ?? 0` — unknown signal 시 exit 128 (misleading)
신규: lookup 실패 시 fall through to `child.status ?? 1` — 더 정확한 폴백

## Test plan

- [x] `bun run lint` 통과
- [x] `bun run typecheck` 통과  
- [x] `bun test` 1679 pass / 0 fail (이전 1675 + 새 4개)
- [x] `bun run build` 성공
- [x] `deep-verify` READY (1 LOW finding 비차단: isTempPath @internal 마킹 권장)
- [x] Registry cleanliness: 새 temp 항목 0개 추가
- [ ] 수동 검증: 머지 후 `omcustom doctor` / `omcustom list` 실행으로 회귀 없음 확인

## 후속 개선 후보

- `isTempPath`를 `@internal` JSDoc 마킹 (TypeScript 시각적 분리, 비차단)
- updater.test.ts 직접 격리 (Bun mock 한계 해결 시)

## 릴리즈 계획

`docs/superpowers/plans/2026-04-14-v0.88.0-release.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)