### PR TITLE
release: v0.114.0 — R020 정량 evidence advisory + 클러스터 정리 (#1034 #1037 #1038)

### DIFF
--- a/.claude/rules/MUST-completion-verification.md
+++ b/.claude/rules/MUST-completion-verification.md
@@ -17,6 +17,32 @@ Before declaring any task `[Done]`, verify completion against task-type-specific
 | Code Review | All findings addressed or explicitly deferred with justification |
 | Agent/Skill Creation | Frontmatter valid, referenced skills exist, routing updated |
 
+## Optional: Quantitative Evidence (advisory, added v0.114.0, #1034)
+
+For complex agent invocations or multi-step workflows, attach 4-metric evidence to [Done] declarations as supplementary evidence (NOT a binary gate):
+
+| Metric | Source | Format |
+|--------|--------|--------|
+| correctness | task-type matrix above | pass/fail |
+| step_ratio | observed/ideal step count | ratio (lower better) |
+| tool_call_ratio | observed/ideal tool calls | ratio (lower better) |
+| latency_ratio | observed/ideal latency | ratio (lower better) |
+
+### When to Apply
+- Dynamic agent variants comparison (e.g., mgr-creator output validation)
+- Long-running workflows where efficiency regression matters
+- A/B testing of agent prompts or configurations
+
+### Workflow
+1. Run task → collect trajectory (steps, tool_calls, latency)
+2. Compare to ideal trajectory annotation (see `agent-eval-framework` skill)
+3. Attach metric values to [Done] contract as evidence
+
+### Cross-references
+- Skill: `agent-eval-framework` (4-metric framework + ideal trajectory schema)
+- Guide: `guides/agent-eval/README.md` (measurement methodology)
+- Issue: #1034
+
 ## Self-Check (Before Declaring Done)
 
 Before [Done]: (1) Verify ACTUAL outcome not just attempt — "ran command" ≠ "succeeded". (2) Check task-type criteria above. (3) No unchecked items. (4) Would bet $100 it's complete.

--- a/.claude/skills/agent-eval-framework/SKILL.md
+++ b/.claude/skills/agent-eval-framework/SKILL.md
@@ -85,7 +85,7 @@ To write eval trajectories or result reports under `.claude/outputs/evals/`:
 
 Reference: `feedback_sensitive_path_tmp_bypass.md`, R006 sensitive-path handling.
 
-## Phased Gate Workflow
+## Phased Opt-in Gate Workflow
 
 **Phase 1: Correctness Gate** (MUST pass before Phase 2)
 
@@ -170,3 +170,5 @@ Quantitative metrics provide **[Done] gate evidence** beyond binary completion c
 | Code Review | tool_call_ratio as efficiency signal for review thoroughness |
 
 When declaring `[Done]` for agent creation or major workflow changes, include eval gate results as completion evidence.
+
+See R020 "Optional: Quantitative Evidence" section for the consumer-side advisory pattern.

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.113.0",
-  "generatedAt": "2026-04-26T14:28:59.675Z",
-  "templateVersion": "0.113.0",
+  "generatorVersion": "0.114.0",
+  "generatedAt": "2026-04-26T17:27:34.639Z",
+  "templateVersion": "0.114.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "dc6ce94ab01e1c6abb76e0a1a33b472a47f21706921e63f61ce2fb43bab9a9cf",
@@ -115,8 +115,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-completion-verification.md": {
-      "templateHash": "71711d39a564088c713103019f1e2b4e1e3bd373b2ab922290666a5c5436a201",
-      "size": 5547,
+      "templateHash": "d9a24ffc1c8f8a81640dd26dcac359210cf955babd35e4aa2f215dff7641172c",
+      "size": 6677,
       "component": "rules"
     },
     ".claude/agents/be-springboot-expert.md": {
@@ -975,8 +975,8 @@
       "component": "skills"
     },
     ".claude/skills/codex-exec/SKILL.md": {
-      "templateHash": "7383e3f6645623a9b5cc174f0a344fd131af9583e8d94f80af7e0954276dcc32",
-      "size": 8190,
+      "templateHash": "61d7c4eb432f258bcfe958d70f106d8db08f4f64863541c0d2eb992543736395",
+      "size": 8963,
       "component": "skills"
     },
     ".claude/skills/create-agent/SKILL.md": {
@@ -1025,8 +1025,8 @@
       "component": "skills"
     },
     ".claude/skills/agent-eval-framework/SKILL.md": {
-      "templateHash": "8eb800ebb7dc62645da31705f25d8609bc6363c14addc3981831ebba99f050e6",
-      "size": 7075,
+      "templateHash": "5dcbe3eb3bf9dc0dd3a6313e2185b5c84018a0dabe1bf61dd082f54141e7be0e",
+      "size": 8070,
       "component": "skills"
     },
     ".claude/skills/task-decomposition/SKILL.md": {
@@ -1420,8 +1420,8 @@
       "component": "guides"
     },
     "guides/agent-eval/README.md": {
-      "templateHash": "c68db10477c1ac50df8bf7588ca1438b4a1893d00333a3ee52020d254674cc39",
-      "size": 27141,
+      "templateHash": "2dee4b525872afc98d064b5d2ba71959d68eaa22919405b19475231818e8f55a",
+      "size": 27146,
       "component": "guides"
     },
     "guides/web-design/accessibility.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2316,7 +2316,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.113.0",
