### PR TITLE
release: v0.124.0 — single-agent 거대 프롬프트 안티패턴 (R009/R018) + arch-documenter 토큰 가이드

### DIFF
--- a/.claude/agents/arch-documenter.md
+++ b/.claude/agents/arch-documenter.md
@@ -36,3 +36,17 @@ You handle software architecture documentation: system design docs, API specs, A
 | API Spec | OpenAPI/Swagger | API documentation |
 | ADR | Markdown | Decision records |
 | README/Guides | Markdown | Project/developer docs |
+
+## Input Constraints (Plan Decomposition Threshold)
+
+When invoked for plan/spec authoring tasks:
+
+| Input prompt size | Action |
+|-------------------|--------|
+| < 5000 tokens, single domain | Proceed normally |
+| 5000-8000 tokens or 2-3 domains | Warn caller; suggest splitting plan into per-domain subagent calls |
+| > 8000 tokens or 4+ domains | **Halt and request decomposition**. Return guidance: "This plan spans N domains; recommend invoking parallel arch-documenter agents per domain (R009) or Agent Teams with reviewer (R018)." |
+
+Rationale: Single-agent giant prompts cause latency timeouts and waste context (#1085). Decomposition by domain enables parallel execution and review loops.
+
+Reference rules: R009 (parallel execution), R018 (Agent Teams).

--- a/.claude/rules/MUST-agent-teams.md
+++ b/.claude/rules/MUST-agent-teams.md
@@ -22,6 +22,7 @@ Available when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or TeamCreate/SendMessag
 | Single file operations | Agent Tool | Overkill for simple tasks |
 | Dynamic agent creation + usage | **Agent Teams** | Create → test → iterate cycle |
 | Multi-issue release batch | **Agent Teams** | Shared task tracking, coordinated release |
+| Large plan / multi-domain prompt (>5000 tokens, 3+ areas) | **Agent Teams** | Domain-split parallel writing + review loop avoids single-agent timeout |
 
 **When Agent Teams is enabled and criteria are met, usage is required.**
 
@@ -112,6 +113,15 @@ The skill's steps are followed, but agent spawning uses Teams when criteria are 
 
 ✓ CORRECT: TeamCreate → spawn researchers → coordinate via shared task list
    TeamCreate("research-team") + Agent(researcher-1/2/3) + SendMessage(coordinate)
+```
+
+```
+❌ WRONG: Single agent receives 9000-token M2 plan covering metrics + DSL + risk gate + UI
+   Agent(arch-documenter, prompt: <huge multi-domain plan>)
+   → Timeout, cancellation, no decomposition opportunity
+
+✓ CORRECT: TeamCreate("plan-team") + parallel domain leads + reviewer
+   TeamCreate("plan-team") + Agent(metrics-lead) + Agent(dsl-lead) + Agent(risk-lead) + Agent(reviewer) + SendMessage(coordinate)
 ```
 
 <!-- DETAIL: Common Violations (full examples)

--- a/.claude/rules/MUST-parallel-execution.md
+++ b/.claude/rules/MUST-parallel-execution.md
@@ -38,7 +38,13 @@ Before writing/editing multiple files:
 ```
 ❌ WRONG: Write(file1.kt) → Write(file2.kt) → ... (sequential)
 ✓ CORRECT: Agent(agent1→file1.kt) + Agent(agent2→file2.kt) + ... (same message, parallel)
+
+❌ WRONG: Single agent receives massive multi-domain prompt (>5000 tokens, e.g., M2 plan with 12 tasks across 7 areas)
+   → Latency timeout, user cancellation, context waste, no review loop
+✓ CORRECT: Pre-decompose by domain, spawn parallel agents per area (R009) or use Agent Teams (R018)
 ```
+
+> **Token threshold heuristic**: When a delegated agent prompt exceeds ~5000 tokens or spans 3+ unrelated domains, decompose by domain and spawn parallel agents. See R018 for Agent Teams criteria when review cycles are needed. Reference: #1085.
 
 <!-- DETAIL: Full violation examples (4 pairs)
 ❌ WRONG: Writing files one by one

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.122.0",
-  "generatedAt": "2026-04-27T06:23:26.042Z",
-  "templateVersion": "0.122.0",
+  "generatorVersion": "0.124.0",
+  "generatedAt": "2026-04-28T00:43:51.351Z",
+  "templateVersion": "0.124.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "dc6ce94ab01e1c6abb76e0a1a33b472a47f21706921e63f61ce2fb43bab9a9cf",
@@ -35,8 +35,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-parallel-execution.md": {
-      "templateHash": "a70981abbe50fa6608f46554f9b8e2f2d6d96bbb65f66799479543c3b01f7c23",
-      "size": 6733,
+      "templateHash": "6c3edcbc4694a0a2c1095d697237f3ff4746470bd3d4f4c73c90adc4d96a9d2b",
+      "size": 7275,
       "component": "rules"
     },
     ".claude/rules/SHOULD-ecomode.md": {
@@ -65,8 +65,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-teams.md": {
-      "templateHash": "f467053c0d2f3da5be551ef1ca2bcda128ea55e9fcdf58e343178e6224584f9b",
-      "size": 15435,
+      "templateHash": "acc42525c7b5dec8b1884741d2d233b9f800f43c6735265e6071513c26f611e0",
+      "size": 16012,
       "component": "rules"
     },
     ".claude/rules/MAY-optimization.md": {
@@ -330,8 +330,8 @@
       "component": "agents"
     },
     ".claude/agents/arch-documenter.md": {
-      "templateHash": "2812a9f73fc6551ab27a9a8e3cdb6e0447e2eadebe3f8057a21dfc0f4eb824ad",
-      "size": 1061,
+      "templateHash": "3e25e6816323b565745415d14d5319ab7c78cab643b0306c1d7926a9d4931c5c",
+      "size": 1824,
       "component": "agents"
     },
     ".claude/agents/test-delete.txt": {
@@ -837,6 +837,11 @@
     ".claude/skills/skills-sh-search/SKILL.md": {
       "templateHash": "d9171fb571d04de22255787e354959fc980febd33fc9e21289208640b12c4d46",
       "size": 6136,
+      "component": "skills"
+    },
+    ".claude/skills/profile/SKILL.md": {
+      "templateHash": "17b45720ff6260a749b66130120c5bd9c8d644f967991c781653de68063a7bde",
+      "size": 4846,
       "component": "skills"
     },
     ".claude/skills/pre-generation-arch-check/SKILL.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2334,7 +2334,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.122.0",
+    version: "0.124.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2014,7 +2014,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.122.0",
+  version: "0.124.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.123.0",
+  "version": "0.124.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/agents/arch-documenter.md
+++ b/templates/.claude/agents/arch-documenter.md
@@ -36,3 +36,17 @@ You handle software architecture documentation: system design docs, API specs, A
 | API Spec | OpenAPI/Swagger | API documentation |
 | ADR | Markdown | Decision records |
 | README/Guides | Markdown | Project/developer docs |
+
+## Input Constraints (Plan Decomposition Threshold)
+
+When invoked for plan/spec authoring tasks:
+
+| Input prompt size | Action |
+|-------------------|--------|
+| < 5000 tokens, single domain | Proceed normally |
+| 5000-8000 tokens or 2-3 domains | Warn caller; suggest splitting plan into per-domain subagent calls |
+| > 8000 tokens or 4+ domains | **Halt and request decomposition**. Return guidance: "This plan spans N domains; recommend invoking parallel arch-documenter agents per domain (R009) or Agent Teams with reviewer (R018)." |
+
+Rationale: Single-agent giant prompts cause latency timeouts and waste context (#1085). Decomposition by domain enables parallel execution and review loops.
+
+Reference rules: R009 (parallel execution), R018 (Agent Teams).

--- a/templates/.claude/rules/MUST-agent-teams.md
+++ b/templates/.claude/rules/MUST-agent-teams.md
@@ -22,6 +22,7 @@ Available when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or TeamCreate/SendMessag
 | Single file operations | Agent Tool | Overkill for simple tasks |
 | Dynamic agent creation + usage | **Agent Teams** | Create → test → iterate cycle |
 | Multi-issue release batch | **Agent Teams** | Shared task tracking, coordinated release |
+| Large plan / multi-domain prompt (>5000 tokens, 3+ areas) | **Agent Teams** | Domain-split parallel writing + review loop avoids single-agent timeout |
 
 **When Agent Teams is enabled and criteria are met, usage is required.**
 
@@ -112,6 +113,15 @@ The skill's steps are followed, but agent spawning uses Teams when criteria are 
 
 ✓ CORRECT: TeamCreate → spawn researchers → coordinate via shared task list
    TeamCreate("research-team") + Agent(researcher-1/2/3) + SendMessage(coordinate)
+```
+
+```
+❌ WRONG: Single agent receives 9000-token M2 plan covering metrics + DSL + risk gate + UI
+   Agent(arch-documenter, prompt: <huge multi-domain plan>)
+   → Timeout, cancellation, no decomposition opportunity
+
+✓ CORRECT: TeamCreate("plan-team") + parallel domain leads + reviewer
+   TeamCreate("plan-team") + Agent(metrics-lead) + Agent(dsl-lead) + Agent(risk-lead) + Agent(reviewer) + SendMessage(coordinate)
 ```
 
 <!-- DETAIL: Common Violations (full examples)

--- a/templates/.claude/rules/MUST-parallel-execution.md
+++ b/templates/.claude/rules/MUST-parallel-execution.md
@@ -38,7 +38,13 @@ Before writing/editing multiple files:
 ```
 ❌ WRONG: Write(file1.kt) → Write(file2.kt) → ... (sequential)
 ✓ CORRECT: Agent(agent1→file1.kt) + Agent(agent2→file2.kt) + ... (same message, parallel)
+
+❌ WRONG: Single agent receives massive multi-domain prompt (>5000 tokens, e.g., M2 plan with 12 tasks across 7 areas)
+   → Latency timeout, user cancellation, context waste, no review loop
+✓ CORRECT: Pre-decompose by domain, spawn parallel agents per area (R009) or use Agent Teams (R018)
 ```
+
+> **Token threshold heuristic**: When a delegated agent prompt exceeds ~5000 tokens or spans 3+ unrelated domains, decompose by domain and spawn parallel agents. See R018 for Agent Teams criteria when review cycles are needed. Reference: #1085.
 
 <!-- DETAIL: Full violation examples (4 pairs)
 ❌ WRONG: Writing files one by one

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.123.0",
+  "version": "0.124.0",
   "lastUpdated": "2026-04-24T07:30:00.000Z",
   "components": [
     {

--- a/wiki/agents/arch-documenter.md
+++ b/wiki/agents/arch-documenter.md
@@ -1,13 +1,15 @@
 ---
 title: arch-documenter
 type: agent
-updated: 2026-04-12
+updated: 2026-04-28
 sources:
   - .claude/agents/arch-documenter.md
 related:
   - [[arch-speckit-agent]]
   - [[mgr-creator]]
   - [[mgr-sauron]]
+  - [[r009]]
+  - [[r018]]
 ---
 
 # arch-documenter
@@ -38,12 +40,25 @@ The agent operates with `project`-scoped memory, meaning it retains knowledge ab
 | Architecture Decision Records | Markdown (ADR format) |
 | README / developer guides | Markdown |
 
+## Input Constraints (Plan Decomposition Threshold)
+
+`arch-documenter`는 plan/spec 작성 작업에 대해 입력 크기를 검사하고 자동으로 halt 또는 경고를 반환한다 (#1085).
+
+| 입력 크기 | 동작 |
+|-----------|------|
+| < 5000 tokens, single domain | 정상 진행 |
+| 5000–8000 tokens 또는 2–3 domains | 경고 반환 — 도메인별 서브에이전트 호출 권장 |
+| > 8000 tokens 또는 4+ domains | **Halt** — "This plan spans N domains; recommend invoking parallel arch-documenter agents per domain ([[r009]]) or Agent Teams with reviewer ([[r018]])" |
+
+이 임계치는 단일 에이전트 거대 프롬프트가 유발하는 latency timeout과 context 낭비를 방지하기 위해 도입되었다. 8000+ 토큰 입력이 예상되면 호출 전에 도메인별로 분할해야 한다.
+
 ## Relationships
 
 - **Depends on**: project source files (read-only), existing docs
 - **Used by**: [[mgr-sauron]] (documentation accuracy verification), [[qa-writer]] (archive destination for QA docs)
 - **See also**: [[arch-speckit-agent]] (spec-driven requirements), [[mgr-creator]] (new guides creation)
+- **Governed by**: [[r009]] (parallel execution threshold), [[r018]] (Agent Teams for large multi-domain plans)
 
 ## Sources
 
-- `.claude/agents/arch-documenter.md` — agent definition
+- `.claude/agents/arch-documenter.md` — agent definition (Input Constraints section #1085)

--- a/wiki/rules/r009.md
+++ b/wiki/rules/r009.md
@@ -1,7 +1,7 @@
 ---
 title: "R009: Parallel Execution Rules"
 type: rule
-updated: 2026-04-27
+updated: 2026-04-28
 sources:
   - .claude/rules/MUST-parallel-execution.md
 related:
@@ -64,6 +64,24 @@ Advisory PostToolUse hook + PostCompact re-injection per [[r021]].
 - **Related rules**: [[r008]], [[r010]], [[r018]]
 - **Affects**: All multi-task operations, batch workflows, research skills
 
+## Anti-Pattern: Single Agent Giant Prompt
+
+단일 에이전트에 5000+ 토큰 multi-domain 프롬프트를 위임하는 것은 R009 위반이다. 이 패턴은 latency timeout, user cancellation, review loop 불가능을 유발한다.
+
+**토큰 임계치 가이드 (#1085):**
+
+| 조건 | 권장 |
+|------|------|
+| < 5000 tokens, single domain | 단일 에이전트 가능 |
+| ≥ 5000 tokens 또는 3+ domains | 도메인별 분할 + 병렬 에이전트 (R009) |
+| ≥ 8000 tokens 또는 4+ domains | Agent Teams 사용 필수 ([[r018]]) |
+
+```
+❌ WRONG: Single agent receives massive multi-domain prompt (>5000 tokens)
+   Agent(arch-documenter, prompt: <9000-token M2 plan across 7 areas>)
+✓ CORRECT: Pre-decompose by domain, spawn parallel agents per area
+```
+
 ## Sources
 
-- `.claude/rules/MUST-parallel-execution.md` — rule definition (HTML detail uplift #1053)
+- `.claude/rules/MUST-parallel-execution.md` — rule definition (HTML detail uplift #1053; anti-pattern + token threshold #1085)

--- a/wiki/rules/r018.md
+++ b/wiki/rules/r018.md
@@ -1,7 +1,7 @@
 ---
 title: "R018: Agent Teams Rules"
 type: rule
-updated: 2026-04-27
+updated: 2026-04-28
 sources:
   - .claude/rules/MUST-agent-teams.md
 related:
@@ -36,6 +36,7 @@ Agent Teams enables peer-to-peer communication between agents via shared task li
 | Research requiring discussion | **Agent Teams** |
 | Code review + fix cycle | **Agent Teams** |
 | Multi-issue release batch | **Agent Teams** |
+| Large plan / multi-domain prompt (>5000 tokens, 3+ areas) | **Agent Teams** |
 
 **Team lifecycle:**
 ```
@@ -60,6 +61,18 @@ Advisory PostToolUse hook + PostCompact re-injection per [[r021]].
 - **Related rules**: [[r009]], [[r010]]
 - **Affects**: `/research`, `/deep-plan`, multi-issue release workflows, code review cycles
 
+## Anti-Pattern: Single Agent 9000-Token Plan
+
+단일 에이전트에 대규모 multi-domain 계획(예: 9000-token M2 plan covering metrics + DSL + risk gate + UI)을 전달하면 timeout, 취소, review loop 불가 문제가 발생한다. Decision Matrix에 "Large plan / multi-domain prompt" 행이 추가되었다 (#1085).
+
+```
+❌ WRONG: Agent(arch-documenter, prompt: <9000-token multi-domain plan>)
+   → Timeout, cancellation, no decomposition opportunity
+✓ CORRECT: TeamCreate("plan-team") + parallel domain leads + reviewer
+```
+
+[[r009]] 의 토큰 임계치 가이드 (5000 / 8000 tokens)와 함께 사용.
+
 ## Sources
 
-- `.claude/rules/MUST-agent-teams.md` — rule definition (HTML detail uplift #1053)
+- `.claude/rules/MUST-agent-teams.md` — rule definition (HTML detail uplift #1053; large-plan scenario + 9000-token anti-pattern #1085)


### PR DESCRIPTION
## Summary
- R009/R018 룰에 "단일 에이전트 거대 multi-domain 프롬프트" 안티패턴을 명시
- arch-documenter에 입력 토큰 임계치 가이드 추가 (3단계 halt/warn 동작)
- Wiki 페이지 3개 동기화 (r009/r018/arch-documenter)

## Issue
Closes #1085 — 사용자 피드백: M2 plan을 단일 arch-documenter에 ~9000 토큰 프롬프트로 위임 → latency 초과로 사용자 취소.

## Changes
| 파일 | 변경 |
|------|------|
| `.claude/rules/MUST-parallel-execution.md` | Common Violations + Token threshold heuristic |
| `.claude/rules/MUST-agent-teams.md` | Decision Matrix 행 + 9000-token 안티패턴 |
| `.claude/agents/arch-documenter.md` | Input Constraints (Plan Decomposition Threshold) |
| `wiki/rules/r009.md`, `wiki/rules/r018.md`, `wiki/agents/arch-documenter.md` | Refresh |
| `templates/.claude/...` | Source ↔ template sync |
| `package.json`, `templates/manifest.json` | 0.123.0 → 0.124.0 |

## Test plan
- [x] pre-commit hooks PASSED (tsc, biome, bun test, coverage)
- [x] bun run build SUCCESS (dist 재생성)
- [ ] CI checks pass on PR
- [ ] auto-tag.yml 자동 close #1085 + npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)