### PR TITLE
release: v0.99.3 — claude-design wiki page fix

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.99.2",
-  "generatedAt": "2026-04-18T14:14:05.106Z",
-  "templateVersion": "0.99.2",
+  "generatorVersion": "0.99.3",
+  "generatedAt": "2026-04-19T03:28:21.147Z",
+  "templateVersion": "0.99.3",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cd2a131d50bc33a228b4b8303662bbc547450e772f19e337e36d56e95d812db2",

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2316,7 +2316,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.99.2",
+    version: "0.99.3",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2025,7 +2025,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.99.2",
+  version: "0.99.3",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.99.2",
+  "version": "0.99.3",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.99.2",
+  "version": "0.99.3",
   "lastUpdated": "2026-04-18T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary

- fix(wiki): claude-design 가이드 위키 페이지 누락 수정 (commit 9f95cb5)
- Version bump: 0.99.2 → 0.99.3 (package.json, templates/manifest.json)
- Build artifacts updated (dist/)

## Test plan

- [ ] CI checks pass (type-check, lint, tests, coverage, validate-docs)
- [ ] auto-tag.yml triggers on merge → v0.99.3 태그 생성
- [ ] release.yml triggers → npm publish v0.99.3
- [ ] GitHub Release v0.99.3 자동 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)