### PR TITLE
release: v0.126.0 — R010 /tmp deprecation + manifest sync gate (#1098 #1101 #1099)

### DIFF
--- a/.claude/agents/mgr-creator.md
+++ b/.claude/agents/mgr-creator.md
@@ -18,17 +18,9 @@ maxTurns: 25
 permissionMode: bypassPermissions
 ---
 
-## Mandatory: .claude/ 경로 처리 (R010 Universal /tmp Script Bypass)
+## .claude/ 경로 처리 (CC v2.1.121+)
 
-ALL tool calls targeting `.claude/` paths MUST go through `/tmp/*.sh` script via Bash. This includes Write, Edit, and write-Bash. Direct `Write(".claude/...")` or `Edit(".claude/...")` triggers user approval prompts that block unattended automation, regardless of `bypassPermissions` mode or allow rules.
-
-Pattern:
-1. Write tool → `/tmp/fix-{topic}-$$.sh` containing heredoc/sed/cp targeting `.claude/`
-2. Bash tool → `bash /tmp/fix-{topic}-$$.sh`
-
-Read tool on `.claude/` paths is exempt (sensitive-path bypass for read-only). For `templates/.claude/` paths, the same pattern applies (also sensitive).
-
-Reference: R010 (.claude/rules/MUST-orchestrator-coordination.md), #1046, #1052, #1062.
+Direct Write/Edit/Bash on `.claude/**` and `templates/.claude/**` is permitted under `mode: "bypassPermissions"` as of CC v2.1.121 (#1101). The legacy `/tmp/*.sh` bypass is deprecated. For CC < v2.1.121, see git history for the legacy pattern.
 
 You are an agent creation specialist following R006 (MUST-agent-design.md) rules.
 

--- a/.claude/agents/mgr-updater.md
+++ b/.claude/agents/mgr-updater.md
@@ -22,17 +22,9 @@ tools:
 permissionMode: bypassPermissions
 ---
 
-## Mandatory: .claude/ 경로 처리 (R010 Universal /tmp Script Bypass)
+## .claude/ 경로 처리 (CC v2.1.121+)
 
-ALL tool calls targeting `.claude/` paths MUST go through `/tmp/*.sh` script via Bash. This includes Write, Edit, and write-Bash. Direct `Write(".claude/...")` or `Edit(".claude/...")` triggers user approval prompts that block unattended automation, regardless of `bypassPermissions` mode or allow rules.
-
-Pattern:
-1. Write tool → `/tmp/fix-{topic}-$$.sh` containing heredoc/sed/cp targeting `.claude/`
-2. Bash tool → `bash /tmp/fix-{topic}-$$.sh`
-
-Read tool on `.claude/` paths is exempt (sensitive-path bypass for read-only). For `templates/.claude/` paths, the same pattern applies (also sensitive).
-
-Reference: R010 (.claude/rules/MUST-orchestrator-coordination.md), #1046, #1052, #1062.
+Direct Write/Edit/Bash on `.claude/**` and `templates/.claude/**` is permitted under `mode: "bypassPermissions"` as of CC v2.1.121 (#1101). The legacy `/tmp/*.sh` bypass is deprecated. For CC < v2.1.121, see git history for the legacy pattern.
 
 You are an external source synchronization specialist keeping external components up-to-date.
 

--- a/.claude/rules/MUST-agent-design.md
+++ b/.claude/rules/MUST-agent-design.md
@@ -244,36 +244,28 @@ Skills persist output to `.claude/outputs/sessions/{YYYY-MM-DD}/{skill-name}-{HH
 
 ### Sensitive Path Handling
 
-CC treats `.claude/` as a sensitive directory, enforced across **all tool categories** — Bash, Write, and Edit. The sensitive-path check runs **above** `bypassPermissions` and explicit allow rules (e.g., `Write(.claude/**)`), so operations on sensitive paths may trigger permission prompts regardless of settings.
+> **Status (CC v2.1.121+)**: `.claude/`, `.git/`, `.vscode/` direct Write/Edit/Bash works without prompts under `mode: "bypassPermissions"`. The historical `/tmp/*.sh` bypass pattern is deprecated. See #1101.
 
-**Key rule**: `.claude/` Bash/Write/Edit triggers sensitive-path prompt regardless of allow rules. Only bypass: use `/tmp/*.sh` scripts via Bash. See full behavior table and recommended practice via Read tool.
+Current CC behavior: under `bypassPermissions`, all `.claude/**` paths (including `.claude/outputs/**`, `.claude/agents/**`, `.claude/skills/**`, `.claude/rules/**`, `templates/.claude/**`) accept Write/Edit/Bash directly. Catastrophic shell operations remain blocked by independent safety guards.
 
-<!-- DETAIL: Sensitive Path Behavior table and Recommended practice
-#### Sensitive Path Behavior
+**Recommended practice**:
+1. Pass `mode: "bypassPermissions"` on every Agent tool call (R010 Universal bypassPermissions)
+2. Use Write/Edit directly for `.claude/**` paths — no `/tmp/*.sh` wrapping needed
+3. For CC < v2.1.121: see git history of this section (pre-v0.126.0) for the legacy bypass pattern
 
-| Path | Tool | Allow rule | Result |
+<!-- DETAIL: Pre-v2.1.121 sensitive path behavior (historical)
+| Path | Tool | Allow rule | Result (CC < v2.1.121) |
 |------|------|-----------|--------|
-| `.claude/**` | Bash (`cp`, `mkdir`, `rm`) | `Bash(*)` allowed | Prompt (sensitive-path overrides) |
-| `.claude/**` | Write, Edit | `Write(.claude/**)` allowed | Prompt (sensitive-path overrides) |
-| `templates/.claude/**` | Write, Edit | `Write(templates/.claude/**)` allowed | Prompt (confirmed CC v2.1.116+; see #960, #961, #981) |
-| `.claude/outputs/**` | Write, Edit | `Write(.claude/outputs/**)` | Prompt (sensitive-path overrides — confirmed #1043) |
-| `.claude/outputs/**` | Bash via `/tmp/*.sh` | — | Allowed (bypass pattern) |
-
-#### Recommended practice
-
-1. **Prefer `Write`/`Edit` over `Bash(cp)`/`Bash(mkdir)`** — `Write`/`Edit` provide better auditability and avoid shell injection risk
-2. **Add allow rules defensively** — `Write(.claude/**)`, `Edit(.claude/**)`, `Write(templates/.claude/**)`, `Edit(templates/.claude/**)` in `.claude/settings.local.json`. Rules may not bypass sensitive-path check but document intent and aid future CC behavior changes
-3. **For `.claude/outputs/**` specifically**: Use `Bash via /tmp/*.sh` bypass — Write/Edit on this path triggers sensitive-path prompt despite being the artifact convention path (confirmed v0.111.1+, #1043, #1046)
+| `.claude/**` | Bash (`cp`, `mkdir`, `rm`) | `Bash(*)` allowed | Prompt (sensitive-path overrode) |
+| `.claude/**` | Write, Edit | `Write(.claude/**)` allowed | Prompt (sensitive-path overrode) |
+| `templates/.claude/**` | Write, Edit | `Write(templates/.claude/**)` allowed | Prompt (#960, #961, #981) |
+| `.claude/outputs/**` | Write, Edit | `Write(.claude/outputs/**)` | Prompt (#1043) |
+| `.claude/outputs/**` | Bash via `/tmp/*.sh` | — | Allowed (legacy bypass) |
 -->
 
-<!--
-3. **Accept interactive prompts as a release-pipeline constraint** — `templates/.claude/` sync during release automation requires human approval; plan release windows accordingly
-4. **This is CC design behavior, not a bug** — sensitive-path check is a defense-in-depth layer. File upstream as a documentation request (not bug report) if behavior is unclear
-
-#### Cross-references
-
-- `feedback_sensitive_path.md` — session memory with Bash + Write scope (#960, #961, #981)
-- `feedback_templates_claude_glob.md` — `.claude/**` glob does not cover `templates/.claude/**`, separate allow rules required
+<!-- DETAIL: Cross-references
+- `feedback_sensitive_path*.md` — historical (pre-v2.1.121) memories, marked with status: historical (#1101)
+- `feedback_templates_claude_glob.md` — `.claude/**` glob does not cover `templates/.claude/**`, separate allow rules required (still applies for non-bypassPermissions modes)
 -->
 
 ### Artifact Channel Protocol

--- a/.claude/rules/MUST-orchestrator-coordination.md
+++ b/.claude/rules/MUST-orchestrator-coordination.md
@@ -257,44 +257,17 @@ Before spawning any agent:
 ```
 
 
-## Universal /tmp Script Bypass for Sensitive Paths
+## Sensitive Path Handling (Historical: pre-CC v2.1.121)
 
-**ALL tool calls targeting `.claude/` MUST be routed through `/tmp/*.sh` script via Bash.**
+> **Status**: Deprecated as of CC v2.1.121 (2026-04-28) and further relaxed in v2.1.126 (2026-05-01). Direct Write/Edit/Bash on `.claude/`, `.git/`, `.vscode/` works without prompts under `bypassPermissions` mode in CC v2.1.121+ (issue #1101).
 
-| Tool | `.claude/` target | Required pattern |
-|------|------------------|------------------|
-| Read | `.claude/*` | OK — Read tool is sensitive-path exempt |
-| Bash (read-only: sed, cat, wc, ls, grep, head, tail, find, file) | `.claude/*` | **/tmp/*.sh bypass required** — direct invocation triggers prompt |
-| Bash (write: mkdir, cp, mv, rm, redirect) | `.claude/*` | **/tmp/*.sh bypass required** |
-| Write | `.claude/*` | **/tmp/*.sh + Bash heredoc required** — Write tool itself triggers prompt |
-| Edit | `.claude/*` | **/tmp/*.sh + Bash sed -i required** — Edit tool itself triggers prompt |
+Current CC versions (>=2.1.121): direct Write/Edit/Bash on `.claude/**` paths are permitted under `mode: "bypassPermissions"`. The `/tmp/*.sh` script wrapping pattern previously required is no longer necessary. Catastrophic operations (e.g., `rm -rf /`) remain blocked by independent safety guards.
 
-### Pattern (mandatory)
+`mode: "bypassPermissions"` on every Agent tool call is still required (see "Universal bypassPermissions" above).
 
-```bash
-cat > /tmp/fix-topic.sh << 'OUTER'
-sed -i 's/old/new/' .claude/path/file       # Edit equivalent
-cat > .claude/path/file << 'INNER'           # Write equivalent
-... content ...
-INNER
-sed '/<!--/,/-->/d' .claude/path/file | wc -c  # measurement
-OUTER
-bash /tmp/fix-topic.sh
-```
+**For CC < v2.1.121 only**: see git history of this rule for the legacy `/tmp/*.sh` bypass pattern (commit before v0.126.0).
 
-### Why
-
-CC sensitive-path check inspects tool-call **target paths** but does NOT audit script-internal file operations. Bypass works because Bash target = `/tmp/`, while internal commands access `.claude/`.
-
-### Scope
-
-Universal — applies to ALL subagents (not just fork skills). Applies to ALL `.claude/` paths regardless of subdirectory (`.claude/agents/`, `.claude/skills/`, `.claude/rules/`, `.claude/output-styles/`, `.claude/agent-memory/`, etc.).
-
-### Failure mode
-
-Direct Write/Edit/Bash on `.claude/` triggers user approval prompt → blocks unattended automation → defeats `/pipeline auto-dev` and `/loop` workflows.
-
-> **Reference**: #1052, #1016 (origin), #1046 (directive loss in delegation chain)
+> **References**: #1052 (origin v0.116.2), #1016 (v0.111.1), #1046 (delegation directive loss v0.116.1), #1099 (CC v2.1.126 tracking), #1101 (v0.126.0 deprecation).
 
 ## Session Continuity
 

--- a/.claude/rules/MUST-permissions.md
+++ b/.claude/rules/MUST-permissions.md
@@ -18,8 +18,10 @@
 | Operation | Allowed | Prohibited |
 |-----------|---------|-----------|
 | Read | All source, configs, docs | - |
-| Write | Source code, new files in project | .env, .git/config, paths outside project |
+| Write | Source code, new files in project, `.claude/**` (CC v2.1.121+ under `bypassPermissions`) | .env, .git/config, paths outside project |
 | Delete | Temp files created by agent | Existing files (without request), entire directories |
+
+> **Sensitive paths note**: As of CC v2.1.121 (2026-04-28) and further relaxed in v2.1.126 (2026-05-01), `.claude/`, `.git/`, `.vscode/` are no longer prompted for Write/Edit/Bash under `mode: "bypassPermissions"`. The legacy `/tmp/*.sh` script bypass (R010 historical section) is deprecated for CC >= v2.1.121. Catastrophic operations (`rm -rf /`) remain blocked. See #1101.
 
 ## Permission Request Format
 

--- a/.claude/skills/agora/SKILL.md
+++ b/.claude/skills/agora/SKILL.md
@@ -114,15 +114,7 @@ When ALL reviewers agree BUILD or BUILD WITH CHANGES:
 
 ### Tool: Writing artifacts under .claude/outputs/
 
-CC sensitive-path check inspects tool target paths and triggers permission prompts on `.claude/` regardless of `bypassPermissions` and allow rules (refs: #960, #961, #978, #981, #1016).
-
-To write agora results under `.claude/outputs/sessions/`:
-
-1. Write the artifact body to `/tmp/agora-$(date +%H%M%S).md` first (Write tool target = `/tmp`, no sensitive-path trigger)
-2. Use a `/tmp/*.sh` Bash script to move/copy the file under `.claude/outputs/sessions/$(date +%Y-%m-%d)/` (Bash target = `/tmp`, script-internal `cp` to `.claude/` is not audited)
-3. Read-only Bash on `.claude/outputs/` (e.g., `cat`, `head`, `wc`) is allowed for verification
-
-Reference: `feedback_sensitive_path_tmp_bypass.md`, R006 sensitive-path handling, #1016, #1045.
+Direct Write to `.claude/outputs/sessions/{date}/agora-{topic}-{time}.md` is permitted under `mode: "bypassPermissions"` (CC v2.1.121+, #1101). Write tool auto-creates parent directory. For CC < v2.1.121, see git history for the legacy /tmp bypass pattern.
 
 3. Shut down team: `SendMessage(to: "*", message: {type: "shutdown_request"})`
 

--- a/.claude/skills/codex-exec/SKILL.md
+++ b/.claude/skills/codex-exec/SKILL.md
@@ -252,15 +252,7 @@ codex-exec "build/fix frontend"
 
 ### Tool: Writing artifacts under .claude/outputs/
 
-CC sensitive-path check inspects tool target paths and triggers permission prompts on `.claude/` regardless of `bypassPermissions` and allow rules (refs: #960, #961, #978, #981, #1016).
-
-To write codex execution results under `.claude/outputs/codex/`:
-
-1. Write the artifact body to `/tmp/codex-{HHmmss}.{ext}` first (Write tool target = /tmp, no sensitive-path trigger)
-2. Use a `/tmp/*.sh` Bash script to move/copy the file under `.claude/outputs/codex/sessions/...` (Bash target = /tmp, script-internal `cp` to `.claude/` is not audited)
-3. Read-only Bash on `.claude/outputs/` (e.g., `cat`, `head`, `wc`) is allowed for verification
-
-Reference: `feedback_sensitive_path_tmp_bypass.md`, R006 sensitive-path handling.
+Direct Write to `.claude/outputs/codex/sessions/{date}/codex-{HHmmss}.{ext}` is permitted under `mode: "bypassPermissions"` (CC v2.1.121+, #1101). Write tool auto-creates parent directory. For CC < v2.1.121, see git history for the legacy /tmp bypass pattern.
 
 ### Attribution
 

--- a/.claude/skills/pipeline/workflows/auto-dev.yaml
+++ b/.claude/skills/pipeline/workflows/auto-dev.yaml
@@ -88,25 +88,11 @@ steps:
       - All Agent tool calls MUST pass mode: "bypassPermissions" to prevent permission prompts during unattended execution
 
 
-      ## Universal /tmp Script Bypass for .claude/ paths (R010 Universal /tmp Script Bypass)
+      ## Sensitive Path Handling (CC v2.1.121+)
 
-      ALL tool calls targeting `.claude/` MUST go through `/tmp/*.sh` script via Bash. This applies to read-only measurement (sed/cat/wc/ls), Write, Edit, and write-Bash. Read tool is exempt.
+      Direct Write/Edit/Bash on `.claude/**` is permitted under `mode: "bypassPermissions"` as of CC v2.1.121 (#1101). The legacy `/tmp/*.sh` bypass is no longer required. Structural changes (new agents/skills) still go through mgr-creator with R017 verification.
 
-      Pattern:
-      1. Write(/tmp/fix-{topic}.sh) — script contents may use heredoc/sed/cp targeting .claude/
-      2. Bash(bash /tmp/fix-{topic}.sh) — Bash target is /tmp/, not .claude/
-      3. Read or Bash(head/grep) on .claude/ paths is fine (Read tool sensitive-path exempt; Bash on .claude/ is also exempt for some commands but to stay safe always use /tmp script for any sed/cat/wc on .claude/).
-
-      Rationale: CC sensitive-path check inspects tool-call target paths but does NOT audit script-internal file operations. Direct Write/Edit/Bash on .claude/ triggers user approval prompts even with bypassPermissions, breaking unattended automation.
-
-      Use this pattern for:
-      - Any documentation fix in .claude/
-      - Any frontmatter change
-      - Any read-only measurement / inspection / counting
-      - Count synchronization between source and templates
-      - Structural changes (new agents/skills) MUST still go through mgr-creator with R017 verification, AND mgr-creator itself uses /tmp bypass for the file writes
-
-      References: #1052, #1016 (v0.111.1 origin), #1046 (v0.116.1 delegation directive loss fix), feedback_sensitive_path_tmp_bypass.md memory
+      For CC < v2.1.121 see git history for the legacy bypass pattern.
 
       ## Local CI-mimic verification (MUST run before marking implement done)
 

--- a/.claude/skills/profile/SKILL.md
+++ b/.claude/skills/profile/SKILL.md
@@ -22,17 +22,8 @@ Switch the active plugin set to match a workflow profile, reducing per-spawn ski
 
 ## Implementation rules
 
-> **MANDATORY — .claude/ path bypass (R010)**
-> ALL writes to `.claude/` paths MUST go through a `/tmp/*.sh` script via Bash.
-> Direct `Write(".claude/...")` or `Edit(".claude/...")` triggers user approval prompts
-> that block automation regardless of `bypassPermissions` mode.
->
-> Pattern:
-> 1. Write tool → `/tmp/profile-{op}-$$.sh` with heredoc targeting `.claude/`
-> 2. Bash tool → `bash /tmp/profile-{op}-$$.sh`
->
-> This applies to `.claude/profiles/.active` and `~/.claude/settings.json` writes.
-> Reference: R010 (MUST-orchestrator-coordination.md), #1046, #1052, #1062.
+> **.claude/ path handling (CC v2.1.121+)**
+> Direct Write/Edit on `.claude/profiles/.active` and `~/.claude/settings.json` is permitted under `mode: "bypassPermissions"` (CC v2.1.121+, #1101). The legacy `/tmp/*.sh` bypass is deprecated. For CC < v2.1.121, see git history for the legacy pattern.
 
 ## Profiles directory
 

--- a/.github/scripts/verify-version-sync.sh
+++ b/.github/scripts/verify-version-sync.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# verify-version-sync.sh — validates package.json version matches templates/manifest.json
+# Mirrors the ci.yml version-sync job for use as a pre-publish gate in release.yml.
+# Idempotent, read-only. Works on macOS and Linux.
+set -euo pipefail
+
+pkg_version=$(node -p "require('./package.json').version")
+manifest_version=$(node -p "require('./templates/manifest.json').version")
+
+echo "package.json version:          $pkg_version"
+echo "templates/manifest.json version: $manifest_version"
+
+if [ "$pkg_version" != "$manifest_version" ]; then
+  echo ""
+  echo "❌ Version mismatch: package.json=$pkg_version, templates/manifest.json=$manifest_version" >&2
+  echo "Fix: update templates/manifest.json version to match package.json before tagging." >&2
+  exit 1
+fi
+
+echo "✓ Version sync OK: $pkg_version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,12 @@ jobs:
           test -f dist/index.js || { echo "::error::Missing dist/index.js"; exit 1; }
           echo "Build artifacts verified"
 
+      - name: Verify template sync
+        run: bash .github/scripts/verify-template-sync.sh
+
+      - name: Verify version sync (package.json vs templates/manifest.json)
+        run: bash .github/scripts/verify-version-sync.sh
+
       # Check if version already exists on npm
       - name: Check npm version
         id: npm_check

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.124.0",
-  "generatedAt": "2026-04-28T00:43:51.351Z",
-  "templateVersion": "0.124.0",
+  "generatorVersion": "0.126.0",
+  "generatedAt": "2026-05-02T02:39:16.625Z",
+  "templateVersion": "0.126.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "dc6ce94ab01e1c6abb76e0a1a33b472a47f21706921e63f61ce2fb43bab9a9cf",
@@ -15,8 +15,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "5a2aa4c264693f426e85cd19688d9a1f4ec174801b372e09b7fd4aba250f9072",
-      "size": 22378,
+      "templateHash": "ab0d6df5f20d07113b44ab4e95b60cc189908090f2eecbf549dcb99b91bdfd92",
+      "size": 21605,
       "component": "rules"
     },
     ".claude/rules/MUST-intent-transparency.md": {
@@ -50,13 +50,13 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
-      "templateHash": "af9c318198b6a5aa4de4b119f234aa01a9027ec1de85242f29daee42f3a35e4b",
-      "size": 25375,
+      "templateHash": "d0e01658d34f12badcf9977133f93d62c91b6f870a71d00867144e60cfb9366a",
+      "size": 24628,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
-      "templateHash": "5316d30c261fe698f896179ce04b3f61fc9556d655e5904262806da0411316fe",
-      "size": 2136,
+      "templateHash": "98b1bd947038a6065029994d8ae6c6a1a4d547fea6b23f69486517cfbac7300a",
+      "size": 2981,
       "component": "rules"
     },
     ".claude/rules/MUST-sync-verification.md": {
@@ -65,8 +65,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-teams.md": {
-      "templateHash": "acc42525c7b5dec8b1884741d2d233b9f800f43c6735265e6071513c26f611e0",
-      "size": 16012,
+      "templateHash": "79d179c9b17f6c175a39cad8848bb5a67b1311a2cc5b2edb91f58b3b8b4f89e9",
+      "size": 16974,
       "component": "rules"
     },
     ".claude/rules/MAY-optimization.md": {
@@ -80,8 +80,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-permissions.md": {
-      "templateHash": "d0a16e5df414eec45c3a323d14f742e4d663bea4783b2e89c297d9e6031ce841",
-      "size": 2245,
+      "templateHash": "2cfd9532094274bc7af493c8796c6ed2863e4c245872f5c80613a50f27a24ba8",
+      "size": 2677,
       "component": "rules"
     },
     ".claude/rules/SHOULD-ontology-rag-routing.md": {
@@ -95,8 +95,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-tool-identification.md": {
-      "templateHash": "c1382fa7b657e61a5a9743e875e9b9527b222df45fe05c84559d1969ebcc1433",
-      "size": 2867,
+      "templateHash": "920fb33b8c73de68943bd706fbb84c63f8b79938f19b20dcbbec8489be240873",
+      "size": 3531,
       "component": "rules"
     },
     ".claude/rules/SHOULD-memory-integration.md": {
@@ -105,8 +105,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-enforcement-policy.md": {
-      "templateHash": "2afe651048e74105f8f64ec19febf86ebe31db2e9325a0ade61860e48f4c8782",
-      "size": 2512,
+      "templateHash": "022b61e51c8ec21456bb4ea43012f0b4d81dd554f4c5189743c74015f6e6dfb6",
+      "size": 2565,
       "component": "rules"
     },
     ".claude/rules/index.yaml": {
@@ -150,8 +150,8 @@
       "component": "agents"
     },
     ".claude/agents/mgr-updater.md": {
-      "templateHash": "0cce5f48d7211989bf8c13ba70a2d645a0281d23df7a2c19fdeb36a75a4f774d",
-      "size": 1798,
+      "templateHash": "540c04f62dd9037fbace5a6d1434f178b9cb81cf9b5e9d0e2732533f70c42034",
+      "size": 1314,
       "component": "agents"
     },
     ".claude/agents/lang-kotlin-expert.md": {
@@ -300,8 +300,8 @@
       "component": "agents"
     },
     ".claude/agents/mgr-creator.md": {
-      "templateHash": "92b1cc4dee9e5802a35ffdc75ff46e640f541b5ad49b92df2200eb1d06ae5468",
-      "size": 2571,
+      "templateHash": "5bee5bfd0fe9a19f201b7716358b6a58caae352ff773a711673338ed35907eac",
+      "size": 2087,
       "component": "agents"
     },
     ".claude/agents/qa-writer.md": {
@@ -330,13 +330,8 @@
       "component": "agents"
     },
     ".claude/agents/arch-documenter.md": {
-      "templateHash": "3e25e6816323b565745415d14d5319ab7c78cab643b0306c1d7926a9d4931c5c",
-      "size": 1824,
-      "component": "agents"
-    },
-    ".claude/agents/test-delete.txt": {
-      "templateHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-      "size": 0,
+      "templateHash": "0c9906e921cbd976412162c72ab9655702b9d164f82a56be56ef1e970d018cf3",
+      "size": 2559,
       "component": "agents"
     },
     ".claude/agents/qa-planner.md": {
@@ -490,8 +485,8 @@
       "component": "skills"
     },
     ".claude/skills/pipeline/workflows/auto-dev.yaml": {
-      "templateHash": "3836396af41f074219f9a78b9ccf5eaabde8be71ad059af21ae490d991a55278",
-      "size": 8458,
+      "templateHash": "c9756d5d580861007a6634ee2b8a2817c6a36b23d81eeb935085f56dbf4aa7ba",
+      "size": 7367,
       "component": "skills"
     },
     ".claude/skills/pipeline/SKILL.md": {
@@ -610,8 +605,8 @@
       "component": "skills"
     },
     ".claude/skills/agora/SKILL.md": {
-      "templateHash": "719a40c7996cd03dd772377636e3c2b351d967984c572eb57e524bb618a84bcb",
-      "size": 10889,
+      "templateHash": "6900276bc356445a8a72769c64853e7e224789d184cdd1513f6c109b3fe7c5b1",
+      "size": 10402,
       "component": "skills"
     },
     ".claude/skills/fastapi-best-practices/SKILL.md": {
@@ -840,8 +835,8 @@
       "component": "skills"
     },
     ".claude/skills/profile/SKILL.md": {
-      "templateHash": "17b45720ff6260a749b66130120c5bd9c8d644f967991c781653de68063a7bde",
-      "size": 4846,
+      "templateHash": "acc632a66351a66c51b688a90fd82a0b6e80cc799e187936ed6de56b8b13f297",
+      "size": 4560,
       "component": "skills"
     },
     ".claude/skills/pre-generation-arch-check/SKILL.md": {
@@ -985,8 +980,8 @@
       "component": "skills"
     },
     ".claude/skills/codex-exec/SKILL.md": {
-      "templateHash": "61d7c4eb432f258bcfe958d70f106d8db08f4f64863541c0d2eb992543736395",
-      "size": 8963,
+      "templateHash": "7c815c5c449a7961e7f1d0a92093e63d6469beb9286d3c88050f68a284fea1f8",
+      "size": 8503,
       "component": "skills"
     },
     ".claude/skills/create-agent/SKILL.md": {

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Architecture
 
-> oh-my-customcode v0.124.0
+> oh-my-customcode v0.126.0
 
 ## 1. System Overview
 
@@ -8,7 +8,7 @@ oh-my-customcode is a batteries-included agent harness for Claude Code. It ships
 
 The harness operates on three engineering pillars — **Context Engineering** (what goes into the prompt), **Architectural Constraints** (rules that shape agent behavior), and **Entropy Management** (hooks, verification, and observability that keep the system coherent at scale).
 
-Current version: **0.124.0** — distributed as `oh-my-customcode` on npm, CLI: `omcustom`.
+Current version: **0.126.0** — distributed as `oh-my-customcode` on npm, CLI: `omcustom`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,5 @@
 <!-- omcustom:start -->
+<!-- omcustomMinClaudeCode: 2.1.121 — sensitive-path direct Write under bypassPermissions (#1101) -->
 # AI 에이전트 시스템
 
 oh-my-customcode로 구동됩니다.

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2334,7 +2334,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.124.0",
+    version: "0.126.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {
@@ -2382,7 +2382,7 @@ var init_package = __esm(() => {
       yaml: "^2.8.2"
     },
     devDependencies: {
-      "@anthropic-ai/sdk": "^0.90.0",
+      "@anthropic-ai/sdk": "^0.92.0",
       "@biomejs/biome": "^2.3.12",
       "@types/bun": "^1.3.6",
       "@types/js-yaml": "^4.0.9",
@@ -2413,6 +2413,8 @@ var init_package = __esm(() => {
     engines: {
       node: ">=18.0.0"
     },
+    omcustomMinClaudeCode: "2.1.121",
+    omcustomMinClaudeCodeReason: "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",
     overrides: {
       rollup: "^4.59.0",
       esbuild: "^0.25.0"

--- a/dist/index.js
+++ b/dist/index.js
@@ -2014,7 +2014,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.124.0",
+  version: "0.126.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {
@@ -2062,7 +2062,7 @@ var package_default = {
     yaml: "^2.8.2"
   },
   devDependencies: {
-    "@anthropic-ai/sdk": "^0.90.0",
+    "@anthropic-ai/sdk": "^0.92.0",
     "@biomejs/biome": "^2.3.12",
     "@types/bun": "^1.3.6",
     "@types/js-yaml": "^4.0.9",
@@ -2093,6 +2093,8 @@ var package_default = {
   engines: {
     node: ">=18.0.0"
   },
+  omcustomMinClaudeCode: "2.1.121",
+  omcustomMinClaudeCodeReason: "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",
   overrides: {
     rollup: "^4.59.0",
     esbuild: "^0.25.0"

--- a/docs/superpowers/plans/2026-05-02-v0.126.0-release.md
+++ b/docs/superpowers/plans/2026-05-02-v0.126.0-release.md
@@ -1,0 +1,47 @@
+# Release v0.126.0 — R010 /tmp Bypass Deprecation + Manifest Sync Gate
+
+## Highlights
+
+- **R010 `/tmp/*.sh` script bypass deprecated** for CC v2.1.121+ — direct Write/Edit on `.claude/**` is now permitted under `mode: "bypassPermissions"` (#1101)
+- **release.yml manifest/version sync pre-publish gate** — prevents v0.125.0-style stale manifest incidents (#1098)
+- **CC v2.1.126 adoption** — sensitive-path relaxation absorbed (#1099)
+
+## :rocket: Features
+
+- **release.yml manifest/version sync pre-publish gate** (#1098): npm publish 직전에 `package.json`과 `templates/manifest.json` 버전 일치 검증. v0.125.0에서 stale manifest(0.124.0)가 publish된 incident 재발 방지.
+- **R010 /tmp bypass deprecation** (#1101): CC v2.1.121 (2026-04-28) + v2.1.126 (2026-05-01) 변경에 따라 `bypassPermissions` 모드 하 `.claude/`, `.git/`, `.vscode/` 직접 접근 가능. R010/R002/R006 historical로 강등, 핵심 5개 skill/agent boilerplate 정리, `omcustomMinClaudeCode: 2.1.121` 가드 추가.
+- **CC v2.1.126 tracking** (#1099): 위 변경의 두 번째 단계 — sensitive-path relaxation이 #1101에 통합 처리됨.
+
+## :wrench: Chores
+
+- @anthropic-ai/sdk 0.90.0 → 0.92.0 (#1083, dependabot)
+
+## Breaking Changes
+
+없음. R010 historical 절은 구버전 CC 사용자를 위한 호환 가이드로 유지.
+
+## Migration
+
+- CC < v2.1.121 사용자: R010 git history 참조하여 legacy `/tmp/*.sh` pattern 유지
+- CC ≥ v2.1.121 사용자: 변경 없이 자동 적용. 신규 skill/agent 작성 시 `/tmp/*.sh` boilerplate 생략.
+
+## Resource Changes
+
+| Resource | Before | After | Delta |
+|----------|--------|-------|-------|
+| Rules | 22 | 22 | 0 |
+| Skills | 116 | 116 | 0 |
+| Agents | 49 | 49 | 0 |
+
+## Follow-ups
+
+- ~25개 추가 skill/agent의 `/tmp` boilerplate scrub (research, deep-verify, secretary-routing 등) — 후속 PR
+- init 스크립트 CC 버전 체크 런타임 enforcement
+- /omcustom:wiki 동기화 (R022)
+
+## Closes
+
+Closes #1098, Closes #1101, Closes #1099
+
+---
+_Release notes generated with Claude Code (Opus 4.7)_

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.125.1",
+  "version": "0.126.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,8 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "omcustomMinClaudeCode": "2.1.121",
+  "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",
   "overrides": {
     "rollup": "^4.59.0",
     "esbuild": "^0.25.0"

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -244,9 +244,14 @@ Skills persist output to `.claude/outputs/sessions/{YYYY-MM-DD}/{skill-name}-{HH
 
 ### Sensitive Path Handling
 
-CC treats `.claude/` as a sensitive directory, enforced across **all tool categories** — Bash, Write, and Edit. The sensitive-path check runs **above** `bypassPermissions` and explicit allow rules (e.g., `Write(.claude/**)`), so operations on sensitive paths may trigger permission prompts regardless of settings.
+> **Status (CC v2.1.121+)**: `.claude/`, `.git/`, `.vscode/` direct Write/Edit/Bash works without prompts under `mode: "bypassPermissions"`. The historical `/tmp/*.sh` bypass pattern is deprecated. See #1101.
 
-**Key rule**: `.claude/` Bash/Write/Edit triggers sensitive-path prompt regardless of allow rules. Only bypass: use `/tmp/*.sh` scripts via Bash. See full behavior table and recommended practice via Read tool.
+Current CC behavior: under `bypassPermissions`, all `.claude/**` paths (including `.claude/outputs/**`, `.claude/agents/**`, `.claude/skills/**`, `.claude/rules/**`, `templates/.claude/**`) accept Write/Edit/Bash directly. Catastrophic shell operations remain blocked by independent safety guards.
+
+**Recommended practice**:
+1. Pass `mode: "bypassPermissions"` on every Agent tool call (R010 Universal bypassPermissions)
+2. Use Write/Edit directly for `.claude/**` paths — no `/tmp/*.sh` wrapping needed
+3. For CC < v2.1.121: see git history of this section (pre-v0.126.0) for the legacy bypass pattern
 
 <!-- DETAIL: Sensitive Path Behavior table and Recommended practice
 #### Sensitive Path Behavior

--- a/templates/.claude/rules/MUST-orchestrator-coordination.md
+++ b/templates/.claude/rules/MUST-orchestrator-coordination.md
@@ -257,44 +257,17 @@ Before spawning any agent:
 ```
 
 
-## Universal /tmp Script Bypass for Sensitive Paths
+## Sensitive Path Handling (Historical: pre-CC v2.1.121)
 
-**ALL tool calls targeting `.claude/` MUST be routed through `/tmp/*.sh` script via Bash.**
+> **Status**: Deprecated as of CC v2.1.121 (2026-04-28) and further relaxed in v2.1.126 (2026-05-01). Direct Write/Edit/Bash on `.claude/`, `.git/`, `.vscode/` works without prompts under `bypassPermissions` mode in CC v2.1.121+ (issue #1101).
 
-| Tool | `.claude/` target | Required pattern |
-|------|------------------|------------------|
-| Read | `.claude/*` | OK — Read tool is sensitive-path exempt |
-| Bash (read-only: sed, cat, wc, ls, grep, head, tail, find, file) | `.claude/*` | **/tmp/*.sh bypass required** — direct invocation triggers prompt |
-| Bash (write: mkdir, cp, mv, rm, redirect) | `.claude/*` | **/tmp/*.sh bypass required** |
-| Write | `.claude/*` | **/tmp/*.sh + Bash heredoc required** — Write tool itself triggers prompt |
-| Edit | `.claude/*` | **/tmp/*.sh + Bash sed -i required** — Edit tool itself triggers prompt |
+Current CC versions (>=2.1.121): direct Write/Edit/Bash on `.claude/**` paths are permitted under `mode: "bypassPermissions"`. The `/tmp/*.sh` script wrapping pattern previously required is no longer necessary. Catastrophic operations (e.g., `rm -rf /`) remain blocked by independent safety guards.
 
-### Pattern (mandatory)
+`mode: "bypassPermissions"` on every Agent tool call is still required (see "Universal bypassPermissions" above).
 
-```bash
-cat > /tmp/fix-topic.sh << 'OUTER'
-sed -i 's/old/new/' .claude/path/file       # Edit equivalent
-cat > .claude/path/file << 'INNER'           # Write equivalent
-... content ...
-INNER
-sed '/<!--/,/-->/d' .claude/path/file | wc -c  # measurement
-OUTER
-bash /tmp/fix-topic.sh
-```
+**For CC < v2.1.121 only**: see git history of this rule for the legacy `/tmp/*.sh` bypass pattern (commit before v0.126.0).
 
-### Why
-
-CC sensitive-path check inspects tool-call **target paths** but does NOT audit script-internal file operations. Bypass works because Bash target = `/tmp/`, while internal commands access `.claude/`.
-
-### Scope
-
-Universal — applies to ALL subagents (not just fork skills). Applies to ALL `.claude/` paths regardless of subdirectory (`.claude/agents/`, `.claude/skills/`, `.claude/rules/`, `.claude/output-styles/`, `.claude/agent-memory/`, etc.).
-
-### Failure mode
-
-Direct Write/Edit/Bash on `.claude/` triggers user approval prompt → blocks unattended automation → defeats `/pipeline auto-dev` and `/loop` workflows.
-
-> **Reference**: #1052, #1016 (origin), #1046 (directive loss in delegation chain)
+> **References**: #1052 (origin v0.116.2), #1016 (v0.111.1), #1046 (delegation directive loss v0.116.1), #1099 (CC v2.1.126 tracking), #1101 (v0.126.0 deprecation).
 
 ## Session Continuity
 

--- a/templates/.claude/rules/MUST-permissions.md
+++ b/templates/.claude/rules/MUST-permissions.md
@@ -18,8 +18,10 @@
 | Operation | Allowed | Prohibited |
 |-----------|---------|-----------|
 | Read | All source, configs, docs | - |
-| Write | Source code, new files in project | .env, .git/config, paths outside project |
+| Write | Source code, new files in project, `.claude/**` (CC v2.1.121+ under `bypassPermissions`) | .env, .git/config, paths outside project |
 | Delete | Temp files created by agent | Existing files (without request), entire directories |
+
+> **Sensitive paths note**: As of CC v2.1.121 (2026-04-28) and further relaxed in v2.1.126 (2026-05-01), `.claude/`, `.git/`, `.vscode/` are no longer prompted for Write/Edit/Bash under `mode: "bypassPermissions"`. The legacy `/tmp/*.sh` script bypass (R010 historical section) is deprecated for CC >= v2.1.121. Catastrophic operations (`rm -rf /`) remain blocked. See #1101.
 
 ## Permission Request Format
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1,4 +1,5 @@
 <!-- omcustom:start -->
+<!-- omcustomMinClaudeCode: 2.1.121 — sensitive-path direct Write under bypassPermissions (#1101) -->
 # AI 에이전트 시스템
 
 oh-my-customcode로 구동됩니다.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.125.1",
+  "version": "0.126.0",
   "lastUpdated": "2026-04-24T07:30:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,8 @@
 {
   "version": "0.125.1",
   "lastUpdated": "2026-04-24T07:30:00.000Z",
+  "omcustomMinClaudeCode": "2.1.121",
+  "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",
   "components": [
     {
       "name": "rules",


### PR DESCRIPTION
## Summary

- R010 `/tmp/*.sh` script bypass deprecated for CC v2.1.121+ — direct Write/Edit on `.claude/**` permitted under `bypassPermissions` (#1101)
- release.yml manifest/version sync pre-publish gate 추가 — v0.125.0 stale manifest incident 재발 방지 (#1098)
- CC v2.1.126 sensitive-path relaxation 흡수 (#1099)
- @anthropic-ai/sdk 0.90.0 → 0.92.0 (dependabot #1083)

## Changes

- `package.json`, `templates/manifest.json`: 0.125.1 → 0.126.0
- `ARCHITECTURE.md`: 버전 헤더 v0.124.0 → v0.126.0
- `dist/`: rebuild
- `docs/superpowers/plans/2026-05-02-v0.126.0-release.md`: 릴리즈 노트

## Closes

Closes #1098, Closes #1101, Closes #1099

## Test plan

- [ ] CI: validate-docs, test, coverage 통과 확인
- [ ] CI: release.yml manifest/version sync gate 동작 확인 (신규 gate 첫 사용 사례)
- [ ] PR merge 후 auto-tag.yml: v0.126.0 tag 생성 + #1098/#1099/#1101 자동 close 확인
- [ ] npm publish 성공 + `npm view oh-my-customcode version` = 0.126.0 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)