### PR TITLE
release: v0.112.0 — Codex Browser Verify 루프 패턴 (#1009)

### DIFF
--- a/guides/browser-automation/01-browser-automation-patterns.md
+++ b/guides/browser-automation/01-browser-automation-patterns.md
@@ -66,3 +66,68 @@ Multiple AI agents can share browser sessions via:
 - [garrytan/gstack](https://github.com/garrytan/gstack) — /browse, /pair-agent patterns
 - [playwright.dev](https://playwright.dev) — Official Playwright documentation
 - [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) — CDP reference
+
+## Codex-Claude Build+Verify 협업 루프
+
+[scout:integrate #1009] Codex Browser Use 패턴을 oh-my-customcode 도구 조합으로 매핑한 루프.
+
+### 사용 사례
+
+- 프론트엔드 빠른 프로토타이핑 (Codex가 생성 → 시각 확인 즉시)
+- AI 디자인 검증 (의도와 실제 렌더링 차이 발견)
+- 회귀 검증 (변경 후 콘솔/네트워크 오류 감지)
+
+### 루프 구조
+
+```mermaid
+graph LR
+  A[codex-exec: build/fix] --> B[Bash: bun dev background]
+  B --> C[chrome navigate]
+  C --> D[gif_creator capture]
+  D --> E[read_console + read_network]
+  E -->|오류 발견| F[codex-exec: fix with error context]
+  F --> A
+  E -->|클린| G[종료 + 보고]
+```
+
+### 코드 예시
+
+```bash
+codex-exec "Add a /dashboard route with sidebar nav"
+bun dev &
+DEV_PID=$!
+# Claude session: mcp__claude-in-chrome__navigate http://localhost:5173/dashboard
+# mcp__claude-in-chrome__gif_creator + read_console_messages + read_network_requests
+# Loop with codex-exec on errors, max 3 iterations
+kill $DEV_PID
+```
+
+### 종료 조건
+
+| 조건 | 결과 |
+|------|------|
+| console error 0 + network failure 0 | 성공 종료 |
+| 동일 오류 2회 반복 | 종료 + 사용자 보고 |
+| 3회 루프 도달 | degeneration 방지 강제 종료 |
+
+### 도구 매핑
+
+| Codex Browser Use | oh-my-customcode |
+|-------------------|------------------|
+| Codex 빌드 | `codex-exec` skill |
+| Browser Use | `mcp__claude-in-chrome__*` MCP |
+| Visual verify | `gif_creator` + console/network |
+| Orchestration | 본 루프 패턴 |
+
+### 차별점 (원본 vs 적용)
+
+| Codex Browser Use 원본 | oh-my-customcode 적용 |
+|----------------------|----------------------|
+| 단일 통합 플러그인 | 도구 조합 (codex-exec + chrome MCP) |
+| 자동 무한 루프 | 3회 하드캡 (degeneration 방지) |
+| Browser Use 사용 | claude-in-chrome MCP 사용 |
+
+### 참고
+
+- 스킬: `.claude/skills/codex-exec/SKILL.md` "Browser Verify Workflow" (#1009 동시 추가)
+- 출처: https://x.com/jameszmsun/status/2047522852854026378 (scout #1009)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.111.1",
+  "version": "0.112.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/codex-exec/SKILL.md
+++ b/templates/.claude/skills/codex-exec/SKILL.md
@@ -204,3 +204,52 @@ When routing skills detect a code generation task and codex is available:
 ```
 /codex-exec "Generate {description} following {framework} best practices" --effort high --full-auto
 ```
+
+## Browser Verify Workflow (Codex + claude-in-chrome 협업 루프)
+
+Codex가 생성/수정한 프론트엔드 결과를 시각적으로 검증하는 루프 패턴. 신규 스킬 불요 — 기존 도구 조합.
+
+### Pattern
+
+```
+codex-exec "build/fix frontend"
+    → bun dev / npm run dev (로컬 서버 기동)
+    → claude-in-chrome:navigate(localhost:port)
+    → claude-in-chrome:gif_creator(action capture)
+    → claude-in-chrome:read_console_messages (오류 감지)
+    → claude-in-chrome:read_network_requests (실패 호출 감지)
+    → 오류 있으면: codex-exec "fix: {error context}" → 루프 재진입
+    → 오류 없으면: 종료 + 결과 보고
+```
+
+### When to Use
+
+| 상황 | 권장 |
+|------|------|
+| 단순 코드 생성 | `codex-exec` 단독 |
+| 프론트엔드 시각 검증 필요 | **이 루프** |
+| API/백엔드 검증 | `deep-verify` skill |
+| 복잡한 디자인 시스템 | `design-shotgun` 병행 |
+
+### Loop Termination Rules
+
+- 최대 반복 3회 (degeneration 방지, R013/agora 패턴 차용)
+- console error 0개 + network failure 0개 → 종료
+- 동일 오류 반복 시 즉시 종료 + 사용자 보고
+
+### Tool Composition
+
+| 단계 | 도구 |
+|------|------|
+| Build/Fix | `codex-exec` |
+| Server | `Bash(bun dev)` (background) |
+| Visual | `mcp__claude-in-chrome__navigate` + `gif_creator` |
+| Diagnose | `read_console_messages` + `read_network_requests` |
+
+자세한 구현 패턴: `guides/browser-automation/01-browser-automation-patterns.md` 참조.
+
+> **Tool**: Use the **Write tool** for any artifact files this loop produces — never Bash mkdir on `.claude/outputs/`.
+
+### Attribution
+
+Pattern source: Codex Browser Use (https://x.com/jameszmsun/status/2047522852854026378), scout #1009.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.111.1",
+  "version": "0.112.0",
   "lastUpdated": "2026-04-24T07:30:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## Summary

- `#1009` scout:integrate — Codex Browser Use 패턴을 oh-my-customcode 도구 조합으로 내재화
- `templates/.claude/skills/codex-exec/SKILL.md`: "Browser Verify Workflow" 섹션 추가
- `guides/browser-automation/01-browser-automation-patterns.md`: "Codex-Claude Build+Verify 협업 루프" 섹션 추가 (mermaid 다이어그램 + 코드 예시 + 종료 조건 + 도구 매핑)

## 핵심 패턴

```
codex-exec "build/fix" → bun dev → claude-in-chrome:navigate → gif_creator capture
→ read_console_messages + read_network_requests
→ 오류 있으면: codex-exec "fix" → 루프 (최대 3회)
→ 클린: 종료 + 보고
```

- 3회 하드캡 (degeneration 방지)
- console error 0 + network failure 0 → 성공 종료
- 동일 오류 반복 시 즉시 종료 + 사용자 보고

## 변경 범위

신규 스킬/가이드/에이전트 없음 — 기존 도구 조합 문서화.

Fixes #1009