### PR TITLE
release: v0.93.0 — Airflow 3.1.8 에이전트/스킬/가이드 업데이트 (#890)

### DIFF
--- a/.claude/agents/de-airflow-expert.md
+++ b/.claude/agents/de-airflow-expert.md
@@ -17,19 +17,31 @@ tools:
 permissionMode: bypassPermissions
 ---
 
-You are an expert Apache Airflow developer for production-ready DAGs following official best practices.
+You are an expert Apache Airflow developer for production-ready DAGs following official best practices, targeting **Airflow 3.1.8**.
 
 ## Capabilities
 
-- DAG authoring (top-level code avoidance, TaskFlow API, classic operators)
-- Task dependency design and scheduling (cron, timetables, data-aware)
-- DAG and task unit testing
+- DAG authoring with `airflow.sdk` namespace (`DAG`, `@task`, `Asset`)
+- TaskFlow API patterns and dynamic task mapping (`expand()`)
+- Task dependency design and scheduling (cron, timetables, data-aware with Assets)
+- DAG and task testing (`dag.test()`, unit tests, integration tests)
 - Connection/variable management and secret backend integration
 - DAG parsing and execution optimization
+- Airflow 2.x → 3.x migration guidance (import paths, deprecated context vars, AIP-72/AIP-44)
+
+## Key Airflow 3.x Differences
+
+| Area | Airflow 2.x | Airflow 3.x |
+|------|-------------|-------------|
+| Imports | `from airflow.models import DAG` | `from airflow.sdk import DAG, task` |
+| Data-aware | `Dataset` | `Asset` |
+| Context | `execution_date` | `dag_run.logical_date` |
+| Architecture | Tight coupling | Task Execution Interface (AIP-72) |
+| API | DB direct access | Internal API (AIP-44) |
 
 ## Skills
 
-Apply **airflow-best-practices** for core Airflow guidelines.
+Apply **airflow-best-practices** for core Airflow 3.1.8 guidelines.
 
 ## Reference Guides
 

--- a/.claude/skills/airflow-best-practices/SKILL.md
+++ b/.claude/skills/airflow-best-practices/SKILL.md
@@ -5,28 +5,47 @@ scope: core
 user-invocable: false
 ---
 
-# Apache Airflow Best Practices
+# Apache Airflow Best Practices (3.1.8)
 
 ## DAG Authoring
 
+### Imports (Airflow 3.x)
+- Use `from airflow.sdk import DAG, task, Asset` — the stable public API
+- Legacy `from airflow.models import DAG` and `from airflow.decorators import task` are deprecated
+
 ### Top-Level Code (CRITICAL)
 - Avoid heavy computation at module level (executed on every DAG parse)
-- Minimize imports at module level
-- Use `@task` decorator (TaskFlow API) for Python tasks
-- Keep DAG file under 1000 lines
+- Minimize imports at module level — lazy-load inside `@task` functions
+- Never call APIs, query databases, or access Variables at top level
+- If Variables needed at top level, enable experimental cache with TTL
+
+### TaskFlow API (Default Pattern)
+- Use `@task` decorator for all Python tasks (preferred over classic operators)
+- XCom serialization is automatic — return values become XCom
+- Use `@task.branch` for branching logic
+- Use `@task.sensor` for sensor tasks
+
+### Dynamic Task Mapping
+- Use `task.expand()` for runtime-determined task instances
+- Combine with `.partial()` for fixed kwargs
+- Map over lists, dicts, or XCom outputs from upstream tasks
 
 ### Scheduling
-- Use cron expressions or timetables
-- Set `catchup=False` for most cases
-- Use data-aware scheduling (datasets) for dependencies
+- Use cron expressions or timetables for `schedule` parameter
+- Set `catchup=False` for most DAGs
+- Use data-aware scheduling with `Asset` (replaces `Dataset`) for dependencies
 - Configure SLA monitoring
 
 ### Task Dependencies
-- Use `>>` / `<<` for clarity
-- Group related tasks with TaskGroup
+- Use `>>` / `<<` operators for clarity
+- Group related tasks with `TaskGroup`
 - Avoid deep nesting (max 3 levels)
 
 ## Testing
+
+### Local Testing
+- Use `dag.test()` in `if __name__ == "__main__":` block for IDE debugging
+- Runs all tasks in single serialized process without executor
 
 ### Unit Tests
 - Test DAG import without errors
@@ -42,16 +61,34 @@ user-invocable: false
 ## Production Deployment
 
 ### Performance
-- Lazy-load heavy libraries inside tasks
+- Lazy-load heavy libraries inside `@task` functions
 - Use connection pooling
-- Minimize DAG parse time
-- Enable parallelism
+- Minimize DAG parse time (target < 30s for all DAGs)
+- Enable parallelism appropriately
 
 ### Reliability
-- Set appropriate retries and retry_delay
+- Set appropriate `retries` and `retry_delay`
 - Use SLA callbacks for monitoring
-- Implement proper error handling
+- Implement proper error handling with `on_failure_callback`
 - Log important events
 
+## Migration: 2.x → 3.x
+
+### Deprecated (Remove or Replace)
+| Deprecated | Replacement |
+|-----------|-------------|
+| `from airflow.models import DAG` | `from airflow.sdk import DAG` |
+| `from airflow.decorators import task` | `from airflow.sdk import task` |
+| `Dataset` | `Asset` |
+| `execution_date` in context | `dag_run.logical_date` |
+| `conf` in task context | Removed — use Variables or params |
+
+### Architecture Changes
+- **AIP-72**: Task Execution Interface — tasks run in isolated subprocesses via Execution API Server
+- **AIP-44**: Internal API — components communicate via API, not direct DB access
+- **New UI**: React-based web interface (replaces Flask-based UI)
+
 ## References
-- [Airflow Best Practices](https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html)
+- [Airflow 3.1.8 Best Practices](https://airflow.apache.org/docs/apache-airflow/3.1.8/best-practices.html)
+- [Airflow SDK (Task SDK)](https://airflow.apache.org/docs/apache-airflow/3.1.8/authoring-and-scheduling/index.html)
+- [Migration Guide 2.x → 3.x](https://airflow.apache.org/docs/apache-airflow/3.1.8/migration-guide.html)

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.92.0",
-  "generatedAt": "2026-04-18T02:54:40.168Z",
-  "templateVersion": "0.92.0",
+  "generatorVersion": "0.93.0",
+  "generatedAt": "2026-04-18T03:22:26.939Z",
+  "templateVersion": "0.93.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "c492110d244673e256299fafd5d62086fc60125533b584e12efdf4eef3ced588",
@@ -180,8 +180,8 @@
       "component": "agents"
     },
     ".claude/agents/de-airflow-expert.md": {
-      "templateHash": "ab7ea2b9976a140902c000a40e17b4a4035b402edfba8353b20f6c1a38d8a075",
-      "size": 996,
+      "templateHash": "d483a56a018814947cb019aabe1cab527f66a684f199dcd36d3f9a6fe280322a",
+      "size": 1643,
       "component": "agents"
     },
     ".claude/agents/sys-naggy.md": {
@@ -495,8 +495,8 @@
       "component": "skills"
     },
     ".claude/skills/airflow-best-practices/SKILL.md": {
-      "templateHash": "7b1a1e17440ee713f033d88abebdd27cd80fd131a07fb4d1d2d8d15d07ef1b32",
-      "size": 1425,
+      "templateHash": "78e80abef84b24bf52122d0477fa6b4018208ff1da1117b513f2f2711ba907a6",
+      "size": 3394,
       "component": "skills"
     },
     ".claude/skills/rtk-exec/scripts/rtk-wrapper.cjs": {
@@ -1510,8 +1510,8 @@
       "component": "guides"
     },
     "guides/airflow/README.md": {
-      "templateHash": "d5bac24dbb1a11605cb7b8ce35fa085a02b297fc2fbc307b9dea91f64da413a5",
-      "size": 1037,
+      "templateHash": "99f5b3e42059688785aacc7ac17bb0acdd7cbf05d94d0387bd008512bd93c10f",
+      "size": 1936,
       "component": "guides"
     },
     "guides/multi-model-routing/README.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2316,7 +2316,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.92.0",
+    version: "0.93.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2018,7 +2018,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.92.0",
+  version: "0.93.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/guides/airflow/README.md
+++ b/guides/airflow/README.md
@@ -1,22 +1,35 @@
-# Apache Airflow Guide
+# Apache Airflow Guide (3.1.8)
 
-Reference documentation for Apache Airflow DAG development best practices.
+Reference documentation for Apache Airflow 3.1.8 DAG development best practices.
 
 ## Source
 
-Based on [Apache Airflow official documentation](https://airflow.apache.org/docs/) and [Astronomer best practices](https://github.com/astronomer/agents).
+Based on [Apache Airflow 3.1.8 official documentation](https://airflow.apache.org/docs/apache-airflow/3.1.8/) and [Astronomer best practices](https://docs.astronomer.io/).
+
+## Airflow 3.x Key Changes
+
+| Change | Details |
+|--------|---------|
+| SDK namespace | `from airflow.sdk import DAG, task, Asset` |
+| Task Execution (AIP-72) | Isolated subprocess execution via Execution API Server |
+| Internal API (AIP-44) | Components use API instead of direct DB access |
+| Asset (was Dataset) | Data-aware scheduling primitive renamed |
+| Context cleanup | `execution_date` → `dag_run.logical_date` |
+| New UI | React-based web interface |
+| TaskFlow API | `@task` is the default pattern for Python tasks |
 
 ## Categories
 
 | Priority | Category | Impact |
 |----------|----------|--------|
-| 1 | DAG Authoring | CRITICAL |
-| 2 | Task Design | CRITICAL |
-| 3 | Testing | HIGH |
-| 4 | Scheduling | HIGH |
+| 1 | DAG Authoring (airflow.sdk) | CRITICAL |
+| 2 | TaskFlow API & Dynamic Mapping | CRITICAL |
+| 3 | Testing (dag.test()) | HIGH |
+| 4 | Scheduling & Assets | HIGH |
 | 5 | Connections & Variables | MEDIUM |
 | 6 | Monitoring & SLA | MEDIUM |
 | 7 | Performance Optimization | LOW-MEDIUM |
+| 8 | 2.x → 3.x Migration | HIGH |
 
 ## Usage
 
@@ -26,7 +39,9 @@ This guide is referenced by:
 
 ## External Resources
 
-- [Airflow Official Docs](https://airflow.apache.org/docs/)
-- [Airflow Best Practices](https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html)
-- [Astronomer Agents](https://github.com/astronomer/agents)
-- [Airflow TaskFlow API](https://airflow.apache.org/docs/apache-airflow/stable/tutorial/taskflow.html)
+- [Airflow 3.1.8 Official Docs](https://airflow.apache.org/docs/apache-airflow/3.1.8/)
+- [Airflow 3.1.8 Best Practices](https://airflow.apache.org/docs/apache-airflow/3.1.8/best-practices.html)
+- [Airflow Task SDK](https://airflow.apache.org/docs/apache-airflow/3.1.8/authoring-and-scheduling/index.html)
+- [Airflow TaskFlow API](https://airflow.apache.org/docs/apache-airflow/3.1.8/core-concepts/taskflow.html)
+- [Migration Guide 2.x → 3.x](https://airflow.apache.org/docs/apache-airflow/3.1.8/migration-guide.html)
+- [Astronomer Docs](https://docs.astronomer.io/)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.92.0",
+  "version": "0.93.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/agents/de-airflow-expert.md
+++ b/templates/.claude/agents/de-airflow-expert.md
@@ -17,19 +17,31 @@ tools:
 permissionMode: bypassPermissions
 ---
 
-You are an expert Apache Airflow developer for production-ready DAGs following official best practices.
+You are an expert Apache Airflow developer for production-ready DAGs following official best practices, targeting **Airflow 3.1.8**.
 
 ## Capabilities
 
-- DAG authoring (top-level code avoidance, TaskFlow API, classic operators)
-- Task dependency design and scheduling (cron, timetables, data-aware)
-- DAG and task unit testing
+- DAG authoring with `airflow.sdk` namespace (`DAG`, `@task`, `Asset`)
+- TaskFlow API patterns and dynamic task mapping (`expand()`)
+- Task dependency design and scheduling (cron, timetables, data-aware with Assets)
+- DAG and task testing (`dag.test()`, unit tests, integration tests)
 - Connection/variable management and secret backend integration
 - DAG parsing and execution optimization
+- Airflow 2.x → 3.x migration guidance (import paths, deprecated context vars, AIP-72/AIP-44)
+
+## Key Airflow 3.x Differences
+
+| Area | Airflow 2.x | Airflow 3.x |
+|------|-------------|-------------|
+| Imports | `from airflow.models import DAG` | `from airflow.sdk import DAG, task` |
+| Data-aware | `Dataset` | `Asset` |
+| Context | `execution_date` | `dag_run.logical_date` |
+| Architecture | Tight coupling | Task Execution Interface (AIP-72) |
+| API | DB direct access | Internal API (AIP-44) |
 
 ## Skills
 
-Apply **airflow-best-practices** for core Airflow guidelines.
+Apply **airflow-best-practices** for core Airflow 3.1.8 guidelines.
 
 ## Reference Guides
 

--- a/templates/.claude/skills/airflow-best-practices/SKILL.md
+++ b/templates/.claude/skills/airflow-best-practices/SKILL.md
@@ -5,28 +5,47 @@ scope: core
 user-invocable: false
 ---
 
-# Apache Airflow Best Practices
+# Apache Airflow Best Practices (3.1.8)
 
 ## DAG Authoring
 
+### Imports (Airflow 3.x)
+- Use `from airflow.sdk import DAG, task, Asset` — the stable public API
+- Legacy `from airflow.models import DAG` and `from airflow.decorators import task` are deprecated
+
 ### Top-Level Code (CRITICAL)
 - Avoid heavy computation at module level (executed on every DAG parse)
-- Minimize imports at module level
-- Use `@task` decorator (TaskFlow API) for Python tasks
-- Keep DAG file under 1000 lines
+- Minimize imports at module level — lazy-load inside `@task` functions
+- Never call APIs, query databases, or access Variables at top level
+- If Variables needed at top level, enable experimental cache with TTL
+
+### TaskFlow API (Default Pattern)
+- Use `@task` decorator for all Python tasks (preferred over classic operators)
+- XCom serialization is automatic — return values become XCom
+- Use `@task.branch` for branching logic
+- Use `@task.sensor` for sensor tasks
+
+### Dynamic Task Mapping
+- Use `task.expand()` for runtime-determined task instances
+- Combine with `.partial()` for fixed kwargs
+- Map over lists, dicts, or XCom outputs from upstream tasks
 
 ### Scheduling
-- Use cron expressions or timetables
-- Set `catchup=False` for most cases
-- Use data-aware scheduling (datasets) for dependencies
+- Use cron expressions or timetables for `schedule` parameter
+- Set `catchup=False` for most DAGs
+- Use data-aware scheduling with `Asset` (replaces `Dataset`) for dependencies
 - Configure SLA monitoring
 
 ### Task Dependencies
-- Use `>>` / `<<` for clarity
-- Group related tasks with TaskGroup
+- Use `>>` / `<<` operators for clarity
+- Group related tasks with `TaskGroup`
 - Avoid deep nesting (max 3 levels)
 
 ## Testing
+
+### Local Testing
+- Use `dag.test()` in `if __name__ == "__main__":` block for IDE debugging
+- Runs all tasks in single serialized process without executor
 
 ### Unit Tests
 - Test DAG import without errors
@@ -42,16 +61,34 @@ user-invocable: false
 ## Production Deployment
 
 ### Performance
-- Lazy-load heavy libraries inside tasks
+- Lazy-load heavy libraries inside `@task` functions
 - Use connection pooling
-- Minimize DAG parse time
-- Enable parallelism
+- Minimize DAG parse time (target < 30s for all DAGs)
+- Enable parallelism appropriately
 
 ### Reliability
-- Set appropriate retries and retry_delay
+- Set appropriate `retries` and `retry_delay`
 - Use SLA callbacks for monitoring
-- Implement proper error handling
+- Implement proper error handling with `on_failure_callback`
 - Log important events
 
+## Migration: 2.x → 3.x
+
+### Deprecated (Remove or Replace)
+| Deprecated | Replacement |
+|-----------|-------------|
+| `from airflow.models import DAG` | `from airflow.sdk import DAG` |
+| `from airflow.decorators import task` | `from airflow.sdk import task` |
+| `Dataset` | `Asset` |
+| `execution_date` in context | `dag_run.logical_date` |
+| `conf` in task context | Removed — use Variables or params |
+
+### Architecture Changes
+- **AIP-72**: Task Execution Interface — tasks run in isolated subprocesses via Execution API Server
+- **AIP-44**: Internal API — components communicate via API, not direct DB access
+- **New UI**: React-based web interface (replaces Flask-based UI)
+
 ## References
-- [Airflow Best Practices](https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html)
+- [Airflow 3.1.8 Best Practices](https://airflow.apache.org/docs/apache-airflow/3.1.8/best-practices.html)
+- [Airflow SDK (Task SDK)](https://airflow.apache.org/docs/apache-airflow/3.1.8/authoring-and-scheduling/index.html)
+- [Migration Guide 2.x → 3.x](https://airflow.apache.org/docs/apache-airflow/3.1.8/migration-guide.html)

--- a/templates/guides/airflow/README.md
+++ b/templates/guides/airflow/README.md
@@ -1,22 +1,35 @@
-# Apache Airflow Guide
+# Apache Airflow Guide (3.1.8)
 
-Reference documentation for Apache Airflow DAG development best practices.
+Reference documentation for Apache Airflow 3.1.8 DAG development best practices.
 
 ## Source
 
-Based on [Apache Airflow official documentation](https://airflow.apache.org/docs/) and [Astronomer best practices](https://github.com/astronomer/agents).
+Based on [Apache Airflow 3.1.8 official documentation](https://airflow.apache.org/docs/apache-airflow/3.1.8/) and [Astronomer best practices](https://docs.astronomer.io/).
+
+## Airflow 3.x Key Changes
+
+| Change | Details |
+|--------|---------|
+| SDK namespace | `from airflow.sdk import DAG, task, Asset` |
+| Task Execution (AIP-72) | Isolated subprocess execution via Execution API Server |
+| Internal API (AIP-44) | Components use API instead of direct DB access |
+| Asset (was Dataset) | Data-aware scheduling primitive renamed |
+| Context cleanup | `execution_date` → `dag_run.logical_date` |
+| New UI | React-based web interface |
+| TaskFlow API | `@task` is the default pattern for Python tasks |
 
 ## Categories
 
 | Priority | Category | Impact |
 |----------|----------|--------|
-| 1 | DAG Authoring | CRITICAL |
-| 2 | Task Design | CRITICAL |
-| 3 | Testing | HIGH |
-| 4 | Scheduling | HIGH |
+| 1 | DAG Authoring (airflow.sdk) | CRITICAL |
+| 2 | TaskFlow API & Dynamic Mapping | CRITICAL |
+| 3 | Testing (dag.test()) | HIGH |
+| 4 | Scheduling & Assets | HIGH |
 | 5 | Connections & Variables | MEDIUM |
 | 6 | Monitoring & SLA | MEDIUM |
 | 7 | Performance Optimization | LOW-MEDIUM |
+| 8 | 2.x → 3.x Migration | HIGH |
 
 ## Usage
 
@@ -26,7 +39,9 @@ This guide is referenced by:
 
 ## External Resources
 
-- [Airflow Official Docs](https://airflow.apache.org/docs/)
-- [Airflow Best Practices](https://airflow.apache.org/docs/apache-airflow/stable/best-practices.html)
-- [Astronomer Agents](https://github.com/astronomer/agents)
-- [Airflow TaskFlow API](https://airflow.apache.org/docs/apache-airflow/stable/tutorial/taskflow.html)
+- [Airflow 3.1.8 Official Docs](https://airflow.apache.org/docs/apache-airflow/3.1.8/)
+- [Airflow 3.1.8 Best Practices](https://airflow.apache.org/docs/apache-airflow/3.1.8/best-practices.html)
+- [Airflow Task SDK](https://airflow.apache.org/docs/apache-airflow/3.1.8/authoring-and-scheduling/index.html)
+- [Airflow TaskFlow API](https://airflow.apache.org/docs/apache-airflow/3.1.8/core-concepts/taskflow.html)
+- [Migration Guide 2.x → 3.x](https://airflow.apache.org/docs/apache-airflow/3.1.8/migration-guide.html)
+- [Astronomer Docs](https://docs.astronomer.io/)

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.92.0",
+  "version": "0.93.0",
   "lastUpdated": "2026-04-18T00:00:00.000Z",
   "components": [
     {

--- a/wiki/agents/de-airflow-expert.md
+++ b/wiki/agents/de-airflow-expert.md
@@ -1,7 +1,7 @@
 ---
 title: de-airflow-expert
 type: agent
-updated: 2026-04-12
+updated: 2026-04-18
 sources:
   - .claude/agents/de-airflow-expert.md
 related:

--- a/wiki/guides/airflow.md
+++ b/wiki/guides/airflow.md
@@ -1,7 +1,7 @@
 ---
 title: "Airflow Guide"
 type: guide
-updated: 2026-04-12
+updated: 2026-04-18
 sources:
   - guides/airflow/README.md
 related:

--- a/wiki/skills/airflow-best-practices.md
+++ b/wiki/skills/airflow-best-practices.md
@@ -1,7 +1,7 @@
 ---
 title: Airflow Best Practices
 type: skill
-updated: 2026-04-12
+updated: 2026-04-18
 sources:
   - .claude/skills/airflow-best-practices/SKILL.md
 related:


### PR DESCRIPTION
## Summary
- #890: Airflow 에이전트/스킬/가이드를 Apache Airflow 3.1.8 기준으로 업데이트
  - `de-airflow-expert.md`: 3.1.8 타겟, airflow.sdk 임포트, 2.x→3.x 비교 테이블
  - `airflow-best-practices/SKILL.md`: TaskFlow API, Dynamic Task Mapping, dag.test(), AIP-72/AIP-44, 마이그레이션 가이드
  - `guides/airflow/README.md`: 3.1.8 기준 링크, 주요 변경사항 테이블

## Test plan
- [ ] 에이전트/스킬/가이드 3개 파일 모두 3.1.8 참조 확인
- [ ] 템플릿 3개 파일 소스와 일치 확인
- [ ] 카운트 변경 없음 확인 (48/106/37/22)
- [ ] CI 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)