### PR TITLE
release: v0.99.1 — bypassPermissions enforcement + /idea skill

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.98.0",
-  "generatedAt": "2026-04-18T09:51:54.072Z",
-  "templateVersion": "0.98.0",
+  "generatorVersion": "0.99.1",
+  "generatedAt": "2026-04-18T11:38:11.277Z",
+  "templateVersion": "0.99.1",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cd2a131d50bc33a228b4b8303662bbc547450e772f19e337e36d56e95d812db2",
@@ -445,8 +445,8 @@
       "component": "skills"
     },
     ".claude/skills/qa-lead-routing/SKILL.md": {
-      "templateHash": "c047ea64c37ba8b3aadce357e4ffb17ae003f5cc5d6952480b04e8a6a8739c75",
-      "size": 3687,
+      "templateHash": "6282676f10eb8bc58be0e7a453280c100b32df35f9f31182c2e5589c20991569",
+      "size": 3736,
       "component": "skills"
     },
     ".claude/skills/memory-recall/SKILL.md": {
@@ -470,13 +470,13 @@
       "component": "skills"
     },
     ".claude/skills/pipeline/workflows/auto-dev.yaml": {
-      "templateHash": "12ae7adf6d40558112c2ab1bf7e9df57f37e7278303e4b6bc5c833296da54fa9",
-      "size": 6134,
+      "templateHash": "2ae868b503022cedf24ac87d33ecfbbd371a60b8666a47d4047bc71d004d7320",
+      "size": 6857,
       "component": "skills"
     },
     ".claude/skills/pipeline/SKILL.md": {
-      "templateHash": "e17f9173050f5035bec9285b24f6a1afa90b8e0712988d47383ea1263f7e9ca5",
-      "size": 4919,
+      "templateHash": "bfb4092237e9c3ad6eab86975d4d0a35a24ac67f71feab1a40f1ddd547a05a08",
+      "size": 5180,
       "component": "skills"
     },
     ".claude/skills/memory-save/SKILL.md": {
@@ -520,8 +520,8 @@
       "component": "skills"
     },
     ".claude/skills/secretary-routing/SKILL.md": {
-      "templateHash": "30a6e36ba4b816b54e9f04f6b471c447657af1509c49811326dcf6a58f55b432",
-      "size": 5008,
+      "templateHash": "d6f07912c2ac18b47b3b2755cc949a2e6e212ff9cabec16660ab85047e280c7d",
+      "size": 5057,
       "component": "skills"
     },
     ".claude/skills/adaptive-harness/SKILL.md": {
@@ -705,13 +705,13 @@
       "component": "skills"
     },
     ".claude/skills/dev-lead-routing/SKILL.md": {
-      "templateHash": "0a87b8387ba9ca23708d351e64c877c58254c0d72f90f9a7eb4d72cc2c532160",
-      "size": 7058,
+      "templateHash": "c2a9f33a363226eb76d2f7def13a17c4006d0c8fcd2171ca80c22d8e5940d442",
+      "size": 7107,
       "component": "skills"
     },
     ".claude/skills/scout/SKILL.md": {
-      "templateHash": "25769dc5e31983a4fe1a287f0daf90a953b8182948c2f67905ba40ae299bb5cb",
-      "size": 7550,
+      "templateHash": "c58b2d82da29c7acef2b5f11d188942212ffff175191ac22eb8428f55a80eb36",
+      "size": 7582,
       "component": "skills"
     },
     ".claude/skills/status/SKILL.md": {
@@ -777,6 +777,11 @@
     ".claude/skills/omcustom-takeover/SKILL.md": {
       "templateHash": "8e4005df217634663e6942c7f8435ad00fb992270621fc98ddb43a1344322dfe",
       "size": 2909,
+      "component": "skills"
+    },
+    ".claude/skills/idea/SKILL.md": {
+      "templateHash": "80110806cf1af053c55132c19150ac6adfa13a0958ddc5dce7b3903583ba7c2b",
+      "size": 2167,
       "component": "skills"
     },
     ".claude/skills/gemini-exec/scripts/gemini-wrapper.cjs": {
@@ -965,8 +970,8 @@
       "component": "skills"
     },
     ".claude/skills/de-lead-routing/SKILL.md": {
-      "templateHash": "618e635b702db9e03aea6ad9d0ded127a79c1fe5648b925578e5e7098dd2961c",
-      "size": 8671,
+      "templateHash": "657f396c7036dd720de599cc9d5b0a76c2257bf46ee6cf905693872efce102f8",
+      "size": 8720,
       "component": "skills"
     },
     ".claude/skills/stuck-recovery/SKILL.md": {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (48 파일)
-|   +-- skills/                  # 스킬 (106 디렉토리)
+|   +-- skills/                  # 스킬 (107 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R022)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Each agent declares its tools, model, memory scope, and limitations in YAML fron
 
 ---
 
-### Skills (106)
+### Skills (107)
 
 | Category | Count | Includes |
 |----------|-------|----------|

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2316,7 +2316,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.98.0",
+    version: "0.99.1",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2018,7 +2018,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.98.0",
+  version: "0.99.1",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.99.0",
+  "version": "0.99.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -114,7 +114,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (48 파일)
-|   +-- skills/                  # 스킬 (106 디렉토리)
+|   +-- skills/                  # 스킬 (107 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R022)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.99.0",
+  "version": "0.99.1",
   "lastUpdated": "2026-04-18T00:00:00.000Z",
   "components": [
     {
@@ -18,7 +18,7 @@
       "name": "skills",
       "path": ".claude/skills",
       "description": "Reusable skill modules (includes slash commands)",
-      "files": 106
+      "files": 107
     },
     {
       "name": "guides",

--- a/wiki/index.yaml
+++ b/wiki/index.yaml
@@ -3,7 +3,7 @@
 
 meta:
   updated: "2026-04-18"
-  total_pages: 241
+  total_pages: 242
   total_sources: 212
 
 pages:
@@ -279,6 +279,9 @@ pages:
     - file: skills/help.md
       title: "Help"
       summary: "Show help information for commands, agents, and skills."
+    - file: skills/idea.md
+      title: "Idea"
+      summary: "Analyze a natural language idea against the project codebase and return structured issue specs for downstream issue creation."
     - file: skills/impeccable-design.md
       title: "Impeccable Design"
       summary: "AI design language for production-ready UI systems."

--- a/wiki/skills/idea.md
+++ b/wiki/skills/idea.md
@@ -1,0 +1,65 @@
+---
+title: Idea
+type: skill
+updated: 2026-04-18
+sources:
+  - .claude/skills/idea/SKILL.md
+related:
+  - [[scout]]
+  - [[deep-plan]]
+  - [[professor-triage]]
+  - [[release-plan]]
+---
+
+# Idea
+
+Analyze a natural language idea against the project codebase and return structured issue specs.
+
+## Overview
+
+Takes a free-form idea description, analyzes it against the current project structure, and returns a structured JSON block containing a feasibility assessment and ready-to-create issue specifications. Works in four phases: intent parsing, codebase analysis (Glob/Grep), sonnet-agent feasibility analysis, and JSON output. The output JSON is a stable contract consumed by downstream systems such as the builder-factory Discord bot.
+
+## Key Details
+
+- **Scope**: core
+- **Version**: 1.0.0
+- **User-invocable**: yes
+- **Command**: `/idea`
+- **Argument hint**: `<idea text>`
+
+## Workflow
+
+1. **Parse** — extract core intent from natural language input
+2. **Analyze** — Glob and Grep current project structure; identify affected modules, patterns, and conflicts
+3. **Assess** — spawn a sonnet agent (bypassPermissions) for feasibility: scope, complexity (XS/S/M/L), dependencies, risks
+4. **Output** — emit a fenced JSON block with `title`, `scope`, `estimatedIssues`, `details`, and `issueSpecs[]`
+
+## Output Contract
+
+```json
+{
+  "title": "concise feature title",
+  "scope": "affected modules and files",
+  "estimatedIssues": 3,
+  "details": "2-3 sentence feasibility analysis",
+  "issueSpecs": [
+    {
+      "title": "issue title",
+      "body": "issue description with acceptance criteria",
+      "labels": ["enhancement"]
+    }
+  ]
+}
+```
+
+The JSON structure is a stable contract — field names must not change.
+
+## Relationships
+
+- **Used by agents**: orchestrator, builder-factory Discord bot
+- **Related skills**: [[scout]], [[deep-plan]], [[professor-triage]], [[release-plan]]
+- **See also**: [[R009]], [[R010]]
+
+## Sources
+
+- `.claude/skills/idea/SKILL.md` — skill definition


### PR DESCRIPTION
## Summary
- Fix #926: enforce `mode: bypassPermissions` on all agent spawns in pipeline/routing/scout skills
- Fix #930: create `/idea` skill for natural language idea → structured issue spec conversion
- Skills count: 106 → 107, wiki page added

## Test plan
- [ ] CI passes (8/8 checks)
- [ ] npm publish via auto-tag workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)