### PR TITLE
release: v0.121.0 — memory aggregation + dedup layer (#1073)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.120.0",
+  "version": "0.121.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/packages/eval-core/src/__tests__/memory-aggregator.test.ts
+++ b/packages/eval-core/src/__tests__/memory-aggregator.test.ts
@@ -1,0 +1,455 @@
+/**
+ * Tests for memory-aggregator.ts (#1073 — aggregation+dedup).
+ *
+ * Covers:
+ *  - No overlap: all records pass through
+ *  - Hash overlap: newest wins (default policy)
+ *  - 'oldest' conflict policy
+ *  - 'priority' conflict policy with custom order
+ *  - Secret-tier auto-rejection
+ *  - Sensitivity escalation on merge
+ *  - Tag union
+ *  - Empty input arrays
+ *  - Stats accuracy
+ *  - Agent null-preference: prefer non-null agent on merge
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  aggregateMemoryRecords,
+  escalateSensitivity,
+  mergeTags,
+  type MemoryRecord,
+} from '../memory-aggregator.js';
+import type { SensitivityTier } from '../adapters/sensitivity.js';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+let _seq = 0;
+function makeRecord(overrides: Partial<MemoryRecord> = {}): MemoryRecord {
+  const n = ++_seq;
+  return {
+    id: `id-${n}`,
+    source: 'native',
+    device_id: 'host',
+    project: '/proj',
+    agent: `agent-${n}`,
+    timestamp: `2026-04-01T00:00:0${n % 10}.000Z`,
+    summary: `Summary ${n}`,
+    content: `Content ${n}`,
+    tags: [`tag-${n}`],
+    sensitivity: 'project',
+    hash: `hash-${n}`,
+    embedding_ref: undefined,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Unit: escalateSensitivity
+// ---------------------------------------------------------------------------
+
+describe('escalateSensitivity', () => {
+  it('returns the single tier when given one element', () => {
+    expect(escalateSensitivity(['public'])).toBe('public');
+    expect(escalateSensitivity(['sensitive'])).toBe('sensitive');
+  });
+
+  it('escalates public + project → project', () => {
+    expect(escalateSensitivity(['public', 'project'])).toBe('project');
+  });
+
+  it('escalates project + sensitive → sensitive', () => {
+    expect(escalateSensitivity(['project', 'sensitive'])).toBe('sensitive');
+  });
+
+  it('escalates sensitive + secret → secret', () => {
+    expect(escalateSensitivity(['sensitive', 'secret'])).toBe('secret');
+  });
+
+  it('escalates mixed list to strictest tier', () => {
+    expect(escalateSensitivity(['public', 'project', 'sensitive', 'secret'])).toBe('secret');
+  });
+
+  it('returns "project" for an empty array (safe default)', () => {
+    expect(escalateSensitivity([])).toBe('project');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit: mergeTags
+// ---------------------------------------------------------------------------
+
+describe('mergeTags', () => {
+  it('returns union of two disjoint tag arrays, sorted', () => {
+    expect(mergeTags(['a', 'b'], ['c', 'd'])).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('deduplicates overlapping tags', () => {
+    expect(mergeTags(['a', 'b'], ['b', 'c'])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('handles empty first array', () => {
+    expect(mergeTags([], ['x', 'y'])).toEqual(['x', 'y']);
+  });
+
+  it('handles empty second array', () => {
+    expect(mergeTags(['x', 'y'], [])).toEqual(['x', 'y']);
+  });
+
+  it('handles both arrays empty', () => {
+    expect(mergeTags([], [])).toEqual([]);
+  });
+
+  it('returns sorted output', () => {
+    expect(mergeTags(['z', 'a'], ['m', 'b'])).toEqual(['a', 'b', 'm', 'z']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateMemoryRecords — no overlap
+// ---------------------------------------------------------------------------
+
+describe('aggregateMemoryRecords: no overlap', () => {
+  it('passes all records through when no hashes clash (2 adapters)', () => {
+    const r1 = makeRecord({ hash: 'h1' });
+    const r2 = makeRecord({ hash: 'h2', source: 'claude-mem' });
+    const r3 = makeRecord({ hash: 'h3', source: 'episodic-memory' });
+
+    const result = aggregateMemoryRecords({ records: [[r1, r2], [r3]] });
+
+    expect(result.records).toHaveLength(3);
+    expect(result.stats.inputTotal).toBe(3);
+    expect(result.stats.deduped).toBe(0);
+    expect(result.stats.rejected).toBe(0);
+  });
+
+  it('handles single adapter with multiple records', () => {
+    const records = [makeRecord({ hash: 'a1' }), makeRecord({ hash: 'a2' })];
+    const result = aggregateMemoryRecords({ records: [records] });
+
+    expect(result.records).toHaveLength(2);
+    expect(result.stats.deduped).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateMemoryRecords — dedup (newest policy)
+// ---------------------------------------------------------------------------
+
+describe('aggregateMemoryRecords: dedup with "newest" policy', () => {
+  it('collapses 1 hash clash across 2 adapters, newest timestamp wins', () => {
+    const older = makeRecord({
+      hash: 'shared',
+      timestamp: '2026-04-01T10:00:00.000Z',
+      summary: 'older summary',
+    });
+    const newer = makeRecord({
+      hash: 'shared',
+      source: 'claude-mem',
+      timestamp: '2026-04-02T10:00:00.000Z',
+      summary: 'newer summary',
+    });
+
+    const result = aggregateMemoryRecords({ records: [[older], [newer]] });
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].summary).toBe('newer summary');
+    expect(result.stats.inputTotal).toBe(2);
+    expect(result.stats.deduped).toBe(1);
+    expect(result.stats.rejected).toBe(0);
+  });
+
+  it('newest is the default conflict policy', () => {
+    const r1 = makeRecord({ hash: 'x', timestamp: '2026-01-01T00:00:00.000Z', content: 'old' });
+    const r2 = makeRecord({ hash: 'x', timestamp: '2026-03-01T00:00:00.000Z', content: 'new' });
+
+    const result = aggregateMemoryRecords({ records: [[r1, r2]] });
+    expect(result.records[0].content).toBe('new');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateMemoryRecords — 'oldest' policy
+// ---------------------------------------------------------------------------
+
+describe('aggregateMemoryRecords: "oldest" conflict policy', () => {
+  it('keeps record with earliest timestamp on hash collision', () => {
+    const r1 = makeRecord({
+      hash: 'dup',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      content: 'earliest',
+    });
+    const r2 = makeRecord({
+      hash: 'dup',
+      source: 'claude-mem',
+      timestamp: '2026-06-01T00:00:00.000Z',
+      content: 'latest',
+    });
+
+    const result = aggregateMemoryRecords({
+      records: [[r1], [r2]],
+      conflictPolicy: 'oldest',
+    });
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].content).toBe('earliest');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateMemoryRecords — 'priority' policy
+// ---------------------------------------------------------------------------
+
+describe('aggregateMemoryRecords: "priority" conflict policy', () => {
+  it('prefers higher-priority source on hash collision', () => {
+    const nativeRecord = makeRecord({
+      hash: 'dup',
+      source: 'native',
+      content: 'from native',
+    });
+    const claudeMemRecord = makeRecord({
+      hash: 'dup',
+      source: 'claude-mem',
+      content: 'from claude-mem',
+    });
+
+    // native has higher priority than claude-mem (default order)
+    const result = aggregateMemoryRecords({
+      records: [[claudeMemRecord], [nativeRecord]],
+      conflictPolicy: 'priority',
+    });
+
+    expect(result.records[0].content).toBe('from native');
+  });
+
+  it('respects custom sourcePriority order', () => {
+    const episodicRecord = makeRecord({
+      hash: 'dup',
+      source: 'episodic-memory',
+      content: 'from episodic',
+    });
+    const nativeRecord = makeRecord({
+      hash: 'dup',
+      source: 'native',
+      content: 'from native',
+    });
+
+    // Flip order: episodic-memory wins
+    const result = aggregateMemoryRecords({
+      records: [[nativeRecord], [episodicRecord]],
+      conflictPolicy: 'priority',
+      sourcePriority: ['episodic-memory', 'native', 'claude-mem', 'llm-memory'],
+    });
+
+    expect(result.records[0].content).toBe('from episodic');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateMemoryRecords — secret-tier rejection
+// ---------------------------------------------------------------------------
+
+describe('aggregateMemoryRecords: secret-tier auto-rejection', () => {
+  it('rejects records with sensitivity === "secret"', () => {
+    const safe = makeRecord({ hash: 'safe', sensitivity: 'project' });
+    const secretRecord = makeRecord({ hash: 'secret-hash', sensitivity: 'secret' });
+
+    const result = aggregateMemoryRecords({ records: [[safe, secretRecord]] });
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].hash).toBe('safe');
+    expect(result.stats.rejected).toBe(1);
+    expect(result.stats.inputTotal).toBe(2);
+  });
+
+  it('rejects all secret records leaving empty output', () => {
+    const r1 = makeRecord({ hash: 'h1', sensitivity: 'secret' });
+    const r2 = makeRecord({ hash: 'h2', sensitivity: 'secret' });
+
+    const result = aggregateMemoryRecords({ records: [[r1], [r2]] });
+
+    expect(result.records).toHaveLength(0);
+    expect(result.stats.rejected).toBe(2);
+    expect(result.stats.deduped).toBe(0);
+  });
+
+  it('does not reject project, sensitive, or public tiers', () => {
+    const tiers: SensitivityTier[] = ['public', 'project', 'sensitive'];
+    const records = tiers.map((sensitivity, i) =>
+      makeRecord({ hash: `h-${i}`, sensitivity })
+    );
+
+    const result = aggregateMemoryRecords({ records: [records] });
+
+    expect(result.records).toHaveLength(3);
+    expect(result.stats.rejected).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateMemoryRecords — sensitivity escalation on merge
+// ---------------------------------------------------------------------------
+
+describe('aggregateMemoryRecords: sensitivity escalation', () => {
+  it('escalates project + sensitive → sensitive on hash collision', () => {
+    const r1 = makeRecord({ hash: 'dup', sensitivity: 'project', source: 'native' });
+    const r2 = makeRecord({ hash: 'dup', sensitivity: 'sensitive', source: 'claude-mem' });
+
+    const result = aggregateMemoryRecords({ records: [[r1], [r2]] });
+
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].sensitivity).toBe('sensitive');
+  });
+
+  it('escalates public + project → project', () => {
+    const r1 = makeRecord({ hash: 'dup', sensitivity: 'public', source: 'native' });
+    const r2 = makeRecord({ hash: 'dup', sensitivity: 'project', source: 'claude-mem' });
+
+    const result = aggregateMemoryRecords({ records: [[r1], [r2]] });
+
+    expect(result.records[0].sensitivity).toBe('project');
+  });
+
+  it('preserves sensitivity for non-colliding records', () => {
+    const r1 = makeRecord({ hash: 'h1', sensitivity: 'public' });
+    const r2 = makeRecord({ hash: 'h2', sensitivity: 'sensitive' });
+
+    const result = aggregateMemoryRecords({ records: [[r1, r2]] });
+
+    const sensitivities = result.records.map((r) => r.sensitivity).sort();
+    expect(sensitivities).toEqual(['public', 'sensitive']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateMemoryRecords — tag union
+// ---------------------------------------------------------------------------
+
+describe('aggregateMemoryRecords: tag union', () => {
+  it('unions tags from colliding records', () => {
+    const r1 = makeRecord({ hash: 'dup', tags: ['a', 'b'] });
+    const r2 = makeRecord({ hash: 'dup', source: 'claude-mem', tags: ['b', 'c'] });
+
+    const result = aggregateMemoryRecords({ records: [[r1], [r2]] });
+
+    expect(result.records[0].tags).toEqual(['a', 'b', 'c']);
+  });
+
+  it('preserves tags for non-colliding records independently', () => {
+    const r1 = makeRecord({ hash: 'h1', tags: ['x'] });
+    const r2 = makeRecord({ hash: 'h2', tags: ['y'] });
+
+    const result = aggregateMemoryRecords({ records: [[r1, r2]] });
+
+    const tagSets = result.records.map((r) => r.tags).sort();
+    expect(tagSets).toEqual([['x'], ['y']]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateMemoryRecords — agent null-preference
+// ---------------------------------------------------------------------------
+
+describe('aggregateMemoryRecords: agent field handling', () => {
+  it('prefers non-null agent over null on merge', () => {
+    const withAgent = makeRecord({ hash: 'dup', agent: 'sys-memory-keeper' });
+    const withoutAgent = makeRecord({ hash: 'dup', source: 'claude-mem', agent: undefined });
+
+    const result = aggregateMemoryRecords({ records: [[withoutAgent], [withAgent]] });
+
+    expect(result.records[0].agent).toBe('sys-memory-keeper');
+  });
+
+  it('keeps null agent when all group members have null agent', () => {
+    const r1 = makeRecord({ hash: 'dup', agent: undefined });
+    const r2 = makeRecord({ hash: 'dup', source: 'claude-mem', agent: undefined });
+
+    const result = aggregateMemoryRecords({ records: [[r1], [r2]] });
+
+    expect(result.records[0].agent).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateMemoryRecords — empty inputs
+// ---------------------------------------------------------------------------
+
+describe('aggregateMemoryRecords: empty inputs', () => {
+  it('returns empty output for empty records array', () => {
+    const result = aggregateMemoryRecords({ records: [] });
+
+    expect(result.records).toHaveLength(0);
+    expect(result.stats.inputTotal).toBe(0);
+    expect(result.stats.deduped).toBe(0);
+    expect(result.stats.rejected).toBe(0);
+    expect(result.stats.bySource).toEqual({});
+  });
+
+  it('returns empty output when all adapter arrays are empty', () => {
+    const result = aggregateMemoryRecords({ records: [[], [], []] });
+
+    expect(result.records).toHaveLength(0);
+    expect(result.stats.inputTotal).toBe(0);
+  });
+
+  it('handles a mix of empty and non-empty adapter arrays', () => {
+    const r1 = makeRecord({ hash: 'only' });
+    const result = aggregateMemoryRecords({ records: [[], [r1], []] });
+
+    expect(result.records).toHaveLength(1);
+    expect(result.stats.inputTotal).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// aggregateMemoryRecords — stats accuracy
+// ---------------------------------------------------------------------------
+
+describe('aggregateMemoryRecords: stats accuracy', () => {
+  it('counts bySource correctly across mixed sources', () => {
+    const records = [
+      makeRecord({ hash: 'n1', source: 'native' }),
+      makeRecord({ hash: 'n2', source: 'native' }),
+      makeRecord({ hash: 'c1', source: 'claude-mem' }),
+      makeRecord({ hash: 'e1', source: 'episodic-memory' }),
+    ];
+
+    const result = aggregateMemoryRecords({ records: [records] });
+
+    expect(result.stats.bySource['native']).toBe(2);
+    expect(result.stats.bySource['claude-mem']).toBe(1);
+    expect(result.stats.bySource['episodic-memory']).toBe(1);
+    expect(result.stats.bySource['llm-memory']).toBeUndefined();
+  });
+
+  it('deduped count equals inputTotal minus output count (after rejection excluded)', () => {
+    // 3 records total, 1 secret (rejected), 2 surviving but 1 dup pair → 1 output
+    const r1 = makeRecord({ hash: 'dup', source: 'native', sensitivity: 'project' });
+    const r2 = makeRecord({ hash: 'dup', source: 'claude-mem', sensitivity: 'project' });
+    const r3 = makeRecord({ hash: 'unique', sensitivity: 'secret' });
+
+    const result = aggregateMemoryRecords({ records: [[r1, r2, r3]] });
+
+    // r3 rejected. r1+r2 deduped to 1.
+    expect(result.stats.inputTotal).toBe(3);
+    expect(result.stats.rejected).toBe(1);
+    expect(result.stats.deduped).toBe(1);
+    expect(result.records).toHaveLength(1);
+  });
+
+  it('reports zero deduped when all hashes unique', () => {
+    const records = [
+      makeRecord({ hash: 'u1' }),
+      makeRecord({ hash: 'u2' }),
+      makeRecord({ hash: 'u3' }),
+    ];
+
+    const result = aggregateMemoryRecords({ records: [records] });
+
+    expect(result.stats.deduped).toBe(0);
+    expect(result.records).toHaveLength(3);
+  });
+});

--- a/packages/eval-core/src/memory-aggregator.ts
+++ b/packages/eval-core/src/memory-aggregator.ts
@@ -1,0 +1,206 @@
+/**
+ * Memory record aggregation and deduplication across multiple adapters.
+ *
+ * Aggregates MemoryRecord arrays from any combination of adapters
+ * (claude-mem, episodic-memory, native, llm-memory) and deduplicates
+ * by the SHA-256 `hash` field. On conflict, the strictest sensitivity
+ * tier wins and tags are unioned.
+ *
+ * Spec: #1047 (Unified Memory System), sub-issue #1073 (aggregation+dedup).
+ *
+ * NOTE: This module is pure (no I/O, no DB). Persistence is a separate concern.
+ */
+
+import type { MemoryRecord } from './adapters/claude-mem.js';
+import { type SensitivityTier } from './adapters/sensitivity.js';
+
+// Re-export MemoryRecord so callers can import from one place.
+export type { MemoryRecord };
+
+// ---------------------------------------------------------------------------
+// Sensitivity tier ordering (lowest → strictest)
+// ---------------------------------------------------------------------------
+
+const SENSITIVITY_ORDER: readonly SensitivityTier[] = ['public', 'project', 'sensitive', 'secret'];
+
+/**
+ * Returns the stricter of two sensitivity tiers.
+ *
+ * @example escalateSensitivity(['project', 'sensitive']) → 'sensitive'
+ */
+export function escalateSensitivity(tiers: SensitivityTier[]): SensitivityTier {
+  if (tiers.length === 0) {
+    return 'project'; // safe default
+  }
+  return tiers.reduce((max, tier) => {
+    return SENSITIVITY_ORDER.indexOf(tier) > SENSITIVITY_ORDER.indexOf(max) ? tier : max;
+  });
+}
+
+/**
+ * Produces a sorted, deduplicated union of two tag arrays.
+ *
+ * @example mergeTags(['a', 'b'], ['b', 'c']) → ['a', 'b', 'c']
+ */
+export function mergeTags(tags1: string[], tags2: string[]): string[] {
+  return [...new Set([...tags1, ...tags2])].sort();
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface AggregateOptions {
+  /** One array per adapter — each inner array is the full output of one adapter. */
+  records: MemoryRecord[][];
+  /**
+   * How to resolve hash collisions (which record becomes the canonical one).
+   * - 'newest'   (default) — keep the record with the latest `timestamp`
+   * - 'oldest'   — keep the record with the earliest `timestamp`
+   * - 'priority' — prefer sources earlier in `sourcePriority`
+   */
+  conflictPolicy?: 'newest' | 'oldest' | 'priority';
+  /**
+   * Source preference order for the 'priority' conflict policy.
+   * Default: ['native', 'claude-mem', 'episodic-memory', 'llm-memory']
+   */
+  sourcePriority?: ('native' | 'claude-mem' | 'episodic-memory' | 'llm-memory')[];
+}
+
+export interface AggregateResult {
+  records: MemoryRecord[];
+  stats: {
+    /** Sum of all input records before any filtering. */
+    inputTotal: number;
+    /** Number of duplicate hashes that were collapsed. */
+    deduped: number;
+    /** Records auto-rejected because their sensitivity === 'secret'. */
+    rejected: number;
+    /** Count of output records broken down by source. */
+    bySource: Record<string, number>;
+  };
+}
+
+/**
+ * Aggregates MemoryRecord arrays from multiple adapters.
+ *
+ * Steps:
+ *  1. Flatten all input records.
+ *  2. Auto-reject records with sensitivity === 'secret'.
+ *  3. Group by `hash`.
+ *  4. Resolve conflicts within each group using `conflictPolicy`.
+ *  5. Escalate sensitivity to the strictest tier present in the group.
+ *  6. Union tags across all group members.
+ *  7. Prefer non-null `agent` from any group member.
+ *  8. Return aggregated records + stats.
+ */
+export function aggregateMemoryRecords(opts: AggregateOptions): AggregateResult {
+  const {
+    records: adapterResults,
+    conflictPolicy = 'newest',
+    sourcePriority = ['native', 'claude-mem', 'episodic-memory', 'llm-memory'],
+  } = opts;
+
+  // 1. Flatten
+  const flat = adapterResults.flat();
+  const inputTotal = flat.length;
+
+  // 2. Reject secret-tier records
+  let rejected = 0;
+  const allowed: MemoryRecord[] = [];
+  for (const record of flat) {
+    if (record.sensitivity === 'secret') {
+      rejected++;
+    } else {
+      allowed.push(record);
+    }
+  }
+
+  // 3. Group by hash
+  const groups = new Map<string, MemoryRecord[]>();
+  for (const record of allowed) {
+    const group = groups.get(record.hash);
+    if (group === undefined) {
+      groups.set(record.hash, [record]);
+    } else {
+      group.push(record);
+    }
+  }
+
+  // 4–7. Resolve each group
+  const deduped = allowed.length - groups.size;
+  const output: MemoryRecord[] = [];
+
+  for (const group of groups.values()) {
+    const winner = resolveConflict(group, conflictPolicy, sourcePriority);
+
+    // 5. Escalate sensitivity across the whole group
+    const mergedSensitivity = escalateSensitivity(group.map((r) => r.sensitivity));
+
+    // 6. Union tags
+    const mergedTags = group.reduce<string[]>(
+      (acc, r) => mergeTags(acc, r.tags),
+      []
+    );
+
+    // 7. Prefer non-null agent
+    const mergedAgent = group.find((r) => r.agent != null)?.agent ?? winner.agent;
+
+    output.push({
+      ...winner,
+      sensitivity: mergedSensitivity,
+      tags: mergedTags,
+      agent: mergedAgent,
+    });
+  }
+
+  // 8. Build bySource stats
+  const bySource: Record<string, number> = {};
+  for (const record of output) {
+    bySource[record.source] = (bySource[record.source] ?? 0) + 1;
+  }
+
+  return {
+    records: output,
+    stats: { inputTotal, deduped, rejected, bySource },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Picks the canonical record from a collision group.
+ *
+ * The winner provides `id`, `source`, `device_id`, `project`, `timestamp`,
+ * `summary`, `content`, `hash`, and `embedding_ref`. Sensitivity and tags
+ * are merged separately by the caller.
+ */
+function resolveConflict(
+  group: MemoryRecord[],
+  policy: 'newest' | 'oldest' | 'priority',
+  sourcePriority: string[]
+): MemoryRecord {
+  if (group.length === 1) {
+    return group[0];
+  }
+
+  if (policy === 'newest') {
+    return group.reduce((best, r) => (r.timestamp > best.timestamp ? r : best));
+  }
+
+  if (policy === 'oldest') {
+    return group.reduce((best, r) => (r.timestamp < best.timestamp ? r : best));
+  }
+
+  // policy === 'priority'
+  return group.reduce((best, r) => {
+    const bestIdx = sourcePriority.indexOf(best.source);
+    const rIdx = sourcePriority.indexOf(r.source);
+    // Lower index = higher priority. Unknown sources get lowest priority.
+    const bestPriority = bestIdx === -1 ? sourcePriority.length : bestIdx;
+    const rPriority = rIdx === -1 ? sourcePriority.length : rIdx;
+    return rPriority < bestPriority ? r : best;
+  });
+}

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.120.0",
+  "version": "0.121.0",
   "lastUpdated": "2026-04-24T07:30:00.000Z",
   "components": [
     {


### PR DESCRIPTION
## 요약

#1047 epic adapter 트랙 final piece. 다중 source MemoryRecord 통합 + hash dedup + sensitivity escalation.

## 변경

### memory_aggregator (#1073)
- `aggregateMemoryRecords({ records, conflictPolicy, sourcePriority })`
- conflict policy 3종: newest/oldest/priority
- secret-tier 자동 reject (#1067)
- sensitivity escalation: 강한 tier 우선 (public < project < sensitive < secret)
- tag union dedup
- stats: { inputTotal, deduped, rejected, bySource }

## 검증

- 35 신규 + 303 기존 = 338 tests pass
- 100% coverage on new module
- bun run lint/build PASS

## Closes
- #1073 aggregation+dedup layer

## Related
- #1047 epic adapter track 완료
- 다음 트랙: persistence service + skill profile loader

🤖 Generated with [Claude Code](https://claude.com/claude-code)