+    version: "0.114.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2025,7 +2025,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.113.0",
+  version: "0.114.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.113.0",
+  "version": "0.114.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-completion-verification.md
+++ b/templates/.claude/rules/MUST-completion-verification.md
@@ -17,6 +17,32 @@ Before declaring any task `[Done]`, verify completion against task-type-specific
 | Code Review | All findings addressed or explicitly deferred with justification |
 | Agent/Skill Creation | Frontmatter valid, referenced skills exist, routing updated |
 
+## Optional: Quantitative Evidence (advisory, added v0.114.0, #1034)
+
+For complex agent invocations or multi-step workflows, attach 4-metric evidence to [Done] declarations as supplementary evidence (NOT a binary gate):
+
+| Metric | Source | Format |
+|--------|--------|--------|
+| correctness | task-type matrix above | pass/fail |
+| step_ratio | observed/ideal step count | ratio (lower better) |
+| tool_call_ratio | observed/ideal tool calls | ratio (lower better) |
+| latency_ratio | observed/ideal latency | ratio (lower better) |
+
+### When to Apply
+- Dynamic agent variants comparison (e.g., mgr-creator output validation)
+- Long-running workflows where efficiency regression matters
+- A/B testing of agent prompts or configurations
+
+### Workflow
+1. Run task → collect trajectory (steps, tool_calls, latency)
+2. Compare to ideal trajectory annotation (see `agent-eval-framework` skill)
+3. Attach metric values to [Done] contract as evidence
+
+### Cross-references
+- Skill: `agent-eval-framework` (4-metric framework + ideal trajectory schema)
+- Guide: `guides/agent-eval/README.md` (measurement methodology)
+- Issue: #1034
+
 ## Self-Check (Before Declaring Done)
 
 Before [Done]: (1) Verify ACTUAL outcome not just attempt — "ran command" ≠ "succeeded". (2) Check task-type criteria above. (3) No unchecked items. (4) Would bet $100 it's complete.

--- a/templates/.claude/skills/agent-eval-framework/SKILL.md
+++ b/templates/.claude/skills/agent-eval-framework/SKILL.md
@@ -85,7 +85,7 @@ To write eval trajectories or result reports under `.claude/outputs/evals/`:
 
 Reference: `feedback_sensitive_path_tmp_bypass.md`, R006 sensitive-path handling.
 
-## Phased Gate Workflow
+## Phased Opt-in Gate Workflow
 
 **Phase 1: Correctness Gate** (MUST pass before Phase 2)
 
@@ -170,3 +170,5 @@ Quantitative metrics provide **[Done] gate evidence** beyond binary completion c
 | Code Review | tool_call_ratio as efficiency signal for review thoroughness |
 
 When declaring `[Done]` for agent creation or major workflow changes, include eval gate results as completion evidence.
