### PR TITLE
release: v0.105.1 — #981 R006 sensitive-path scope extension

### DIFF
--- a/.claude/rules/MUST-agent-design.md
+++ b/.claude/rules/MUST-agent-design.md
@@ -232,7 +232,35 @@ Skills persist output to `.claude/outputs/sessions/{YYYY-MM-DD}/{skill-name}-{HH
 
 ### Sensitive Path Handling
 
-CC treats `.claude/` as a sensitive directory. The sensitive-path check runs **above** `bypassPermissions` and `Bash(*)` allow rules, so Bash-based file operations (`cp`, `mkdir`) on `.claude/` paths trigger permission prompts regardless of settings. Subagents and skills that modify `.claude/` files SHOULD prefer `Write`/`Edit` tools over `Bash(cp)`/`Bash(mkdir)`, and projects SHOULD add `Write(.claude/**)` and `Edit(.claude/**)` to `.claude/settings.local.json` allow list.
+CC treats `.claude/` as a sensitive directory, enforced across **all tool categories** — Bash, Write, and Edit. The sensitive-path check runs **above** `bypassPermissions` and explicit allow rules (e.g., `Write(.claude/**)`), so operations on sensitive paths may trigger permission prompts regardless of settings.
+
+#### Scope
+
+| Path pattern | Sensitive? | Applies to |
+|--------------|-----------|-----------|
+| `.claude/**` | Yes | Bash (`cp`, `mkdir`, `rm`), Write, Edit |
+| `templates/.claude/**` | Yes | Bash, Write, Edit (confirmed v2.1.116+, 3x repeat v0.105.0 session) |
+| `.claude/outputs/**` | No (artifact convention) | — |
+
+#### Behavior
+
+| Tool | Allow rule | Result |
+|------|-----------|--------|
+| `Bash(cp ...)` on `.claude/` | `Bash(*)` allowed | Prompt (sensitive-path overrides) |
+| `Write(.claude/**)` | `Write(.claude/**)` allowed | Prompt (sensitive-path overrides) |
+| `Edit(templates/.claude/**)` | `Edit(templates/.claude/**)` allowed | Prompt (sensitive-path overrides) |
+
+#### Recommended practice
+
+1. **Prefer `Write`/`Edit` over `Bash(cp)`/`Bash(mkdir)`** — even though both trigger prompts, `Write`/`Edit` provide better auditability and avoid shell injection risk
+2. **Add allow rules defensively** — `Write(.claude/**)`, `Edit(.claude/**)`, `Write(templates/.claude/**)`, `Edit(templates/.claude/**)` in `.claude/settings.local.json`. Rules may not bypass sensitive-path check but document intent and aid future CC behavior changes
+3. **Accept interactive prompts as a release-pipeline constraint** — `templates/.claude/` sync during release automation requires human approval; plan release windows accordingly
+4. **This is CC design behavior, not a bug** — sensitive-path check is a defense-in-depth layer. File upstream as a documentation request (not bug report) if behavior is unclear
+
+#### Cross-references
+
+- `feedback_sensitive_path.md` — session memory with Bash + Write scope (#960, #961, #981)
+- `feedback_templates_claude_glob.md` — `.claude/**` glob does not cover `templates/.claude/**`, separate allow rules required
 
 ### Artifact Channel Protocol
 

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,7 +16,9 @@
       "Bash(sed:*)",
       "Bash(chmod:*)",
       "Write(.claude/**)",
-      "Edit(.claude/**)"
+      "Edit(.claude/**)",
+      "Write(templates/.claude/**)",
+      "Edit(templates/.claude/**)"
     ],
     "defaultMode": "bypassPermissions"
   },

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.105.0",
-  "generatedAt": "2026-04-24T02:47:22.590Z",
-  "templateVersion": "0.105.0",
+  "generatorVersion": "0.105.1",
+  "generatedAt": "2026-04-24T06:48:37.612Z",
+  "templateVersion": "0.105.1",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cd2a131d50bc33a228b4b8303662bbc547450e772f19e337e36d56e95d812db2",
@@ -50,8 +50,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
-      "templateHash": "67a0a8614cd9d782866f3149ea005124283361297cf01d1e25bff40e2bc34817",
-      "size": 21899,
+      "templateHash": "0f6bcc7f491e2748ec999454d0cad24778ddb8e2244a00f10675168d971d4c37",
+      "size": 23500,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2316,7 +2316,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.105.0",
+    version: "0.105.1",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2025,7 +2025,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.105.0",
+  version: "0.105.1",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/docs/superpowers/plans/2026-04-24-v0.105.1-release.md
+++ b/docs/superpowers/plans/2026-04-24-v0.105.1-release.md
@@ -1,0 +1,28 @@
+# 릴리즈 계획 — 2026-04-24 생성
+
+> 출처: 2026-04-24 기준 `verify-done` 라벨 오픈 이슈
+> 제외된 이슈 (이미 오픈 PR에 포함): 없음
+
+## v0.105.1 릴리즈 계획
+
+**예상 범위**: XS | **이슈**: 1 | **병렬 가능**: 1
+
+| # | 우선순위 | 규모 | 제목 | 의존성 |
+|---|----------|------|------|--------|
+| #981 | P2 | XS | templates/.claude/** sensitive-path 프롬프트가 Write 도구에서도 발생 — R006 스펙 확장 필요 | 없음 |
+
+### 구현 순서
+1. #981 — R006 L233-235 Sensitive Path Handling 섹션 Write 도구 포함으로 확장 (권장 에이전트: arch-documenter)
+   - templates/.claude/rules/MUST-agent-design.md 동기화 (권장 에이전트: mgr-updater)
+   - wiki/rules/r006.md 갱신 R022 (권장 에이전트: wiki-curator)
+
+### 참고 사항
+- auto-dev "bug tier first" 원칙 적용 → 단일 bug 이슈 patch 사이클
+- CC 상위 이슈 조사, skill-extractor --mode failure 파일럿은 Phase 9 (post-release-followup)에서 별도 이슈로 등록 검토
+- templates/.claude/ 쓰기는 CC sensitive-path 정책상 interactive 프롬프트 발생 — 작업 중 사용자 승인 필요 구간 존재
+- R006 수정만으로 CC 실제 동작은 변경되지 않음 (문서 defect 수정)
+
+## 요약
+| 릴리즈 | 이슈 수 | 규모 | P1 | P2 | P3 |
+|--------|---------|------|----|----|-----|
+| v0.105.1 | 1 | XS | 0 | 1 | 0 |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.105.0",
+  "version": "0.105.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -232,7 +232,35 @@ Skills persist output to `.claude/outputs/sessions/{YYYY-MM-DD}/{skill-name}-{HH
 
 ### Sensitive Path Handling
 
-CC treats `.claude/` as a sensitive directory. The sensitive-path check runs **above** `bypassPermissions` and `Bash(*)` allow rules, so Bash-based file operations (`cp`, `mkdir`) on `.claude/` paths trigger permission prompts regardless of settings. Subagents and skills that modify `.claude/` files SHOULD prefer `Write`/`Edit` tools over `Bash(cp)`/`Bash(mkdir)`, and projects SHOULD add `Write(.claude/**)` and `Edit(.claude/**)` to `.claude/settings.local.json` allow list.
+CC treats `.claude/` as a sensitive directory, enforced across **all tool categories** — Bash, Write, and Edit. The sensitive-path check runs **above** `bypassPermissions` and explicit allow rules (e.g., `Write(.claude/**)`), so operations on sensitive paths may trigger permission prompts regardless of settings.
+
+#### Scope
+
+| Path pattern | Sensitive? | Applies to |
+|--------------|-----------|-----------|
+| `.claude/**` | Yes | Bash (`cp`, `mkdir`, `rm`), Write, Edit |
+| `templates/.claude/**` | Yes | Bash, Write, Edit (confirmed v2.1.116+, 3x repeat v0.105.0 session) |
+| `.claude/outputs/**` | No (artifact convention) | — |
+
+#### Behavior
+
+| Tool | Allow rule | Result |
+|------|-----------|--------|
+| `Bash(cp ...)` on `.claude/` | `Bash(*)` allowed | Prompt (sensitive-path overrides) |
+| `Write(.claude/**)` | `Write(.claude/**)` allowed | Prompt (sensitive-path overrides) |
+| `Edit(templates/.claude/**)` | `Edit(templates/.claude/**)` allowed | Prompt (sensitive-path overrides) |
+
+#### Recommended practice
+
+1. **Prefer `Write`/`Edit` over `Bash(cp)`/`Bash(mkdir)`** — even though both trigger prompts, `Write`/`Edit` provide better auditability and avoid shell injection risk
+2. **Add allow rules defensively** — `Write(.claude/**)`, `Edit(.claude/**)`, `Write(templates/.claude/**)`, `Edit(templates/.claude/**)` in `.claude/settings.local.json`. Rules may not bypass sensitive-path check but document intent and aid future CC behavior changes
+3. **Accept interactive prompts as a release-pipeline constraint** — `templates/.claude/` sync during release automation requires human approval; plan release windows accordingly
+4. **This is CC design behavior, not a bug** — sensitive-path check is a defense-in-depth layer. File upstream as a documentation request (not bug report) if behavior is unclear
+
+#### Cross-references
+
+- `feedback_sensitive_path.md` — session memory with Bash + Write scope (#960, #961, #981)
+- `feedback_templates_claude_glob.md` — `.claude/**` glob does not cover `templates/.claude/**`, separate allow rules required
 
 ### Artifact Channel Protocol
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.105.0",
+  "version": "0.105.1",
   "lastUpdated": "2026-04-18T00:00:00.000Z",
   "components": [
     {

--- a/wiki/rules/r006.md
+++ b/wiki/rules/r006.md
@@ -75,7 +75,7 @@ Skills persist output to `.claude/outputs/sessions/{YYYY-MM-DD}/{skill-name}-{HH
 - `Bash(cp)` on `.claude/` → prompt, even with `Bash(*)` allow rule
 - `Write(.claude/**)` → prompt, even with matching allow rule
 - `Edit(templates/.claude/**)` → prompt, even with matching allow rule
-- Allow rules are **not bypassed** — sensitive-path check is upstream of all permission settings
+- Allow rules do not override the sensitive-path check — the check runs upstream of all permission settings
 
 **Recommended practice:**
 1. Prefer `Write`/`Edit` over `Bash(cp)`/`Bash(mkdir)` for `.claude/` paths — better auditability even though both trigger prompts
@@ -83,7 +83,7 @@ Skills persist output to `.claude/outputs/sessions/{YYYY-MM-DD}/{skill-name}-{HH
 3. Plan release pipelines to expect interactive prompts for `templates/.claude/` sync steps
 4. This is CC design behavior (defense-in-depth), not a bug — file as documentation request if unclear
 
-> See also: [feedback_sensitive_path.md](../../.claude/agent-memory/wiki-curator/), [feedback_templates_claude_glob.md](../../.claude/agent-memory/wiki-curator/) — `.claude/**` glob does not cover `templates/.claude/**`; separate allow entries required.
+> See also: [feedback_sensitive_path.md](../../.claude/agent-memory/sys-memory-keeper/feedback_sensitive_path.md) — session memory with Bash + Write scope (#960, #961, #981). Note: `.claude/**` glob does not cover `templates/.claude/**`; separate allow entries required.
 
 ## Enforcement
 

--- a/wiki/rules/r006.md
+++ b/wiki/rules/r006.md
@@ -1,7 +1,7 @@
 ---
 title: "R006: Agent Design Rules"
 type: rule
-updated: 2026-04-12
+updated: 2026-04-24
 sources:
   - .claude/rules/MUST-agent-design.md
 related:
@@ -9,6 +9,7 @@ related:
   - [[r010]]
   - [[r017]]
   - [[r021]]
+  - [[r022]]
 ---
 
 # R006: Agent Design Rules
@@ -54,6 +55,36 @@ Agents live in `.claude/agents/{name}.md`. Skills live in `.claude/skills/{name}
 
 **Protected paths:** `.claude/agents/*.md`, `.claude/skills/*/SKILL.md`, `guides/*/` (new dirs) — creation MUST go through `mgr-creator` per [[r010]].
 
+## Artifact Output Convention
+
+Skills persist output to `.claude/outputs/sessions/{YYYY-MM-DD}/{skill-name}-{HHmmss}.md`. Opt-in, git-untracked. Final subagent writes per [[r010]].
+
+## Sensitive Path Handling
+
+`.claude/` is treated as a sensitive directory by CC. The sensitive-path check runs **above** `bypassPermissions` and explicit allow rules — prompts may appear even with `Write(.claude/**)` in settings.
+
+**Scope (confirmed v2.1.116+, v0.105.0 session):**
+
+| Path pattern | Sensitive? | Tools affected |
+|--------------|-----------|----------------|
+| `.claude/**` | Yes | Bash, Write, Edit |
+| `templates/.claude/**` | Yes | Bash, Write, Edit |
+| `.claude/outputs/**` | No | — (artifact convention) |
+
+**Key behaviors:**
+- `Bash(cp)` on `.claude/` → prompt, even with `Bash(*)` allow rule
+- `Write(.claude/**)` → prompt, even with matching allow rule
+- `Edit(templates/.claude/**)` → prompt, even with matching allow rule
+- Allow rules are **not bypassed** — sensitive-path check is upstream of all permission settings
+
+**Recommended practice:**
+1. Prefer `Write`/`Edit` over `Bash(cp)`/`Bash(mkdir)` for `.claude/` paths — better auditability even though both trigger prompts
+2. Add defensive allow rules (`Write(.claude/**)`, `Write(templates/.claude/**)`, etc.) — documents intent, may benefit from future CC changes
+3. Plan release pipelines to expect interactive prompts for `templates/.claude/` sync steps
+4. This is CC design behavior (defense-in-depth), not a bug — file as documentation request if unclear
+
+> See also: [feedback_sensitive_path.md](../../.claude/agent-memory/wiki-curator/), [feedback_templates_claude_glob.md](../../.claude/agent-memory/wiki-curator/) — `.claude/**` glob does not cover `templates/.claude/**`; separate allow entries required.
+
 ## Enforcement
 
 Prompt-based + mgr-sauron R017 verification. mgr-creator enforces frontmatter validation on creation.
@@ -61,9 +92,9 @@ Prompt-based + mgr-sauron R017 verification. mgr-creator enforces frontmatter va
 ## Relationships
 
 - **Enforced by**: `mgr-creator` (creation), `mgr-sauron` ([[r017]])
-- **Related rules**: [[r007]], [[r010]], [[r017]]
-- **Affects**: All 47 agents, 101 skill directories
+- **Related rules**: [[r007]], [[r010]], [[r017]], [[r022]]
+- **Affects**: All 48 agents, 113 skill directories
 
 ## Sources
 
-- `.claude/rules/MUST-agent-design.md` — rule definition
+- `.claude/rules/MUST-agent-design.md` — rule definition (Sensitive Path Handling section updated v0.105.1 via #981)


### PR DESCRIPTION
## 요약

v0.105.1 patch 릴리즈 — #981 단일 이슈.

R006 Sensitive Path Handling 스펙을 Bash 중심에서 **Bash + Write + Edit 전 도구 카테고리**로 확장했습니다. v0.105.0 세션에서 `templates/.claude/**` Write 도구 호출 시 sensitive-path prompt가 3회 반복되며 발견된 문서 결함을 수정합니다.

## 변경 사항

### 문서 (R006 Sensitive Path Handling 섹션)
- 4개 하위 섹션으로 확장: Scope / Behavior / Recommended practice / Cross-references
- Scope table: `.claude/**`, `templates/.claude/**` 양쪽에 Bash/Write/Edit 모두 적용됨을 명시
- Recommended practice: 4개 가이드라인 (Write/Edit 선호, defensive allow rules, release pipeline constraint 인정, CC design behavior로 위치 지정)
- Cross-references: feedback memory 파일 명시

### 3중 동기화
- `.claude/rules/MUST-agent-design.md` (source)
- `templates/.claude/rules/MUST-agent-design.md` (identical)
- `wiki/rules/r006.md` (compiled knowledge, related [[r022]] 추가)

### 설정
- `.claude/settings.local.json`: defensive allow rules 추가 (`Write(templates/.claude/**)`, `Edit(templates/.claude/**)`)

### 버전
- `package.json`, `templates/manifest.json`: 0.105.0 → 0.105.1
- `dist/` 재빌드 (version 문자열만 변경)

## 검증

### Deep-verify Report
- HIGH 1건, MEDIUM 1건: 모두 수정 완료 (커밋 6ffe0be)
- LOW 7건: v0.106.0 후속 개선 대상 (advisory)
- Philosophy: ALIGNED
- Regression: CLEAN

### CI-mimic
- verify-template-sync.sh: pass
- verify-wiki-sync.sh: pass (254 pages, 0 missing)

### 로컬 빌드
- bun run lint: pass
- bun run typecheck: pass
- bun run build: pass
- bun run test: 1683 pass / 0 fail

## Fixes

Fixes #981

## Test plan
- [x] bun run test (1683 pass)
- [x] bun run lint (pass)
- [x] bun run typecheck (pass)
- [x] bun run build (pass)
- [x] CI-mimic template-sync + wiki-sync (pass)
- [ ] CI (auto-trigger on PR)
- [ ] Post-merge: auto-tag → npm publish → GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)