### PR TITLE
release: v0.119.0 — OTEL trajectory mode + memory_records table (#1035 #1069)

### DIFF
--- a/.claude/skills/monitoring-setup/SKILL.md
+++ b/.claude/skills/monitoring-setup/SKILL.md
@@ -213,3 +213,102 @@ claude-inspector
 ```
 
 Claude Inspector is external to oh-my-customcode and does not require any project configuration changes.
+
+## Agent Trajectory Export Mode
+
+Toggle: `/monitoring-setup trajectory-otel on|off`
+
+When enabled, agent-eval-framework 4-metric data is emitted as OpenTelemetry spans for external analysis.
+
+### trajectory-otel on
+
+1. Read `.claude/settings.local.json` (create if not exists)
+2. Add or update `env` field with trajectory export configuration:
+   ```json
+   {
+     "env": {
+       "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+       "OTEL_METRICS_EXPORTER": "console",
+       "OTEL_LOGS_EXPORTER": "console",
+       "CLAUDE_TRAJECTORY_OTEL": "1"
+     }
+   }
+   ```
+3. If `OTEL_EXPORTER_OTLP_ENDPOINT` is set in the environment, also add:
+   ```json
+   {
+     "env": {
+       "OTEL_TRACES_EXPORTER": "otlp"
+     }
+   }
+   ```
+   Otherwise default to `"OTEL_TRACES_EXPORTER": "console"`.
+4. Preserve all existing settings
+5. Report:
+   ```
+   [Done] Agent Trajectory Export enabled
+
+   Configured in: .claude/settings.local.json
+   Span exporter: console (default) | otlp (if OTEL_EXPORTER_OTLP_ENDPOINT set)
+   Metrics: correctness, step_ratio, tool_call_ratio, latency_ratio
+   Events: tool_call (tool_name, duration_ms, exit_code)
+
+   Note: Takes effect on next `claude` session restart.
+   To disable: /monitoring-setup trajectory-otel off
+   ```
+
+### trajectory-otel off
+
+1. Read `.claude/settings.local.json`
+2. Remove trajectory-related keys from `env`:
+   - `CLAUDE_TRAJECTORY_OTEL`
+   - `OTEL_TRACES_EXPORTER`
+3. Report:
+   ```
+   [Done] Agent Trajectory Export disabled
+
+   Removed from: .claude/settings.local.json
+   Takes effect on next session restart.
+   ```
+
+### Span Schema
+
+```
+operation: agent.invocation
+attributes:
+  agent.type: string          // e.g. "lang-golang-expert"
+  agent.model: string         // e.g. "claude-sonnet-4-6"
+  task.id: string             // eval task identifier
+  task.capability: string     // research | implement | review | debug | manage
+  metric.correctness: bool
+  metric.step_ratio: float
+  metric.tool_call_ratio: float
+  metric.latency_ratio: float
+events:
+  - tool_call
+      attrs: tool_name (string), duration_ms (int), exit_code (int)
+duration: total wall clock time of agent invocation
+```
+
+### Activation Notes
+
+- Independent from the existing console monitoring mode (`enable`/`disable`). Both can be active simultaneously.
+- `trajectory-otel on` does NOT implicitly call `enable` — console metrics monitoring remains a separate toggle.
+- Console exporter (default): prints span JSON to stdout for local dev / debugging.
+- OTLP exporter (optional): activated when `OTEL_EXPORTER_OTLP_ENDPOINT` env var is set. Compatible with Grafana, Datadog, Honeycomb, and any OTLP-compliant collector. No LangSmith dependency.
+- Actual OTEL SDK emission is handled by the Claude Code telemetry layer. This skill configures the env vars that activate the trajectory span pipeline.
+
+### status (extended)
+
+When `trajectory-otel` is active, `status` command output includes:
+
+```
+[Monitoring Status]
+├── Enabled: Yes/No
+├── Metrics exporter: console / otlp / none
+├── Logs exporter: console / otlp / none
+├── Trajectory export: Yes/No
+├── Traces exporter: console / otlp / none
+└── Config: .claude/settings.local.json
+```
+

--- a/guides/agent-eval/README.md
+++ b/guides/agent-eval/README.md
@@ -652,7 +652,47 @@ find .claude/outputs/eval -name "result.yaml" | \
 
 **한계**: 집계가 수동이며, LangSmith Insights의 시계열 추이나 분포 시각화는 제공하지 않는다.
 
-**향후 보강**: monitoring-setup 가이드의 OTEL 통합이 완성되면 step trace를 OTEL span으로 내보내고 Grafana에서 시각화하는 경로가 열린다. 별도 followup 이슈로 추적 권장.
+**향후 보강**: monitoring-setup의 `trajectory-otel` 모드(#1035)로 step trace를 OTEL span으로 내보내고 Grafana에서 시각화하는 경로가 열린다.
+
+### 5.5 OpenTelemetry Trajectory Export (#1035)
+
+`monitoring-setup` 스킬의 `trajectory-otel` 모드를 활성화하면 agent-eval-framework가 측정한 4-metric 데이터를 OTEL span/event로 내보낸다.
+
+**활성화**: `/monitoring-setup trajectory-otel on`
+**비활성화**: `/monitoring-setup trajectory-otel off`
+
+#### Span 구조
+
+```
+operation: agent.invocation
+attributes:
+  agent.type, agent.model, task.id, task.capability
+  metric.correctness, metric.step_ratio, metric.tool_call_ratio, metric.latency_ratio
+events:
+  tool_call (tool_name, duration_ms, exit_code)
+```
+
+#### 내보내기 옵션
+
+| 옵션 | 조건 | 대상 |
+|------|------|------|
+| Console exporter | 기본 (항상) | stdout — 로컬 디버깅 |
+| OTLP exporter | `OTEL_EXPORTER_OTLP_ENDPOINT` 환경변수 설정 시 | Grafana / Datadog / Honeycomb 등 |
+
+#### 장점
+
+- **표준 OTEL 생태계**: LangSmith 의존 없음. 모든 OTLP 호환 collector에 연결 가능.
+- **다른 LLM 시스템과 비교**: 동일 OTEL 인프라를 사용하는 시스템(예: LangChain) 메트릭과 직접 비교 가능.
+- **기존 모니터링과 독립**: `enable`/`disable` 콘솔 모니터링과 별도 토글. 동시 활성화 가능.
+
+#### 대안 매핑 테이블 업데이트
+
+| LangChain 컴포넌트 | 역할 | oh-my-customcode 대안 |
+|--------------------|------|----------------------|
+| LangSmith trace | step별 실행 기록 수집 | claude-mem `save_memory` per step (5.2) |
+| Polly (record/replay) | 결정론적 재현 | episodic-memory 검색 (5.3) |
+| Insights dashboard | 집계 메트릭 시각화 | statusline.sh + omcustom-improve-report (5.4) |
+| **LangSmith OTEL export** | **표준 OTEL span 수집** | **trajectory-otel mode (5.5, #1035)** |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.118.3",
+  "version": "0.119.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/packages/eval-core/drizzle/0001_aromatic_gambit.sql
+++ b/packages/eval-core/drizzle/0001_aromatic_gambit.sql
@@ -1,0 +1,18 @@
+CREATE TABLE `memory_records` (
+	`id` text PRIMARY KEY NOT NULL,
+	`source` text NOT NULL,
+	`device_id` text NOT NULL,
+	`project` text NOT NULL,
+	`agent` text,
+	`timestamp` text NOT NULL,
+	`summary` text NOT NULL,
+	`content` text NOT NULL,
+	`tags` text NOT NULL,
+	`sensitivity` text NOT NULL,
+	`hash` text NOT NULL,
+	`embedding_ref` text,
+	`created_at` text NOT NULL,
+	`updated_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `memory_records_hash_unique` ON `memory_records` (`hash`);

--- a/packages/eval-core/drizzle/meta/0001_snapshot.json
+++ b/packages/eval-core/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,992 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "50512a83-7ac0-474a-bbf6-9c4a0d9b7ad4",
+  "prevId": "3aff0c8d-8201-48e0-b619-0410b6dc8693",
+  "tables": {
+    "agent_invocations": {
+      "name": "agent_invocations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_ppid": {
+          "name": "session_ppid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_type": {
+          "name": "agent_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pattern_used": {
+          "name": "pattern_used",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_summary": {
+          "name": "error_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_trajectories": {
+      "name": "agent_trajectories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "baseline_id": {
+          "name": "baseline_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "observed_steps": {
+          "name": "observed_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_tool_calls": {
+          "name": "observed_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "observed_latency_ms": {
+          "name": "observed_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "correctness": {
+          "name": "correctness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "step_ratio": {
+          "name": "step_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_ratio": {
+          "name": "tool_call_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latency_ratio": {
+          "name": "latency_ratio",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_trajectories_baseline_id_eval_baselines_id_fk": {
+          "name": "agent_trajectories_baseline_id_eval_baselines_id_fk",
+          "tableFrom": "agent_trajectories",
+          "tableTo": "eval_baselines",
+          "columnsFrom": [
+            "baseline_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "eval_baselines": {
+      "name": "eval_baselines",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ideal_steps": {
+          "name": "ideal_steps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ideal_tool_calls": {
+          "name": "ideal_tool_calls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ideal_latency_ms": {
+          "name": "ideal_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "evaluations": {
+      "name": "evaluations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "evaluated_at": {
+          "name": "evaluated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "evaluations_turn_id_turns_turn_id_fk": {
+          "name": "evaluations_turn_id_turns_turn_id_fk",
+          "tableFrom": "evaluations",
+          "tableTo": "turns",
+          "columnsFrom": [
+            "turn_id"
+          ],
+          "columnsTo": [
+            "turn_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "evaluations_session_id_sessions_session_id_fk": {
+          "name": "evaluations_session_id_sessions_session_id_fk",
+          "tableFrom": "evaluations",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "improvement_actions": {
+      "name": "improvement_actions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "feedback_source": {
+          "name": "feedback_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_type": {
+          "name": "action_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'proposed'"
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cooldown_days": {
+          "name": "cooldown_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 7
+        },
+        "conflict_resolved_by": {
+          "name": "conflict_resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memory_records": {
+      "name": "memory_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent": {
+          "name": "agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sensitivity": {
+          "name": "sensitivity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_ref": {
+          "name": "embedding_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "memory_records_hash_unique": {
+          "name": "memory_records_hash_unique",
+          "columns": [
+            "hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_cwd_unique": {
+          "name": "projects_cwd_unique",
+          "columns": [
+            "cwd"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_feedback": {
+      "name": "session_feedback",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_feedback_session_id_sessions_session_id_fk": {
+          "name": "session_feedback_session_id_sessions_session_id_fk",
+          "tableFrom": "session_feedback",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cwd": {
+          "name": "cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pid": {
+          "name": "pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_source": {
+          "name": "token_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sessions_session_id_unique": {
+          "name": "sessions_session_id_unique",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_project_id_projects_id_fk": {
+          "name": "sessions_project_id_projects_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "turns": {
+      "name": "turns",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_preview": {
+          "name": "input_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_preview": {
+          "name": "output_preview",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_chars": {
+          "name": "input_chars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_chars": {
+          "name": "output_chars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimated_input_tokens": {
+          "name": "estimated_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "estimated_output_tokens": {
+          "name": "estimated_output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "turns_turn_id_unique": {
+          "name": "turns_turn_id_unique",
+          "columns": [
+            "turn_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "turns_session_id_sessions_session_id_fk": {
+          "name": "turns_session_id_sessions_session_id_fk",
+          "tableFrom": "turns",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "session_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/eval-core/drizzle/meta/_journal.json
+++ b/packages/eval-core/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777247148365,
       "tag": "0000_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1777268508357,
+      "tag": "0001_aromatic_gambit",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/eval-core/src/__tests__/memory-records.test.ts
+++ b/packages/eval-core/src/__tests__/memory-records.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Tests for memory_records table (v0.118.3, #1047).
+ * Uses in-memory SQLite for isolation.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { drizzle } from 'drizzle-orm/bun-sqlite';
+import { eq, and } from 'drizzle-orm';
+import * as schema from '../db/schema.js';
+import type { EvalDb } from '../db/client.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(): { db: EvalDb; sqlite: Database } {
+  const sqlite = new Database(':memory:');
+  sqlite.run('PRAGMA foreign_keys = ON');
+  const db = drizzle(sqlite, { schema });
+  sqlite.run(`
+    CREATE TABLE IF NOT EXISTS memory_records (
+      id TEXT PRIMARY KEY NOT NULL,
+      source TEXT NOT NULL,
+      device_id TEXT NOT NULL,
+      project TEXT NOT NULL,
+      agent TEXT,
+      timestamp TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      content TEXT NOT NULL,
+      tags TEXT NOT NULL,
+      sensitivity TEXT NOT NULL,
+      hash TEXT NOT NULL UNIQUE,
+      embedding_ref TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+  sqlite.run('CREATE INDEX IF NOT EXISTS idx_memory_records_source ON memory_records(source)');
+  sqlite.run('CREATE INDEX IF NOT EXISTS idx_memory_records_device_project ON memory_records(device_id, project)');
+  sqlite.run("CREATE INDEX IF NOT EXISTS idx_memory_records_timestamp ON memory_records(timestamp DESC)");
+  return { db, sqlite };
+}
+
+function makeRecord(overrides: Partial<typeof schema.memoryRecords.$inferInsert> = {}) {
+  return {
+    id: crypto.randomUUID(),
+    source: 'native' as const,
+    deviceId: 'macbook-sangyi',
+    project: '/Users/sangyi/workspace/projects/oh-my-customcode',
+    agent: 'sys-memory-keeper',
+    timestamp: new Date().toISOString(),
+    summary: 'Agent discovered bun lockfile must be committed',
+    content: 'Full memory body: bun.lockb must be committed after bun add',
+    tags: JSON.stringify(['feedback', 'bun']),
+    sensitivity: 'project' as const,
+    hash: `sha256-${crypto.randomUUID().replace(/-/g, '')}`,
+    embeddingRef: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Insert valid record
+// ---------------------------------------------------------------------------
+
+describe('memory_records: insert valid record', () => {
+  it('inserts and retrieves a full record via drizzle', () => {
+    const { db } = makeDb();
+    const record = makeRecord();
+    db.insert(schema.memoryRecords).values(record).run();
+
+    const row = db
+      .select()
+      .from(schema.memoryRecords)
+      .where(eq(schema.memoryRecords.id, record.id))
+      .get();
+
+    expect(row).toBeDefined();
+    expect(row?.id).toBe(record.id);
+    expect(row?.source).toBe('native');
+    expect(row?.deviceId).toBe('macbook-sangyi');
+    expect(row?.project).toBe('/Users/sangyi/workspace/projects/oh-my-customcode');
+    expect(row?.agent).toBe('sys-memory-keeper');
+    expect(row?.summary).toBe('Agent discovered bun lockfile must be committed');
+    expect(row?.content).toBe('Full memory body: bun.lockb must be committed after bun add');
+    expect(row?.tags).toBe(JSON.stringify(['feedback', 'bun']));
+    expect(row?.sensitivity).toBe('project');
+    expect(row?.hash).toBe(record.hash);
+    expect(row?.embeddingRef).toBeNull();
+  });
+
+  it('allows null agent (session-wide memory)', () => {
+    const { db } = makeDb();
+    const record = makeRecord({ agent: undefined });
+    db.insert(schema.memoryRecords).values(record).run();
+
+    const row = db
+      .select()
+      .from(schema.memoryRecords)
+      .where(eq(schema.memoryRecords.id, record.id))
+      .get();
+
+    expect(row?.agent).toBeNull();
+  });
+
+  it('allows null embeddingRef', () => {
+    const { db } = makeDb();
+    const record = makeRecord({ embeddingRef: null });
+    db.insert(schema.memoryRecords).values(record).run();
+
+    const row = db
+      .select()
+      .from(schema.memoryRecords)
+      .where(eq(schema.memoryRecords.id, record.id))
+      .get();
+
+    expect(row?.embeddingRef).toBeNull();
+  });
+
+  it('stores embeddingRef when provided', () => {
+    const { db } = makeDb();
+    const record = makeRecord({ embeddingRef: 'chroma://collection/doc-id-abc123' });
+    db.insert(schema.memoryRecords).values(record).run();
+
+    const row = db
+      .select()
+      .from(schema.memoryRecords)
+      .where(eq(schema.memoryRecords.id, record.id))
+      .get();
+
+    expect(row?.embeddingRef).toBe('chroma://collection/doc-id-abc123');
+  });
+
+  it('uses $defaultFn for createdAt and updatedAt when omitted', () => {
+    const { db } = makeDb();
+    const record = makeRecord();
+    const before = new Date().toISOString();
+    db.insert(schema.memoryRecords).values(record).run();
+
+    const row = db
+      .select()
+      .from(schema.memoryRecords)
+      .where(eq(schema.memoryRecords.id, record.id))
+      .get();
+
+    expect(typeof row?.createdAt).toBe('string');
+    expect(typeof row?.updatedAt).toBe('string');
+    expect(row!.createdAt >= before.slice(0, 10)).toBe(true); // date part >=
+  });
+
+  it('accepts all valid source values', () => {
+    const { db } = makeDb();
+    const sources = ['native', 'claude-mem', 'episodic-memory', 'llm-memory'] as const;
+    for (const source of sources) {
+      const record = makeRecord({ source });
+      db.insert(schema.memoryRecords).values(record).run();
+    }
+    const rows = db.select().from(schema.memoryRecords).all();
+    expect(rows).toHaveLength(4);
+    const storedSources = rows.map((r) => r.source).sort();
+    expect(storedSources).toEqual(['claude-mem', 'episodic-memory', 'llm-memory', 'native']);
+  });
+
+  it('accepts all valid sensitivity values', () => {
+    const { db } = makeDb();
+    const sensitivities = ['public', 'project', 'sensitive', 'secret'] as const;
+    for (const sensitivity of sensitivities) {
+      const record = makeRecord({ sensitivity });
+      db.insert(schema.memoryRecords).values(record).run();
+    }
+    const rows = db.select().from(schema.memoryRecords).all();
+    expect(rows).toHaveLength(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reject duplicate hash (UNIQUE constraint)
+// ---------------------------------------------------------------------------
+
+describe('memory_records: UNIQUE hash constraint', () => {
+  it('rejects duplicate hash via drizzle', () => {
+    const { db } = makeDb();
+    const sharedHash = 'sha256-deadbeef000000000000000000000000';
+    const record1 = makeRecord({ hash: sharedHash });
+    const record2 = makeRecord({ hash: sharedHash }); // different id, same hash
+
+    db.insert(schema.memoryRecords).values(record1).run();
+
+    expect(() => {
+      db.insert(schema.memoryRecords).values(record2).run();
+    }).toThrow();
+  });
+
+  it('rejects duplicate hash via raw SQL', () => {
+    const { sqlite } = makeDb();
+    const id1 = crypto.randomUUID();
+    const id2 = crypto.randomUUID();
+    const duplicateHash = 'sha256-aaaa1111bbbb2222cccc3333dddd4444';
+    const ts = new Date().toISOString();
+
+    sqlite.run(
+      `INSERT INTO memory_records (id, source, device_id, project, timestamp, summary, content, tags, sensitivity, hash)
+       VALUES ('${id1}', 'native', 'host1', '/proj', '${ts}', 'summary', 'content', '[]', 'public', '${duplicateHash}')`
+    );
+
+    expect(() => {
+      sqlite.run(
+        `INSERT INTO memory_records (id, source, device_id, project, timestamp, summary, content, tags, sensitivity, hash)
+         VALUES ('${id2}', 'native', 'host2', '/proj', '${ts}', 'summary2', 'content2', '[]', 'public', '${duplicateHash}')`
+      );
+    }).toThrow();
+  });
+
+  it('allows two records with different hashes', () => {
+    const { db } = makeDb();
+    const record1 = makeRecord({ hash: 'sha256-hash1111111111111111111111111111' });
+    const record2 = makeRecord({ hash: 'sha256-hash2222222222222222222222222222' });
+
+    db.insert(schema.memoryRecords).values(record1).run();
+    db.insert(schema.memoryRecords).values(record2).run();
+
+    const rows = db.select().from(schema.memoryRecords).all();
+    expect(rows).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query by source filter
+// ---------------------------------------------------------------------------
+
+describe('memory_records: query by source', () => {
+  it('returns only records matching a single source', () => {
+    const { db } = makeDb();
+    db.insert(schema.memoryRecords)
+      .values([
+        makeRecord({ source: 'native' }),
+        makeRecord({ source: 'native' }),
+        makeRecord({ source: 'claude-mem' }),
+        makeRecord({ source: 'episodic-memory' }),
+      ])
+      .run();
+
+    const nativeRows = db
+      .select()
+      .from(schema.memoryRecords)
+      .where(eq(schema.memoryRecords.source, 'native'))
+      .all();
+
+    expect(nativeRows).toHaveLength(2);
+    expect(nativeRows.every((r) => r.source === 'native')).toBe(true);
+  });
+
+  it('returns empty array when no records match source', () => {
+    const { db } = makeDb();
+    db.insert(schema.memoryRecords)
+      .values([makeRecord({ source: 'native' })])
+      .run();
+
+    const rows = db
+      .select()
+      .from(schema.memoryRecords)
+      .where(eq(schema.memoryRecords.source, 'llm-memory'))
+      .all();
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('filters episodic-memory records from mixed dataset', () => {
+    const { db } = makeDb();
+    db.insert(schema.memoryRecords)
+      .values([
+        makeRecord({ source: 'native' }),
+        makeRecord({ source: 'episodic-memory' }),
+        makeRecord({ source: 'episodic-memory' }),
+        makeRecord({ source: 'claude-mem' }),
+      ])
+      .run();
+
+    const rows = db
+      .select()
+      .from(schema.memoryRecords)
+      .where(eq(schema.memoryRecords.source, 'episodic-memory'))
+      .all();
+
+    expect(rows).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Query by device_id + project composite
+// ---------------------------------------------------------------------------
+
+describe('memory_records: query by device_id + project composite', () => {
+  it('returns only records matching both device_id and project', () => {
+    const { db } = makeDb();
+    const targetDevice = 'macbook-sangyi';
+    const targetProject = '/Users/sangyi/workspace/projects/oh-my-customcode';
+
+    db.insert(schema.memoryRecords)
+      .values([
+        makeRecord({ deviceId: targetDevice, project: targetProject }),
+        makeRecord({ deviceId: targetDevice, project: targetProject }),
+        makeRecord({ deviceId: targetDevice, project: '/other/project' }),
+        makeRecord({ deviceId: 'other-device', project: targetProject }),
+        makeRecord({ deviceId: 'other-device', project: '/other/project' }),
+      ])
+      .run();
+
+    const rows = db
+      .select()
+      .from(schema.memoryRecords)
+      .where(
+        and(
+          eq(schema.memoryRecords.deviceId, targetDevice),
+          eq(schema.memoryRecords.project, targetProject)
+        )
+      )
+      .all();
+
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.deviceId === targetDevice && r.project === targetProject)).toBe(true);
+  });
+
+  it('returns empty when device_id matches but project does not', () => {
+    const { db } = makeDb();
+    db.insert(schema.memoryRecords)
+      .values([makeRecord({ deviceId: 'device-a', project: '/proj-a' })])
+      .run();
+
+    const rows = db
+      .select()
+      .from(schema.memoryRecords)
+      .where(
+        and(
+          eq(schema.memoryRecords.deviceId, 'device-a'),
+          eq(schema.memoryRecords.project, '/proj-b')
+        )
+      )
+      .all();
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('returns empty when project matches but device_id does not', () => {
+    const { db } = makeDb();
+    db.insert(schema.memoryRecords)
+      .values([makeRecord({ deviceId: 'device-x', project: '/shared-proj' })])
+      .run();
+
+    const rows = db
+      .select()
+      .from(schema.memoryRecords)
+      .where(
+        and(
+          eq(schema.memoryRecords.deviceId, 'device-y'),
+          eq(schema.memoryRecords.project, '/shared-proj')
+        )
+      )
+      .all();
+
+    expect(rows).toHaveLength(0);
+  });
+
+  it('correctly isolates records across multiple device+project combinations', () => {
+    const { db } = makeDb();
+    const combinations = [
+      { deviceId: 'dev-1', project: '/proj-a' },
+      { deviceId: 'dev-1', project: '/proj-b' },
+      { deviceId: 'dev-2', project: '/proj-a' },
+      { deviceId: 'dev-2', project: '/proj-b' },
+    ];
+
+    for (const combo of combinations) {
+      db.insert(schema.memoryRecords).values(makeRecord(combo)).run();
+    }
+
+    for (const combo of combinations) {
+      const rows = db
+        .select()
+        .from(schema.memoryRecords)
+        .where(
+          and(
+            eq(schema.memoryRecords.deviceId, combo.deviceId),
+            eq(schema.memoryRecords.project, combo.project)
+          )
+        )
+        .all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.deviceId).toBe(combo.deviceId);
+      expect(rows[0]?.project).toBe(combo.project);
+    }
+  });
+});

--- a/packages/eval-core/src/__tests__/schema-query.test.ts
+++ b/packages/eval-core/src/__tests__/schema-query.test.ts
@@ -255,6 +255,7 @@ describe('runMigrations', () => {
     expect(names).toContain('session_feedback');
     expect(names).toContain('eval_baselines');
     expect(names).toContain('agent_trajectories');
+    expect(names).toContain('memory_records');
     db.close();
   });
 
@@ -286,6 +287,9 @@ describe('runMigrations', () => {
     expect(indexNames).toContain('idx_eval_baselines_capability');
     expect(indexNames).toContain('idx_agent_trajectories_baseline_id');
     expect(indexNames).toContain('idx_agent_trajectories_agent_name');
+    expect(indexNames).toContain('idx_memory_records_source');
+    expect(indexNames).toContain('idx_memory_records_device_project');
+    expect(indexNames).toContain('idx_memory_records_timestamp');
     db.close();
   });
 

--- a/packages/eval-core/src/db/migrate.ts
+++ b/packages/eval-core/src/db/migrate.ts
@@ -118,6 +118,27 @@ function runMigrationsOnDb(db: InstanceType<typeof Database>): void {
     'CREATE INDEX IF NOT EXISTS idx_feedback_session_id ON session_feedback(session_id)',
     'CREATE INDEX IF NOT EXISTS idx_improvement_actions_target ON improvement_actions(target_name)',
     'CREATE INDEX IF NOT EXISTS idx_improvement_actions_status ON improvement_actions(status)',
+    // v0.118.3, #1047 — unified memory records
+    `CREATE TABLE IF NOT EXISTS memory_records (
+      id TEXT PRIMARY KEY NOT NULL,
+      source TEXT NOT NULL,
+      device_id TEXT NOT NULL,
+      project TEXT NOT NULL,
+      agent TEXT,
+      timestamp TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      content TEXT NOT NULL,
+      tags TEXT NOT NULL,
+      sensitivity TEXT NOT NULL,
+      hash TEXT NOT NULL UNIQUE,
+      embedding_ref TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )`,
+    'CREATE INDEX IF NOT EXISTS idx_memory_records_source ON memory_records(source)',
+    'CREATE INDEX IF NOT EXISTS idx_memory_records_device_project ON memory_records(device_id, project)',
+    'CREATE INDEX IF NOT EXISTS idx_memory_records_timestamp ON memory_records(timestamp DESC)',
+    // idx_memory_records_hash is covered by the UNIQUE constraint on hash column
     // v0.116.0, #1036 — eval baselines and trajectories
     `CREATE TABLE IF NOT EXISTS eval_baselines (
       id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/packages/eval-core/src/db/schema.ts
+++ b/packages/eval-core/src/db/schema.ts
@@ -111,6 +111,28 @@ export const sessionFeedback = sqliteTable('session_feedback', {
     .$defaultFn(() => new Date().toISOString()),
 });
 
+// added v0.118.3, #1047 — unified memory records across all four sources
+export const memoryRecords = sqliteTable('memory_records', {
+  id: text('id').primaryKey(), // UUID
+  source: text('source').notNull(), // 'native' | 'claude-mem' | 'episodic-memory' | 'llm-memory'
+  deviceId: text('device_id').notNull(), // hostname
+  project: text('project').notNull(), // workspace path
+  agent: text('agent'), // nullable
+  timestamp: text('timestamp').notNull(), // ISO8601
+  summary: text('summary').notNull(), // 1-2 sentence
+  content: text('content').notNull(), // full body
+  tags: text('tags').notNull(), // JSON array stringified
+  sensitivity: text('sensitivity').notNull(), // 'public' | 'project' | 'sensitive' | 'secret'
+  hash: text('hash').notNull().unique(), // SHA-256
+  embeddingRef: text('embedding_ref'), // nullable
+  createdAt: text('created_at')
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
+  updatedAt: text('updated_at')
+    .notNull()
+    .$defaultFn(() => new Date().toISOString()),
+});
+
 // added v0.116.0, #1036 — ideal trajectory annotations (baseline)
 export const evalBaselines = sqliteTable('eval_baselines', {
   id: integer('id').primaryKey({ autoIncrement: true }),

--- a/templates/.claude/skills/monitoring-setup/SKILL.md
+++ b/templates/.claude/skills/monitoring-setup/SKILL.md
@@ -213,3 +213,102 @@ claude-inspector
 ```
 
 Claude Inspector is external to oh-my-customcode and does not require any project configuration changes.
+
+## Agent Trajectory Export Mode
+
+Toggle: `/monitoring-setup trajectory-otel on|off`
+
+When enabled, agent-eval-framework 4-metric data is emitted as OpenTelemetry spans for external analysis.
+
+### trajectory-otel on
+
+1. Read `.claude/settings.local.json` (create if not exists)
+2. Add or update `env` field with trajectory export configuration:
+   ```json
+   {
+     "env": {
+       "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+       "OTEL_METRICS_EXPORTER": "console",
+       "OTEL_LOGS_EXPORTER": "console",
+       "CLAUDE_TRAJECTORY_OTEL": "1"
+     }
+   }
+   ```
+3. If `OTEL_EXPORTER_OTLP_ENDPOINT` is set in the environment, also add:
+   ```json
+   {
+     "env": {
+       "OTEL_TRACES_EXPORTER": "otlp"
+     }
+   }
+   ```
+   Otherwise default to `"OTEL_TRACES_EXPORTER": "console"`.
+4. Preserve all existing settings
+5. Report:
+   ```
+   [Done] Agent Trajectory Export enabled
+
+   Configured in: .claude/settings.local.json
+   Span exporter: console (default) | otlp (if OTEL_EXPORTER_OTLP_ENDPOINT set)
+   Metrics: correctness, step_ratio, tool_call_ratio, latency_ratio
+   Events: tool_call (tool_name, duration_ms, exit_code)
+
+   Note: Takes effect on next `claude` session restart.
+   To disable: /monitoring-setup trajectory-otel off
+   ```
+
+### trajectory-otel off
+
+1. Read `.claude/settings.local.json`
+2. Remove trajectory-related keys from `env`:
+   - `CLAUDE_TRAJECTORY_OTEL`
+   - `OTEL_TRACES_EXPORTER`
+3. Report:
+   ```
+   [Done] Agent Trajectory Export disabled
+
+   Removed from: .claude/settings.local.json
+   Takes effect on next session restart.
+   ```
+
+### Span Schema
+
+```
+operation: agent.invocation
+attributes:
+  agent.type: string          // e.g. "lang-golang-expert"
+  agent.model: string         // e.g. "claude-sonnet-4-6"
+  task.id: string             // eval task identifier
+  task.capability: string     // research | implement | review | debug | manage
+  metric.correctness: bool
+  metric.step_ratio: float
+  metric.tool_call_ratio: float
+  metric.latency_ratio: float
+events:
+  - tool_call
+      attrs: tool_name (string), duration_ms (int), exit_code (int)
+duration: total wall clock time of agent invocation
+```
+
+### Activation Notes
+
+- Independent from the existing console monitoring mode (`enable`/`disable`). Both can be active simultaneously.
+- `trajectory-otel on` does NOT implicitly call `enable` — console metrics monitoring remains a separate toggle.
+- Console exporter (default): prints span JSON to stdout for local dev / debugging.
+- OTLP exporter (optional): activated when `OTEL_EXPORTER_OTLP_ENDPOINT` env var is set. Compatible with Grafana, Datadog, Honeycomb, and any OTLP-compliant collector. No LangSmith dependency.
+- Actual OTEL SDK emission is handled by the Claude Code telemetry layer. This skill configures the env vars that activate the trajectory span pipeline.
+
+### status (extended)
+
+When `trajectory-otel` is active, `status` command output includes:
+
+```
+[Monitoring Status]
+├── Enabled: Yes/No
+├── Metrics exporter: console / otlp / none
+├── Logs exporter: console / otlp / none
+├── Trajectory export: Yes/No
+├── Traces exporter: console / otlp / none
+└── Config: .claude/settings.local.json
+```
+

--- a/templates/guides/agent-eval/README.md
+++ b/templates/guides/agent-eval/README.md
@@ -652,7 +652,47 @@ find .claude/outputs/eval -name "result.yaml" | \
 
 **한계**: 집계가 수동이며, LangSmith Insights의 시계열 추이나 분포 시각화는 제공하지 않는다.
 
-**향후 보강**: monitoring-setup 가이드의 OTEL 통합이 완성되면 step trace를 OTEL span으로 내보내고 Grafana에서 시각화하는 경로가 열린다. 별도 followup 이슈로 추적 권장.
+**향후 보강**: monitoring-setup의 `trajectory-otel` 모드(#1035)로 step trace를 OTEL span으로 내보내고 Grafana에서 시각화하는 경로가 열린다.
+
+### 5.5 OpenTelemetry Trajectory Export (#1035)
+
+`monitoring-setup` 스킬의 `trajectory-otel` 모드를 활성화하면 agent-eval-framework가 측정한 4-metric 데이터를 OTEL span/event로 내보낸다.
+
+**활성화**: `/monitoring-setup trajectory-otel on`
+**비활성화**: `/monitoring-setup trajectory-otel off`
+
+#### Span 구조
+
+```
+operation: agent.invocation
+attributes:
+  agent.type, agent.model, task.id, task.capability
+  metric.correctness, metric.step_ratio, metric.tool_call_ratio, metric.latency_ratio
+events:
+  tool_call (tool_name, duration_ms, exit_code)
+```
+
+#### 내보내기 옵션
+
+| 옵션 | 조건 | 대상 |
+|------|------|------|
+| Console exporter | 기본 (항상) | stdout — 로컬 디버깅 |
+| OTLP exporter | `OTEL_EXPORTER_OTLP_ENDPOINT` 환경변수 설정 시 | Grafana / Datadog / Honeycomb 등 |
+
+#### 장점
+
+- **표준 OTEL 생태계**: LangSmith 의존 없음. 모든 OTLP 호환 collector에 연결 가능.
+- **다른 LLM 시스템과 비교**: 동일 OTEL 인프라를 사용하는 시스템(예: LangChain) 메트릭과 직접 비교 가능.
+- **기존 모니터링과 독립**: `enable`/`disable` 콘솔 모니터링과 별도 토글. 동시 활성화 가능.
+
+#### 대안 매핑 테이블 업데이트
+
+| LangChain 컴포넌트 | 역할 | oh-my-customcode 대안 |
+|--------------------|------|----------------------|
+| LangSmith trace | step별 실행 기록 수집 | claude-mem `save_memory` per step (5.2) |
+| Polly (record/replay) | 결정론적 재현 | episodic-memory 검색 (5.3) |
+| Insights dashboard | 집계 메트릭 시각화 | statusline.sh + omcustom-improve-report (5.4) |
+| **LangSmith OTEL export** | **표준 OTEL span 수집** | **trajectory-otel mode (5.5, #1035)** |
 
 ---
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.118.3",
+  "version": "0.119.0",
   "lastUpdated": "2026-04-24T07:30:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## 요약

minor release: 외부 OTEL 통합 옵션 + #1047 epic 코드 트랙 시작.

## #1035 OTEL trajectory mode

monitoring-setup 스킬에 `trajectory-otel on|off` 토글 추가. agent-eval-framework 4-metric을 OTEL span으로 export. Console + OTLP exporter 지원 → Grafana/Datadog/Honeycomb 호환.

## #1069 memory_records table (#1047 epic sub #2)

#1065 schema 명세 기반 drizzle 테이블 추가:
- 14 컬럼 (UUID PK, source enum, deviceId, project, timestamp, content, tags, sensitivity, hash UNIQUE, embedding_ref, ...)
- 4 indexes (source, device+project, timestamp, hash UNIQUE)
- Additive migration (0001_aromatic_gambit.sql)
- 17 tests pass (insert/dedup/query)
- eval-core: 9 → 10 tables

## 검증

- bun run lint / build PASS
- 1740 tests pass (1723 기존 + 17 신규)
- Coverage: Function 98.42%, Line 98.11% (threshold 98% 통과)
- verify-template-sync, verify-wiki-sync PASS

## Closes
- #1035 OTEL agent trajectory tracing
- #1069 drizzle memory_records 테이블

## Related
- #1047 epic — adapters #3-#6 (#1070-#1072) 다음 트랙

🤖 Generated with [Claude Code](https://claude.com/claude-code)