### PR TITLE
release: v0.104.1 — #978 skill mkdir sensitive-path rule fix + regression guard

### DIFF
--- a/.claude/rules/MUST-agent-design.md
+++ b/.claude/rules/MUST-agent-design.md
@@ -236,7 +236,7 @@ CC treats `.claude/` as a sensitive directory. The sensitive-path check runs **a
 
 <!-- DETAIL: Artifact Output full spec
 **Format**: Metadata header with `skill`, `date`, `query` fields, followed by skill output content.
-**Rules**: Opt-in per skill, final subagent writes (R010 compliance), Skills create directory (mkdir -p), .claude/outputs/ is git-untracked, no indexing required.
+**Rules**: Opt-in per skill, final subagent writes (R010 compliance), Write tool auto-creates parent directory (no Bash `mkdir` required — avoids `.claude/` sensitive-path prompt per #960/#961/#978), .claude/outputs/ is git-untracked, no indexing required.
 -->
 
 ## Separation of Concerns

--- a/.claude/skills/deep-verify/SKILL.md
+++ b/.claude/skills/deep-verify/SKILL.md
@@ -78,6 +78,16 @@ Each agent receives the full diff and returns findings as structured JSON:
 - Performance sanity: no O(n^2) on large datasets, no missing indexes for new queries
 - If any CONCERN or VIOLATION found: report for manual review before release
 
+## Regression Guards
+
+Run these checks before declaring release READY. Any match is a release blocker.
+
+| Guard | Detection Command | Severity | Remediation |
+|-------|-------------------|----------|-------------|
+| Skill Bash sensitive-path | `grep -rnE 'mkdir\s+-p[^` + "`" + `\n]*\.claude/(outputs\|agent-memory\|agent-memory-local)' .claude/skills/ templates/.claude/skills/ .claude/rules/ templates/.claude/rules/ 2>/dev/null` | **BLOCK** | Remove `mkdir` directive; rely on Write tool auto-dir-create. See R006 "Sensitive Path Handling" + `feedback_sensitive_path.md` |
+
+> **Why**: CC sensitive-path check runs above `bypassPermissions` and Bash allow rules (#960/#961/#978). Skills instructing directory creation via Bash on artifact paths trigger permission prompts during unattended auto-dev execution. Use Write tool instead (auto-creates parents).
+
 ## Output Format
 
 ```

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.104.0",
+  "version": "0.104.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -236,7 +236,7 @@ CC treats `.claude/` as a sensitive directory. The sensitive-path check runs **a
 
 <!-- DETAIL: Artifact Output full spec
 **Format**: Metadata header with `skill`, `date`, `query` fields, followed by skill output content.
-**Rules**: Opt-in per skill, final subagent writes (R010 compliance), Skills create directory (mkdir -p), .claude/outputs/ is git-untracked, no indexing required.
+**Rules**: Opt-in per skill, final subagent writes (R010 compliance), Write tool auto-creates parent directory (no Bash `mkdir` required — avoids `.claude/` sensitive-path prompt per #960/#961/#978), .claude/outputs/ is git-untracked, no indexing required.
 -->
 
 ## Separation of Concerns

--- a/templates/.claude/skills/deep-verify/SKILL.md
+++ b/templates/.claude/skills/deep-verify/SKILL.md
@@ -78,6 +78,16 @@ Each agent receives the full diff and returns findings as structured JSON:
 - Performance sanity: no O(n^2) on large datasets, no missing indexes for new queries
 - If any CONCERN or VIOLATION found: report for manual review before release
 
+## Regression Guards
+
+Run these checks before declaring release READY. Any match is a release blocker.
+
+| Guard | Detection Command | Severity | Remediation |
+|-------|-------------------|----------|-------------|
+| Skill Bash sensitive-path | `grep -rnE 'mkdir\s+-p[^` + "`" + `\n]*\.claude/(outputs\|agent-memory\|agent-memory-local)' .claude/skills/ templates/.claude/skills/ .claude/rules/ templates/.claude/rules/ 2>/dev/null` | **BLOCK** | Remove `mkdir` directive; rely on Write tool auto-dir-create. See R006 "Sensitive Path Handling" + `feedback_sensitive_path.md` |
+
+> **Why**: CC sensitive-path check runs above `bypassPermissions` and Bash allow rules (#960/#961/#978). Skills instructing directory creation via Bash on artifact paths trigger permission prompts during unattended auto-dev execution. Use Write tool instead (auto-creates parents).
+
 ## Output Format
 
 ```

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.104.0",
+  "version": "0.104.1",
   "lastUpdated": "2026-04-18T00:00:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary
- #978 수정: 스킬이 `mkdir -p .claude/outputs/...`를 Bash로 실행하도록 LLM에 지시하던 R006 규칙 문구를 Write 도구 사용으로 재조정
- deep-verify에 회귀 방지 가드 추가: `.claude/skills/`, `templates/.claude/skills/`, 룰 파일에서 `mkdir -p ... .claude/(outputs|agent-memory|...)` 패턴을 BLOCK 심각도로 감지
- 버전 범프 0.104.0 → 0.104.1 (patch)
- `templates/.claude/` 3중 동기화 유지

## Test plan
- [x] `grep -rnE 'mkdir\s+-p[^`+"`"+`\n]*\.claude/(outputs|agent-memory|agent-memory-local)' .claude/skills/ templates/.claude/skills/ .claude/rules/ templates/.claude/rules/` → empty
- [x] `diff .claude/rules/MUST-agent-design.md templates/.claude/rules/MUST-agent-design.md` → empty
- [x] `diff .claude/skills/deep-verify/SKILL.md templates/.claude/skills/deep-verify/SKILL.md` → empty
- [x] `jq -r .version package.json templates/manifest.json` → 0.104.1 (both)
- [ ] CI (bun test, validate-docs, Template Sync, etc.) 전체 통과
- [ ] auto-tag.yml 자동 태그 + npm publish + GitHub Release 자동 생성

## Related
- #978 (release blocker)
- Follow-up of #960, #961 (v0.104.0 sensitive-path groundwork)

🤖 Generated with [Claude Code](https://claude.com/claude-code)