### PR TITLE
release: v0.107.0 — R006 refactor + PAL analysis + CI/docs batch (8 issues)

### DIFF
--- a/.claude/rules/MUST-agent-design.md
+++ b/.claude/rules/MUST-agent-design.md
@@ -234,26 +234,21 @@ Skills persist output to `.claude/outputs/sessions/{YYYY-MM-DD}/{skill-name}-{HH
 
 CC treats `.claude/` as a sensitive directory, enforced across **all tool categories** — Bash, Write, and Edit. The sensitive-path check runs **above** `bypassPermissions` and explicit allow rules (e.g., `Write(.claude/**)`), so operations on sensitive paths may trigger permission prompts regardless of settings.
 
-#### Scope
+#### Sensitive Path Behavior
 
-| Path pattern | Sensitive? | Applies to |
-|--------------|-----------|-----------|
-| `.claude/**` | Yes | Bash (`cp`, `mkdir`, `rm`), Write, Edit |
-| `templates/.claude/**` | Yes | Bash, Write, Edit (confirmed v2.1.116+, 3x repeat v0.105.0 session) |
-| `.claude/outputs/**` | No (artifact convention) | — |
-
-#### Behavior
-
-| Tool | Allow rule | Result |
-|------|-----------|--------|
-| `Bash(cp ...)` on `.claude/` | `Bash(*)` allowed | Prompt (sensitive-path overrides) |
-| `Write(.claude/**)` | `Write(.claude/**)` allowed | Prompt (sensitive-path overrides) |
-| `Edit(templates/.claude/**)` | `Edit(templates/.claude/**)` allowed | Prompt (sensitive-path overrides) |
+| Path | Tool | Allow rule | Result |
+|------|------|-----------|--------|
+| `.claude/**` | Bash (`cp`, `mkdir`, `rm`) | `Bash(*)` allowed | Prompt (sensitive-path overrides) |
+| `.claude/**` | Write, Edit | `Write(.claude/**)` allowed | Prompt (sensitive-path overrides) |
+| `templates/.claude/**` | Write, Edit | `Write(templates/.claude/**)` allowed | Prompt (confirmed CC v2.1.116+; see #960, #961, #981) |
+| `.claude/outputs/**` | Any | — | Allowed (artifact convention) |
 
 #### Recommended practice
 
-1. **Prefer `Write`/`Edit` over `Bash(cp)`/`Bash(mkdir)`** — even though both trigger prompts, `Write`/`Edit` provide better auditability and avoid shell injection risk
+1. **Prefer `Write`/`Edit` over `Bash(cp)`/`Bash(mkdir)`** — `Write`/`Edit` provide better auditability and avoid shell injection risk
 2. **Add allow rules defensively** — `Write(.claude/**)`, `Edit(.claude/**)`, `Write(templates/.claude/**)`, `Edit(templates/.claude/**)` in `.claude/settings.local.json`. Rules may not bypass sensitive-path check but document intent and aid future CC behavior changes
+
+<!--
 3. **Accept interactive prompts as a release-pipeline constraint** — `templates/.claude/` sync during release automation requires human approval; plan release windows accordingly
 4. **This is CC design behavior, not a bug** — sensitive-path check is a defense-in-depth layer. File upstream as a documentation request (not bug report) if behavior is unclear
 
@@ -261,6 +256,7 @@ CC treats `.claude/` as a sensitive directory, enforced across **all tool catego
 
 - `feedback_sensitive_path.md` — session memory with Bash + Write scope (#960, #961, #981)
 - `feedback_templates_claude_glob.md` — `.claude/**` glob does not cover `templates/.claude/**`, separate allow rules required
+-->
 
 ### Artifact Channel Protocol
 

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -68,7 +68,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          ISSUES=$(echo "$PR_BODY" | grep -oE '(Closes|Fixes|Resolves) #[0-9]+' | grep -oE '[0-9]+' | sort -u)
+          ISSUES=$(echo "$PR_BODY" | grep -oEi '(Closes|Fixes|Resolves)(\s+#[0-9]+)+' | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -u)
           for ISSUE in $ISSUES; do
             echo "Closing issue #$ISSUE"
             gh issue close "$ISSUE" \

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.106.1",
-  "generatedAt": "2026-04-24T09:00:42.878Z",
-  "templateVersion": "0.106.1",
+  "generatorVersion": "0.107.0",
+  "generatedAt": "2026-04-24T09:33:55.060Z",
+  "templateVersion": "0.107.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cd2a131d50bc33a228b4b8303662bbc547450e772f19e337e36d56e95d812db2",
@@ -50,8 +50,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
-      "templateHash": "0f6bcc7f491e2748ec999454d0cad24778ddb8e2244a00f10675168d971d4c37",
-      "size": 23500,
+      "templateHash": "f71ae0171a07946da0feae97dc1ba838100e39f0099744708d2f9a5c58944f8f",
+      "size": 23300,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
@@ -1334,6 +1334,11 @@
       "size": 1842,
       "component": "guides"
     },
+    "guides/claude-code/15-version-compatibility.md": {
+      "templateHash": "b363120737bfacaa3c750873dfa967d255589e37e90602bede4de02be81bb8a7",
+      "size": 3068,
+      "component": "guides"
+    },
     "guides/claude-code/11-sub-agents.md": {
       "templateHash": "a793f29a29f966175e7b68dc7c0ebb4dcf814a8444a5bab977f9c121c43e12cb",
       "size": 4200,
@@ -1637,6 +1642,11 @@
     "guides/agent-design/ralph-loop-pattern.md": {
       "templateHash": "6be38a8cc7f6b666f4a40f44f69c771b50ee04a8f8a59e743fd964ba405d6778",
       "size": 1403,
+      "component": "guides"
+    },
+    "guides/agent-design/pal-cost-routing-analysis.md": {
+      "templateHash": "de5b31d3554c3d200c28deacdb48b880058c394cf31fba28ea6c5cc1970ffd53",
+      "size": 4074,
       "component": "guides"
     },
     "guides/drizzle-orm/README.md": {

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 ## 1. System Overview
 
-oh-my-customcode is a batteries-included agent harness for Claude Code. It ships 49 pre-built subagents, 113 skills, 22 governing rules, and a comprehensive hook system — all wired together so that any Claude Code session inherits a complete multi-agent operating model without additional configuration. The core philosophy is: **"No expert? CREATE one, connect knowledge, and USE it."** When a task arrives with no matching specialist, the system auto-creates one by discovering relevant skills and guides, then immediately executes the task.
+oh-my-customcode is a batteries-included agent harness for Claude Code. It ships 49 pre-built subagents, 113 skills, 22 governing rules, and a comprehensive hook system — all wired together so that any Claude Code session inherits a complete multi-agent operating model without additional configuration. The reference library ships 43 guide documents spanning agent design, best practices, and integration patterns. The core philosophy is: **"No expert? CREATE one, connect knowledge, and USE it."** When a task arrives with no matching specialist, the system auto-creates one by discovering relevant skills and guides, then immediately executes the task.
 
 The harness operates on three engineering pillars — **Context Engineering** (what goes into the prompt), **Architectural Constraints** (rules that shape agent behavior), and **Entropy Management** (hooks, verification, and observability that keep the system coherent at scale).
 

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2316,7 +2316,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.106.1",
+    version: "0.107.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2025,7 +2025,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.106.1",
+  version: "0.107.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/guides/agent-design/pal-cost-routing-analysis.md
+++ b/guides/agent-design/pal-cost-routing-analysis.md
@@ -1,0 +1,93 @@
+# PAL Router vs model-escalation — Cost Routing Analysis
+
+> Source: #992 (ouroboros PAL Router internalization analysis)
+> Date: 2026-04-24
+> Release: v0.107.0
+
+## Executive Summary
+
+**Decision**: Option C — Defer + observe
+
+Current model-escalation system's actual failure and escalation frequency is unmeasured. Premature PAL Router internalization without baseline data risks double-routing complexity without clear benefit. Introduce escalation metrics first, re-evaluate after 3 months of data collection.
+
+## Background
+
+### model-escalation (현재)
+- 철학: reactive — 실패 후 상위 모델 재시도
+- 트리거: 에이전트 실패 횟수 임계치 (기본 2회)
+- 경로: haiku → sonnet → opus
+- R016 연계: 연속 실패 패턴 감지 시 스킬 업데이트 후보
+
+### PAL Router (ouroboros)
+- 철학: proactive — 사전 복잡도 평가
+- 트리거: 작업 입력의 복잡도 스코어 (프롬프트 길이, 키워드, 파일 범위)
+- 비용 티어: 1x (haiku, $0.25/M) / 10x (sonnet, $3/M) / 30x (opus, $15/M)
+- 장점: 오버킬/언더킬 최소화, 초기 티어 자동 선택
+
+## Comparison Matrix
+
+| 기준 | model-escalation (현재) | PAL Router (ouroboros) |
+|------|------------------------|----------------------|
+| 철학 | Reactive | Proactive |
+| 실패 복구 | 자동 escalation | N/A (사전 선택) |
+| 초기 비용 | 최저 (haiku) | 복잡도 맞춤 |
+| 오버킬 위험 | 낮음 (점진 증가) | 중간 (threshold 민감) |
+| 언더킬 위험 | 중간 (1회 실패 후 해결) | 낮음 (사전 적정) |
+| 구현 복잡도 | 기존 활용 | 신규 복잡도 평가 로직 |
+| 비용 효율 | 실패율 낮으면 최적 | 복잡도 예측 정확하면 최적 |
+| 부작용 | 실패 시 재실행 오버헤드 | 오분류 시 과도한 비용 |
+| 디버깅 | escalation trace 명확 | 복잡도 스코어 설명 필요 |
+
+## Option A — pal-cost-routing 신설 스킬
+
+**장점**:
+- 명확한 관심사 분리 (proactive ≠ reactive, 독립)
+- model-escalation과 orthogonal (양쪽 활성 가능)
+- ouroboros 구현 참조 직접 활용
+
+**단점**:
+- 스킬 카운트 113 → 114 (context fork cap 12/12 포화 상태, fork 스킬 아니므로 무관하긴 함)
+- 라우팅 결정 보드에 두 메커니즘 공존 → decision boundary 명시 필요
+- 복잡도 스코어 튜닝 비용 (프로젝트마다 분포 다름)
+
+## Option B — model-escalation 확장 (pre-assessment 추가)
+
+**장점**:
+- 단일 스킬에서 reactive + proactive 통합
+- 사용자 단일 진입점
+- 마이그레이션 불필요 (기존 호출부 유지)
+
+**단점**:
+- 스킬 스코프 확장 → 단일 책임 원칙 희석
+- 기존 advisory-first 특성과 pre-assessment의 predictive 특성 충돌 가능
+- 테스트 복잡도 증가 (두 플로우 경로)
+
+## Option C — Defer + observe (권장)
+
+**근거**:
+1. **데이터 부재**: model-escalation 현재 실패율, escalation 빈도, 시간당 비용 메트릭이 없음
+2. **선제 내재화의 함정**: 내재화 없이도 기존 시스템이 충분한지 증거 부재
+3. **측정 가능성**: R012 HUD statusline에 escalation 카운터 추가는 경량 작업
+
+**행동 계획**:
+- Phase 1 (즉시): R012 statusline에 `ESC:{count}/{total}` 지표 추가
+- Phase 2 (4주): model-escalation 스킬이 로그 파일에 escalation 기록 축적
+- Phase 3 (3개월): 데이터 분석 — 실패 → escalation 빈도, 비용 절감률, 오버킬 패턴
+- Phase 4 (결정): 데이터 기반으로 Option A vs B vs 현상 유지 재평가
+
+## Recommendation
+
+**Option C**로 진행. #992를 closed 처리 (분석 완료), Phase 1-2 구현은 별도 P3 이슈로 트래킹.
+
+## Decision Record
+
+To be created when implementation path is finalized (Phase 4):
+- `sdd/decisions/2026-XX-XX-pal-router-internalization.md` (per #985 DR template)
+
+## References
+
+- #992 (source issue)
+- #966 (ouroboros 저장소 재평가)
+- `.claude/skills/model-escalation/SKILL.md`
+- `.claude/rules/SHOULD-hud-statusline.md` (R012 statusline 통합 지점)
+- ouroboros PAL Router docs (GitHub)

--- a/guides/claude-code/15-version-compatibility.md
+++ b/guides/claude-code/15-version-compatibility.md
@@ -1,0 +1,61 @@
+# Claude Code Version Compatibility
+
+> Updated: 2026-04-24
+> Source: Claude Code release notes (#967, #968, #969 auto-detected by claude-native skill)
+
+## Compatibility Baseline
+
+oh-my-customcode v0.107.0 targets Claude Code v2.1.116+. All v2.1.117-119 additions are backward-compatible — no config changes required.
+
+## v2.1.117 (2026-04-22)
+
+**Key changes relevant to oh-my-customcode:**
+
+- `CLAUDE_CODE_FORK_SUBAGENT=1` enables forked subagents on external builds — relevant for R018 Agent Teams expansion
+- Main-thread agent `mcpServers` frontmatter loading via `--agent` — broadens MCP integration scope (affects sys-memory-keeper, claude-mem users)
+- `/model` persistence across restarts — reduces repeated model selection in long sessions
+- `/resume` summarization of stale sessions — aligns with R013 ecomode context budget
+- Concurrent MCP server startup — shorter session bootstrap
+
+**Action items**: None. Features are additive.
+
+## v2.1.118 (2026-04-23)
+
+**Key changes relevant to oh-my-customcode:**
+
+- `/cost` + `/stats` → merged into `/usage` — update CLAUDE.md quick-reference if these appear (they don't in current docs)
+- Vim visual modes (`v`, `V`) — orthogonal to harness
+- Custom themes via `~/.claude/themes/` + plugin `themes/` directory — R012 HUD statusline unaffected
+- **Hooks can invoke MCP tools directly (`type: "mcp_tool"`)** — new hook capability, R022 wiki-sync or memory hooks could benefit
+- `DISABLE_UPDATES` env var — stricter than `DISABLE_AUTOUPDATER`
+
+**Action items**: Consider R022/R011 hooks migration to `type: "mcp_tool"` for direct wiki/memory integration (P3 follow-up).
+
+## v2.1.119 (2026-04-23)
+
+**Key changes relevant to oh-my-customcode:**
+
+- `/config` persistence to `~/.claude/settings.json` with proper override precedence — project/local/policy stacking more predictable
+- `prUrlTemplate` setting — useful if mirroring to GitHub Enterprise or GitLab
+- `CLAUDE_CODE_HIDE_CWD` env var — cosmetic
+- `--from-pr` now accepts GitLab MR, Bitbucket PR, GitHub Enterprise URLs — widens reviewer scenarios
+- **`--print` mode honors agent `tools:` and `disallowedTools:` frontmatter** — fixes a long-standing gap, relevant for CI runs using `--print`
+
+**Action items**: Verify `--print` based CI scripts (if any) work correctly with restricted-tools agents like `arch-documenter` (which has `disallowedTools: [Bash]`).
+
+## Action Items Summary
+
+| Version | oh-my-customcode action | Priority |
+|---------|------------------------|----------|
+| v2.1.117 | None (additive) | — |
+| v2.1.118 | Evaluate hooks `type: mcp_tool` for R022/R011 | P3 follow-up |
+| v2.1.119 | Audit `--print` CI with disallowedTools agents | P3 follow-up |
+
+## References
+
+- #967 — Claude Code v2.1.117 release note
+- #968 — Claude Code v2.1.118 release note
+- #969 — Claude Code v2.1.119 release note
+- `.claude/skills/claude-native/` — auto-generation source
+- `.claude/rules/SHOULD-hud-statusline.md` — R012 statusline integration
+- `.claude/rules/MUST-agent-design.md` — R006 agent frontmatter spec

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.106.1",
+  "version": "0.107.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -234,26 +234,21 @@ Skills persist output to `.claude/outputs/sessions/{YYYY-MM-DD}/{skill-name}-{HH
 
 CC treats `.claude/` as a sensitive directory, enforced across **all tool categories** — Bash, Write, and Edit. The sensitive-path check runs **above** `bypassPermissions` and explicit allow rules (e.g., `Write(.claude/**)`), so operations on sensitive paths may trigger permission prompts regardless of settings.
 
-#### Scope
+#### Sensitive Path Behavior
 
-| Path pattern | Sensitive? | Applies to |
-|--------------|-----------|-----------|
-| `.claude/**` | Yes | Bash (`cp`, `mkdir`, `rm`), Write, Edit |
-| `templates/.claude/**` | Yes | Bash, Write, Edit (confirmed v2.1.116+, 3x repeat v0.105.0 session) |
-| `.claude/outputs/**` | No (artifact convention) | — |
-
-#### Behavior
-
-| Tool | Allow rule | Result |
-|------|-----------|--------|
-| `Bash(cp ...)` on `.claude/` | `Bash(*)` allowed | Prompt (sensitive-path overrides) |
-| `Write(.claude/**)` | `Write(.claude/**)` allowed | Prompt (sensitive-path overrides) |
-| `Edit(templates/.claude/**)` | `Edit(templates/.claude/**)` allowed | Prompt (sensitive-path overrides) |
+| Path | Tool | Allow rule | Result |
+|------|------|-----------|--------|
+| `.claude/**` | Bash (`cp`, `mkdir`, `rm`) | `Bash(*)` allowed | Prompt (sensitive-path overrides) |
+| `.claude/**` | Write, Edit | `Write(.claude/**)` allowed | Prompt (sensitive-path overrides) |
+| `templates/.claude/**` | Write, Edit | `Write(templates/.claude/**)` allowed | Prompt (confirmed CC v2.1.116+; see #960, #961, #981) |
+| `.claude/outputs/**` | Any | — | Allowed (artifact convention) |
 
 #### Recommended practice
 
-1. **Prefer `Write`/`Edit` over `Bash(cp)`/`Bash(mkdir)`** — even though both trigger prompts, `Write`/`Edit` provide better auditability and avoid shell injection risk
+1. **Prefer `Write`/`Edit` over `Bash(cp)`/`Bash(mkdir)`** — `Write`/`Edit` provide better auditability and avoid shell injection risk
 2. **Add allow rules defensively** — `Write(.claude/**)`, `Edit(.claude/**)`, `Write(templates/.claude/**)`, `Edit(templates/.claude/**)` in `.claude/settings.local.json`. Rules may not bypass sensitive-path check but document intent and aid future CC behavior changes
+
+<!--
 3. **Accept interactive prompts as a release-pipeline constraint** — `templates/.claude/` sync during release automation requires human approval; plan release windows accordingly
 4. **This is CC design behavior, not a bug** — sensitive-path check is a defense-in-depth layer. File upstream as a documentation request (not bug report) if behavior is unclear
 
@@ -261,6 +256,7 @@ CC treats `.claude/` as a sensitive directory, enforced across **all tool catego
 
 - `feedback_sensitive_path.md` — session memory with Bash + Write scope (#960, #961, #981)
 - `feedback_templates_claude_glob.md` — `.claude/**` glob does not cover `templates/.claude/**`, separate allow rules required
+-->
 
 ### Artifact Channel Protocol
 

--- a/templates/guides/agent-design/pal-cost-routing-analysis.md
+++ b/templates/guides/agent-design/pal-cost-routing-analysis.md
@@ -1,0 +1,93 @@
+# PAL Router vs model-escalation — Cost Routing Analysis
+
+> Source: #992 (ouroboros PAL Router internalization analysis)
+> Date: 2026-04-24
+> Release: v0.107.0
+
+## Executive Summary
+
+**Decision**: Option C — Defer + observe
+
+Current model-escalation system's actual failure and escalation frequency is unmeasured. Premature PAL Router internalization without baseline data risks double-routing complexity without clear benefit. Introduce escalation metrics first, re-evaluate after 3 months of data collection.
+
+## Background
+
+### model-escalation (현재)
+- 철학: reactive — 실패 후 상위 모델 재시도
+- 트리거: 에이전트 실패 횟수 임계치 (기본 2회)
+- 경로: haiku → sonnet → opus
+- R016 연계: 연속 실패 패턴 감지 시 스킬 업데이트 후보
+
+### PAL Router (ouroboros)
+- 철학: proactive — 사전 복잡도 평가
+- 트리거: 작업 입력의 복잡도 스코어 (프롬프트 길이, 키워드, 파일 범위)
+- 비용 티어: 1x (haiku, $0.25/M) / 10x (sonnet, $3/M) / 30x (opus, $15/M)
+- 장점: 오버킬/언더킬 최소화, 초기 티어 자동 선택
+
+## Comparison Matrix
+
+| 기준 | model-escalation (현재) | PAL Router (ouroboros) |
+|------|------------------------|----------------------|
+| 철학 | Reactive | Proactive |
+| 실패 복구 | 자동 escalation | N/A (사전 선택) |
+| 초기 비용 | 최저 (haiku) | 복잡도 맞춤 |
+| 오버킬 위험 | 낮음 (점진 증가) | 중간 (threshold 민감) |
+| 언더킬 위험 | 중간 (1회 실패 후 해결) | 낮음 (사전 적정) |
+| 구현 복잡도 | 기존 활용 | 신규 복잡도 평가 로직 |
+| 비용 효율 | 실패율 낮으면 최적 | 복잡도 예측 정확하면 최적 |
+| 부작용 | 실패 시 재실행 오버헤드 | 오분류 시 과도한 비용 |
+| 디버깅 | escalation trace 명확 | 복잡도 스코어 설명 필요 |
+
+## Option A — pal-cost-routing 신설 스킬
+
+**장점**:
+- 명확한 관심사 분리 (proactive ≠ reactive, 독립)
+- model-escalation과 orthogonal (양쪽 활성 가능)
+- ouroboros 구현 참조 직접 활용
+
+**단점**:
+- 스킬 카운트 113 → 114 (context fork cap 12/12 포화 상태, fork 스킬 아니므로 무관하긴 함)
+- 라우팅 결정 보드에 두 메커니즘 공존 → decision boundary 명시 필요
+- 복잡도 스코어 튜닝 비용 (프로젝트마다 분포 다름)
+
+## Option B — model-escalation 확장 (pre-assessment 추가)
+
+**장점**:
+- 단일 스킬에서 reactive + proactive 통합
+- 사용자 단일 진입점
+- 마이그레이션 불필요 (기존 호출부 유지)
+
+**단점**:
+- 스킬 스코프 확장 → 단일 책임 원칙 희석
+- 기존 advisory-first 특성과 pre-assessment의 predictive 특성 충돌 가능
+- 테스트 복잡도 증가 (두 플로우 경로)
+
+## Option C — Defer + observe (권장)
+
+**근거**:
+1. **데이터 부재**: model-escalation 현재 실패율, escalation 빈도, 시간당 비용 메트릭이 없음
+2. **선제 내재화의 함정**: 내재화 없이도 기존 시스템이 충분한지 증거 부재
+3. **측정 가능성**: R012 HUD statusline에 escalation 카운터 추가는 경량 작업
+
+**행동 계획**:
+- Phase 1 (즉시): R012 statusline에 `ESC:{count}/{total}` 지표 추가
+- Phase 2 (4주): model-escalation 스킬이 로그 파일에 escalation 기록 축적
+- Phase 3 (3개월): 데이터 분석 — 실패 → escalation 빈도, 비용 절감률, 오버킬 패턴
+- Phase 4 (결정): 데이터 기반으로 Option A vs B vs 현상 유지 재평가
+
+## Recommendation
+
+**Option C**로 진행. #992를 closed 처리 (분석 완료), Phase 1-2 구현은 별도 P3 이슈로 트래킹.
+
+## Decision Record
+
+To be created when implementation path is finalized (Phase 4):
+- `sdd/decisions/2026-XX-XX-pal-router-internalization.md` (per #985 DR template)
+
+## References
+
+- #992 (source issue)
+- #966 (ouroboros 저장소 재평가)
+- `.claude/skills/model-escalation/SKILL.md`
+- `.claude/rules/SHOULD-hud-statusline.md` (R012 statusline 통합 지점)
+- ouroboros PAL Router docs (GitHub)

--- a/templates/guides/claude-code/15-version-compatibility.md
+++ b/templates/guides/claude-code/15-version-compatibility.md
@@ -1,0 +1,61 @@
+# Claude Code Version Compatibility
+
+> Updated: 2026-04-24
+> Source: Claude Code release notes (#967, #968, #969 auto-detected by claude-native skill)
+
+## Compatibility Baseline
+
+oh-my-customcode v0.107.0 targets Claude Code v2.1.116+. All v2.1.117-119 additions are backward-compatible — no config changes required.
+
+## v2.1.117 (2026-04-22)
+
+**Key changes relevant to oh-my-customcode:**
+
+- `CLAUDE_CODE_FORK_SUBAGENT=1` enables forked subagents on external builds — relevant for R018 Agent Teams expansion
+- Main-thread agent `mcpServers` frontmatter loading via `--agent` — broadens MCP integration scope (affects sys-memory-keeper, claude-mem users)
+- `/model` persistence across restarts — reduces repeated model selection in long sessions
+- `/resume` summarization of stale sessions — aligns with R013 ecomode context budget
+- Concurrent MCP server startup — shorter session bootstrap
+
+**Action items**: None. Features are additive.
+
+## v2.1.118 (2026-04-23)
+
+**Key changes relevant to oh-my-customcode:**
+
+- `/cost` + `/stats` → merged into `/usage` — update CLAUDE.md quick-reference if these appear (they don't in current docs)
+- Vim visual modes (`v`, `V`) — orthogonal to harness
+- Custom themes via `~/.claude/themes/` + plugin `themes/` directory — R012 HUD statusline unaffected
+- **Hooks can invoke MCP tools directly (`type: "mcp_tool"`)** — new hook capability, R022 wiki-sync or memory hooks could benefit
+- `DISABLE_UPDATES` env var — stricter than `DISABLE_AUTOUPDATER`
+
+**Action items**: Consider R022/R011 hooks migration to `type: "mcp_tool"` for direct wiki/memory integration (P3 follow-up).
+
+## v2.1.119 (2026-04-23)
+
+**Key changes relevant to oh-my-customcode:**
+
+- `/config` persistence to `~/.claude/settings.json` with proper override precedence — project/local/policy stacking more predictable
+- `prUrlTemplate` setting — useful if mirroring to GitHub Enterprise or GitLab
+- `CLAUDE_CODE_HIDE_CWD` env var — cosmetic
+- `--from-pr` now accepts GitLab MR, Bitbucket PR, GitHub Enterprise URLs — widens reviewer scenarios
+- **`--print` mode honors agent `tools:` and `disallowedTools:` frontmatter** — fixes a long-standing gap, relevant for CI runs using `--print`
+
+**Action items**: Verify `--print` based CI scripts (if any) work correctly with restricted-tools agents like `arch-documenter` (which has `disallowedTools: [Bash]`).
+
+## Action Items Summary
+
+| Version | oh-my-customcode action | Priority |
+|---------|------------------------|----------|
+| v2.1.117 | None (additive) | — |
+| v2.1.118 | Evaluate hooks `type: mcp_tool` for R022/R011 | P3 follow-up |
+| v2.1.119 | Audit `--print` CI with disallowedTools agents | P3 follow-up |
+
+## References
+
+- #967 — Claude Code v2.1.117 release note
+- #968 — Claude Code v2.1.118 release note
+- #969 — Claude Code v2.1.119 release note
+- `.claude/skills/claude-native/` — auto-generation source
+- `.claude/rules/SHOULD-hud-statusline.md` — R012 statusline integration
+- `.claude/rules/MUST-agent-design.md` — R006 agent frontmatter spec

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.106.1",
+  "version": "0.107.0",
   "lastUpdated": "2026-04-24T07:30:00.000Z",
   "components": [
     {

--- a/wiki/rules/r006.md
+++ b/wiki/rules/r006.md
@@ -63,27 +63,16 @@ Skills persist output to `.claude/outputs/sessions/{YYYY-MM-DD}/{skill-name}-{HH
 
 `.claude/` is treated as a sensitive directory by CC. The sensitive-path check runs **above** `bypassPermissions` and explicit allow rules — prompts may appear even with `Write(.claude/**)` in settings.
 
-**Scope (confirmed v2.1.116+, v0.105.0 session):**
-
-| Path pattern | Sensitive? | Tools affected |
-|--------------|-----------|----------------|
-| `.claude/**` | Yes | Bash, Write, Edit |
-| `templates/.claude/**` | Yes | Bash, Write, Edit |
-| `.claude/outputs/**` | No | — (artifact convention) |
-
-**Key behaviors:**
-- `Bash(cp)` on `.claude/` → prompt, even with `Bash(*)` allow rule
-- `Write(.claude/**)` → prompt, even with matching allow rule
-- `Edit(templates/.claude/**)` → prompt, even with matching allow rule
-- Allow rules do not override the sensitive-path check — the check runs upstream of all permission settings
+| Path | Tool | Allow rule | Result |
+|------|------|-----------|--------|
+| `.claude/**` | Bash (`cp`, `mkdir`, `rm`) | `Bash(*)` allowed | Prompt (overrides allow) |
+| `.claude/**` | Write, Edit | `Write(.claude/**)` allowed | Prompt (overrides allow) |
+| `templates/.claude/**` | Write, Edit | `Write(templates/.claude/**)` allowed | Prompt (confirmed CC v2.1.116+; see #960, #961, #981) |
+| `.claude/outputs/**` | Any | — | Allowed (artifact convention) |
 
 **Recommended practice:**
-1. Prefer `Write`/`Edit` over `Bash(cp)`/`Bash(mkdir)` for `.claude/` paths — better auditability even though both trigger prompts
-2. Add defensive allow rules (`Write(.claude/**)`, `Write(templates/.claude/**)`, etc.) — documents intent, may benefit from future CC changes
-3. Plan release pipelines to expect interactive prompts for `templates/.claude/` sync steps
-4. This is CC design behavior (defense-in-depth), not a bug — file as documentation request if unclear
-
-> See also: [feedback_sensitive_path.md](../../.claude/agent-memory/sys-memory-keeper/feedback_sensitive_path.md) — session memory with Bash + Write scope (#960, #961, #981). Note: `.claude/**` glob does not cover `templates/.claude/**`; separate allow entries required.
+1. Prefer `Write`/`Edit` over `Bash(cp)`/`Bash(mkdir)` for `.claude/` paths — better auditability
+2. Add defensive allow rules (`Write(.claude/**)`, `Write(templates/.claude/**)`, etc.) — `.claude/**` glob does not cover `templates/.claude/**`; separate entries required
 
 ## Enforcement
 
@@ -97,4 +86,4 @@ Prompt-based + mgr-sauron R017 verification. mgr-creator enforces frontmatter va
 
 ## Sources
 
-- `.claude/rules/MUST-agent-design.md` — rule definition (Sensitive Path Handling section updated v0.105.1 via #981)
+- `.claude/rules/MUST-agent-design.md` — rule definition (Sensitive Path Handling section updated v0.107.0 via #989, #990, #991)


### PR DESCRIPTION
## Summary

- **R006 Sensitive Path Handling 리팩토링** (#989, #990, #991): 세션-특정 서술 제거, HTML 주석으로 배경 산문 이동 (~200 tokens 절약), Scope+Behavior 테이블 4-컬럼으로 통합
- **PAL Router 내재화 분석** (#992): reactive(모델 에스컬레이션) vs proactive(PAL Router) 비용 라우팅 비교 — Option C (Defer + observe) 결정, 3개월 후 데이터 기반 재평가
- **auto-tag.yml multi-issue close 수정** (#982): `Closes #A #B #C` 형식에서 모든 이슈 번호 파싱, 대소문자 무관 키워드 지원
- **CC v2.1.117-119 버전 호환성 문서화** (#967, #968, #969): `guides/claude-code/15-version-compatibility.md` 신규, 버전별 변경사항 및 액션 아이템 정리

## Test plan

- [x] pre-commit 통과: 1683 tests pass, coverage 98%+ (function + line)
- [x] lint/type check 통과
- [x] documentation counts verified
- [x] package.json + templates/manifest.json: 0.106.1 → 0.107.0 sync

## Fixes

Fixes #982, #989, #990, #991, #992, #967, #968, #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)