### PR TITLE
release: v0.118.3 — memory unification docs (#1065 #1066 #1067)

### DIFF
--- a/docs/memory-unification/schema.md
+++ b/docs/memory-unification/schema.md
@@ -1,0 +1,275 @@
+# Memory Unification Schema
+
+> Epic: [#1047](https://github.com/baekenough/oh-my-customcode/issues/1047) — Local Memory Integration + Skill Context Budget  
+> Related: [#1066](https://github.com/baekenough/oh-my-customcode/issues/1066) (skill budget), [#1067](https://github.com/baekenough/oh-my-customcode/issues/1067) (sensitivity), [#1065](https://github.com/baekenough/oh-my-customcode/issues/1065) (this schema)
+
+---
+
+## Overview
+
+`MemoryRecord` is the normalized unit of memory across all four sources in oh-my-customcode:
+
+| Source | Storage | Access mechanism |
+|---|---|---|
+| `native` | `.claude/agent-memory/<name>/MEMORY.md` | File read via R011 auto-inject |
+| `claude-mem` | Chroma vector DB (MCP) | `mcp__plugin_claude-mem_mcp-search__*` |
+| `episodic-memory` | Auto-indexed conversation log | Auto (no manual action) |
+| `llm-memory` | In-context, session-scoped | Prompt injection |
+
+Adapter implementations are tracked in sub-issues #3–#6 of #1047.
+
+---
+
+## Schema Definition
+
+```typescript
+interface MemoryRecord {
+  /**
+   * Stable unique identifier.
+   * native:         SHA-256 of (source + device_id + project + timestamp)
+   * claude-mem:     MCP-assigned UUID
+   * episodic-memory: conversation-session-id + chunk index
+   * llm-memory:     ephemeral UUID, valid only within the session
+   */
+  id: string;
+
+  /** Memory source system. */
+  source: 'native' | 'claude-mem' | 'episodic-memory' | 'llm-memory';
+
+  /**
+   * Machine or environment identifier.
+   * Derived from $HOSTNAME or a stable fingerprint in settings.local.json.
+   * Enables deduplication when the same project is open on multiple machines.
+   */
+  device_id: string;
+
+  /**
+   * Absolute project path or logical project slug.
+   * native:   working directory at save time (e.g. /Users/sangyi/workspace/projects/oh-my-customcode)
+   * others:   project tag passed to MCP save call
+   */
+  project: string;
+
+  /**
+   * Agent that produced or owns this memory.
+   * Omit for session-wide memories not tied to a specific agent.
+   * Example: "arch-documenter", "sys-memory-keeper"
+   */
+  agent?: string;
+
+  /** ISO 8601 UTC timestamp of when the record was created or last updated. */
+  timestamp: string;
+
+  /**
+   * Human-readable one-line summary.
+   * Used for MEMORY.md index lines and search result display.
+   * Max 150 characters.
+   */
+  summary: string;
+
+  /**
+   * Full body of the memory.
+   * native:   entire Markdown file content (or the relevant frontmatter block)
+   * claude-mem: content passed to save_memory
+   * episodic-memory: extracted conversation chunk
+   * llm-memory: plain text injected into the agent prompt
+   */
+  content: string;
+
+  /**
+   * Freeform tags for filtering and routing.
+   * Convention: lowercase, hyphen-separated.
+   * Examples: ["feedback", "sensitive-path", "release"], ["project", "agents"]
+   */
+  tags: string[];
+
+  /**
+   * Visibility and handling tier. See #1067 for enforcement details.
+   *
+   * public     — safe to log, share, or include in any prompt
+   * project    — scoped to this project; do not send to external services
+   * sensitive  — omit from logs; inject only when explicitly needed
+   * secret     — never inject into prompts; read only via secure MCP tool
+   */
+  sensitivity: 'public' | 'project' | 'sensitive' | 'secret';
+
+  /**
+   * SHA-256 of (source + content) for deduplication across adapters.
+   * Collision → keep record with later timestamp, merge tags.
+   */
+  hash: string;
+
+  /**
+   * Optional reference to a pre-computed embedding stored in the vector DB.
+   * Format: "<collection>/<vector-id>" (e.g. "claude-mem/abc123")
+   * Populated by the claude-mem adapter; omit for native and llm-memory.
+   */
+  embedding_ref?: string;
+}
+```
+
+---
+
+## Field Semantics
+
+| Field | Required | Valid values / constraints | Notes |
+|---|---|---|---|
+| `id` | Yes | String, globally unique | Derivation rule per source above |
+| `source` | Yes | `native` \| `claude-mem` \| `episodic-memory` \| `llm-memory` | Immutable after creation |
+| `device_id` | Yes | Non-empty string | Defaults to `$HOSTNAME`; override in settings |
+| `project` | Yes | Absolute path or slug | Normalise trailing slash before hashing |
+| `agent` | No | kebab-case agent name | Omit for orchestrator-level memories |
+| `timestamp` | Yes | ISO 8601 UTC (`2026-04-27T09:00:00Z`) | Set at creation; update on meaningful edit |
+| `summary` | Yes | ≤150 chars, no newline | Used in MEMORY.md index and search preview |
+| `content` | Yes | Any string | No enforced length limit; compress via R013 if needed |
+| `tags` | Yes | String array, may be empty | Lowercase, hyphen-separated recommended |
+| `sensitivity` | Yes | See tier table above | Default: `project` when source is `native` |
+| `hash` | Yes | `sha256(source + content)` | Recompute on content change |
+| `embedding_ref` | No | `"<collection>/<id>"` | Only claude-mem adapter populates this |
+
+---
+
+## Adapter Mapping Guide
+
+### native (MEMORY.md)
+
+| Schema field | Derived from |
+|---|---|
+| `id` | `sha256("native" + device_id + project + timestamp)` |
+| `source` | `"native"` |
+| `device_id` | `$HOSTNAME` at save time |
+| `project` | Working directory passed by sys-memory-keeper |
+| `agent` | Memory directory name: `.claude/agent-memory/<name>/` |
+| `timestamp` | File mtime (ISO 8601 UTC) |
+| `summary` | First non-blank line of MEMORY.md (after `#` heading stripped) |
+| `content` | Full MEMORY.md content |
+| `tags` | Extract from `## ` section headings (lowercase) |
+| `sensitivity` | `"project"` (default; elevate to `"sensitive"` if file contains secrets) |
+| `hash` | `sha256("native" + content)` |
+| `embedding_ref` | Omit |
+
+### claude-mem (Chroma MCP)
+
+| Schema field | Derived from |
+|---|---|
+| `id` | MCP-returned UUID from `save_memory` response |
+| `source` | `"claude-mem"` |
+| `device_id` | `$HOSTNAME` at save time |
+| `project` | `project` tag passed to `save_memory` |
+| `agent` | `agent` tag if present in MCP metadata |
+| `timestamp` | MCP `created_at` field |
+| `summary` | First sentence of `content` (≤150 chars) |
+| `content` | Full content string passed to `save_memory` |
+| `tags` | MCP tags array |
+| `sensitivity` | `"project"` default; map MCP `sensitivity` tag if present |
+| `hash` | `sha256("claude-mem" + content)` |
+| `embedding_ref` | `"claude-mem/" + vector_id` from MCP response |
+
+### episodic-memory (auto-indexed)
+
+| Schema field | Derived from |
+|---|---|
+| `id` | `session_id + "-" + chunk_index` |
+| `source` | `"episodic-memory"` |
+| `device_id` | `$HOSTNAME` |
+| `project` | Project path active during the session |
+| `agent` | Omit (whole-session scope) |
+| `timestamp` | Session end time |
+| `summary` | Auto-generated by episodic-memory indexer |
+| `content` | Extracted conversation chunk |
+| `tags` | `["episodic"]` + any topic tags from indexer |
+| `sensitivity` | `"project"` |
+| `hash` | `sha256("episodic-memory" + content)` |
+| `embedding_ref` | Episodic index reference if available |
+
+### llm-memory (in-context, session-scoped)
+
+| Schema field | Derived from |
+|---|---|
+| `id` | Ephemeral UUID, regenerated each session |
+| `source` | `"llm-memory"` |
+| `device_id` | `$HOSTNAME` |
+| `project` | Active working directory |
+| `agent` | Injecting agent name |
+| `timestamp` | Injection time |
+| `summary` | Short label passed at injection |
+| `content` | Injected text block |
+| `tags` | `["llm-memory", "session-scoped"]` |
+| `sensitivity` | `"public"` (already in prompt — no additional restriction) |
+| `hash` | `sha256("llm-memory" + content)` |
+| `embedding_ref` | Omit |
+
+---
+
+## Concrete Examples
+
+### Example 1 — native record (arch-documenter feedback)
+
+```json
+{
+  "id": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+  "source": "native",
+  "device_id": "macbook-sangyi",
+  "project": "/Users/sangyi/workspace/projects/oh-my-customcode",
+  "agent": "arch-documenter",
+  "timestamp": "2026-04-27T09:12:00Z",
+  "summary": "arch-documenter has disallowedTools:[Bash] — avoid /tmp/*.sh bypass, delegate Bash tasks",
+  "content": "# arch-documenter Memory\n\n...(full MEMORY.md)...",
+  "tags": ["feedback", "arch-documenter", "sensitive-path"],
+  "sensitivity": "project",
+  "hash": "sha256:native+<content>",
+  "embedding_ref": null
+}
+```
+
+### Example 2 — claude-mem record (session summary)
+
+```json
+{
+  "id": "f7e8d9c0-1a2b-3c4d-5e6f-7a8b9c0d1e2f",
+  "source": "claude-mem",
+  "device_id": "macbook-sangyi",
+  "project": "oh-my-customcode",
+  "agent": null,
+  "timestamp": "2026-04-27T10:30:00Z",
+  "summary": "Session 88: v0.116.1 bootstrap hotfix — professor-triage Phase 4 mismatch fixed",
+  "content": "Tasks: #1043 arch-documenter Bash disallowedTools, #1046 inline directive loss. Decisions: general-purpose fallback for Phase 4. Open: #1048 #1047 #1045 #1041 #1035.",
+  "tags": ["session-summary", "release", "hotfix"],
+  "sensitivity": "project",
+  "hash": "sha256:claude-mem+<content>",
+  "embedding_ref": "claude-mem/f7e8d9c0vector"
+}
+```
+
+### Example 3 — llm-memory record (injected skill budget)
+
+```json
+{
+  "id": "ephemeral-uuid-abc123",
+  "source": "llm-memory",
+  "device_id": "macbook-sangyi",
+  "project": "/Users/sangyi/workspace/projects/oh-my-customcode",
+  "agent": "sys-memory-keeper",
+  "timestamp": "2026-04-27T11:00:00Z",
+  "summary": "Skill budget: research=40%, impl=50%, review=60%",
+  "content": "Context budget thresholds injected for this session: research 40%, implementation 50%, review 60%, management 70%, general 80%.",
+  "tags": ["llm-memory", "session-scoped", "skill-budget"],
+  "sensitivity": "public",
+  "hash": "sha256:llm-memory+<content>",
+  "embedding_ref": null
+}
+```
+
+---
+
+## Cross-References
+
+| Reference | Relationship |
+|---|---|
+| [#1047](https://github.com/baekenough/oh-my-customcode/issues/1047) | Parent epic — local memory integration + skill context budget |
+| [#1065](https://github.com/baekenough/oh-my-customcode/issues/1065) | This document |
+| [#1066](https://github.com/baekenough/oh-my-customcode/issues/1066) | Skill budget — `llm-memory` records for context thresholds |
+| [#1067](https://github.com/baekenough/oh-my-customcode/issues/1067) | Sensitivity tier enforcement — governs `sensitivity` field values |
+| `.claude/agent-memory/arch-documenter/MEMORY.md` | Example native source; see adapter mapping above |
+| `.claude/rules/SHOULD-memory-integration.md` (R011) | Memory system architecture and session-end save protocol |
+| `.claude/rules/SHOULD-ecomode.md` (R013) | Context budget management; informs `llm-memory` content compression |

--- a/docs/memory-unification/sensitivity.md
+++ b/docs/memory-unification/sensitivity.md
@@ -1,0 +1,177 @@
+# Memory Unification — Content Sensitivity Policy
+
+> **Epic**: #1047 — Unified Memory System
+> **Depends on**: #1065 (schema), #1066 (skill budget)
+> **Implements**: #1067
+> **Cross-reference**: R001 (Safety Rules)
+
+---
+
+## Sensitivity Tiers
+
+| Tier | Description | Storage | Committed to Git? | Prompt Injection |
+|------|-------------|---------|-------------------|-----------------|
+| `public` | Non-sensitive project knowledge, architecture notes, workflow patterns | Any adapter | Yes | Full content |
+| `project` | Default tier. Work-in-progress context, task state, routing decisions | Project-scoped adapter | Yes | Full content |
+| `sensitive` | PII, user-provided credentials placeholders, personal identifiers | Local adapter only | No | Summary only (no raw content) |
+| `secret` | API keys, tokens, passwords, private keys matching detection regexes | Rejected — never stored | Never | Excluded entirely |
+
+**Default tier**: `project` (applied when no explicit tier is set — conservative choice that avoids accidental secret commits while preserving usefulness).
+
+---
+
+## Detection Rules
+
+### `secret` — Regex Detection (auto-applied on every record before persist)
+
+The following patterns trigger automatic `secret` classification and MUST cause the adapter to reject the persist with a warning:
+
+| Pattern | Matches |
+|---------|---------|
+| `sk-[a-zA-Z0-9]{30,}` | OpenAI API keys |
+| `ghp_[a-zA-Z0-9]{36}` | GitHub personal access tokens |
+| `ghs_[a-zA-Z0-9]{36}` | GitHub OAuth app tokens |
+| `AKIA[0-9A-Z]{16}` | AWS access key IDs |
+| `xoxb-[0-9]+-[0-9]+-[a-zA-Z0-9]+` | Slack bot tokens |
+| `xoxp-[0-9]+-[0-9]+-[a-zA-Z0-9]+` | Slack user tokens |
+| `-----BEGIN (RSA\|EC\|OPENSSH\|PGP) PRIVATE KEY-----` | Private keys |
+| `[0-9a-f]{40}` (in key-named fields) | SHA-1 secrets (field-context check required) |
+| `eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+` | JWT tokens |
+| `[Pp]assword\s*[:=]\s*\S+` | Inline password assignments |
+
+Detection runs against both the record `value` field and any string sub-fields recursively. A single match in any field is sufficient to classify the entire record as `secret`.
+
+### `sensitive` — Explicit Metadata Required
+
+Records are classified `sensitive` only through explicit declaration. There is no auto-detection for PII; callers must set `sensitivity: sensitive` in the record metadata. This prevents over-classification while maintaining a clear audit trail.
+
+Examples of content that SHOULD be declared `sensitive`:
+- User email addresses or names stored as project context
+- Internal server hostnames or IP addresses
+- Workspace paths that expose username (`/Users/johndoe/...`)
+
+### Tier Precedence
+
+```
+secret (detected) > sensitive (explicit) > project (default) > public (explicit)
+```
+
+Detected `secret` always wins — explicit metadata cannot downgrade a detected secret to a lower tier.
+
+---
+
+## Storage Rules
+
+| Tier | Storage Target | Git Committed | On Detect |
+|------|---------------|---------------|-----------|
+| `public` | Any adapter (project/user/local) | Yes | Store normally |
+| `project` | Project or local adapter | Yes (project), No (local) | Store normally |
+| `sensitive` | Local adapter only | No | Store with warning log |
+| `secret` | **Not stored anywhere** | Never | Reject + emit warning |
+
+### `secret` Handling Protocol
+
+1. Run detection regex suite against record content
+2. If any pattern matches → set `sensitivity: secret` internally
+3. **Reject the persist call** — return error: `[Memory] REJECTED: secret-tier content detected in field '{field}'. Record not stored.`
+4. Emit warning to stderr (not stdout, to avoid prompt contamination)
+5. Redact matched value in the warning: show first 4 chars + `****` (e.g., `sk-Ab****`)
+6. Do NOT log the full matched string anywhere
+
+### PreWrite Hook Integration Point
+
+Adapters implementing the unified memory interface MUST expose a `preWrite` scan step. The hook fires before any storage operation and receives the full record. The `secret` detection regex suite runs at this step.
+
+```
+preWrite(record) → scan(record) → {
+  secret detected  → reject(record, warning)
+  sensitive        → enforce local-only adapter routing
+  project/public   → proceed to storage
+}
+```
+
+The `.claude/hooks/` PreToolUse hook system MAY integrate this scan as an advisory check for the `Write` tool targeting memory paths, but the adapter-level scan is the authoritative gate (hooks are advisory per R021).
+
+No existing redaction scripts are present in `.claude/hooks/scripts/` — this policy defines the first redaction contract in the project.
+
+---
+
+## Disclosure Rules
+
+### Subagent Prompt Synthesis
+
+When injecting memory records into a spawned agent's prompt:
+
+| Tier | Injected Content |
+|------|-----------------|
+| `public` | Full content |
+| `project` | Full content |
+| `sensitive` | Summary only: `[sensitive record: {key}, created {date}]` — no raw value |
+| `secret` | Never injected (records should not exist; skip if encountered) |
+
+This ensures subagents receive the context they need without receiving raw credentials or PII.
+
+### `/memory-recall` Tier Filter
+
+The `/memory-recall` command MUST accept a `--tier` filter parameter:
+
+```
+/memory-recall [query] [--tier public|project|sensitive]
+```
+
+- Default (no `--tier`): returns `public` and `project` records only
+- `--tier sensitive`: requires explicit invocation; returns `sensitive` records with a disclosure notice
+- `secret` tier: never returned by any query path
+
+### Export Safety
+
+Any memory export operation (full dump, backup, share) MUST:
+
+1. Verify zero `secret`-tier records in the export set (fail-stop if found)
+2. Exclude `sensitive`-tier records unless the user explicitly opts in with `--include-sensitive`
+3. Emit a pre-export summary: `Exporting {n} records: {public: x, project: y, sensitive: z (excluded)}`
+
+---
+
+## Implementation Contract for Adapters
+
+Adapters implementing the unified memory schema (#1065) MUST satisfy the following sensitivity contract. This applies to all follow-up adapter issues (#3–#6 under epic #1047).
+
+### Required Adapter Behaviors
+
+1. **Secret detection on every record before persisting**
+   - Run the full regex suite defined in [Detection Rules](#detection-rules) above
+   - Apply to all string fields recursively (including nested metadata)
+   - This is not optional — adapters that skip detection are non-compliant
+
+2. **Tag with derived `sensitivity` field**
+   - Every persisted record MUST carry a `sensitivity` field set to one of: `public | project | sensitive | secret`
+   - If detection fires → set `secret` regardless of caller-supplied value
+   - If caller supplied `sensitive` and no secret detected → honor it
+   - Otherwise → default to `project`
+
+3. **Reject persist if `secret` detected**
+   - Return a structured error object, not an exception:
+     ```
+     { ok: false, error: "secret_detected", field: "<field_name>", hint: "<redacted_prefix>****" }
+     ```
+   - Do NOT swallow the error silently
+
+4. **Local-only routing for `sensitive`**
+   - If `sensitivity === "sensitive"`, adapter MUST route to local (non-git-tracked) storage
+   - Raise an error if no local adapter is available: `"sensitive record requires local adapter — none configured"`
+
+5. **Disclosure filter in read path**
+   - Read operations MUST respect the tier filter contract described in [Disclosure Rules](#disclosure-rules)
+   - Default read excludes `sensitive` unless caller passes `includeSensitive: true`
+
+---
+
+## Cross-References
+
+| Reference | Relationship |
+|-----------|-------------|
+| R001 (MUST-safety.md) | Prohibits exposing API keys/secrets/passwords — this policy operationalizes that rule for memory storage |
+| #1047 | Parent epic — Unified Memory System |
+| #1065 | Memory schema — defines the `sensitivity` field this policy populates |
+| #1066 | Skill budget — per-skill memory access controls interact with sensitivity tier (sensitive records excluded from skill context by default) |

--- a/docs/skill-budget/research.md
+++ b/docs/skill-budget/research.md
@@ -1,0 +1,148 @@
+# Skill Budget Research: Static Profile vs Memory-Derived Dynamic Activation
+
+**Epic**: #1047 — per-spawn skill enumeration overhead reduction
+**Related**: #1041 (token over-spend root cause), #1055 (follow-up), #1066 (this document)
+**Status**: Research only — no implementation
+
+---
+
+## 1. Baseline Measurement (from #1041)
+
+| Component | Size | Notes |
+|-----------|------|-------|
+| Orchestrator skill descriptions | ~14.5 KB | 115 skills × avg description |
+| Per-spawn enumeration block | ~22–40 KB | Plugin skills dominate; varies by active plugins |
+| Per-turn auto-injected payload | ~29 K tokens | Includes rules, CLAUDE.md, skill manifest |
+
+**Root cause**: Every agent spawn injects the full skill list regardless of task domain.
+A Go code review spawn receives the same enumeration as an Airflow pipeline spawn.
+At 4 parallel agents, the overhead multiplies to ~120–160 KB before task content.
+
+---
+
+## 2. Option 1: Static Profiles
+
+### Mechanism
+
+- Introduce `.claude/profiles/{name}.json` — a curated allow-list of skill names per persona (e.g., `backend-dev`, `data-engineer`, `qa`).
+- User activates a profile at session start via slash command: `/profile backend-dev`.
+- Orchestrator filters the skill enumeration block to only listed skills before injecting into any spawned agent prompt.
+- Profile files are checked into version control; maintained by `mgr-creator` or manually.
+
+### Profile schema (draft)
+
+```json
+{
+  "name": "backend-dev",
+  "description": "Go/Python/Kotlin backend development sessions",
+  "skills": [
+    "dev-review", "dev-refactor", "structured-dev-cycle",
+    "sdd-dev", "deep-verify", "adversarial-review"
+  ],
+  "always-include": ["task-decomposition", "dag-orchestration"]
+}
+```
+
+### Effect estimate
+
+- Typical backend profile: 15–25 skills vs 115 full set → **60–70% reduction** in enumeration block.
+- Per-spawn payload drops from ~22–40 KB to ~7–15 KB.
+- Benefit compounds at high parallelism (R009 4-agent default).
+
+### Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|-----------|
+| UX burden: user must remember to activate | Medium | Default profile = full set (no regression) |
+| Profile staleness as skills are added | Medium | CI lint check profiles against skill manifest |
+| Wrong profile active → missing skill | Low | Fallback: user can override with full enumeration |
+| Maintenance overhead (47+ guides to curate) | Low | Start with 3–4 profiles covering 80% of sessions |
+
+---
+
+## 3. Option 2: Memory-Derived Dynamic Activation
+
+### Mechanism
+
+- `claude-mem` stores an invocation log: each skill invocation writes `{skill, timestamp, session_id}` to memory.
+- A scoring function computes an activity score per skill: `score = Σ(recency_weight × invocation_count)` over a rolling 30-day window.
+- At session start, the orchestrator queries claude-mem, ranks skills by score, and activates the top-N (e.g., top 30).
+- Skills below threshold are excluded from the per-spawn enumeration block unless explicitly requested.
+
+### Effect estimate
+
+- If top-30 active skills cover 80%+ of actual usage, enumeration block shrinks by ~74%.
+- Zero explicit user action after the initial warm-up period (after ~5 sessions).
+
+### Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|-----------|
+| Cold start: no history → full enumeration | High | Fall back to full set for first N sessions |
+| Infrequent skill drop: legitimate but rare skill excluded | Medium | Always-include override list per agent frontmatter |
+| claude-mem unavailable → no scoring | High | Graceful degrade to full enumeration |
+| Scoring bias toward recent activity | Low | Apply time-decay, not pure recency |
+| Privacy: invocation log stored externally | Low | Log skill names only, no payload content |
+
+---
+
+## 4. Option 3: Hybrid
+
+### Mechanism
+
+- A base static profile defines a **floor** (always-included skills, never scored out).
+- Memory-derived scoring adjusts the **ceiling**: dynamically adds skills above the floor based on recent activity.
+- Effective set = `profile.always-include ∪ top_scored_skills`.
+- User can activate a domain profile (`/profile data-engineer`) to shift the floor.
+
+### Effect estimate
+
+- Reduction: 55–65% (slightly less aggressive than pure dynamic due to guaranteed floor).
+- Risk profile: lower than Option 2 (floor prevents cold-start failures), lower UX burden than Option 1.
+
+---
+
+## 5. Comparison Matrix
+
+| Dimension | Option 1: Static | Option 2: Dynamic | Option 3: Hybrid |
+|-----------|:-----------------:|:-----------------:|:----------------:|
+| Implementation cost | Low | High | Medium |
+| UX impact | Medium (manual activate) | None after warm-up | Low |
+| Expected reduction | 60–70% | 70–80% | 55–65% |
+| Risk level | Low | High (cold start) | Medium |
+| claude-mem dependency | None | Required | Optional |
+| Maintenance burden | Medium (profile curation) | Low | Medium |
+| Time to value | Immediate | 5+ sessions warm-up | 5+ sessions |
+| Graceful degrade | Yes (full set default) | Yes (full set fallback) | Yes |
+
+---
+
+## 6. Recommendation
+
+**Implement Option 1 first** to validate the UX assumption (do users adopt profile activation?), measure the real-world reduction, and establish baseline metrics before introducing scoring infrastructure.
+
+Rationale:
+- No external dependency (claude-mem not required).
+- Immediately measurable: compare per-spawn token counts before/after.
+- If profile adoption is low (users forget to activate), that invalidates the UX assumption and shifts the recommendation toward Option 2 or 3.
+- If adoption is high, profile curation effort is justified and Option 3 becomes the natural evolution.
+
+**Evaluation gate**: After 2 weeks of Option 1 usage, measure (a) profile activation rate, (b) actual token reduction vs baseline, (c) "missing skill" incidents. Use these to decide whether to invest in Option 2 scoring infrastructure.
+
+---
+
+## 7. Open Questions
+
+1. **UX assumption validity**: Will users reliably activate a profile at session start, or does this create friction that leads to abandoning the feature? No data yet.
+
+2. **Minimum effective profile count**: How many profiles cover 80%+ of session types? Hypothesis: 4 (backend-dev, data-engineer, qa, docs-only) — needs session log analysis.
+
+3. **claude-mem availability baseline**: What fraction of sessions have claude-mem configured? Option 2/3 value depends on this. Current estimate: unknown.
+
+4. **Always-include list authority**: Should `always-include` be defined per profile (Option 1) or per agent frontmatter (Option 2/3)? Conflict resolution policy needed.
+
+5. **Scoring window**: Is 30 days appropriate for skill activity decay, or should it be session-count based (e.g., last 20 sessions)? Temporal vs usage-count decay TBD.
+
+6. **CI enforcement**: Should missing skills in a profile cause CI failure, or only a warning? Strict enforcement reduces drift but increases maintenance overhead.
+
+7. **Interaction with plugin skills**: Plugin-injected skills dominate the 22–40 KB range. Do profiles need to filter plugin skill enumeration, or only core/harness skills? Plugin skill filtering may require a different hook point.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.118.2",
+  "version": "0.118.3",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.118.2",
+  "version": "0.118.3",
   "lastUpdated": "2026-04-24T07:30:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## 요약

#1047 epic 분해의 doc/research 트랙 batch — 3개 문서 신규 작성. 코드 변경 없음.

## 신규 문서

### docs/memory-unification/schema.md (#1065, 145 lines)
4 source (native MEMORY.md / claude-mem / episodic-memory / llm-memory)에 대한 normalized MemoryRecord interface, field semantics, adapter mapping guide, 3 concrete examples.

### docs/memory-unification/sensitivity.md (#1067, 163 lines)
4 sensitivity tiers (public/project/sensitive/secret) + 10 secret regex 패턴 + 어댑터 5-rule contract + storage/disclosure/export 정책.

### docs/skill-budget/research.md (#1066, 148 lines)
115 skills 페이로드 절감 옵션 3가지 비교 — 정적 프로필 vs memory-derived dynamic vs hybrid. 권장: Option 1 (정적 프로필) 먼저 UX 검증.

## 검증
- 카운트 변경 없음 (49/115/22/49)
- verify-template-sync, verify-wiki-sync PASS

## Closes
- #1065 schema spec
- #1066 skill budget research
- #1067 privacy/sensitivity policy

## Related
- #1047 epic — adapter implementations (#3-#6) is next track

🤖 Generated with [Claude Code](https://claude.com/claude-code)