### PR TITLE
release: v0.100.0 — token-efficiency-audit + pre-generation-arch-check + DCP transparency (#938, #935)

### DIFF
--- a/.claude/rules/SHOULD-ecomode.md
+++ b/.claude/rules/SHOULD-ecomode.md
@@ -36,6 +36,22 @@ Ecomode: `[lang-golang-expert] ✓ src/main.go reviewed: 1 naming issue (handle_
 
 Disable with: "ecomode off", "verbose mode", or "show full details".
 
+## Pruning Transparency
+
+When ecomode is active, report what was compressed so users can audit context decisions:
+
+```
+[Pruned] {n} chunks, ~{tokens} tokens saved | Retained: {m} | Summarized: {k} | Dropped: {j}
+```
+
+| When | Report |
+|------|--------|
+| After input context pruning | `[Pruned]` line in agent output |
+| After output compression | `[Compressed]` line in batch summary |
+| On request ("what was pruned?") | Full pruning ledger with chunk names |
+
+Pruning transparency is advisory — it adds ~1 line per pruning event. Disable with "ecomode off" or "hide pruning".
+
 ## Input Context Pruning — Active removal of irrelevant content. See full spec via Read tool.
 
 <!-- DETAIL: Input Context Pruning

--- a/.claude/skills/pre-generation-arch-check/SKILL.md
+++ b/.claude/skills/pre-generation-arch-check/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: pre-generation-arch-check
+description: Pre-generation architecture check — detect R006 separation-of-concerns and compilation metaphor violations before code generation begins
+scope: core
+user-invocable: false
+version: 1.0.0
+---
+
+# Pre-Generation Architecture Check
+
+AASM-inspired pre-generation architecture guard. Detects design violations before code generation (the "pre-compile lint" phase), complementing adversarial-review and deep-verify which operate post-generation.
+
+## Overview
+
+This skill fills the PRE-generation gap in the verification pipeline:
+
+| Phase | Skill | When |
+|-------|-------|------|
+| Pre-generation | **pre-generation-arch-check** | Before code is written |
+| Post-generation | adversarial-review | After code is written |
+| Post-generation | deep-verify | After changes are committed |
+
+Inspired by Contexty's AASM (AI Anti-pattern Severity Matrix) mechanism. Detects when a requested change might violate:
+- R006 separation of concerns (agents vs skills vs guides)
+- Compilation metaphor boundaries (source/build/spec/linker/stdlib)
+- R010 orchestrator delegation rules
+- Protected path rules (.claude/agents/, .claude/skills/, guides/)
+
+## Input
+
+- **Request summary**: What the user or pipeline is asking to generate
+- **Target files/paths**: Where changes will be made
+
+## Processing — Anti-Pattern Detection
+
+Check for each of the following anti-patterns against the request summary and target paths:
+
+### 1. Skill-in-Agent (WARN)
+An agent file (`.claude/agents/*.md`) body contains detailed step-by-step instructions, scripts, or workflow logic that belongs in a skill file.
+- **Signal**: Agent body exceeds ~50 lines OR contains code blocks / numbered step sequences
+- **Suggestion**: Extract instructions into `.claude/skills/{name}/SKILL.md`, reference from agent `skills:` frontmatter
+
+### 2. Agent-in-Skill (WARN)
+A skill file contains agent configuration fields (`model:`, `tools:`, `memory:`, `permissionMode:`).
+- **Signal**: Proposed skill SKILL.md frontmatter contains agent-only fields
+- **Suggestion**: Move agent configuration to `.claude/agents/{name}.md`; keep skill focused on instructions
+
+### 3. Guide-in-Skill (WARN)
+A skill file contains reference documentation, best-practices tutorials, or conceptual explanations that belong in `guides/`.
+- **Signal**: Proposed SKILL.md body contains "## Background", "## Concepts", or sections > 100 lines of prose
+- **Suggestion**: Move reference content to `guides/{topic}/`, link from skill
+
+### 4. Cross-Concern Write Without mgr-creator (BLOCK)
+A single atomic change spans two or more of: `.claude/agents/`, `.claude/skills/`, `guides/` — without routing through mgr-creator.
+- **Signal**: Target paths include files in 2+ protected directories in the same request
+- **Suggestion**: Route the request through mgr-creator (R010 protected path rule)
+
+### 5. Direct Orchestrator Write (BLOCK)
+An implementation step would have the orchestrator (main conversation) directly write or edit files, bypassing subagent delegation.
+- **Signal**: Request implies "I will write X" from orchestrator context rather than "delegate to specialist"
+- **Suggestion**: Delegate file writes to appropriate specialist agent per R010 delegation table
+
+### 6. Spec-Build Confusion (WARN)
+Rules (`.claude/rules/`) are being modified in the same atomic change as source code or agent/skill files.
+- **Signal**: Target paths include both `.claude/rules/*.md` and any code or `.claude/agents/` or `.claude/skills/` files
+- **Suggestion**: Separate rule updates (spec changes) from agent/skill/code changes (build changes) into distinct commits
+
+## Output Format
+
+When no violations are detected:
+
+```
+[ARCH-CHECK] No violations detected — proceed with generation
+```
+
+When violations are detected:
+
+```
+[ARCH-WARNING] {count} potential violation(s) detected:
+├── {pattern-name} ({severity}): {description}
+│   └── Suggestion: {fix}
+├── {pattern-name} ({severity}): {description}
+│   └── Suggestion: {fix}
+```
+
+## Severity Levels
+
+| Severity | Action |
+|----------|--------|
+| WARN | Advisory — proceed with caution, note in generation plan |
+| BLOCK | Halt — requires architectural redesign before proceeding |
+
+BLOCK violations must be resolved before generation continues. WARN violations are logged and surfaced to the user but do not halt execution (consistent with R021 advisory-first enforcement model).
+
+## Integration
+
+Auto-invoked at structured-dev-cycle Phase 1 (planning phase) before any file generation begins.
+
+This skill is advisory only — it does NOT hard-block execution. This is consistent with R021's advisory-first enforcement model. Future promotion to a PreToolUse hook is possible if violation rates warrant escalation.
+
+Invocation pattern:
+```
+[structured-dev-cycle Phase 1]
+  → pre-generation-arch-check
+    → returns [ARCH-CHECK] or [ARCH-WARNING]
+  → continue to Phase 2 (generation) with findings surfaced
+```
+
+## Cross-References
+
+- `.claude/rules/MUST-agent-design.md` (R006) — separation of concerns
+- `.claude/rules/MUST-orchestrator-coordination.md` (R010) — protected paths and delegation
+- `.claude/skills/adversarial-review/` — post-generation security counterpart
+- `.claude/skills/deep-verify/` — post-generation quality counterpart
+- Source concept: Contexty AASM (https://github.com/ttalkkak-lab/opencode-contexty)

--- a/.claude/skills/token-efficiency-audit/SKILL.md
+++ b/.claude/skills/token-efficiency-audit/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: token-efficiency-audit
+description: Three-layer token defense stack — audit current settings, apply safe/CI levers, and monitor status
+scope: package
+user-invocable: true
+argument-hint: "[audit|apply-interactive|apply-ci|status]"
+version: 1.0.0
+---
+
+# Token Efficiency Audit Skill
+
+Layer 3 of the three-layer token defense stack. Audits current Claude Code settings against the token efficiency lever reference table, applies safe interactive levers, and reports combined layer status.
+
+Reference guide: `guides/claude-code/14-token-efficiency.md`
+
+## Three-Layer Stack
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Layer 1: cc-token-saver (CACHE DEFENSE)                        │
+│  Before session — protect prompt cache TTL from idle expiry     │
+├─────────────────────────────────────────────────────────────────┤
+│  Layer 2: R013 Ecomode (RUNTIME COMPRESSION)                    │
+│  During session — compact output, aggregate results, prune input│
+├─────────────────────────────────────────────────────────────────┤
+│  Layer 3: token-efficiency-audit (PRE-SESSION PREVENTION)       │
+│  Config time — disable injections before they happen            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Each layer is independently deployable and non-overlapping. Layer 3 (this skill) operates at config time — it prevents overhead from ever entering the context window.
+
+## Modes
+
+### audit (default)
+
+1. Read `.claude/settings.json` (project-level, git-tracked)
+2. Read `.claude/settings.local.json` (local, not git-tracked)
+3. Check each lever from the Interactive Session Levers table in the guide:
+   - `includeGitInstructions`
+   - `autoConnectIde`
+   - `attribution.commit`
+   - `attribution.pr`
+   - `env.BASH_MAX_OUTPUT_LENGTH`
+   - `env.CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS`
+   - `env.MAX_MCP_OUTPUT_TOKENS`
+4. Output a table:
+
+```
+[Token Efficiency Audit]
+Reference: guides/claude-code/14-token-efficiency.md (CC v2.1.114+)
+
+| Lever                               | Current     | Recommended | Gap    | Location              |
+|-------------------------------------|-------------|-------------|--------|-----------------------|
+| includeGitInstructions              | true        | false       | ⚠ SET  | settings.json         |
+| autoConnectIde                      | true        | false       | ⚠ SET  | settings.json         |
+| attribution.commit                  | auto text   | ""          | ⚠ SET  | settings.json         |
+| attribution.pr                      | auto text   | ""          | ⚠ SET  | settings.json         |
+| BASH_MAX_OUTPUT_LENGTH              | unlimited   | 15000       | ⚠ SET  | settings.local.json   |
+| CLAUDE_CODE_FILE_READ_MAX_OUTPUT... | unlimited   | 8000        | ⚠ SET  | settings.local.json   |
+| MAX_MCP_OUTPUT_TOKENS               | unlimited   | 8000        | ⚠ SET  | settings.local.json   |
+
+Run /token-efficiency-audit apply-interactive to apply all safe levers.
+```
+
+Gap column values:
+- `OK` — already at recommended value
+- `⚠ SET` — currently at default, recommended change available
+- `CUSTOM` — non-default value that differs from recommendation (display actual value)
+
+### apply-interactive
+
+Applies Interactive Session Levers only (safe for development use).
+
+1. Read `.claude/settings.json` and `.claude/settings.local.json` (create if not exists)
+2. Apply to `settings.json`:
+   ```json
+   {
+     "includeGitInstructions": false,
+     "autoConnectIde": false,
+     "attribution": {
+       "commit": "",
+       "pr": ""
+     }
+   }
+   ```
+3. Apply to `settings.local.json` (env block):
+   ```json
+   {
+     "env": {
+       "BASH_MAX_OUTPUT_LENGTH": "15000",
+       "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS": "8000",
+       "MAX_MCP_OUTPUT_TOKENS": "8000"
+     }
+   }
+   ```
+4. Preserve all existing settings (merge, do not overwrite unrelated keys)
+5. Report applied changes:
+   ```
+   [Done] Interactive levers applied
+
+   settings.json:
+     includeGitInstructions: true → false
+     autoConnectIde: true → false
+     attribution.commit: (auto) → ""
+     attribution.pr: (auto) → ""
+
+   settings.local.json:
+     BASH_MAX_OUTPUT_LENGTH: (none) → 15000
+     CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS: (none) → 8000
+     MAX_MCP_OUTPUT_TOKENS: (none) → 8000
+
+   Note: settings.json is git-tracked. Commit if appropriate.
+   Takes effect on next claude session restart.
+   ```
+
+### apply-ci
+
+Applies CI/Worker-Only Levers. These disable core oh-my-customcode functionality.
+
+**R001 Risk: HIGH** — Display this warning prominently BEFORE applying:
+
+```
+⚠ WARNING — CI/WORKER LEVERS
+
+These settings disable core oh-my-customcode functionality:
+  • CLAUDE_CODE_DISABLE_CLAUDE_MDS=1  → ALL rules and routing offline (R010 disabled)
+  • CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS=1 → All 48 agents unavailable
+  • ENABLE_CLAUDEAI_MCP_SERVERS=false → MCP-dependent skills unavailable
+  • CLAUDE_CODE_DISABLE_AUTO_MEMORY=1 → No persistent memory across sessions
+
+Only use for CI/worker pipelines. Never apply to interactive development sessions.
+
+Type "yes" to confirm, or anything else to cancel:
+```
+
+1. Require explicit user confirmation ("yes") before proceeding
+2. On confirmation, apply to `settings.local.json`:
+   ```json
+   {
+     "env": {
+       "CLAUDE_CODE_DISABLE_CLAUDE_MDS": "1",
+       "CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS": "1",
+       "ENABLE_CLAUDEAI_MCP_SERVERS": "false",
+       "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1"
+     }
+   }
+   ```
+3. Report:
+   ```
+   [Done] CI/Worker levers applied to settings.local.json
+
+   This file is NOT git-tracked.
+   To undo: remove the four env keys or run /token-efficiency-audit status
+   ```
+4. On cancellation: `[Cancelled] No changes made.`
+
+### status
+
+Reports current state of all three layers.
+
+1. Check Layer 1 — cc-token-saver:
+   - Check if plugin is present (look for cc-token-saver in `.claude/` plugin config or known plugin markers)
+   - Report: Installed / Not installed
+2. Check Layer 2 — R013 Ecomode:
+   - Read `.claude/settings.json` for ecomode config
+   - Report: threshold, result_format, max_result_length if set; otherwise "auto-threshold (4 tasks)"
+3. Check Layer 3 — Settings levers:
+   - Run the same lever checks as `audit` mode
+   - Summarize: N/7 levers at recommended values
+4. Check OTel availability:
+   - Look for `CLAUDE_CODE_ENABLE_TELEMETRY` in settings
+   - If present: report "OTel enabled — use /monitoring-setup status for metrics"
+5. Output:
+
+```
+[Token Efficiency Status]
+
+Layer 1: cc-token-saver    ✓ Installed / ✗ Not installed
+Layer 2: R013 Ecomode      ✓ Active (threshold: 4) / ✗ Not configured
+Layer 3: Settings levers   4/7 at recommended
+
+Layer 3 details:
+  includeGitInstructions: false ✓
+  autoConnectIde: true ⚠
+  attribution.commit: "" ✓
+  attribution.pr: "" ✓
+  BASH_MAX_OUTPUT_LENGTH: 15000 ✓
+  CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS: unlimited ⚠
+  MAX_MCP_OUTPUT_TOKENS: unlimited ⚠
+
+Run /token-efficiency-audit apply-interactive to fix ⚠ levers.
+OTel: not enabled — run /monitoring-setup enable to measure effectiveness.
+```
+
+## Codex Levers
+
+When Codex CLI is in use (detected by presence of `~/.codex/config.toml`):
+
+Recommended settings in `config.toml`:
+```toml
+[features]
+apps = false
+
+[apps._default]
+enabled = false
+
+web_search = "disabled"
+
+tool_output_token_limit = 10000
+```
+
+Non-interactive Codex CLI flag reference: `guides/claude-code/13-cli-flags.md`
+
+## Guardrails
+
+### The Re-Call Trap
+
+Setting output limits too low forces repeated re-call loops — the model issues `tail -n 50 output.txt` or re-reads files in chunks, costing more tokens than the original uncapped output.
+
+**Enforce these minimum floors (never go below):**
+
+| Variable | Safe minimum | Recommended |
+|----------|-------------|-------------|
+| `BASH_MAX_OUTPUT_LENGTH` | 10000 | 15000 |
+| `CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS` | 4000 | 8000 |
+| `MAX_MCP_OUTPUT_TOKENS` | 4000 | 8000 |
+| Codex `tool_output_token_limit` | 5000 | 10000 |
+
+If a user requests values below these floors, warn them of the re-call trap risk before applying.
+
+### Version Drift
+
+Settings defaults change with minor CC version releases. After each upgrade, re-run `/token-efficiency-audit audit` to verify active defaults. Reference baseline: CC v2.1.114+ / Codex v0.121.0+.
+
+## Cross-References
+
+- `guides/claude-code/14-token-efficiency.md` — Full three-layer stack guide and lever table
+- `.claude/rules/SHOULD-ecomode.md` (R013) — Layer 2 specification
+- `.claude/skills/monitoring-setup/SKILL.md` — Measure effectiveness via OTel metrics
+- `guides/cc-token-saver/README.md` — Layer 1 detailed guide
+- `guides/claude-code/13-cli-flags.md` — Non-interactive/CI CLI flags

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.99.3",
-  "generatedAt": "2026-04-19T03:28:21.147Z",
-  "templateVersion": "0.99.3",
+  "generatorVersion": "0.100.0",
+  "generatedAt": "2026-04-19T06:38:39.998Z",
+  "templateVersion": "0.100.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cd2a131d50bc33a228b4b8303662bbc547450e772f19e337e36d56e95d812db2",
@@ -40,8 +40,8 @@
       "component": "rules"
     },
     ".claude/rules/SHOULD-ecomode.md": {
-      "templateHash": "eea1abea618f0081f310bd0fc57044e6462c3925ede35552f57d8cece2d95b61",
-      "size": 4656,
+      "templateHash": "9ab3a1f3afb1077da0dc484b02dcb197040e6a391e33d1e99dc4bbf09204d1c9",
+      "size": 5238,
       "component": "rules"
     },
     ".claude/rules/MUST-language-policy.md": {
@@ -444,6 +444,11 @@
       "size": 2539,
       "component": "skills"
     },
+    ".claude/skills/token-efficiency-audit/SKILL.md": {
+      "templateHash": "1f3cef1bd3b3c63fd361823af6d897da5752be6d33a4aa36ddea52fd97874dbc",
+      "size": 9351,
+      "component": "skills"
+    },
     ".claude/skills/qa-lead-routing/SKILL.md": {
       "templateHash": "6282676f10eb8bc58be0e7a453280c100b32df35f9f31182c2e5589c20991569",
       "size": 3736,
@@ -802,6 +807,11 @@
     ".claude/skills/skills-sh-search/SKILL.md": {
       "templateHash": "d9171fb571d04de22255787e354959fc980febd33fc9e21289208640b12c4d46",
       "size": 6136,
+      "component": "skills"
+    },
+    ".claude/skills/pre-generation-arch-check/SKILL.md": {
+      "templateHash": "03c64a53c95ed60d7079773abb8015a0b345888e67cbfea3b4f0cc194a96e670",
+      "size": 5395,
       "component": "skills"
     },
     ".claude/skills/typescript-best-practices/SKILL.md": {
@@ -1330,13 +1340,18 @@
       "component": "guides"
     },
     "guides/claude-code/13-cli-flags.md": {
-      "templateHash": "da13ae95b0e5c58e5315390f9a1b1017e260187ed798826b256963b430d4d4dc",
-      "size": 4782,
+      "templateHash": "10944bd8ad507ffda0c0439c248b0950e7ef27111fe362f655eb8c554dd6f2b8",
+      "size": 4932,
       "component": "guides"
     },
     "guides/claude-code/12-workflow-patterns.md": {
       "templateHash": "f37063285b43f2737fa09496d380dc41c571dc166f8974f636af3b69280f9774",
       "size": 6349,
+      "component": "guides"
+    },
+    "guides/claude-code/14-token-efficiency.md": {
+      "templateHash": "73bd80afcfb95f09bdd8e6be406f97dd0659aeb12ed7870067ea1b3dd8f905c2",
+      "size": 9237,
       "component": "guides"
     },
     "guides/claude-code/09-guardrails.md": {
@@ -1345,8 +1360,8 @@
       "component": "guides"
     },
     "guides/claude-code/index.yaml": {
-      "templateHash": "746e403f0b003b3e58512d290bc8786318633ef4174eaab88462ccec22334836",
-      "size": 1836,
+      "templateHash": "56a02f73e013462f540bb3b6721dc1ac63d61b6aca61e00263168848db110c1e",
+      "size": 2031,
       "component": "guides"
     },
     "guides/claude-code/05-agent-sdk.md": {
@@ -1430,8 +1445,8 @@
       "component": "guides"
     },
     "guides/cc-token-saver/README.md": {
-      "templateHash": "90aa2e533a39626d2172079846db46bd2d4d7ce2a459ace8c29499f997cf6887",
-      "size": 3631,
+      "templateHash": "de52a953f71b4c4fca9cf7cdea733b6724b5d7166c7d8eead14523222c8187af",
+      "size": 4212,
       "component": "guides"
     },
     "guides/dbt/README.md": {

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 ## 1. System Overview
 
-oh-my-customcode is a batteries-included agent harness for Claude Code. It ships 48 pre-built subagents, 107 skills, 22 governing rules, and a comprehensive hook system — all wired together so that any Claude Code session inherits a complete multi-agent operating model without additional configuration. The core philosophy is: **"No expert? CREATE one, connect knowledge, and USE it."** When a task arrives with no matching specialist, the system auto-creates one by discovering relevant skills and guides, then immediately executes the task.
+oh-my-customcode is a batteries-included agent harness for Claude Code. It ships 48 pre-built subagents, 109 skills, 22 governing rules, and a comprehensive hook system — all wired together so that any Claude Code session inherits a complete multi-agent operating model without additional configuration. The core philosophy is: **"No expert? CREATE one, connect knowledge, and USE it."** When a task arrives with no matching specialist, the system auto-creates one by discovering relevant skills and guides, then immediately executes the task.
 
 The harness operates on three engineering pillars — **Context Engineering** (what goes into the prompt), **Architectural Constraints** (rules that shape agent behavior), and **Entropy Management** (hooks, verification, and observability that keep the system coherent at scale).
 
@@ -88,7 +88,7 @@ The takeover pattern — reverse-compiling an existing codebase into structured 
 
 Each agent is defined in `.claude/agents/{name}.md` with YAML frontmatter specifying model, tools, skills, memory scope, and optional features (soul identity, escalation policy, isolation mode).
 
-### 3.3 Skill Catalog (107 skills)
+### 3.3 Skill Catalog (109 skills)
 
 **Routing skills (4, context: fork)**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (48 파일)
-|   +-- skills/                  # 스킬 (107 디렉토리)
+|   +-- skills/                  # 스킬 (109 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R022)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **[한국어 문서 (Korean)](./README_ko.md)**
 
-48 agents. 107 skills. 22 rules. One command.
+48 agents. 109 skills. 22 rules. One command.
 
 ```bash
 npm install -g oh-my-customcode && cd your-project && omcustom init
@@ -132,7 +132,7 @@ Each agent declares its tools, model, memory scope, and limitations in YAML fron
 
 ---
 
-### Skills (107)
+### Skills (109)
 
 | Category | Count | Includes |
 |----------|-------|----------|
@@ -272,7 +272,7 @@ your-project/
 ├── CLAUDE.md                   # Entry point
 ├── .claude/
 │   ├── agents/                 # 48 agent definitions
-│   ├── skills/                 # 107 skill modules
+│   ├── skills/                 # 109 skill modules
 │   ├── rules/                  # 22 governance rules (R000-R021)
 │   ├── hooks/                  # 15 lifecycle hook scripts
 │   ├── schemas/                # Tool input validation schemas

--- a/README_ko.md
+++ b/README_ko.md
@@ -13,7 +13,7 @@
 
 **[English Documentation](./README.md)**
 
-48개 에이전트. 107개 스킬. 22개 규칙. 명령어 하나.
+48개 에이전트. 109개 스킬. 22개 규칙. 명령어 하나.
 
 > **v0.74.0** — omcustom sync, init --from-snapshot, analysis --interview, skill-extractor (100번째 스킬), User Model, 릴리즈 정리 자동화
 
@@ -149,7 +149,7 @@ Agent(arch-documenter):haiku      ┘
 
 ---
 
-## 스킬 (107개)
+## 스킬 (109개)
 
 | 카테고리 | 수 | 포함 |
 |---------|-----|------|
@@ -286,7 +286,7 @@ your-project/
 ├── CLAUDE.md                   # 진입점
 ├── .claude/
 │   ├── agents/                 # 48개 에이전트 정의
-│   ├── skills/                 # 107개 스킬 모듈
+│   ├── skills/                 # 109개 스킬 모듈
 │   ├── rules/                  # 22개 거버넌스 규칙 (R000-R022)
 │   ├── hooks/                  # 15개 라이프사이클 훅 스크립트
 │   ├── schemas/                # 도구 입력 검증 스키마

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2316,7 +2316,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.99.3",
+    version: "0.100.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2025,7 +2025,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.99.3",
+  version: "0.100.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.99.3",
+  "version": "0.100.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/pre-generation-arch-check/SKILL.md
+++ b/templates/.claude/skills/pre-generation-arch-check/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: pre-generation-arch-check
+description: Pre-generation architecture check — detect R006 separation-of-concerns and compilation metaphor violations before code generation begins
+scope: core
+user-invocable: false
+version: 1.0.0
+---
+
+# Pre-Generation Architecture Check
+
+AASM-inspired pre-generation architecture guard. Detects design violations before code generation (the "pre-compile lint" phase), complementing adversarial-review and deep-verify which operate post-generation.
+
+## Overview
+
+This skill fills the PRE-generation gap in the verification pipeline:
+
+| Phase | Skill | When |
+|-------|-------|------|
+| Pre-generation | **pre-generation-arch-check** | Before code is written |
+| Post-generation | adversarial-review | After code is written |
+| Post-generation | deep-verify | After changes are committed |
+
+Inspired by Contexty's AASM (AI Anti-pattern Severity Matrix) mechanism. Detects when a requested change might violate:
+- R006 separation of concerns (agents vs skills vs guides)
+- Compilation metaphor boundaries (source/build/spec/linker/stdlib)
+- R010 orchestrator delegation rules
+- Protected path rules (.claude/agents/, .claude/skills/, guides/)
+
+## Input
+
+- **Request summary**: What the user or pipeline is asking to generate
+- **Target files/paths**: Where changes will be made
+
+## Processing — Anti-Pattern Detection
+
+Check for each of the following anti-patterns against the request summary and target paths:
+
+### 1. Skill-in-Agent (WARN)
+An agent file (`.claude/agents/*.md`) body contains detailed step-by-step instructions, scripts, or workflow logic that belongs in a skill file.
+- **Signal**: Agent body exceeds ~50 lines OR contains code blocks / numbered step sequences
+- **Suggestion**: Extract instructions into `.claude/skills/{name}/SKILL.md`, reference from agent `skills:` frontmatter
+
+### 2. Agent-in-Skill (WARN)
+A skill file contains agent configuration fields (`model:`, `tools:`, `memory:`, `permissionMode:`).
+- **Signal**: Proposed skill SKILL.md frontmatter contains agent-only fields
+- **Suggestion**: Move agent configuration to `.claude/agents/{name}.md`; keep skill focused on instructions
+
+### 3. Guide-in-Skill (WARN)
+A skill file contains reference documentation, best-practices tutorials, or conceptual explanations that belong in `guides/`.
+- **Signal**: Proposed SKILL.md body contains "## Background", "## Concepts", or sections > 100 lines of prose
+- **Suggestion**: Move reference content to `guides/{topic}/`, link from skill
+
+### 4. Cross-Concern Write Without mgr-creator (BLOCK)
+A single atomic change spans two or more of: `.claude/agents/`, `.claude/skills/`, `guides/` — without routing through mgr-creator.
+- **Signal**: Target paths include files in 2+ protected directories in the same request
+- **Suggestion**: Route the request through mgr-creator (R010 protected path rule)
+
+### 5. Direct Orchestrator Write (BLOCK)
+An implementation step would have the orchestrator (main conversation) directly write or edit files, bypassing subagent delegation.
+- **Signal**: Request implies "I will write X" from orchestrator context rather than "delegate to specialist"
+- **Suggestion**: Delegate file writes to appropriate specialist agent per R010 delegation table
+
+### 6. Spec-Build Confusion (WARN)
+Rules (`.claude/rules/`) are being modified in the same atomic change as source code or agent/skill files.
+- **Signal**: Target paths include both `.claude/rules/*.md` and any code or `.claude/agents/` or `.claude/skills/` files
+- **Suggestion**: Separate rule updates (spec changes) from agent/skill/code changes (build changes) into distinct commits
+
+## Output Format
+
+When no violations are detected:
+
+```
+[ARCH-CHECK] No violations detected — proceed with generation
+```
+
+When violations are detected:
+
+```
+[ARCH-WARNING] {count} potential violation(s) detected:
+├── {pattern-name} ({severity}): {description}
+│   └── Suggestion: {fix}
+├── {pattern-name} ({severity}): {description}
+│   └── Suggestion: {fix}
+```
+
+## Severity Levels
+
+| Severity | Action |
+|----------|--------|
+| WARN | Advisory — proceed with caution, note in generation plan |
+| BLOCK | Halt — requires architectural redesign before proceeding |
+
+BLOCK violations must be resolved before generation continues. WARN violations are logged and surfaced to the user but do not halt execution (consistent with R021 advisory-first enforcement model).
+
+## Integration
+
+Auto-invoked at structured-dev-cycle Phase 1 (planning phase) before any file generation begins.
+
+This skill is advisory only — it does NOT hard-block execution. This is consistent with R021's advisory-first enforcement model. Future promotion to a PreToolUse hook is possible if violation rates warrant escalation.
+
+Invocation pattern:
+```
+[structured-dev-cycle Phase 1]
+  → pre-generation-arch-check
+    → returns [ARCH-CHECK] or [ARCH-WARNING]
+  → continue to Phase 2 (generation) with findings surfaced
+```
+
+## Cross-References
+
+- `.claude/rules/MUST-agent-design.md` (R006) — separation of concerns
+- `.claude/rules/MUST-orchestrator-coordination.md` (R010) — protected paths and delegation
+- `.claude/skills/adversarial-review/` — post-generation security counterpart
+- `.claude/skills/deep-verify/` — post-generation quality counterpart
+- Source concept: Contexty AASM (https://github.com/ttalkkak-lab/opencode-contexty)

--- a/templates/.claude/skills/token-efficiency-audit/SKILL.md
+++ b/templates/.claude/skills/token-efficiency-audit/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: token-efficiency-audit
+description: Three-layer token defense stack — audit current settings, apply safe/CI levers, and monitor status
+scope: package
+user-invocable: true
+argument-hint: "[audit|apply-interactive|apply-ci|status]"
+version: 1.0.0
+---
+
+# Token Efficiency Audit Skill
+
+Layer 3 of the three-layer token defense stack. Audits current Claude Code settings against the token efficiency lever reference table, applies safe interactive levers, and reports combined layer status.
+
+Reference guide: `guides/claude-code/14-token-efficiency.md`
+
+## Three-Layer Stack
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Layer 1: cc-token-saver (CACHE DEFENSE)                        │
+│  Before session — protect prompt cache TTL from idle expiry     │
+├─────────────────────────────────────────────────────────────────┤
+│  Layer 2: R013 Ecomode (RUNTIME COMPRESSION)                    │
+│  During session — compact output, aggregate results, prune input│
+├─────────────────────────────────────────────────────────────────┤
+│  Layer 3: token-efficiency-audit (PRE-SESSION PREVENTION)       │
+│  Config time — disable injections before they happen            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Each layer is independently deployable and non-overlapping. Layer 3 (this skill) operates at config time — it prevents overhead from ever entering the context window.
+
+## Modes
+
+### audit (default)
+
+1. Read `.claude/settings.json` (project-level, git-tracked)
+2. Read `.claude/settings.local.json` (local, not git-tracked)
+3. Check each lever from the Interactive Session Levers table in the guide:
+   - `includeGitInstructions`
+   - `autoConnectIde`
+   - `attribution.commit`
+   - `attribution.pr`
+   - `env.BASH_MAX_OUTPUT_LENGTH`
+   - `env.CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS`
+   - `env.MAX_MCP_OUTPUT_TOKENS`
+4. Output a table:
+
+```
+[Token Efficiency Audit]
+Reference: guides/claude-code/14-token-efficiency.md (CC v2.1.114+)
+
+| Lever                               | Current     | Recommended | Gap    | Location              |
+|-------------------------------------|-------------|-------------|--------|-----------------------|
+| includeGitInstructions              | true        | false       | ⚠ SET  | settings.json         |
+| autoConnectIde                      | true        | false       | ⚠ SET  | settings.json         |
+| attribution.commit                  | auto text   | ""          | ⚠ SET  | settings.json         |
+| attribution.pr                      | auto text   | ""          | ⚠ SET  | settings.json         |
+| BASH_MAX_OUTPUT_LENGTH              | unlimited   | 15000       | ⚠ SET  | settings.local.json   |
+| CLAUDE_CODE_FILE_READ_MAX_OUTPUT... | unlimited   | 8000        | ⚠ SET  | settings.local.json   |
+| MAX_MCP_OUTPUT_TOKENS               | unlimited   | 8000        | ⚠ SET  | settings.local.json   |
+
+Run /token-efficiency-audit apply-interactive to apply all safe levers.
+```
+
+Gap column values:
+- `OK` — already at recommended value
+- `⚠ SET` — currently at default, recommended change available
+- `CUSTOM` — non-default value that differs from recommendation (display actual value)
+
+### apply-interactive
+
+Applies Interactive Session Levers only (safe for development use).
+
+1. Read `.claude/settings.json` and `.claude/settings.local.json` (create if not exists)
+2. Apply to `settings.json`:
+   ```json
+   {
+     "includeGitInstructions": false,
+     "autoConnectIde": false,
+     "attribution": {
+       "commit": "",
+       "pr": ""
+     }
+   }
+   ```
+3. Apply to `settings.local.json` (env block):
+   ```json
+   {
+     "env": {
+       "BASH_MAX_OUTPUT_LENGTH": "15000",
+       "CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS": "8000",
+       "MAX_MCP_OUTPUT_TOKENS": "8000"
+     }
+   }
+   ```
+4. Preserve all existing settings (merge, do not overwrite unrelated keys)
+5. Report applied changes:
+   ```
+   [Done] Interactive levers applied
+
+   settings.json:
+     includeGitInstructions: true → false
+     autoConnectIde: true → false
+     attribution.commit: (auto) → ""
+     attribution.pr: (auto) → ""
+
+   settings.local.json:
+     BASH_MAX_OUTPUT_LENGTH: (none) → 15000
+     CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS: (none) → 8000
+     MAX_MCP_OUTPUT_TOKENS: (none) → 8000
+
+   Note: settings.json is git-tracked. Commit if appropriate.
+   Takes effect on next claude session restart.
+   ```
+
+### apply-ci
+
+Applies CI/Worker-Only Levers. These disable core oh-my-customcode functionality.
+
+**R001 Risk: HIGH** — Display this warning prominently BEFORE applying:
+
+```
+⚠ WARNING — CI/WORKER LEVERS
+
+These settings disable core oh-my-customcode functionality:
+  • CLAUDE_CODE_DISABLE_CLAUDE_MDS=1  → ALL rules and routing offline (R010 disabled)
+  • CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS=1 → All 48 agents unavailable
+  • ENABLE_CLAUDEAI_MCP_SERVERS=false → MCP-dependent skills unavailable
+  • CLAUDE_CODE_DISABLE_AUTO_MEMORY=1 → No persistent memory across sessions
+
+Only use for CI/worker pipelines. Never apply to interactive development sessions.
+
+Type "yes" to confirm, or anything else to cancel:
+```
+
+1. Require explicit user confirmation ("yes") before proceeding
+2. On confirmation, apply to `settings.local.json`:
+   ```json
+   {
+     "env": {
+       "CLAUDE_CODE_DISABLE_CLAUDE_MDS": "1",
+       "CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS": "1",
+       "ENABLE_CLAUDEAI_MCP_SERVERS": "false",
+       "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1"
+     }
+   }
+   ```
+3. Report:
+   ```
+   [Done] CI/Worker levers applied to settings.local.json
+
+   This file is NOT git-tracked.
+   To undo: remove the four env keys or run /token-efficiency-audit status
+   ```
+4. On cancellation: `[Cancelled] No changes made.`
+
+### status
+
+Reports current state of all three layers.
+
+1. Check Layer 1 — cc-token-saver:
+   - Check if plugin is present (look for cc-token-saver in `.claude/` plugin config or known plugin markers)
+   - Report: Installed / Not installed
+2. Check Layer 2 — R013 Ecomode:
+   - Read `.claude/settings.json` for ecomode config
+   - Report: threshold, result_format, max_result_length if set; otherwise "auto-threshold (4 tasks)"
+3. Check Layer 3 — Settings levers:
+   - Run the same lever checks as `audit` mode
+   - Summarize: N/7 levers at recommended values
+4. Check OTel availability:
+   - Look for `CLAUDE_CODE_ENABLE_TELEMETRY` in settings
+   - If present: report "OTel enabled — use /monitoring-setup status for metrics"
+5. Output:
+
+```
+[Token Efficiency Status]
+
+Layer 1: cc-token-saver    ✓ Installed / ✗ Not installed
+Layer 2: R013 Ecomode      ✓ Active (threshold: 4) / ✗ Not configured
+Layer 3: Settings levers   4/7 at recommended
+
+Layer 3 details:
+  includeGitInstructions: false ✓
+  autoConnectIde: true ⚠
+  attribution.commit: "" ✓
+  attribution.pr: "" ✓
+  BASH_MAX_OUTPUT_LENGTH: 15000 ✓
+  CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS: unlimited ⚠
+  MAX_MCP_OUTPUT_TOKENS: unlimited ⚠
+
+Run /token-efficiency-audit apply-interactive to fix ⚠ levers.
+OTel: not enabled — run /monitoring-setup enable to measure effectiveness.
+```
+
+## Codex Levers
+
+When Codex CLI is in use (detected by presence of `~/.codex/config.toml`):
+
+Recommended settings in `config.toml`:
+```toml
+[features]
+apps = false
+
+[apps._default]
+enabled = false
+
+web_search = "disabled"
+
+tool_output_token_limit = 10000
+```
+
+Non-interactive Codex CLI flag reference: `guides/claude-code/13-cli-flags.md`
+
+## Guardrails
+
+### The Re-Call Trap
+
+Setting output limits too low forces repeated re-call loops — the model issues `tail -n 50 output.txt` or re-reads files in chunks, costing more tokens than the original uncapped output.
+
+**Enforce these minimum floors (never go below):**
+
+| Variable | Safe minimum | Recommended |
+|----------|-------------|-------------|
+| `BASH_MAX_OUTPUT_LENGTH` | 10000 | 15000 |
+| `CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS` | 4000 | 8000 |
+| `MAX_MCP_OUTPUT_TOKENS` | 4000 | 8000 |
+| Codex `tool_output_token_limit` | 5000 | 10000 |
+
+If a user requests values below these floors, warn them of the re-call trap risk before applying.
+
+### Version Drift
+
+Settings defaults change with minor CC version releases. After each upgrade, re-run `/token-efficiency-audit audit` to verify active defaults. Reference baseline: CC v2.1.114+ / Codex v0.121.0+.
+
+## Cross-References
+
+- `guides/claude-code/14-token-efficiency.md` — Full three-layer stack guide and lever table
+- `.claude/rules/SHOULD-ecomode.md` (R013) — Layer 2 specification
+- `.claude/skills/monitoring-setup/SKILL.md` — Measure effectiveness via OTel metrics
+- `guides/cc-token-saver/README.md` — Layer 1 detailed guide
+- `guides/claude-code/13-cli-flags.md` — Non-interactive/CI CLI flags

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -114,7 +114,7 @@ project/
 +-- CLAUDE.md                    # 진입점
 +-- .claude/
 |   +-- agents/                  # 서브에이전트 정의 (48 파일)
-|   +-- skills/                  # 스킬 (107 디렉토리)
+|   +-- skills/                  # 스킬 (109 디렉토리)
 |   +-- rules/                   # 전역 규칙 (R000-R022)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.99.3",
+  "version": "0.100.0",
   "lastUpdated": "2026-04-18T00:00:00.000Z",
   "components": [
     {
@@ -18,7 +18,7 @@
       "name": "skills",
       "path": ".claude/skills",
       "description": "Reusable skill modules (includes slash commands)",
-      "files": 107
+      "files": 109
     },
     {
       "name": "guides",

--- a/wiki/index.yaml
+++ b/wiki/index.yaml
@@ -3,7 +3,7 @@
 
 meta:
   updated: "2026-04-19"
-  total_pages: 244
+  total_pages: 246
   total_sources: 212
 
 pages:
@@ -372,6 +372,9 @@ pages:
     - file: skills/pipeline.md
       title: "Pipeline"
       summary: "Invoke and resume YAML-defined pipelines — /pipeline auto-dev runs the full release"
+    - file: skills/pre-generation-arch-check.md
+      title: "Pre-Generation Architecture Check"
+      summary: "AASM-inspired pre-generation guard — detects R006 and R010 violations before code generation begins"
     - file: skills/post-release-followup.md
       title: "Post-Release Followup"
       summary: "Analyze release workflow findings and recommend follow-up actions"
@@ -465,6 +468,9 @@ pages:
     - file: skills/task-decomposition.md
       title: "Task Decomposition"
       summary: "Auto-decompose large tasks into DAG of parallel subtasks for execution."
+    - file: skills/token-efficiency-audit.md
+      title: "Token Efficiency Audit"
+      summary: "Three-layer token defense stack — audit settings, apply safe/CI levers, and monitor status"
     - file: skills/typescript-best-practices.md
       title: "TypeScript Best Practices"
       summary: "Type-safe TypeScript patterns from the TypeScript Handbook and community standards"

--- a/wiki/skills/pre-generation-arch-check.md
+++ b/wiki/skills/pre-generation-arch-check.md
@@ -1,0 +1,59 @@
+---
+title: Pre-Generation Architecture Check
+type: skill
+updated: 2026-04-19
+sources:
+  - .claude/skills/pre-generation-arch-check/SKILL.md
+related:
+  - [[adversarial-review]]
+  - [[deep-verify]]
+  - [[structured-dev-cycle]]
+  - [[R006]]
+  - [[R010]]
+---
+
+# Pre-Generation Architecture Check
+
+AASM-inspired pre-generation architecture guard — detects R006 separation-of-concerns and compilation metaphor violations before code generation begins.
+
+## Overview
+
+Fills the PRE-generation gap in the verification pipeline. While `adversarial-review` and `deep-verify` run post-generation, this skill acts as a "pre-compile lint" phase: it checks the request summary and target paths for architectural design violations before any file is written. Auto-invoked at structured-dev-cycle Phase 1.
+
+## Key Details
+
+- **Scope**: core
+- **User-invocable**: no
+- **Version**: 1.0.0
+- **Invoked by**: [[structured-dev-cycle]] Phase 1 (planning phase)
+
+## Anti-Patterns Detected
+
+| Pattern | Severity | Signal |
+|---------|----------|--------|
+| Skill-in-Agent | WARN | Agent body > ~50 lines or contains code blocks / step sequences |
+| Agent-in-Skill | WARN | SKILL.md frontmatter contains agent-only fields (`model:`, `tools:`, `memory:`) |
+| Guide-in-Skill | WARN | SKILL.md contains reference prose sections > 100 lines |
+| Cross-Concern Write Without mgr-creator | BLOCK | Target paths span 2+ protected directories in one request |
+| Direct Orchestrator Write | BLOCK | Request implies orchestrator will write files directly |
+| Spec-Build Confusion | WARN | Rule files modified in same commit as agent/skill/code files |
+
+## Severity Levels
+
+| Severity | Action |
+|----------|--------|
+| WARN | Advisory — proceed with caution, surface to user |
+| BLOCK | Halt — requires architectural redesign before proceeding |
+
+Consistent with R021 advisory-first enforcement model. Future promotion to a PreToolUse hook is possible if violation rates warrant.
+
+## Relationships
+
+- **Invoked by**: [[structured-dev-cycle]]
+- **Post-generation counterparts**: [[adversarial-review]], [[deep-verify]]
+- **Governed by**: [[R006]] (separation of concerns), [[R010]] (protected paths and delegation)
+- **Source concept**: Contexty AASM (https://github.com/ttalkkak-lab/opencode-contexty)
+
+## Sources
+
+- `.claude/skills/pre-generation-arch-check/SKILL.md` — skill definition

--- a/wiki/skills/token-efficiency-audit.md
+++ b/wiki/skills/token-efficiency-audit.md
@@ -1,0 +1,50 @@
+---
+title: Token Efficiency Audit
+type: skill
+updated: 2026-04-19
+sources:
+  - .claude/skills/token-efficiency-audit/SKILL.md
+related:
+  - [[monitoring-setup]]
+  - [[R013]]
+  - [[pipeline]]
+---
+
+# Token Efficiency Audit
+
+Layer 3 of the three-layer token defense stack — audit Claude Code settings against the lever reference table, apply safe levers interactively or for CI, and report combined stack status.
+
+## Overview
+
+Operates at config time to prevent token overhead before it enters the context window. Works alongside cc-token-saver (Layer 1, cache defense) and R013 Ecomode (Layer 2, runtime compression). Each layer is independently deployable and non-overlapping.
+
+## Key Details
+
+- **Scope**: package
+- **User-invocable**: yes
+- **Command**: `/token-efficiency-audit`
+- **Version**: 1.0.0
+- **Argument hint**: `[audit|apply-interactive|apply-ci|status]`
+
+## Modes
+
+| Mode | Purpose |
+|------|---------|
+| `audit` (default) | Report current vs recommended for 7 levers across `settings.json` and `settings.local.json` |
+| `apply-interactive` | Apply safe interactive levers (git instructions, IDE connect, attribution, output caps) |
+| `apply-ci` | Apply CI/worker-only levers — **HIGH risk**, requires explicit confirmation, disables rules/agents/MCP/memory |
+| `status` | Show all three stack layers: cc-token-saver installed?, Ecomode configured?, N/7 levers at recommended |
+
+## Guardrails
+
+Output caps have a minimum floor to avoid the re-call trap (setting limits too low forces repeated chunked re-reads costing more tokens). Recommended floors: `BASH_MAX_OUTPUT_LENGTH` 15000, `CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS` 8000, `MAX_MCP_OUTPUT_TOKENS` 8000. Values below floor trigger a warning before applying.
+
+## Relationships
+
+- **Related skills**: [[monitoring-setup]] (OTel metrics to measure effectiveness)
+- **Governed by**: [[R013]] (Layer 2 Ecomode specification)
+- **See also**: `guides/claude-code/14-token-efficiency.md`, `guides/cc-token-saver/README.md`, `guides/claude-code/13-cli-flags.md`
+
+## Sources
+
+- `.claude/skills/token-efficiency-audit/SKILL.md` — skill definition


### PR DESCRIPTION
## Summary

- **#938**: `token-efficiency-audit` 스킬 신설 — 3-layer token defense stack의 Layer 3 감사 도구
- **#935**: `pre-generation-arch-check` 스킬 신설 — AASM 기반 생성 전 아키텍처 가드
- **#935**: R013 ecomode에 DCP-inspired pruning transparency 섹션 추가
- Skills count: 107 → 109, wiki pages: 245 → 247

## Test plan

- [ ] CI 전체 통과 확인 (8/8)
- [ ] `validate-docs` — README/CLAUDE/manifest skill count 109 일치 확인
- [ ] `template-sync` — templates/ 복사본 동기화 확인
- [ ] `wiki-sync` — wiki/skills/token-efficiency-audit.md + pre-generation-arch-check.md 존재 확인
- [ ] pre-commit hooks 통과 (타입 체크, lint, 테스트, 커버리지)
- [ ] auto-tag.yml 트리거 → npm v0.100.0 publish 확인
- [ ] GitHub Release v0.100.0 자동 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)