### PR TITLE
release: v0.99.0 — auto-dev pipeline CI-mimic local verification

### DIFF
--- a/.claude/skills/pipeline/workflows/auto-dev.yaml
+++ b/.claude/skills/pipeline/workflows/auto-dev.yaml
@@ -85,7 +85,21 @@ steps:
       - Parallel execution per R009 (max 4 concurrent, respect dependencies)
       - Issues whose prerequisites failed in-run MUST be skipped (log reason)
       - No direct orchestrator writes (R010)
-    description: "Per-issue implementation with lifecycle and specialist routing"
+
+      ## Local CI-mimic verification (MUST run before marking implement done)
+
+      After all implementation tasks complete, run these scripts in sequence and halt on failure:
+
+      1. bash .github/scripts/verify-template-sync.sh
+      2. bash .github/scripts/verify-wiki-sync.sh
+
+      If either fails:
+      - For wiki-sync failures: delegate to wiki-curator to generate missing pages (`/omcustom:wiki ingest <path>`)
+      - For template-sync failures: delegate to mgr-updater to sync `.claude/` -> `templates/.claude/`
+      - After fixes, re-run the scripts until both pass
+
+      This mirrors CI and prevents the known 1-2 wasted push cycles per release (ref: issue #927, v0.98.0 PR #925).
+    description: "Per-issue implementation with lifecycle, specialist routing, and CI-mimic verification"
     depends_on: deep-plan
 
   - name: verify-build

--- a/.github/scripts/verify-template-sync.sh
+++ b/.github/scripts/verify-template-sync.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# verify-template-sync.sh — mirrors template-sync job of ci.yml
+# Accumulates all errors before exiting. Idempotent, read-only.
+# Works on macOS and Linux.
+set -euo pipefail
+
+errors=0
+
+# ── Skill count ──────────────────────────────────────────────────────────────
+src_skills=$(find .claude/skills -name "SKILL.md" 2>/dev/null | wc -l | tr -d ' ')
+tpl_skills=$(find templates/.claude/skills -name "SKILL.md" 2>/dev/null | wc -l | tr -d ' ')
+if [ "$src_skills" != "$tpl_skills" ]; then
+  echo "ERROR: Skill count mismatch: .claude/skills=$src_skills, templates/.claude/skills=$tpl_skills"
+  # List differing skill names (portable: no process substitution with diff)
+  src_skill_names=$(find .claude/skills -name "SKILL.md" -exec dirname {} \; | xargs -I{} basename {} 2>/dev/null | sort)
+  tpl_skill_names=$(find templates/.claude/skills -name "SKILL.md" -exec dirname {} \; | xargs -I{} basename {} 2>/dev/null | sort)
+  # Print names only in src (missing from template)
+  while IFS= read -r sname; do
+    case "$tpl_skill_names" in
+      *"$sname"*) ;;
+      *) echo "  < only in .claude/skills: $sname" ;;
+    esac
+  done <<EOF
+$src_skill_names
+EOF
+  # Print names only in template (extra in template)
+  while IFS= read -r tname; do
+    case "$src_skill_names" in
+      *"$tname"*) ;;
+      *) echo "  > only in templates/.claude/skills: $tname" ;;
+    esac
+  done <<EOF
+$tpl_skill_names
+EOF
+  errors=$((errors + 1))
+fi
+
+# ── Hook script count ────────────────────────────────────────────────────────
+src_hooks=0
+for f in .claude/hooks/scripts/*.sh; do [ -e "$f" ] && src_hooks=$((src_hooks + 1)); done
+tpl_hooks=0
+for f in templates/.claude/hooks/scripts/*.sh; do [ -e "$f" ] && tpl_hooks=$((tpl_hooks + 1)); done
+if [ "$src_hooks" != "$tpl_hooks" ]; then
+  echo "ERROR: Hook script count mismatch: .claude/hooks/scripts=$src_hooks, templates/.claude/hooks/scripts=$tpl_hooks"
+  errors=$((errors + 1))
+fi
+
+# ── hooks.json matcher count ─────────────────────────────────────────────────
+src_hook_entries=0
+tpl_hook_entries=0
+if [ -f ".claude/hooks/hooks.json" ]; then
+  src_hook_entries=$(grep -c '"matcher"' .claude/hooks/hooks.json 2>/dev/null || echo 0)
+fi
+if [ -f "templates/.claude/hooks/hooks.json" ]; then
+  tpl_hook_entries=$(grep -c '"matcher"' templates/.claude/hooks/hooks.json 2>/dev/null || echo 0)
+fi
+if [ "$src_hook_entries" != "$tpl_hook_entries" ]; then
+  echo "ERROR: hooks.json matcher count mismatch: .claude=$src_hook_entries, templates=$tpl_hook_entries"
+  errors=$((errors + 1))
+fi
+
+# ── Schema count ─────────────────────────────────────────────────────────────
+if [ -d ".claude/schemas" ]; then
+  src_schemas=0
+  for f in .claude/schemas/*.json; do [ -e "$f" ] && src_schemas=$((src_schemas + 1)); done
+  tpl_schemas=0
+  for f in templates/.claude/schemas/*.json; do [ -e "$f" ] && tpl_schemas=$((tpl_schemas + 1)); done
+  if [ "$src_schemas" != "$tpl_schemas" ]; then
+    echo "ERROR: Schema count mismatch: .claude/schemas=$src_schemas, templates/.claude/schemas=$tpl_schemas"
+    errors=$((errors + 1))
+  fi
+fi
+
+# ── Skill script files ───────────────────────────────────────────────────────
+SCRIPT_ERRORS=0
+for script_dir in .claude/skills/*/scripts; do
+  if [ -d "$script_dir" ]; then
+    skill_name=$(basename "$(dirname "$script_dir")")
+    template_dir="templates/.claude/skills/$skill_name/scripts"
+    if [ ! -d "$template_dir" ]; then
+      echo "ERROR: Missing template scripts dir: $template_dir"
+      SCRIPT_ERRORS=$((SCRIPT_ERRORS + 1))
+    else
+      for script in "$script_dir"/*; do
+        [ -e "$script" ] || continue
+        script_name=$(basename "$script")
+        if [ ! -f "$template_dir/$script_name" ]; then
+          echo "ERROR: Missing template script: $template_dir/$script_name"
+          SCRIPT_ERRORS=$((SCRIPT_ERRORS + 1))
+        fi
+      done
+    fi
+  fi
+done
+errors=$((errors + SCRIPT_ERRORS))
+
+# ── Agent count ──────────────────────────────────────────────────────────────
+src_agent_count=0
+for f in .claude/agents/*.md; do [ -e "$f" ] && src_agent_count=$((src_agent_count + 1)); done
+tpl_agent_count=0
+for f in templates/.claude/agents/*.md; do [ -e "$f" ] && tpl_agent_count=$((tpl_agent_count + 1)); done
+if [ "$src_agent_count" != "$tpl_agent_count" ]; then
+  echo "ERROR: Agent count mismatch: source=$src_agent_count template=$tpl_agent_count"
+  errors=$((errors + 1))
+fi
+
+# ── Rules count ──────────────────────────────────────────────────────────────
+src_rules_count=0
+for f in .claude/rules/*.md; do [ -e "$f" ] && src_rules_count=$((src_rules_count + 1)); done
+tpl_rules_count=0
+for f in templates/.claude/rules/*.md; do [ -e "$f" ] && tpl_rules_count=$((tpl_rules_count + 1)); done
+if [ "$src_rules_count" != "$tpl_rules_count" ]; then
+  echo "ERROR: Rules count mismatch: source=$src_rules_count template=$tpl_rules_count"
+  errors=$((errors + 1))
+fi
+
+# ── Guides count ─────────────────────────────────────────────────────────────
+src_guides_count=$(find guides -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+tpl_guides_count=$(find templates/guides -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+if [ "$src_guides_count" != "$tpl_guides_count" ]; then
+  echo "ERROR: Guides count mismatch: source=$src_guides_count template=$tpl_guides_count"
+  errors=$((errors + 1))
+fi
+
+# ── CLAUDE.md agent and skill counts ─────────────────────────────────────────
+actual_agents=$(ls .claude/agents/*.md 2>/dev/null | wc -l | tr -d ' ')
+actual_skills=$(find .claude/skills -name 'SKILL.md' 2>/dev/null | wc -l | tr -d ' ')
+
+# Extract counts from CLAUDE.md — pattern: "(48 파일)" or "(106 디렉토리)"
+doc_agents=$(grep -oE 'agents/[^(]*\(([0-9]+) 파일\)' CLAUDE.md 2>/dev/null | grep -oE '[0-9]+' | head -1 || echo "0")
+doc_skills=$(grep -oE 'skills/[^(]*\(([0-9]+) 디렉토리\)' CLAUDE.md 2>/dev/null | grep -oE '[0-9]+' | head -1 || echo "0")
+
+echo "Actual: agents=$actual_agents skills=$actual_skills rules=$src_rules_count guides=$src_guides_count"
+echo "CLAUDE.md documented: agents=$doc_agents skills=$doc_skills"
+
+if [ "$doc_agents" != "0" ] && [ "$actual_agents" != "$doc_agents" ]; then
+  echo "WARNING: CLAUDE.md agent count ($doc_agents) != actual ($actual_agents)"
+  errors=$((errors + 1))
+fi
+if [ "$doc_skills" != "0" ] && [ "$actual_skills" != "$doc_skills" ]; then
+  echo "WARNING: CLAUDE.md skill count ($doc_skills) != actual ($actual_skills)"
+  errors=$((errors + 1))
+fi
+
+# ── Final result ─────────────────────────────────────────────────────────────
+if [ "$errors" -gt 0 ]; then
+  echo ""
+  echo "Fix: copy missing files from .claude/ to templates/.claude/"
+  echo "Example: cp .claude/skills/NEW_SKILL/SKILL.md templates/.claude/skills/NEW_SKILL/SKILL.md"
+  exit 1
+fi
+
+echo "Template sync verified: $src_skills skills, $src_hooks hooks, $src_hook_entries hook matchers, skill scripts OK"
+echo "Agents: $src_agent_count  Rules: $src_rules_count  Guides: $src_guides_count"

--- a/.github/scripts/verify-wiki-sync.sh
+++ b/.github/scripts/verify-wiki-sync.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# verify-wiki-sync.sh — mirrors "Check for missing wiki pages" step of wiki-sync.yml
+# Idempotent, read-only. Exits 1 on any missing page.
+# Works on macOS and Linux.
+set -euo pipefail
+
+ERRORS=0
+MISSING=0
+
+# ── Guard: wiki/ directory must exist ────────────────────────────────────────
+if [ ! -d "wiki" ]; then
+  echo "ERROR: wiki/ directory not found. Run '/omcustom:wiki' first."
+  exit 1
+fi
+
+# ── Agents ───────────────────────────────────────────────────────────────────
+src_agents=0
+for src in .claude/agents/*.md; do
+  [ -e "$src" ] || continue
+  src_agents=$((src_agents + 1))
+  name=$(basename "$src" .md)
+  wiki_page="wiki/agents/${name}.md"
+  if [ ! -f "$wiki_page" ]; then
+    echo "MISSING: $wiki_page  (source: $src)"
+    MISSING=$((MISSING + 1))
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+
+# ── Skills ───────────────────────────────────────────────────────────────────
+src_skills=0
+while IFS= read -r src; do
+  src_skills=$((src_skills + 1))
+  skill_dir=$(dirname "$src")
+  name=$(basename "$skill_dir")
+  wiki_page="wiki/skills/${name}.md"
+  if [ ! -f "$wiki_page" ]; then
+    echo "MISSING: $wiki_page  (source: $src)"
+    MISSING=$((MISSING + 1))
+    ERRORS=$((ERRORS + 1))
+  fi
+done < <(find .claude/skills -name "SKILL.md" 2>/dev/null)
+
+# ── Rules ────────────────────────────────────────────────────────────────────
+src_rules=0
+for src in .claude/rules/*.md; do
+  [ -e "$src" ] || continue
+  src_rules=$((src_rules + 1))
+  # Extract numeric part of rule ID (e.g. "ID**: R007" → "7")
+  rule_id=$(grep -oE 'ID\*\*: R[0-9]+' "$src" 2>/dev/null | grep -oE '[0-9]+' | head -1 || true)
+  if [ -n "$rule_id" ]; then
+    wiki_page="wiki/rules/r$(printf '%03d' "$((10#$rule_id))").md"
+    if [ ! -f "$wiki_page" ]; then
+      echo "MISSING: $wiki_page  (source: $src)"
+      MISSING=$((MISSING + 1))
+      ERRORS=$((ERRORS + 1))
+    fi
+  fi
+done
+
+# ── Guides ───────────────────────────────────────────────────────────────────
+src_guides=0
+while IFS= read -r src; do
+  src_guides=$((src_guides + 1))
+  name=$(basename "$src")
+  wiki_page="wiki/guides/${name}.md"
+  if [ ! -f "$wiki_page" ]; then
+    echo "MISSING: $wiki_page  (source: $src)"
+    MISSING=$((MISSING + 1))
+    ERRORS=$((ERRORS + 1))
+  fi
+done < <(find guides -mindepth 1 -maxdepth 1 -type d 2>/dev/null)
+
+# ── wiki/index.yaml ──────────────────────────────────────────────────────────
+if [ ! -f "wiki/index.yaml" ]; then
+  echo "MISSING: wiki/index.yaml"
+  ERRORS=$((ERRORS + 1))
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+total_wiki=$(find wiki -name "*.md" ! -name "index.md" ! -name "log.md" 2>/dev/null | wc -l | tr -d ' ')
+echo "Source entities: agents=$src_agents skills=$src_skills rules=$src_rules guides=$src_guides"
+echo "Wiki pages (total .md): $total_wiki  |  Missing: $MISSING"
+
+if [ "$ERRORS" -gt 0 ]; then
+  echo ""
+  echo "Fix: run '/omcustom:wiki' to regenerate wiki pages"
+  exit 1
+fi
+
+echo "Wiki sync check passed"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.98.0",
+  "version": "0.99.0",
   "lastUpdated": "2026-04-18T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## 요약

- auto-dev 파이프라인의 `implement` 단계에 로컬 CI-mimic 검증 스크립트 추가
- 릴리즈당 1-2회 불필요한 push + CI 대기 시간 제거 (각 ~3-5분)

## 변경사항

- `.github/scripts/verify-wiki-sync.sh` — `.github/workflows/wiki-sync.yml`의 "Check for missing wiki pages" 단계를 로컬에서 동일하게 실행
- `.github/scripts/verify-template-sync.sh` — `.github/workflows/ci.yml`의 `template-sync` job을 로컬에서 동일하게 실행
- `.claude/skills/pipeline/workflows/auto-dev.yaml` — `implement` 단계 종료 전 두 스크립트 실행, 실패 시 wiki-curator / mgr-updater에 위임
- package.json, templates/manifest.json — 버전 0.99.0

## Test plan

- [x] 로컬에서 verify-template-sync.sh 실행 → exit 0 (`106 skills, 31 hooks, 47 hook matchers`)
- [x] 로컬에서 verify-wiki-sync.sh 실행 → exit 0 (`242 wiki pages, 0 missing`)
- [ ] CI 통과 확인
- [ ] v0.99.0 릴리즈 태그 자동 생성 확인

Closes #927

🤖 Generated with [Claude Code](https://claude.com/claude-code)