+
+See R020 "Optional: Quantitative Evidence" section for the consumer-side advisory pattern.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.113.0",
+  "version": "0.114.0",
   "lastUpdated": "2026-04-24T07:30:00.000Z",
   "components": [
     {

--- a/wiki/rules/r020.md
+++ b/wiki/rules/r020.md
@@ -85,6 +85,10 @@ When entering autonomous mode (user grants extended execution without per-step c
 
 Record findings in session context. Failure to inventory automation is a R020 violation (unknown external state = unverifiable completion).
 
+## Optional: Quantitative Evidence (advisory, v0.114.0, #1034)
+
+For complex agent invocations or multi-step workflows, 4-metric evidence from the `agent-eval-framework` skill can be attached to `[Done]` declarations as supplementary evidence (NOT a binary gate). Metrics: `correctness`, `step_ratio`, `tool_call_ratio`, `latency_ratio`. See source rule for full table and when-to-apply guidance.
+
 ## Enforcement
 
 Prompt-based per [[r021]]. Integrates with [[r003]] `[Done]` format and [[r017]] structural verification.

--- a/wiki/skills/agent-eval-framework.md
+++ b/wiki/skills/agent-eval-framework.md
@@ -32,10 +32,12 @@ Fills the measurement gap in the existing evaluation stack: harness-eval covers 
 
 Default thresholds: step_ratio ≤ 1.5, tool_call_ratio ≤ 1.3, latency_ratio ≤ 2.0.
 
-## Phased Gate
+## Phased Opt-in Gate
 
 1. **Phase 1 — Correctness**: correctness ≥ 0.80 required before efficiency measurement. Failures are diagnosed and re-evaluated.
 2. **Phase 2 — Efficiency**: step/tool_call/latency ratios computed, aggregated by capability category, compared to baseline. Regressions > 20% flagged.
+
+> Note: renamed from "Phased Gate" to "Phased Opt-in Gate" in v0.114.0 (#1037) to clarify opt-in nature for new agents.
 
 ## Capability Taxonomy
 


### PR DESCRIPTION
# Release v0.114.0

## Highlights

- v0.113.0 (#1025) post-release-followup 빠른 정리 — R020 정량 evidence advisory 통합 + agent-eval-framework "Opt-in Gate" 일관화 + LangChain 클러스터 11 이슈 정리.

## :books: Documentation / :recycle: Refactor

- **R020 + agent-eval-framework 양방향 link** (#1034): R020 (`MUST-completion-verification.md`)에 "Optional: Quantitative Evidence" advisory 섹션 추가 — 4-metric framework 측정값을 [Done] 선언의 보조 evidence로 첨부 가능 (binary gate 아님). agent-eval-framework SKILL의 R020 Linkage 섹션도 양방향 reference 추가.
- **Phased Gate → Phased Opt-in Gate 일관화** (#1037): agent-eval-framework SKILL.md의 mgr-creator 표현 불일치 해소 ("candidate/opt-in" vs "Gate" 모순). mgr-creator 본체 통합은 데이터 기반 trigger 후 재평가 (defer + observe, PAL Router #992 패턴).

## :wrench: Issue Cleanup

- **LangChain 클러스터 정리** (#1038): 11 이슈 cross-analysis triage 완료. 7개 close (중복/이미해결 — #1023, #1027, #1028, #1029, #1030, #1031, #1032), 4개 verify-done 보존 (#1021, #1022, #1024, #1026 → v0.115.0 후보). #1038 메타 이슈 자체 close.

## Resource Changes

| Resource | Before | After | Delta |
|----------|--------|-------|-------|
| Skills | 115 | 115 | 0 |
| Guides | 46 | 46 | 0 |
| Agents | 49 | 49 | 0 |
| Rules | 22 | 22 | 0 |

신규 산출물 없음 — doc-only release.

## Verification

- `verify-template-sync.sh`: ✅ pass
- `verify-wiki-sync.sh`: ✅ pass (262 wiki pages, 0 missing)
- `bun run build`: ✅ clean
- Regression guards: clean

Closes #1034 #1037 #1038.

---
_Release notes generated with Claude Code_
