### PR TITLE
feat: trigger Airflow issue_triage DAG on issue open

### DIFF
--- a/.github/workflows/triage-dispatch.yml
+++ b/.github/workflows/triage-dispatch.yml
@@ -1,0 +1,55 @@
+name: Issue Triage Dispatch
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: read
+
+jobs:
+  trigger-airflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Airflow JWT token
+        id: token
+        run: |
+          set -euo pipefail
+          TOKEN=$(curl -fsS -X POST "${AIRFLOW_URL}/auth/token" \
+            -H "Content-Type: application/json" \
+            -d "{\"username\":\"${AIRFLOW_USER}\",\"password\":\"${AIRFLOW_PASSWORD}\"}" \
+            | jq -r '.access_token')
+          if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+            echo "Failed to obtain Airflow JWT token" >&2
+            exit 1
+          fi
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+        env:
+          AIRFLOW_URL: ${{ secrets.AIRFLOW_URL }}
+          AIRFLOW_USER: ${{ secrets.AIRFLOW_USER }}
+          AIRFLOW_PASSWORD: ${{ secrets.AIRFLOW_PASSWORD }}
+
+      - name: Trigger issue_triage DAG
+        env:
+          AIRFLOW_URL: ${{ secrets.AIRFLOW_URL }}
+          AIRFLOW_TOKEN: ${{ steps.token.outputs.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+        run: |
+          set -euo pipefail
+          LOGICAL_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          DAG_RUN_ID="github-${REPO//\//-}-${ISSUE_NUMBER}-$(date -u +%s)"
+          PAYLOAD=$(jq -n \
+            --arg dag_run_id "$DAG_RUN_ID" \
+            --arg logical_date "$LOGICAL_DATE" \
+            --arg repo "$REPO" \
+            --argjson issue_number "$ISSUE_NUMBER" \
+            --arg issue_url "$ISSUE_URL" \
+            '{dag_run_id: $dag_run_id, logical_date: $logical_date, conf: {repo: $repo, issue_number: $issue_number, issue_url: $issue_url}}')
+          echo "Triggering DAG with payload: $PAYLOAD"
+          curl -fsS -X POST "${AIRFLOW_URL}/api/v2/dags/issue_triage/dagRuns" \
+            -H "Authorization: Bearer ${AIRFLOW_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD"


### PR DESCRIPTION
## 개요

새 이슈가 등록될 때마다 Airflow의 `issue_triage` DAG를 자동으로 트리거하는 GitHub Actions workflow를 추가합니다.

## 변경 사항

- `.github/workflows/triage-dispatch.yml` 추가
- 트리거: `issues.opened` 이벤트
- 동작:
  1. Airflow REST API에 JWT 인증 (`/auth/token`)
  2. 획득한 토큰으로 `issue_triage` DAG 실행 요청 (`/api/v2/dags/issue_triage/dagRuns`)
  3. `conf` 페이로드로 `repo`, `issue_number`, `issue_url` 전달

## 필요한 Repository Secrets

아래 세 가지 secret을 리포 Settings → Secrets and variables → Actions에 등록해야 합니다.

| Secret 이름 | 설명 |
|-------------|------|
| `AIRFLOW_URL` | Airflow 서버 베이스 URL (예: `https://airflow.example.com`) |
| `AIRFLOW_USER` | Airflow 로그인 사용자명 |
| `AIRFLOW_PASSWORD` | Airflow 로그인 비밀번호 |

## 보안

- JWT 토큰은 `::add-mask::` 처리로 로그에 노출되지 않습니다.
- workflow 권한은 `issues: read` 최소 권한만 부여합니다.

## 관련 컨텍스트

이슈 트리아지 자동화 파이프라인의 일환으로, Airflow에서 실행 중인 `issue_triage` DAG가 이슈 내용을 분석하고 라우팅하는 역할을 담당합니다.