### PR TITLE
release: v0.106.0 — caveman plugin + ouroboros Ralph Loop (partial scope)

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.105.1",
-  "generatedAt": "2026-04-24T06:48:37.612Z",
-  "templateVersion": "0.105.1",
+  "generatorVersion": "0.106.0",
+  "generatedAt": "2026-04-24T07:18:36.071Z",
+  "templateVersion": "0.106.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cd2a131d50bc33a228b4b8303662bbc547450e772f19e337e36d56e95d812db2",
@@ -1360,8 +1360,8 @@
       "component": "guides"
     },
     "guides/claude-code/14-token-efficiency.md": {
-      "templateHash": "ac6348da76c5af1fa74ddd29ab904852fcdf8f7c7b9f6acc8fdbb13b0c75b52d",
-      "size": 10534,
+      "templateHash": "3cb5586f1993c7bd5754d5dd52439ece0c71d355471477df7429db689bd48551",
+      "size": 13044,
       "component": "guides"
     },
     "guides/claude-code/09-guardrails.md": {
@@ -1622,6 +1622,11 @@
     "guides/postgres/README.md": {
       "templateHash": "679a0b942439d7559621633b6cd5692554cec2c6a3895a2511733ee6bd3e5f83",
       "size": 2157,
+      "component": "guides"
+    },
+    "guides/agent-design/ralph-loop-pattern.md": {
+      "templateHash": "6be38a8cc7f6b666f4a40f44f69c771b50ee04a8f8a59e743fd964ba405d6778",
+      "size": 1403,
       "component": "guides"
     },
     "guides/drizzle-orm/README.md": {

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -115,7 +115,7 @@ analysis, create-agent, update-docs, update-external, audit-agents, fix-refs, de
 
 intent-detection, model-escalation, stuck-recovery, result-aggregation, multi-model-verification, pr-auto-improve, memory-management, claude-code-bible, cve-triage, jinja2-prompts, skills-sh-search, reasoning-sandwich, evaluator-optimizer, systematic-debugging, workflow-runner, alembic-best-practices, action-validator, peer-messaging
 
-### 3.4 Guide Library (42 topics)
+### 3.4 Guide Library (43 topics)
 
 | Category | Guides |
 |----------|--------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ oh-my-customcode로 구동됩니다.
 | 릴리즈 | `/pipeline auto-dev`, `/omcustom-release-notes`, `/release-plan` | 자동 개발, 릴리즈 노트 |
 | 리서치 | `/research`, `/scout`, `/deep-plan`, `/omcustom:agora` | 병렬 분석, URL 평가, 연구 계획 |
 | 메모리 | `/memory-save`, `/memory-recall` | 세션 메모리 관리 |
-| 최적화 | `/token-efficiency-audit` | 토큰 효율 감사 (3계층 방어 스택) |
+| 최적화 | `/token-efficiency-audit` | 토큰 효율 감사 (5계층 방어 스택) |
 | 시스템 | `/omcustom:lists`, `/omcustom:status`, `/omcustom:help` | 전체 목록, 상태, 도움말 |
 
 > 전체 커맨드 목록 (60+ 커맨드): `/omcustom:lists` 실행
@@ -119,7 +119,7 @@ project/
 |   +-- rules/                   # 전역 규칙 (R000-R022)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)
-+-- guides/                      # 레퍼런스 문서 (42 토픽)
++-- guides/                      # 레퍼런스 문서 (43 토픽)
 ```
 
 ## 오케스트레이션
@@ -236,6 +236,7 @@ Claude Code의 Agent Teams 기능이 활성화되어 있으면 (`CLAUDE_CODE_EXP
 | 플러그인 | 소스 | 용도 |
 |----------|------|------|
 | cc-token-saver | ww-w-ai/cc-token-saver | 토큰/비용 최적화 (Token Guardian, /continue, /usage-view) |
+| caveman | JuliusBrussee/caveman | 영어 출력 토큰 압축 (코드 리뷰·커밋 메시지). R013 ecomode 미적용 구간 보완. 한국어 컨텍스트(R000)에는 ecomode 우선. `lite`/`full` 권장, `ultra`/`文言文` 가독성 저하 주의 |
 
 ### 권장 MCP 서버
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Key rules: R010 (orchestrator never writes files), R009 (parallel execution mand
 
 ---
 
-### Guides (42)
+### Guides (43)
 
 Reference documentation covering best practices, architecture decisions, and integration patterns. Located in `guides/` at project root, covering topics from agent design to CI/CD to observability.
 
@@ -279,7 +279,7 @@ your-project/
 │   ├── specs/                  # Extracted canonical specs
 │   ├── contexts/               # 4 shared context files
 │   └── ontology/               # Knowledge graph for RAG
-└── guides/                     # 42 reference documents
+└── guides/                     # 43 reference documents
 ```
 
 ---

--- a/README_ko.md
+++ b/README_ko.md
@@ -295,7 +295,7 @@ your-project/
 │   └── ontology/               # RAG용 지식 그래프
 ├── packages/
 │   └── eval-core/              # LLM 평가 엔진 (세션/턴/결과 수집, SQLite)
-└── guides/                     # 42개 레퍼런스 문서
+└── guides/                     # 43개 레퍼런스 문서
 ```
 
 ---

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2316,7 +2316,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.105.1",
+    version: "0.106.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2025,7 +2025,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.105.1",
+  version: "0.106.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/guides/agent-design/ralph-loop-pattern.md
+++ b/guides/agent-design/ralph-loop-pattern.md
@@ -1,0 +1,32 @@
+# Ralph Loop Pattern — 세션 경계 지속 진화
+
+> 출처: Q00/ouroboros Ralph Loop 패턴 (INTEGRATE #966)
+> 도입일: v0.106.0
+
+## Context
+
+LLM 에이전트는 세션 종료 시 누적된 맥락(tacit knowledge, 실패 교훈, 선호 패턴)을 잃는다. Ralph Loop는 세션 간 경계를 넘는 지속 진화 메커니즘으로, 각 세션의 실패/성공 sticky patterns를 다음 세션의 초기 컨텍스트로 주입한다.
+
+## Claude Code 통합
+
+- **claude-mem MCP**: feedback memories + session archives를 영속 저장소로
+- **sys-memory-keeper 에이전트**: 세션 종료 시 Ralph Loop 요약 수행
+- **R011 Memory Integration**: native auto-memory를 Ralph Loop의 primary writer로
+
+## Pattern
+
+1. **Bootstrap**: 세션 시작 시 MEMORY.md에서 이전 Ralph Loop 요약 로드
+2. **Evolve**: 세션 진행 중 발견한 새 패턴/실패를 feedback memory에 기록
+3. **Compact**: 세션 종료 시 sys-memory-keeper가 Ralph Loop 요약을 MEMORY.md 업데이트
+4. **Persist**: claude-mem MCP에 long-term save (cross-session search)
+
+## Anti-patterns
+
+- 세션마다 처음부터 다시 시작하는 sessionless 모드 (R011 native memory 사용)
+- 모든 세션 로그를 저장하는 brute-force persistence (selective feedback만)
+
+## References
+
+- R011 SHOULD-memory-integration.md
+- sys-memory-keeper 에이전트
+- Q00/ouroboros `ooo interview/run/ralph` CLI

--- a/guides/claude-code/14-token-efficiency.md
+++ b/guides/claude-code/14-token-efficiency.md
@@ -1,4 +1,4 @@
-# Token Efficiency — Three-Layer Defense Stack
+# Token Efficiency — Five-Layer Defense Stack
 
 > **Source**: [Claude Code & Codex token efficiency by settings adjustment](https://www.stdy.blog/increasing-token-efficiency-by-setting-adjustment-in-claude-and-codex/)
 > **Reference baseline**: Claude Code v2.1.114+ / Codex v0.121.0+
@@ -7,7 +7,7 @@
 
 Token spend in Claude Code is not purely a function of task complexity. A significant portion of token consumption occurs through structural overhead: auto-injected git instructions, IDE file listings, tool output that exceeds what the model actually needs, and session state reloaded unnecessarily across turns.
 
-The three-layer defense stack addresses this overhead at three distinct points in the session lifecycle:
+The five-layer defense stack addresses this overhead at distinct points in the session lifecycle:
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -22,6 +22,10 @@ The three-layer defense stack addresses this overhead at three distinct points i
 ├─────────────────────────────────────────────────────────────────┤
 │  Layer 4: playwright-compress (MCP OUTPUT INTELLIGENCE)         │
 │  PostToolUse hook — Haiku summarization of browser MCP output   │
+├─────────────────────────────────────────────────────────────────┤
+│  Layer 5: caveman (OUTPUT STYLE COMPRESSION)                    │
+│  SessionStart hook — primitive-speech output reduces token spend│
+│  English scenarios only — R000 Korean-first contexts use Layer 2│
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -153,6 +157,7 @@ Disabling `includeGitInstructions` removes git workflow guidance from the contex
 | R001 Safety | `apply-ci` mode is Risk Level High — requires user confirmation before applying. |
 | R012 HUD Statusline | Statusline shows CTX% — effective measure of Layer 2+3 combined impact. |
 | playwright-compress | Layer 4 hook — complements Layer 3 MAX_MCP_OUTPUT_TOKENS with intelligent lossless compression. |
+| caveman | Layer 5 style compression — orthogonal to Layer 2 (volume) and Layer 4 (MCP). R000 Korean-first: use Layer 2 as primary. |
 
 ---
 
@@ -175,6 +180,43 @@ Hook trigger: `mcp__playwright__.*` and `mcp__claude-in-chrome__.*`
 
 ---
 
+## Layer 5: caveman (Output Style Compression)
+
+External plugin (JuliusBrussee/caveman, 41.6k stars, MIT) that rewrites Claude responses into compressed "primitive speech" via a SessionStart hook.
+
+**Measured savings:**
+- ~75% output token reduction
+- ~46% input token reduction (context accumulation effect)
+
+**Intensity levels:**
+
+| Level | Description | Recommendation |
+|-------|-------------|----------------|
+| `lite` | Light compression, high readability | Recommended |
+| `full` | Moderate compression | Recommended |
+| `ultra` | Heavy compression, reduced readability | Caution |
+| `文言文` | Classical Chinese style | Avoid for shared sessions |
+
+**Installation:** `/plugin install caveman` (requires marketplace access)
+
+**When to use:**
+
+| Scenario | Layer to apply |
+|----------|---------------|
+| English-only output sessions (code review, commit messages) | Layer 5 (caveman) |
+| Korean-first sessions (R000 contexts) | Layer 2 (R013 ecomode) — caveman articles/prepositions not present in Korean |
+| Mixed sessions | Layer 2 primary, Layer 5 optional |
+
+**Coexistence with other layers:**
+
+- Layer 5 compresses output style; Layer 2 (ecomode) compresses output volume. These are orthogonal — both can be active simultaneously.
+- Layer 5 applies globally to all responses; Layer 2 activates conditionally (4+ tasks threshold).
+- For Korean-first projects following R000, Layer 2 provides the primary compression benefit. Layer 5's article-removal compression is largely ineffective against Korean (article-free language).
+
+**R000 compatibility note:** caveman's compression relies on English grammatical structure (removing articles, prepositions). Korean lacks these structures, so compression rates are significantly lower in Korean-dominant sessions. Use `lite` or `full` mode only; avoid `ultra`/`文言文` in shared or multilingual sessions.
+
+---
+
 ## Cross-References
 
 - `guides/claude-code/13-cli-flags.md` — CLI flags for non-interactive/CI invocation
@@ -185,3 +227,4 @@ Hook trigger: `mcp__playwright__.*` and `mcp__claude-in-chrome__.*`
 - `.claude/skills/update-config/` — Generic settings.json manipulation (broader scope)
 - `.claude/skills/playwright-compress/SKILL.md` — Layer 4 MCP output compression hook
 - `.claude/hooks/scripts/playwright-compress.sh` — Layer 4 hook script
+- `https://github.com/JuliusBrussee/caveman` — Layer 5 caveman plugin (external)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.105.1",
+  "version": "0.106.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -103,7 +103,7 @@ oh-my-customcode로 구동됩니다.
 | 릴리즈 | `/pipeline auto-dev`, `/omcustom-release-notes`, `/release-plan` | 자동 개발, 릴리즈 노트 |
 | 리서치 | `/research`, `/scout`, `/deep-plan`, `/omcustom:agora` | 병렬 분석, URL 평가, 연구 계획 |
 | 메모리 | `/memory-save`, `/memory-recall` | 세션 메모리 관리 |
-| 최적화 | `/token-efficiency-audit` | 토큰 효율 감사 (3계층 방어 스택) |
+| 최적화 | `/token-efficiency-audit` | 토큰 효율 감사 (5계층 방어 스택) |
 | 시스템 | `/omcustom:lists`, `/omcustom:status`, `/omcustom:help` | 전체 목록, 상태, 도움말 |
 
 > 전체 커맨드 목록 (60+ 커맨드): `/omcustom:lists` 실행
@@ -119,7 +119,7 @@ project/
 |   +-- rules/                   # 전역 규칙 (R000-R022)
 |   +-- hooks/                   # 훅 스크립트 (보안, 검증, HUD)
 |   +-- contexts/                # 컨텍스트 파일 (ecomode)
-+-- guides/                      # 레퍼런스 문서 (42 토픽)
++-- guides/                      # 레퍼런스 문서 (43 토픽)
 ```
 
 ## 오케스트레이션
@@ -236,6 +236,7 @@ Claude Code의 Agent Teams 기능이 활성화되어 있으면 (`CLAUDE_CODE_EXP
 | 플러그인 | 소스 | 용도 |
 |----------|------|------|
 | cc-token-saver | ww-w-ai/cc-token-saver | 토큰/비용 최적화 (Token Guardian, /continue, /usage-view) |
+| caveman | JuliusBrussee/caveman | 영어 출력 토큰 압축 (코드 리뷰·커밋 메시지). R013 ecomode 미적용 구간 보완. 한국어 컨텍스트(R000)에는 ecomode 우선. `lite`/`full` 권장, `ultra`/`文言文` 가독성 저하 주의 |
 
 ### 권장 MCP 서버
 

--- a/templates/guides/agent-design/ralph-loop-pattern.md
+++ b/templates/guides/agent-design/ralph-loop-pattern.md
@@ -1,0 +1,32 @@
+# Ralph Loop Pattern — 세션 경계 지속 진화
+
+> 출처: Q00/ouroboros Ralph Loop 패턴 (INTEGRATE #966)
+> 도입일: v0.106.0
+
+## Context
+
+LLM 에이전트는 세션 종료 시 누적된 맥락(tacit knowledge, 실패 교훈, 선호 패턴)을 잃는다. Ralph Loop는 세션 간 경계를 넘는 지속 진화 메커니즘으로, 각 세션의 실패/성공 sticky patterns를 다음 세션의 초기 컨텍스트로 주입한다.
+
+## Claude Code 통합
+
+- **claude-mem MCP**: feedback memories + session archives를 영속 저장소로
+- **sys-memory-keeper 에이전트**: 세션 종료 시 Ralph Loop 요약 수행
+- **R011 Memory Integration**: native auto-memory를 Ralph Loop의 primary writer로
+
+## Pattern
+
+1. **Bootstrap**: 세션 시작 시 MEMORY.md에서 이전 Ralph Loop 요약 로드
+2. **Evolve**: 세션 진행 중 발견한 새 패턴/실패를 feedback memory에 기록
+3. **Compact**: 세션 종료 시 sys-memory-keeper가 Ralph Loop 요약을 MEMORY.md 업데이트
+4. **Persist**: claude-mem MCP에 long-term save (cross-session search)
+
+## Anti-patterns
+
+- 세션마다 처음부터 다시 시작하는 sessionless 모드 (R011 native memory 사용)
+- 모든 세션 로그를 저장하는 brute-force persistence (selective feedback만)
+
+## References
+
+- R011 SHOULD-memory-integration.md
+- sys-memory-keeper 에이전트
+- Q00/ouroboros `ooo interview/run/ralph` CLI

--- a/templates/guides/claude-code/14-token-efficiency.md
+++ b/templates/guides/claude-code/14-token-efficiency.md
@@ -1,4 +1,4 @@
-# Token Efficiency — Three-Layer Defense Stack
+# Token Efficiency — Five-Layer Defense Stack
 
 > **Source**: [Claude Code & Codex token efficiency by settings adjustment](https://www.stdy.blog/increasing-token-efficiency-by-setting-adjustment-in-claude-and-codex/)
 > **Reference baseline**: Claude Code v2.1.114+ / Codex v0.121.0+
@@ -7,7 +7,7 @@
 
 Token spend in Claude Code is not purely a function of task complexity. A significant portion of token consumption occurs through structural overhead: auto-injected git instructions, IDE file listings, tool output that exceeds what the model actually needs, and session state reloaded unnecessarily across turns.
 
-The three-layer defense stack addresses this overhead at three distinct points in the session lifecycle:
+The five-layer defense stack addresses this overhead at distinct points in the session lifecycle:
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -22,6 +22,10 @@ The three-layer defense stack addresses this overhead at three distinct points i
 ├─────────────────────────────────────────────────────────────────┤
 │  Layer 4: playwright-compress (MCP OUTPUT INTELLIGENCE)         │
 │  PostToolUse hook — Haiku summarization of browser MCP output   │
+├─────────────────────────────────────────────────────────────────┤
+│  Layer 5: caveman (OUTPUT STYLE COMPRESSION)                    │
+│  SessionStart hook — primitive-speech output reduces token spend│
+│  English scenarios only — R000 Korean-first contexts use Layer 2│
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -153,6 +157,7 @@ Disabling `includeGitInstructions` removes git workflow guidance from the contex
 | R001 Safety | `apply-ci` mode is Risk Level High — requires user confirmation before applying. |
 | R012 HUD Statusline | Statusline shows CTX% — effective measure of Layer 2+3 combined impact. |
 | playwright-compress | Layer 4 hook — complements Layer 3 MAX_MCP_OUTPUT_TOKENS with intelligent lossless compression. |
+| caveman | Layer 5 style compression — orthogonal to Layer 2 (volume) and Layer 4 (MCP). R000 Korean-first: use Layer 2 as primary. |
 
 ---
 
@@ -175,6 +180,43 @@ Hook trigger: `mcp__playwright__.*` and `mcp__claude-in-chrome__.*`
 
 ---
 
+## Layer 5: caveman (Output Style Compression)
+
+External plugin (JuliusBrussee/caveman, 41.6k stars, MIT) that rewrites Claude responses into compressed "primitive speech" via a SessionStart hook.
+
+**Measured savings:**
+- ~75% output token reduction
+- ~46% input token reduction (context accumulation effect)
+
+**Intensity levels:**
+
+| Level | Description | Recommendation |
+|-------|-------------|----------------|
+| `lite` | Light compression, high readability | Recommended |
+| `full` | Moderate compression | Recommended |
+| `ultra` | Heavy compression, reduced readability | Caution |
+| `文言文` | Classical Chinese style | Avoid for shared sessions |
+
+**Installation:** `/plugin install caveman` (requires marketplace access)
+
+**When to use:**
+
+| Scenario | Layer to apply |
+|----------|---------------|
+| English-only output sessions (code review, commit messages) | Layer 5 (caveman) |
+| Korean-first sessions (R000 contexts) | Layer 2 (R013 ecomode) — caveman articles/prepositions not present in Korean |
+| Mixed sessions | Layer 2 primary, Layer 5 optional |
+
+**Coexistence with other layers:**
+
+- Layer 5 compresses output style; Layer 2 (ecomode) compresses output volume. These are orthogonal — both can be active simultaneously.
+- Layer 5 applies globally to all responses; Layer 2 activates conditionally (4+ tasks threshold).
+- For Korean-first projects following R000, Layer 2 provides the primary compression benefit. Layer 5's article-removal compression is largely ineffective against Korean (article-free language).
+
+**R000 compatibility note:** caveman's compression relies on English grammatical structure (removing articles, prepositions). Korean lacks these structures, so compression rates are significantly lower in Korean-dominant sessions. Use `lite` or `full` mode only; avoid `ultra`/`文言文` in shared or multilingual sessions.
+
+---
+
 ## Cross-References
 
 - `guides/claude-code/13-cli-flags.md` — CLI flags for non-interactive/CI invocation
@@ -185,3 +227,4 @@ Hook trigger: `mcp__playwright__.*` and `mcp__claude-in-chrome__.*`
 - `.claude/skills/update-config/` — Generic settings.json manipulation (broader scope)
 - `.claude/skills/playwright-compress/SKILL.md` — Layer 4 MCP output compression hook
 - `.claude/hooks/scripts/playwright-compress.sh` — Layer 4 hook script
+- `https://github.com/JuliusBrussee/caveman` — Layer 5 caveman plugin (external)

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.105.1",
-  "lastUpdated": "2026-04-18T00:00:00.000Z",
+  "version": "0.106.0",
+  "lastUpdated": "2026-04-24T07:30:00.000Z",
   "components": [
     {
       "name": "rules",
@@ -24,7 +24,7 @@
       "name": "guides",
       "path": "guides",
       "description": "Reference documentation",
-      "files": 42
+      "files": 43
     },
     {
       "name": "hooks",

--- a/wiki/guides/agent-design.md
+++ b/wiki/guides/agent-design.md
@@ -1,0 +1,52 @@
+---
+title: "Agent Design Patterns"
+type: guide
+updated: 2026-04-24
+sources:
+  - guides/agent-design/ralph-loop-pattern.md
+related:
+  - [[r006]]
+  - [[r011]]
+  - [[guides/harness-engineering]]
+  - [[guides/skill-bundle-design]]
+  - [[agents/sys-memory-keeper]]
+  - [[skills/secretary-routing]]
+---
+
+# Agent Design Patterns
+
+에이전트 설계 시 참조할 패턴 모음. 세션 지속성, 메모리 통합, 역할 분리 등 에이전트 수명주기 전반의 실천 패턴을 다룬다.
+
+## Patterns
+
+### Ralph Loop Pattern
+
+세션 경계를 넘는 지속 진화 메커니즘. Q00/ouroboros에서 내재화 (#966, v0.106.0).
+
+**Core idea**: 각 세션의 sticky patterns(실패 교훈, 선호 패턴)을 다음 세션 초기 컨텍스트로 주입하여 tacit knowledge 손실 방지.
+
+**4-step cycle**:
+1. **Bootstrap** — 세션 시작 시 MEMORY.md에서 이전 요약 로드
+2. **Evolve** — 세션 중 발견한 패턴/실패를 feedback memory에 즉시 기록 (mid-session save)
+3. **Compact** — 세션 종료 시 sys-memory-keeper가 Ralph Loop 요약 수행
+4. **Persist** — claude-mem MCP에 long-term save (cross-session search)
+
+**Claude Code 통합**:
+- `claude-mem MCP` — feedback memories + session archives 영속 저장소
+- `sys-memory-keeper` — 세션 종료 요약 에이전트 (R011 위임)
+- `R011 native auto-memory` — primary writer (MEMORY.md)
+
+**Anti-patterns**: 세션마다 처음부터 시작하는 sessionless 모드 / 모든 로그를 저장하는 brute-force persistence.
+
+→ Full guide: `guides/agent-design/ralph-loop-pattern.md`
+
+## Relationships
+
+- **Rules**: [[r006]] (agent design frontmatter), [[r011]] (memory integration and session-end protocol)
+- **Agents**: [[agents/sys-memory-keeper]] (Ralph Loop Compact executor)
+- **Guides**: [[guides/harness-engineering]] (context engineering), [[guides/skill-bundle-design]] (composability)
+- **Source issues**: #966 ouroboros repository re-evaluation
+
+## Sources
+
+- `guides/agent-design/ralph-loop-pattern.md` — Ralph Loop Pattern v0.106.0 via #966

--- a/wiki/index.yaml
+++ b/wiki/index.yaml
@@ -3,7 +3,7 @@
 
 meta:
   updated: "2026-04-19"
-  total_pages: 253
+  total_pages: 254
   total_sources: 216
 
 pages:
@@ -580,6 +580,9 @@ pages:
       summary: "When agents, skills, rules, or guides change, corresponding wiki pages should be updated"
 
   guides:
+    - file: guides/agent-design.md
+      title: "Agent Design Patterns Guide"
+      summary: "Agent design patterns for session persistence and tacit knowledge retention — Ralph Loop Pattern (Q00/ouroboros) for cross-session sticky pattern injection via sys-memory-keeper and claude-mem MCP"
     - file: guides/airflow.md
       title: "Airflow Guide"
       summary: "Reference documentation for Apache Airflow DAG development and workflow orchestration"


### PR DESCRIPTION
## 요약

v0.106.0 minor 릴리즈. P2 enhancement scope 2건 처리:
- **#964** caveman 플러그인 문서화 (영어 출력 토큰 압축, 5계층 방어 스택 확장)
- **#966** ouroboros Ralph Loop 패턴 내재화 (guides/agent-design/ 신설)

## Scope 감소 공지

초기 v0.106.0 scope 4건 중 2건을 v0.106.1로 deferred:
- **#985** sdd-dev Harness Decision Record 템플릿 — `.claude/skills/` sensitive-path prompt 블로커
- **#983** Tracker 체크포인트 에이전트 구현 — `.claude/agents/` sensitive-path prompt 블로커

원인: 자동화 파이프라인 내 subagent가 `.claude/` 경로 Write 시 CC sensitive-path check에 막혀 진전 불가. 이는 v0.105.1 R006 문서에서 예측한 정확한 현상 (재귀 검증).

v0.106.1에서 대화형 승인 모드로 재시도 예정.

## 변경 사항

### #964 — caveman 토큰 압축 플러그인 추가

- CLAUDE.md 권장 플러그인 테이블에 `caveman` (JuliusBrussee/caveman, 41.6k stars) 엔트리
- `guides/claude-code/14-token-efficiency.md`: 3계층 → **5계층 방어 스택** 확장
  - Layer 5: caveman — output style compression (~75% 출력 토큰 / ~46% 입력 토큰 절감)
- R000 한국어 호환성 각주: Korean 컨텍스트는 Layer 2 (R013 ecomode) 우선
- `lite`/`full` 모드 권장, `ultra`/`文言文` 가독성 저하 경고

### #966 — ouroboros Ralph Loop 패턴 내재화

- `guides/agent-design/ralph-loop-pattern.md` 신규 (세션 경계 지속 진화 패턴)
- claude-mem MCP + sys-memory-keeper + R011 native auto-memory 통합 방식 명시
- `wiki/guides/agent-design.md` 신규 wiki 페이지 생성
- 별도 follow-up 이슈 3건 생성:
  - #992 PAL Router 내재화 분석 (P2)
  - #993 Ontology Convergence for agora (P3)
  - #994 Socratic Interview 9-역할 템플릿 (P3)
- #507 크로스 레퍼런스 코멘트

### 3중 동기화

- Guides 카운트 42 → 43: CLAUDE.md, templates/CLAUDE.md, README.md, README_ko.md, ARCHITECTURE.md, templates/manifest.json
- package.json + templates/manifest.json: 0.105.1 → 0.106.0
- dist/ rebuild + .omcustom.lock.json (352 파일)
- wiki/index.yaml total_pages 253 → 254

## 검증

### 로컬 빌드
- bun run lint: pass
- bun run typecheck: pass
- bun run build: pass
- bun run test: **1683 / 0 fail**

### CI-mimic
- verify-template-sync.sh: pass (agents=48, skills=113, rules=22, guides=43)
- verify-wiki-sync.sh: pass (255 wiki pages, 0 missing)

### pre-commit
- typecheck, lint, test, coverage, validate-docs, template-sync 전부 통과

## Deferred

| 이슈 | 원인 | 대상 |
|------|------|------|
| #985 sdd-dev DR | `.claude/skills/` sensitive-path | v0.106.1 |
| #983 Tracker agent | `.claude/agents/` sensitive-path | v0.106.1 |

## Fixes

Fixes #964
Fixes #966

## Test plan
- [x] bun run test (1683 pass)
- [x] bun run lint + typecheck + build
- [x] CI-mimic template-sync + wiki-sync
- [ ] CI (auto-trigger)
- [ ] Post-merge: auto-tag → npm publish → GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)