### PR TITLE
release: v0.97.1

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.97.0",
-  "generatedAt": "2026-04-18T08:03:43.739Z",
-  "templateVersion": "0.97.0",
+  "generatorVersion": "0.97.1",
+  "generatedAt": "2026-04-18T08:36:15.008Z",
+  "templateVersion": "0.97.1",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cd2a131d50bc33a228b4b8303662bbc547450e772f19e337e36d56e95d812db2",
@@ -385,8 +385,8 @@
       "component": "skills"
     },
     ".claude/skills/hada-scout/SKILL.md": {
-      "templateHash": "f488805805ace9a0c9b06023d0d04a3730ed5c89030fe75cde84619c5c5fa160",
-      "size": 3261,
+      "templateHash": "c18094d1d455e2a50222c701f078f1d7b649e53a86aaa19a888e94061129025a",
+      "size": 5443,
       "component": "skills"
     },
     ".claude/skills/audit-agents/SKILL.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2316,7 +2316,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.97.0",
+    version: "0.97.1",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2018,7 +2018,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.97.0",
+  version: "0.97.1",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.97.0",
+  "version": "0.97.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.97.0",
+  "version": "0.97.1",
   "lastUpdated": "2026-04-18T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## 요약

- hada-scout v2.0으로 업그레이드 — LLM 기반 pre-scout 필터링 도입 (#912)
- keyword regex 방식에서 haiku LLM pre-scoring 방식으로 전환
- false positive 비율: 30-40% → 5-10%로 대폭 감소
- `/hada-scout` 사용자 직접 호출 가능 (user-invocable 추가)
- skill scope: `package` → `core`로 변경 (init 배포 포함)

## 변경 파일

- `package.json`: version `0.97.0` → `0.97.1`
- `templates/manifest.json`: version `0.97.0` → `0.97.1`
- `dist/`: `bun run build` 결과물 갱신

## 테스트 계획

- [ ] CI 통과 확인 (8/8)
- [ ] auto-tag.yml 트리거 → v0.97.1 태그 생성
- [ ] release.yml → npm 0.97.1 publish + GitHub Release v0.97.1 생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)