### PR TITLE
release: v0.101.0 — 라우팅 정확도 개선 (#946)

### DIFF
--- a/.claude/rules/SHOULD-ontology-rag-routing.md
+++ b/.claude/rules/SHOULD-ontology-rag-routing.md
@@ -1,49 +1,66 @@
-# [SHOULD] Ontology-RAG Assisted Routing
+# [SHOULD] Routing Enrichment Rules
 
 > **Priority**: SHOULD | **ID**: R019
 
 ## Core Rule
 
-Routing skills SHOULD use ontology-RAG's `get_agent_for_task` MCP tool to enrich agent selection with contextual skill suggestions. Ontology-RAG is an enrichment layer — it does NOT replace static routing.
+Routing skills SHOULD use enrichment layers to improve agent/skill/guide selection accuracy. Two enrichment sources are available — they complement each other and both are advisory only.
 
-## Integration Pattern
+## Enrichment Layers
 
-After static routing selects an agent, call `get_agent_for_task(query)` and extract `suggested_skills` from the response. Inject these into the spawned agent's prompt as contextual hints.
+### Layer 1: Ontology-RAG (MCP-based)
+
+When the `ontology-rag` MCP server is available, routing skills call `get_agent_for_task(query)` to get `suggested_skills` from the ontology graph. Inject suggestions into the spawned agent's prompt.
 
 ```
 Static routing → agent selected
   ↓
-get_agent_for_task(original_query)
+get_agent_for_task(original_query) [MCP]
   ↓
 Extract suggested_skills
   ↓
-Prepend to spawned agent prompt:
-  "Ontology context suggests these skills may be relevant: {suggested_skills}"
+Prepend to spawned agent prompt
+```
+
+### Layer 2: Wiki-RAG (wiki index-based)
+
+When routing confidence is below 90%, query `wiki/index.yaml` for relevant agent/skill/guide pages. Inject findings as supplementary routing signals.
+
+```
+Static routing → ambiguous (confidence < 90%)
+  ↓
+wiki/index.yaml search for matching pages
+  ↓
+Extract agent/skill/guide suggestions
+  ↓
+Inject as suggested_context in agent prompt
 ```
 
 ## Failure Handling
 
 | Scenario | Action |
 |----------|--------|
-| MCP server unavailable | Skip silently, proceed with unmodified prompt |
-| get_agent_for_task returns empty | Proceed with unmodified prompt |
-| Response parsing error | Skip silently, log warning |
+| MCP server unavailable | Skip silently, proceed without ontology enrichment |
+| wiki/index.yaml missing | Skip silently, proceed without wiki enrichment |
+| Either returns empty | Proceed with unmodified prompt |
+| Parsing error | Skip silently, log warning |
 
-**MCP failure MUST NOT block or delay routing.** Ontology-RAG is advisory only.
+**Enrichment failure MUST NOT block or delay routing.** Both layers are advisory only.
 
 ## Scope
 
-| Applies to | Details |
-|------------|---------|
-| secretary-routing | Enriches manager agent selection |
-| dev-lead-routing | Enriches language/framework expert selection |
-| de-lead-routing | Enriches data engineering expert selection |
-| qa-lead-routing | Enriches QA workflow routing |
+| Applies to | Ontology-RAG | Wiki-RAG |
+|------------|:------------:|:--------:|
+| secretary-routing | ✓ | ✓ |
+| dev-lead-routing | ✓ | ✓ |
+| de-lead-routing | ✓ | ✓ |
+| qa-lead-routing | ✓ | ✓ |
 
 ## Interaction with Other Rules
 
 | Rule | Interaction |
 |------|-------------|
-| R010 | Orchestrator calls MCP tool; subagent receives enriched prompt |
-| R015 | Post-fix confidence (0.30-0.40) remains below R015's 70% threshold; display behavior unchanged |
-| R009 | Ontology-RAG call adds ~300 tokens; no parallelism impact |
+| R010 | Orchestrator calls enrichment tools; subagent receives enriched prompt |
+| R015 | Enrichment does not change R015 confidence thresholds — display behavior unchanged |
+| R009 | Each enrichment call adds ~300 tokens; no parallelism impact |
+| R022 | Wiki-RAG depends on up-to-date wiki pages — stale wiki reduces enrichment quality |

--- a/.claude/skills/de-lead-routing/SKILL.md
+++ b/.claude/skills/de-lead-routing/SKILL.md
@@ -90,6 +90,16 @@ Route to appropriate DE expert based on tool/framework detection.
 
 If `get_agent_for_task` MCP tool is available, call it with the original query and inject `suggested_skills` into the agent prompt. Skip silently on failure.
 
+### Step 4b: Wiki-RAG Enrichment
+
+For ambiguous routing (confidence < 90%), query the wiki for context:
+
+1. Search `wiki/index.yaml` for DE-related pages matching the request
+2. Inject relevant skill/guide suggestions into the spawned agent's prompt
+3. Particularly useful for cross-domain DE tasks (e.g., Kafka + Spark)
+
+Advisory only — skip silently if wiki unavailable.
+
 ### Step 5: Soul Injection (R006)
 
 If the selected agent has `soul: true` in frontmatter, read and prepend `.claude/agents/souls/{agent-name}.soul.md` content to the prompt. Skip silently if file doesn't exist.

--- a/.claude/skills/dev-lead-routing/SKILL.md
+++ b/.claude/skills/dev-lead-routing/SKILL.md
@@ -129,6 +129,20 @@ Route to appropriate language/framework expert based on file extension and keywo
 
 If `get_agent_for_task` MCP tool is available, call it with the original query and inject `suggested_skills` into the agent prompt. Skip silently on failure.
 
+### Step 4b: Wiki-RAG Enrichment
+
+For ambiguous routing (confidence < 90%), query the wiki for context:
+
+1. Search `wiki/index.yaml` for agent/skill pages matching detected keywords
+2. If wiki suggests a specific skill or guide for the task, inject as `suggested_context` in the agent prompt
+3. This helps agents receive relevant guide references automatically
+
+```
+wiki-rag query: "{user_request}" → wiki agent/skill pages → suggested_context injection
+```
+
+Advisory only — skip silently if wiki unavailable.
+
 ### Step 5: Soul Injection (R006)
 
 If the selected agent has `soul: true` in frontmatter, read and prepend `.claude/agents/souls/{agent-name}.soul.md` content to the prompt. Skip silently if file doesn't exist.

--- a/.claude/skills/intent-detection/SKILL.md
+++ b/.claude/skills/intent-detection/SKILL.md
@@ -175,6 +175,21 @@ Each agent defines:
 - weights (scoring factors)
 ```
 
+### With Skill Triggers
+
+```
+Skill triggers are defined in agent-triggers.yaml alongside agent triggers.
+Each skill trigger has a `routing_rule` field that specifies which skill to invoke.
+
+When a skill trigger matches with confidence >= 70%:
+1. Display the intent detection output with skill name
+2. Invoke the skill via Skill tool instead of spawning an agent
+3. If confidence < 70%, list skill options for user selection
+
+Skill triggers use the `skill-` prefix in their YAML key to distinguish
+from agent triggers.
+```
+
 ## Error Handling
 
 ### No Match (< 30% confidence)

--- a/.claude/skills/intent-detection/patterns/agent-triggers.yaml
+++ b/.claude/skills/intent-detection/patterns/agent-triggers.yaml
@@ -436,3 +436,323 @@ agents:
     file_patterns: []
     supported_actions: [optimize, compress, proxy]
     base_confidence: 85
+
+  # ---------------------------------------------------------------------------
+  # Skill Triggers — route user intent to skill invocation
+  # ---------------------------------------------------------------------------
+
+  # Development workflow skills
+  skill-tdd:
+    keywords:
+      korean: [TDD, 테스트 주도, 테스트 먼저]
+      english: [tdd, "test driven", "test first", "write tests first"]
+    file_patterns: []
+    supported_actions: [implement, test, develop]
+    base_confidence: 80
+    routing_rule: "Invoke superpowers:test-driven-development skill"
+
+  skill-sdd:
+    keywords:
+      korean: [SDD, 스펙 주도, 스펙 기반]
+      english: [sdd, "spec driven", specification, "spec first"]
+    file_patterns: ["sdd/**"]
+    supported_actions: [plan, spec, design]
+    base_confidence: 80
+    routing_rule: "Invoke sdd-dev skill"
+
+  skill-structured-dev:
+    keywords:
+      korean: [구조화 개발, 6단계, 단계별]
+      english: ["structured dev", "6 stage", "stage-based"]
+    file_patterns: []
+    supported_actions: [implement, develop]
+    base_confidence: 75
+    routing_rule: "Invoke structured-dev-cycle skill"
+
+  # Review and verification skills
+  skill-deep-verify:
+    keywords:
+      korean: [딥검증, 릴리즈 검증, 다각도 검증]
+      english: ["deep verify", "release verify", "multi-angle"]
+    file_patterns: []
+    supported_actions: [verify, review, check]
+    base_confidence: 80
+    routing_rule: "Invoke deep-verify skill"
+
+  skill-adversarial-review:
+    keywords:
+      korean: [보안 리뷰, 적대적 리뷰, 공격자 관점]
+      english: ["security review", adversarial, "attacker mindset", "trust boundary"]
+    file_patterns: []
+    supported_actions: [review, audit, security]
+    base_confidence: 80
+    routing_rule: "Invoke adversarial-review skill"
+
+  skill-code-review:
+    keywords:
+      korean: [코드 리뷰, 베스트 프랙티스 리뷰]
+      english: ["code review", "best practice review", "dev review"]
+    file_patterns: []
+    supported_actions: [review, check]
+    base_confidence: 70
+    routing_rule: "Invoke dev-review skill"
+
+  # Planning skills
+  skill-deep-plan:
+    keywords:
+      korean: [딥플랜, 연구 계획, 검증 계획]
+      english: ["deep plan", "research plan", "validated plan"]
+    file_patterns: []
+    supported_actions: [plan, research, design]
+    base_confidence: 80
+    routing_rule: "Invoke deep-plan skill"
+
+  skill-release-plan:
+    keywords:
+      korean: [릴리즈 계획, 배포 계획]
+      english: ["release plan", "deployment plan"]
+    file_patterns: []
+    supported_actions: [plan, release]
+    base_confidence: 85
+    routing_rule: "Invoke release-plan skill"
+
+  # Pipeline and automation skills
+  skill-pipeline:
+    keywords:
+      korean: [파이프라인, 자동 개발, 자동화]
+      english: [pipeline, "auto dev", automation]
+    file_patterns: ["workflows/*.yaml"]
+    supported_actions: [run, execute, automate]
+    base_confidence: 85
+    routing_rule: "Invoke pipeline skill"
+
+  skill-evaluator-optimizer:
+    keywords:
+      korean: [평가, 최적화 루프, 루브릭, 반복 개선]
+      english: [evaluator, optimizer, rubric, "iterative improvement", "ralph loop", "ralph wiggum"]
+    file_patterns: []
+    supported_actions: [evaluate, optimize, iterate]
+    base_confidence: 80
+    routing_rule: "Invoke evaluator-optimizer skill"
+
+  # Analysis and triage skills
+  skill-professor-triage:
+    keywords:
+      korean: [트리아지, 이슈 분석, 프로페서]
+      english: [triage, "issue analysis", professor, "cross analysis"]
+    file_patterns: []
+    supported_actions: [analyze, triage, assess]
+    base_confidence: 85
+    routing_rule: "Invoke professor-triage skill"
+
+  skill-scout:
+    keywords:
+      korean: [스카우트, URL 평가, 외부 분석]
+      english: [scout, "url analysis", "external evaluation"]
+    file_patterns: []
+    supported_actions: [scout, analyze, evaluate]
+    base_confidence: 85
+    routing_rule: "Invoke scout skill"
+
+  skill-idea:
+    keywords:
+      korean: [아이디어, 이슈 제안]
+      english: [idea, "issue proposal", "feature idea"]
+    file_patterns: []
+    supported_actions: [propose, ideate, suggest]
+    base_confidence: 80
+    routing_rule: "Invoke idea skill"
+
+  # Wiki and knowledge skills
+  skill-wiki:
+    keywords:
+      korean: [위키, 지식 베이스, 위키 생성]
+      english: [wiki, "knowledge base", "wiki generate", "wiki ingest"]
+    file_patterns: ["wiki/**"]
+    supported_actions: [generate, ingest, lint, update]
+    base_confidence: 85
+    routing_rule: "Invoke wiki skill"
+
+  skill-wiki-rag:
+    keywords:
+      korean: [위키 검색, 프로젝트 질문, 아키텍처 질문, 어떻게 작동]
+      english: ["wiki search", "how does", "which agent", "what rule", architecture, workflow]
+    file_patterns: []
+    supported_actions: [search, query, ask]
+    base_confidence: 75
+    routing_rule: "Invoke wiki-rag skill"
+
+  # Token and optimization skills
+  skill-token-efficiency:
+    keywords:
+      korean: [토큰 효율, 토큰 감사, 토큰 절감]
+      english: ["token efficiency", "token audit", "token saving", "token defense"]
+    file_patterns: []
+    supported_actions: [audit, optimize, monitor]
+    base_confidence: 85
+    routing_rule: "Invoke token-efficiency-audit skill"
+
+  skill-simplify:
+    keywords:
+      korean: [단순화, 코드 정리, 중복 제거]
+      english: [simplify, cleanup, deduplicate, "reduce complexity"]
+    file_patterns: []
+    supported_actions: [simplify, clean, reduce]
+    base_confidence: 75
+    routing_rule: "Invoke simplify skill"
+
+  # Memory skills
+  skill-memory-save:
+    keywords:
+      korean: [메모리 저장, 기억해, 저장해]
+      english: ["save memory", "remember this", "store this"]
+    file_patterns: []
+    supported_actions: [save, store, remember]
+    base_confidence: 85
+    routing_rule: "Invoke memory-management skill"
+
+  skill-memory-recall:
+    keywords:
+      korean: [메모리 검색, 기억 찾기, 회상]
+      english: ["recall memory", "search memory", "find memory", "what did we"]
+    file_patterns: []
+    supported_actions: [recall, search, find]
+    base_confidence: 85
+    routing_rule: "Invoke memory-recall skill"
+
+  # Harness management skills
+  skill-analysis:
+    keywords:
+      korean: [프로젝트 분석, 하네스 분석, 에이전트 분석]
+      english: ["project analysis", "harness analysis", "agent analysis", "analyze project"]
+    file_patterns: []
+    supported_actions: [analyze, configure, optimize]
+    base_confidence: 80
+    routing_rule: "Invoke analysis skill"
+
+  skill-adaptive-harness:
+    keywords:
+      korean: [하네스 최적화, 에이전트 비활성화, 프로젝트 프로필]
+      english: ["harness optimize", "deactivate agents", "project profile", "adaptive harness"]
+    file_patterns: []
+    supported_actions: [optimize, profile, adapt]
+    base_confidence: 80
+    routing_rule: "Invoke adaptive-harness skill"
+
+  # Worker-reviewer skills
+  skill-worker-reviewer:
+    keywords:
+      korean: [워커 리뷰어, 반복 리뷰, 리뷰 사이클]
+      english: ["worker reviewer", "review cycle", "iterative review"]
+    file_patterns: []
+    supported_actions: [review, iterate, cycle]
+    base_confidence: 75
+    routing_rule: "Invoke worker-reviewer-pipeline skill"
+
+  skill-agora:
+    keywords:
+      korean: [아고라, 합의, 적대적 합의, 다중 LLM]
+      english: [agora, consensus, "adversarial consensus", "multi llm"]
+    file_patterns: []
+    supported_actions: [debate, consensus, verify]
+    base_confidence: 85
+    routing_rule: "Invoke agora skill"
+
+  # Debugging skill
+  skill-debugging:
+    keywords:
+      korean: [디버깅, 버그 찾기, 재현]
+      english: [debug, "find bug", reproduce, "root cause"]
+    file_patterns: []
+    supported_actions: [debug, reproduce, diagnose]
+    base_confidence: 80
+    routing_rule: "Invoke systematic-debugging skill"
+
+  skill-stuck-recovery:
+    keywords:
+      korean: [멈춤, 루프, 무한 반복, 복구]
+      english: [stuck, loop, "infinite loop", recovery, "not progressing"]
+    file_patterns: []
+    supported_actions: [recover, unstick, diagnose]
+    base_confidence: 85
+    routing_rule: "Invoke stuck-recovery skill"
+
+  # CVE and security skills
+  skill-cve-triage:
+    keywords:
+      korean: [CVE, 취약점, 보안 취약점]
+      english: [cve, vulnerability, "security vulnerability", "cve triage"]
+    file_patterns: []
+    supported_actions: [triage, analyze, patch]
+    base_confidence: 85
+    routing_rule: "Invoke cve-triage skill"
+
+  skill-npm-audit:
+    keywords:
+      korean: [npm 감사, 의존성 보안, 패키지 취약점]
+      english: ["npm audit", "dependency security", "package vulnerability"]
+    file_patterns: ["package.json", "package-lock.json"]
+    supported_actions: [audit, scan, fix]
+    base_confidence: 85
+    routing_rule: "Invoke npm-audit skill"
+
+  # Best practices skills (framework-specific)
+  skill-best-practices:
+    keywords:
+      korean: [베스트 프랙티스, 모범 사례, 패턴]
+      english: ["best practices", "best practice", pattern, convention]
+    file_patterns: []
+    supported_actions: [review, apply, check]
+    base_confidence: 60
+    routing_rule: "Route to language/framework specific best-practices skill based on file context"
+
+  # Monitoring skill
+  skill-monitoring:
+    keywords:
+      korean: [모니터링, 텔레메트리, 사용량 추적]
+      english: [monitoring, telemetry, "usage tracking", opentelemetry]
+    file_patterns: []
+    supported_actions: [setup, enable, disable, configure]
+    base_confidence: 80
+    routing_rule: "Invoke monitoring-setup skill"
+
+  # Deployment skill
+  skill-vercel-deploy:
+    keywords:
+      korean: [버셀 배포, 프리뷰, 프로덕션 배포]
+      english: ["vercel deploy", preview, "production deploy"]
+    file_patterns: ["vercel.json"]
+    supported_actions: [deploy, preview, promote]
+    base_confidence: 85
+    routing_rule: "Invoke vercel-deploy skill"
+
+  # ---------------------------------------------------------------------------
+  # Guide Reference Triggers — route user questions to relevant guides
+  # ---------------------------------------------------------------------------
+
+  guide-claude-code:
+    keywords:
+      korean: [클로드 코드, CC 가이드, 에이전트 가이드, 스킬 가이드, 훅 가이드]
+      english: ["claude code", "cc guide", "agent guide", "skill guide", "hook guide"]
+    file_patterns: []
+    supported_actions: [explain, reference, lookup]
+    base_confidence: 70
+    routing_rule: "Reference guides/claude-code/ directory"
+
+  guide-development:
+    keywords:
+      korean: [개발 가이드, 코딩 가이드, 개발 패턴]
+      english: ["dev guide", "coding guide", "development pattern"]
+    file_patterns: []
+    supported_actions: [reference, lookup]
+    base_confidence: 65
+    routing_rule: "Reference guides/development/ directory"
+
+  guide-best-practices:
+    keywords:
+      korean: [참조 가이드, 레퍼런스]
+      english: ["reference guide", "best practice guide"]
+    file_patterns: []
+    supported_actions: [reference, lookup]
+    base_confidence: 60
+    routing_rule: "Reference appropriate guides/ subdirectory"

--- a/.claude/skills/qa-lead-routing/SKILL.md
+++ b/.claude/skills/qa-lead-routing/SKILL.md
@@ -51,6 +51,15 @@ full_qa_cycle      → all agents (sequential)
 
 If `get_agent_for_task` MCP tool is available, call it with the original query and inject `suggested_skills` into the agent prompt. Skip silently on failure.
 
+### Wiki-RAG Enrichment
+
+For ambiguous routing (confidence < 90%), query the wiki for context:
+
+1. Search `wiki/index.yaml` for QA-related pages matching the request
+2. Inject relevant skill/guide suggestions into the spawned agent's prompt
+
+Advisory only — skip silently if wiki unavailable.
+
 ### Step 5: Soul Injection (R006)
 
 If the selected agent has `soul: true` in frontmatter, read and prepend `.claude/agents/souls/{agent-name}.soul.md` content to the prompt. Skip silently if file doesn't exist.

--- a/.claude/skills/secretary-routing/SKILL.md
+++ b/.claude/skills/secretary-routing/SKILL.md
@@ -66,6 +66,20 @@ batch           → multiple (parallel)
 
 If `get_agent_for_task` MCP tool is available, call it with the original query and inject `suggested_skills` into the agent prompt. Skip silently on failure.
 
+### Step 4b: Wiki-RAG Enrichment
+
+If the user's request is ambiguous or confidence is below 90%, query the wiki for additional context:
+
+1. Search `wiki/index.yaml` for pages matching the detected domain keywords
+2. Extract relevant agent/skill/guide recommendations from wiki pages
+3. Inject findings into the routing decision as supplementary signals
+
+```
+wiki-rag query: "{user_request}" → wiki pages → agent/skill/guide suggestions
+```
+
+Wiki-RAG enrichment is advisory — it supplements but does not override keyword matching. Skip silently if wiki/index.yaml doesn't exist.
+
 ### Step 5: Soul Injection (R006)
 
 If the selected agent has `soul: true` in frontmatter, read and prepend `.claude/agents/souls/{agent-name}.soul.md` content to the prompt. Skip silently if file doesn't exist.

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.100.1",
-  "generatedAt": "2026-04-19T08:59:05.210Z",
-  "templateVersion": "0.100.1",
+  "generatorVersion": "0.101.0",
+  "generatedAt": "2026-04-19T09:26:34.883Z",
+  "templateVersion": "0.101.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cd2a131d50bc33a228b4b8303662bbc547450e772f19e337e36d56e95d812db2",
@@ -85,8 +85,8 @@
       "component": "rules"
     },
     ".claude/rules/SHOULD-ontology-rag-routing.md": {
-      "templateHash": "2857a8f5f9e4af89e7f817f4fbe6d9afe1f9bf126917a72594f419b25010cae2",
-      "size": 1728,
+      "templateHash": "209bee296e9ab4d99865958934cf7fdf7c75b8379c5b8ab2422ca61de530aa74",
+      "size": 2157,
       "component": "rules"
     },
     ".claude/rules/MUST-safety.md": {
@@ -450,8 +450,8 @@
       "component": "skills"
     },
     ".claude/skills/qa-lead-routing/SKILL.md": {
-      "templateHash": "6282676f10eb8bc58be0e7a453280c100b32df35f9f31182c2e5589c20991569",
-      "size": 3736,
+      "templateHash": "05d114e1ff9c8d0c4df7d27834212bd754b7302ca2874dc43eeace6882f7d931",
+      "size": 4032,
       "component": "skills"
     },
     ".claude/skills/memory-recall/SKILL.md": {
@@ -525,8 +525,8 @@
       "component": "skills"
     },
     ".claude/skills/secretary-routing/SKILL.md": {
-      "templateHash": "d6f07912c2ac18b47b3b2755cc949a2e6e212ff9cabec16660ab85047e280c7d",
-      "size": 5057,
+      "templateHash": "53fde5c0279544f6ae565a165f762ea90e09919fa939bbfcee5628e4ec97e2e9",
+      "size": 5642,
       "component": "skills"
     },
     ".claude/skills/adaptive-harness/SKILL.md": {
@@ -595,13 +595,13 @@
       "component": "skills"
     },
     ".claude/skills/intent-detection/patterns/agent-triggers.yaml": {
-      "templateHash": "1594af52152993f610ee269d37334160403fe1bb58eb010fe4d3bb04c30bfbb8",
-      "size": 13975,
+      "templateHash": "01175f600611d996c22f896bcb30ad411361bfbf692b20b42871fa0f5c90d908",
+      "size": 25275,
       "component": "skills"
     },
     ".claude/skills/intent-detection/SKILL.md": {
-      "templateHash": "6d67334da4de55e281cd834bdbbc59752ca2e920fff98ce63cde1102bcc43842",
-      "size": 6494,
+      "templateHash": "d3d1fade6d3f1ef62a92356b500eab6f470c8339ad25183fc4010da751a8ed9e",
+      "size": 7017,
       "component": "skills"
     },
     ".claude/skills/python-best-practices/SKILL.md": {
@@ -710,8 +710,8 @@
       "component": "skills"
     },
     ".claude/skills/dev-lead-routing/SKILL.md": {
-      "templateHash": "c2a9f33a363226eb76d2f7def13a17c4006d0c8fcd2171ca80c22d8e5940d442",
-      "size": 7107,
+      "templateHash": "a3eba1c30a8457b29fb15d32defa043bf1c4c6aa8ab999d99123b81ae3aa13f2",
+      "size": 7624,
       "component": "skills"
     },
     ".claude/skills/scout/SKILL.md": {
@@ -980,8 +980,8 @@
       "component": "skills"
     },
     ".claude/skills/de-lead-routing/SKILL.md": {
-      "templateHash": "657f396c7036dd720de599cc9d5b0a76c2257bf46ee6cf905693872efce102f8",
-      "size": 8720,
+      "templateHash": "c9f51885585b2c5ff63e034483f4f402c196abbca9c4fb6823118a6ea9e23c34",
+      "size": 9096,
       "component": "skills"
     },
     ".claude/skills/stuck-recovery/SKILL.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2316,7 +2316,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.100.1",
+    version: "0.101.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2025,7 +2025,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.100.1",
+  version: "0.101.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.100.1",
+  "version": "0.101.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/SHOULD-ontology-rag-routing.md
+++ b/templates/.claude/rules/SHOULD-ontology-rag-routing.md
@@ -1,49 +1,66 @@
-# [SHOULD] Ontology-RAG Assisted Routing
+# [SHOULD] Routing Enrichment Rules
 
 > **Priority**: SHOULD | **ID**: R019
 
 ## Core Rule
 
-Routing skills SHOULD use ontology-RAG's `get_agent_for_task` MCP tool to enrich agent selection with contextual skill suggestions. Ontology-RAG is an enrichment layer — it does NOT replace static routing.
+Routing skills SHOULD use enrichment layers to improve agent/skill/guide selection accuracy. Two enrichment sources are available — they complement each other and both are advisory only.
 
-## Integration Pattern
+## Enrichment Layers
 
-After static routing selects an agent, call `get_agent_for_task(query)` and extract `suggested_skills` from the response. Inject these into the spawned agent's prompt as contextual hints.
+### Layer 1: Ontology-RAG (MCP-based)
+
+When the `ontology-rag` MCP server is available, routing skills call `get_agent_for_task(query)` to get `suggested_skills` from the ontology graph. Inject suggestions into the spawned agent's prompt.
 
 ```
 Static routing → agent selected
   ↓
-get_agent_for_task(original_query)
+get_agent_for_task(original_query) [MCP]
   ↓
 Extract suggested_skills
   ↓
-Prepend to spawned agent prompt:
-  "Ontology context suggests these skills may be relevant: {suggested_skills}"
+Prepend to spawned agent prompt
+```
+
+### Layer 2: Wiki-RAG (wiki index-based)
+
+When routing confidence is below 90%, query `wiki/index.yaml` for relevant agent/skill/guide pages. Inject findings as supplementary routing signals.
+
+```
+Static routing → ambiguous (confidence < 90%)
+  ↓
+wiki/index.yaml search for matching pages
+  ↓
+Extract agent/skill/guide suggestions
+  ↓
+Inject as suggested_context in agent prompt
 ```
 
 ## Failure Handling
 
 | Scenario | Action |
 |----------|--------|
-| MCP server unavailable | Skip silently, proceed with unmodified prompt |
-| get_agent_for_task returns empty | Proceed with unmodified prompt |
-| Response parsing error | Skip silently, log warning |
+| MCP server unavailable | Skip silently, proceed without ontology enrichment |
+| wiki/index.yaml missing | Skip silently, proceed without wiki enrichment |
+| Either returns empty | Proceed with unmodified prompt |
+| Parsing error | Skip silently, log warning |
 
-**MCP failure MUST NOT block or delay routing.** Ontology-RAG is advisory only.
+**Enrichment failure MUST NOT block or delay routing.** Both layers are advisory only.
 
 ## Scope
 
-| Applies to | Details |
-|------------|---------|
-| secretary-routing | Enriches manager agent selection |
-| dev-lead-routing | Enriches language/framework expert selection |
-| de-lead-routing | Enriches data engineering expert selection |
-| qa-lead-routing | Enriches QA workflow routing |
+| Applies to | Ontology-RAG | Wiki-RAG |
+|------------|:------------:|:--------:|
+| secretary-routing | ✓ | ✓ |
+| dev-lead-routing | ✓ | ✓ |
+| de-lead-routing | ✓ | ✓ |
+| qa-lead-routing | ✓ | ✓ |
 
 ## Interaction with Other Rules
 
 | Rule | Interaction |
 |------|-------------|
-| R010 | Orchestrator calls MCP tool; subagent receives enriched prompt |
-| R015 | Post-fix confidence (0.30-0.40) remains below R015's 70% threshold; display behavior unchanged |
-| R009 | Ontology-RAG call adds ~300 tokens; no parallelism impact |
+| R010 | Orchestrator calls enrichment tools; subagent receives enriched prompt |
+| R015 | Enrichment does not change R015 confidence thresholds — display behavior unchanged |
+| R009 | Each enrichment call adds ~300 tokens; no parallelism impact |
+| R022 | Wiki-RAG depends on up-to-date wiki pages — stale wiki reduces enrichment quality |

--- a/templates/.claude/skills/de-lead-routing/SKILL.md
+++ b/templates/.claude/skills/de-lead-routing/SKILL.md
@@ -84,11 +84,21 @@ For **new pipeline code**, **DAG scaffolding**, or **SQL model generation**:
 ### Step 3: Expert Selection
 Route to appropriate DE expert based on tool/framework detection.
 
-> **Permission Mode**: When spawning agents, pass `mode: "bypassPermissions"` in the Agent tool call if the session uses bypassPermissions. Without explicit mode, CC defaults to `acceptEdits`.
+> **Permission Mode**: When spawning agents via Agent tool, always pass `mode: "bypassPermissions"`. The Agent tool default (`acceptEdits`) overrides agent frontmatter `permissionMode`, causing permission prompts during unattended execution.
 
 ### Step 4: Ontology-RAG Enrichment (R019)
 
 If `get_agent_for_task` MCP tool is available, call it with the original query and inject `suggested_skills` into the agent prompt. Skip silently on failure.
+
+### Step 4b: Wiki-RAG Enrichment
+
+For ambiguous routing (confidence < 90%), query the wiki for context:
+
+1. Search `wiki/index.yaml` for DE-related pages matching the request
+2. Inject relevant skill/guide suggestions into the spawned agent's prompt
+3. Particularly useful for cross-domain DE tasks (e.g., Kafka + Spark)
+
+Advisory only — skip silently if wiki unavailable.
 
 ### Step 5: Soul Injection (R006)
 

--- a/templates/.claude/skills/dev-lead-routing/SKILL.md
+++ b/templates/.claude/skills/dev-lead-routing/SKILL.md
@@ -20,6 +20,7 @@ context: fork
 | Architect | arch-documenter, arch-speckit-agent |
 | Security | sec-codeql-expert |
 | Infra | infra-docker-expert, infra-aws-expert |
+| Slack | slack-cli-expert |
 
 ## File Extension Mapping
 
@@ -74,6 +75,7 @@ context: fork
 | security, codeql, cve, vulnerability, sarif, sast, security audit | sec-codeql-expert |
 | architecture, adr, openapi, swagger, diagram | arch-documenter |
 | spec, specification, tdd, requirements | arch-speckit-agent |
+| slack, slack-cli, slack app, slack deploy, slack trigger, slack datastore | slack-cli-expert |
 
 ## Model Selection
 
@@ -121,11 +123,25 @@ For **new file creation**, **boilerplate**, or **test code generation**:
 ### Step 3: Expert Agent Selection
 Route to appropriate language/framework expert based on file extension and keyword mapping.
 
-> **Permission Mode**: When spawning agents, pass `mode: "bypassPermissions"` in the Agent tool call if the session uses bypassPermissions. Without explicit mode, CC defaults to `acceptEdits`.
+> **Permission Mode**: When spawning agents via Agent tool, always pass `mode: "bypassPermissions"`. The Agent tool default (`acceptEdits`) overrides agent frontmatter `permissionMode`, causing permission prompts during unattended execution.
 
 ### Step 4: Ontology-RAG Enrichment (R019)
 
 If `get_agent_for_task` MCP tool is available, call it with the original query and inject `suggested_skills` into the agent prompt. Skip silently on failure.
+
+### Step 4b: Wiki-RAG Enrichment
+
+For ambiguous routing (confidence < 90%), query the wiki for context:
+
+1. Search `wiki/index.yaml` for agent/skill pages matching detected keywords
+2. If wiki suggests a specific skill or guide for the task, inject as `suggested_context` in the agent prompt
+3. This helps agents receive relevant guide references automatically
+
+```
+wiki-rag query: "{user_request}" → wiki agent/skill pages → suggested_context injection
+```
+
+Advisory only — skip silently if wiki unavailable.
 
 ### Step 5: Soul Injection (R006)
 

--- a/templates/.claude/skills/intent-detection/SKILL.md
+++ b/templates/.claude/skills/intent-detection/SKILL.md
@@ -175,6 +175,21 @@ Each agent defines:
 - weights (scoring factors)
 ```
 
+### With Skill Triggers
+
+```
+Skill triggers are defined in agent-triggers.yaml alongside agent triggers.
+Each skill trigger has a `routing_rule` field that specifies which skill to invoke.
+
+When a skill trigger matches with confidence >= 70%:
+1. Display the intent detection output with skill name
+2. Invoke the skill via Skill tool instead of spawning an agent
+3. If confidence < 70%, list skill options for user selection
+
+Skill triggers use the `skill-` prefix in their YAML key to distinguish
+from agent triggers.
+```
+
 ## Error Handling
 
 ### No Match (< 30% confidence)

--- a/templates/.claude/skills/intent-detection/patterns/agent-triggers.yaml
+++ b/templates/.claude/skills/intent-detection/patterns/agent-triggers.yaml
@@ -436,3 +436,323 @@ agents:
     file_patterns: []
     supported_actions: [optimize, compress, proxy]
     base_confidence: 85
+
+  # ---------------------------------------------------------------------------
+  # Skill Triggers — route user intent to skill invocation
+  # ---------------------------------------------------------------------------
+
+  # Development workflow skills
+  skill-tdd:
+    keywords:
+      korean: [TDD, 테스트 주도, 테스트 먼저]
+      english: [tdd, "test driven", "test first", "write tests first"]
+    file_patterns: []
+    supported_actions: [implement, test, develop]
+    base_confidence: 80
+    routing_rule: "Invoke superpowers:test-driven-development skill"
+
+  skill-sdd:
+    keywords:
+      korean: [SDD, 스펙 주도, 스펙 기반]
+      english: [sdd, "spec driven", specification, "spec first"]
+    file_patterns: ["sdd/**"]
+    supported_actions: [plan, spec, design]
+    base_confidence: 80
+    routing_rule: "Invoke sdd-dev skill"
+
+  skill-structured-dev:
+    keywords:
+      korean: [구조화 개발, 6단계, 단계별]
+      english: ["structured dev", "6 stage", "stage-based"]
+    file_patterns: []
+    supported_actions: [implement, develop]
+    base_confidence: 75
+    routing_rule: "Invoke structured-dev-cycle skill"
+
+  # Review and verification skills
+  skill-deep-verify:
+    keywords:
+      korean: [딥검증, 릴리즈 검증, 다각도 검증]
+      english: ["deep verify", "release verify", "multi-angle"]
+    file_patterns: []
+    supported_actions: [verify, review, check]
+    base_confidence: 80
+    routing_rule: "Invoke deep-verify skill"
+
+  skill-adversarial-review:
+    keywords:
+      korean: [보안 리뷰, 적대적 리뷰, 공격자 관점]
+      english: ["security review", adversarial, "attacker mindset", "trust boundary"]
+    file_patterns: []
+    supported_actions: [review, audit, security]
+    base_confidence: 80
+    routing_rule: "Invoke adversarial-review skill"
+
+  skill-code-review:
+    keywords:
+      korean: [코드 리뷰, 베스트 프랙티스 리뷰]
+      english: ["code review", "best practice review", "dev review"]
+    file_patterns: []
+    supported_actions: [review, check]
+    base_confidence: 70
+    routing_rule: "Invoke dev-review skill"
+
+  # Planning skills
+  skill-deep-plan:
+    keywords:
+      korean: [딥플랜, 연구 계획, 검증 계획]
+      english: ["deep plan", "research plan", "validated plan"]
+    file_patterns: []
+    supported_actions: [plan, research, design]
+    base_confidence: 80
+    routing_rule: "Invoke deep-plan skill"
+
+  skill-release-plan:
+    keywords:
+      korean: [릴리즈 계획, 배포 계획]
+      english: ["release plan", "deployment plan"]
+    file_patterns: []
+    supported_actions: [plan, release]
+    base_confidence: 85
+    routing_rule: "Invoke release-plan skill"
+
+  # Pipeline and automation skills
+  skill-pipeline:
+    keywords:
+      korean: [파이프라인, 자동 개발, 자동화]
+      english: [pipeline, "auto dev", automation]
+    file_patterns: ["workflows/*.yaml"]
+    supported_actions: [run, execute, automate]
+    base_confidence: 85
+    routing_rule: "Invoke pipeline skill"
+
+  skill-evaluator-optimizer:
+    keywords:
+      korean: [평가, 최적화 루프, 루브릭, 반복 개선]
+      english: [evaluator, optimizer, rubric, "iterative improvement", "ralph loop", "ralph wiggum"]
+    file_patterns: []
+    supported_actions: [evaluate, optimize, iterate]
+    base_confidence: 80
+    routing_rule: "Invoke evaluator-optimizer skill"
+
+  # Analysis and triage skills
+  skill-professor-triage:
+    keywords:
+      korean: [트리아지, 이슈 분석, 프로페서]
+      english: [triage, "issue analysis", professor, "cross analysis"]
+    file_patterns: []
+    supported_actions: [analyze, triage, assess]
+    base_confidence: 85
+    routing_rule: "Invoke professor-triage skill"
+
+  skill-scout:
+    keywords:
+      korean: [스카우트, URL 평가, 외부 분석]
+      english: [scout, "url analysis", "external evaluation"]
+    file_patterns: []
+    supported_actions: [scout, analyze, evaluate]
+    base_confidence: 85
+    routing_rule: "Invoke scout skill"
+
+  skill-idea:
+    keywords:
+      korean: [아이디어, 이슈 제안]
+      english: [idea, "issue proposal", "feature idea"]
+    file_patterns: []
+    supported_actions: [propose, ideate, suggest]
+    base_confidence: 80
+    routing_rule: "Invoke idea skill"
+
+  # Wiki and knowledge skills
+  skill-wiki:
+    keywords:
+      korean: [위키, 지식 베이스, 위키 생성]
+      english: [wiki, "knowledge base", "wiki generate", "wiki ingest"]
+    file_patterns: ["wiki/**"]
+    supported_actions: [generate, ingest, lint, update]
+    base_confidence: 85
+    routing_rule: "Invoke wiki skill"
+
+  skill-wiki-rag:
+    keywords:
+      korean: [위키 검색, 프로젝트 질문, 아키텍처 질문, 어떻게 작동]
+      english: ["wiki search", "how does", "which agent", "what rule", architecture, workflow]
+    file_patterns: []
+    supported_actions: [search, query, ask]
+    base_confidence: 75
+    routing_rule: "Invoke wiki-rag skill"
+
+  # Token and optimization skills
+  skill-token-efficiency:
+    keywords:
+      korean: [토큰 효율, 토큰 감사, 토큰 절감]
+      english: ["token efficiency", "token audit", "token saving", "token defense"]
+    file_patterns: []
+    supported_actions: [audit, optimize, monitor]
+    base_confidence: 85
+    routing_rule: "Invoke token-efficiency-audit skill"
+
+  skill-simplify:
+    keywords:
+      korean: [단순화, 코드 정리, 중복 제거]
+      english: [simplify, cleanup, deduplicate, "reduce complexity"]
+    file_patterns: []
+    supported_actions: [simplify, clean, reduce]
+    base_confidence: 75
+    routing_rule: "Invoke simplify skill"
+
+  # Memory skills
+  skill-memory-save:
+    keywords:
+      korean: [메모리 저장, 기억해, 저장해]
+      english: ["save memory", "remember this", "store this"]
+    file_patterns: []
+    supported_actions: [save, store, remember]
+    base_confidence: 85
+    routing_rule: "Invoke memory-management skill"
+
+  skill-memory-recall:
+    keywords:
+      korean: [메모리 검색, 기억 찾기, 회상]
+      english: ["recall memory", "search memory", "find memory", "what did we"]
+    file_patterns: []
+    supported_actions: [recall, search, find]
+    base_confidence: 85
+    routing_rule: "Invoke memory-recall skill"
+
+  # Harness management skills
+  skill-analysis:
+    keywords:
+      korean: [프로젝트 분석, 하네스 분석, 에이전트 분석]
+      english: ["project analysis", "harness analysis", "agent analysis", "analyze project"]
+    file_patterns: []
+    supported_actions: [analyze, configure, optimize]
+    base_confidence: 80
+    routing_rule: "Invoke analysis skill"
+
+  skill-adaptive-harness:
+    keywords:
+      korean: [하네스 최적화, 에이전트 비활성화, 프로젝트 프로필]
+      english: ["harness optimize", "deactivate agents", "project profile", "adaptive harness"]
+    file_patterns: []
+    supported_actions: [optimize, profile, adapt]
+    base_confidence: 80
+    routing_rule: "Invoke adaptive-harness skill"
+
+  # Worker-reviewer skills
+  skill-worker-reviewer:
+    keywords:
+      korean: [워커 리뷰어, 반복 리뷰, 리뷰 사이클]
+      english: ["worker reviewer", "review cycle", "iterative review"]
+    file_patterns: []
+    supported_actions: [review, iterate, cycle]
+    base_confidence: 75
+    routing_rule: "Invoke worker-reviewer-pipeline skill"
+
+  skill-agora:
+    keywords:
+      korean: [아고라, 합의, 적대적 합의, 다중 LLM]
+      english: [agora, consensus, "adversarial consensus", "multi llm"]
+    file_patterns: []
+    supported_actions: [debate, consensus, verify]
+    base_confidence: 85
+    routing_rule: "Invoke agora skill"
+
+  # Debugging skill
+  skill-debugging:
+    keywords:
+      korean: [디버깅, 버그 찾기, 재현]
+      english: [debug, "find bug", reproduce, "root cause"]
+    file_patterns: []
+    supported_actions: [debug, reproduce, diagnose]
+    base_confidence: 80
+    routing_rule: "Invoke systematic-debugging skill"
+
+  skill-stuck-recovery:
+    keywords:
+      korean: [멈춤, 루프, 무한 반복, 복구]
+      english: [stuck, loop, "infinite loop", recovery, "not progressing"]
+    file_patterns: []
+    supported_actions: [recover, unstick, diagnose]
+    base_confidence: 85
+    routing_rule: "Invoke stuck-recovery skill"
+
+  # CVE and security skills
+  skill-cve-triage:
+    keywords:
+      korean: [CVE, 취약점, 보안 취약점]
+      english: [cve, vulnerability, "security vulnerability", "cve triage"]
+    file_patterns: []
+    supported_actions: [triage, analyze, patch]
+    base_confidence: 85
+    routing_rule: "Invoke cve-triage skill"
+
+  skill-npm-audit:
+    keywords:
+      korean: [npm 감사, 의존성 보안, 패키지 취약점]
+      english: ["npm audit", "dependency security", "package vulnerability"]
+    file_patterns: ["package.json", "package-lock.json"]
+    supported_actions: [audit, scan, fix]
+    base_confidence: 85
+    routing_rule: "Invoke npm-audit skill"
+
+  # Best practices skills (framework-specific)
+  skill-best-practices:
+    keywords:
+      korean: [베스트 프랙티스, 모범 사례, 패턴]
+      english: ["best practices", "best practice", pattern, convention]
+    file_patterns: []
+    supported_actions: [review, apply, check]
+    base_confidence: 60
+    routing_rule: "Route to language/framework specific best-practices skill based on file context"
+
+  # Monitoring skill
+  skill-monitoring:
+    keywords:
+      korean: [모니터링, 텔레메트리, 사용량 추적]
+      english: [monitoring, telemetry, "usage tracking", opentelemetry]
+    file_patterns: []
+    supported_actions: [setup, enable, disable, configure]
+    base_confidence: 80
+    routing_rule: "Invoke monitoring-setup skill"
+
+  # Deployment skill
+  skill-vercel-deploy:
+    keywords:
+      korean: [버셀 배포, 프리뷰, 프로덕션 배포]
+      english: ["vercel deploy", preview, "production deploy"]
+    file_patterns: ["vercel.json"]
+    supported_actions: [deploy, preview, promote]
+    base_confidence: 85
+    routing_rule: "Invoke vercel-deploy skill"
+
+  # ---------------------------------------------------------------------------
+  # Guide Reference Triggers — route user questions to relevant guides
+  # ---------------------------------------------------------------------------
+
+  guide-claude-code:
+    keywords:
+      korean: [클로드 코드, CC 가이드, 에이전트 가이드, 스킬 가이드, 훅 가이드]
+      english: ["claude code", "cc guide", "agent guide", "skill guide", "hook guide"]
+    file_patterns: []
+    supported_actions: [explain, reference, lookup]
+    base_confidence: 70
+    routing_rule: "Reference guides/claude-code/ directory"
+
+  guide-development:
+    keywords:
+      korean: [개발 가이드, 코딩 가이드, 개발 패턴]
+      english: ["dev guide", "coding guide", "development pattern"]
+    file_patterns: []
+    supported_actions: [reference, lookup]
+    base_confidence: 65
+    routing_rule: "Reference guides/development/ directory"
+
+  guide-best-practices:
+    keywords:
+      korean: [참조 가이드, 레퍼런스]
+      english: ["reference guide", "best practice guide"]
+    file_patterns: []
+    supported_actions: [reference, lookup]
+    base_confidence: 60
+    routing_rule: "Reference appropriate guides/ subdirectory"

--- a/templates/.claude/skills/qa-lead-routing/SKILL.md
+++ b/templates/.claude/skills/qa-lead-routing/SKILL.md
@@ -45,11 +45,20 @@ quality_analysis   → qa-planner + qa-engineer (parallel)
 full_qa_cycle      → all agents (sequential)
 ```
 
-> **Permission Mode**: When spawning agents, pass `mode: "bypassPermissions"` in the Agent tool call if the session uses bypassPermissions. Without explicit mode, CC defaults to `acceptEdits`.
+> **Permission Mode**: When spawning agents via Agent tool, always pass `mode: "bypassPermissions"`. The Agent tool default (`acceptEdits`) overrides agent frontmatter `permissionMode`, causing permission prompts during unattended execution.
 
 ### Ontology-RAG Enrichment (R019)
 
 If `get_agent_for_task` MCP tool is available, call it with the original query and inject `suggested_skills` into the agent prompt. Skip silently on failure.
+
+### Wiki-RAG Enrichment
+
+For ambiguous routing (confidence < 90%), query the wiki for context:
+
+1. Search `wiki/index.yaml` for QA-related pages matching the request
+2. Inject relevant skill/guide suggestions into the spawned agent's prompt
+
+Advisory only — skip silently if wiki unavailable.
 
 ### Step 5: Soul Injection (R006)
 

--- a/templates/.claude/skills/secretary-routing/SKILL.md
+++ b/templates/.claude/skills/secretary-routing/SKILL.md
@@ -16,7 +16,7 @@ Routes agent management tasks to the appropriate manager agent. This skill conta
 
 | Agent | Purpose | Triggers |
 |-------|---------|----------|
-| mgr-creator | Create new agents | "create agent", "new agent" |
+| mgr-creator | Create new agents, skills, guides | "create agent", "new agent", "create skill", "new skill", "create guide", "new guide" |
 | mgr-updater | Update external agents | "update agent", "sync" |
 | mgr-supplier | Validate dependencies | "audit", "check deps" |
 | mgr-gitnerd | Git operations | "commit", "push", "pr" |
@@ -44,6 +44,8 @@ Before routing via Task tool, evaluate Agent Teams eligibility first:
 User Input → Routing → Manager Agent
 
 create   → mgr-creator
+create skill → mgr-creator
+create guide → mgr-creator
 update   → mgr-updater
 audit    → mgr-supplier
 git      → mgr-gitnerd
@@ -64,6 +66,20 @@ batch           → multiple (parallel)
 
 If `get_agent_for_task` MCP tool is available, call it with the original query and inject `suggested_skills` into the agent prompt. Skip silently on failure.
 
+### Step 4b: Wiki-RAG Enrichment
+
+If the user's request is ambiguous or confidence is below 90%, query the wiki for additional context:
+
+1. Search `wiki/index.yaml` for pages matching the detected domain keywords
+2. Extract relevant agent/skill/guide recommendations from wiki pages
+3. Inject findings into the routing decision as supplementary signals
+
+```
+wiki-rag query: "{user_request}" → wiki pages → agent/skill/guide suggestions
+```
+
+Wiki-RAG enrichment is advisory — it supplements but does not override keyword matching. Skip silently if wiki/index.yaml doesn't exist.
+
 ### Step 5: Soul Injection (R006)
 
 If the selected agent has `soul: true` in frontmatter, read and prepend `.claude/agents/souls/{agent-name}.soul.md` content to the prompt. Skip silently if file doesn't exist.
@@ -80,7 +96,7 @@ If the selected agent has `soul: true` in frontmatter, read and prepend `.claude
 5. Report result to user
 ```
 
-> **Permission Mode**: When spawning agents, pass `mode: "bypassPermissions"` in the Agent tool call if the session uses bypassPermissions. Without explicit mode, CC defaults to `acceptEdits`.
+> **Permission Mode**: When spawning agents via Agent tool, always pass `mode: "bypassPermissions"`. The Agent tool default (`acceptEdits`) overrides agent frontmatter `permissionMode`, causing permission prompts during unattended execution.
 
 ### 2. Batch/Parallel Task Routing
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.100.1",
+  "version": "0.101.0",
   "lastUpdated": "2026-04-18T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## 요약

- **agent-triggers.yaml**: 스킬 트리거 30개 + 가이드 트리거 3개 추가 (43개 → 76개 total entries)
- **4개 라우팅 스킬**: wiki-rag enrichment (Step 4b) 통합
  - secretary-routing, dev-lead-routing, de-lead-routing, qa-lead-routing
- **R019**: "Ontology-RAG Assisted Routing" → "Routing Enrichment Rules"로 업데이트
  - 이중 레이어 enrichment: ontology-rag MCP + wiki-rag 동시 지원
- **intent-detection**: 스킬 트리거 라우팅 문서화 추가

Fixes #946

## 테스트

- 1683 tests pass (bun test)
- TypeScript: no type errors
- Biome lint: no issues

## 체크리스트

- [x] package.json version: 0.100.1 → 0.101.0
- [x] templates/manifest.json version: 0.100.1 → 0.101.0
- [x] template sync: 7개 파일 동기화 완료
- [x] bun run build: 성공
- [x] agent-triggers.yaml: 43 → 76 entries
- [x] R019 업데이트: dual-layer enrichment (ontology-rag + wiki-rag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)