### PR TITLE
release: v0.128.0 — forward-looking CHANGELOG [Unreleased] 정책 (#1113)

### DIFF
--- a/.claude/skills/omcustom-release-notes/SKILL.md
+++ b/.claude/skills/omcustom-release-notes/SKILL.md
@@ -99,13 +99,51 @@ The generated notes can be:
 2. **File**: Written to `release_notes.md` for review before use
 3. **Update**: Used with `gh release edit v{VERSION} --notes "{notes}"`
 
+### Phase 5: Promote `## [Unreleased]` in CHANGELOG.md (Optional but Recommended)
+
+After generating release notes, promote any pending `## [Unreleased]` entries to a versioned section so `release.yml` (awk extract at line ~217) finds the authored notes instead of falling back to GitHub auto-generated content.
+
+```bash
+# Promote [Unreleased] to [VERSION] with today's date
+DATE=$(date -u +%Y-%m-%d)
+python3 - "$VERSION" "$DATE" <<'PY'
+import sys, re, pathlib
+version, date = sys.argv[1], sys.argv[2]
+path = pathlib.Path("CHANGELOG.md")
+text = path.read_text()
+header = f"## [{version}] - {date}"
+if re.search(rf"^## \[{re.escape(version)}\]", text, flags=re.M):
+    print(f"[skip] [{version}] section already exists — manual reconciliation needed")
+    sys.exit(0)
+new = re.sub(
+    r"^## \[Unreleased\]\s*\n",
+    f"## [Unreleased]\n\n{header}\n",
+    text,
+    count=1,
+    flags=re.M,
+)
+if new == text:
+    print("[error] [Unreleased] section not found — CHANGELOG.md format unexpected")
+    sys.exit(1)
+path.write_text(new)
+print(f"[ok] promoted [Unreleased] -> [{version}]")
+PY
+```
+
+Behavior:
+- If `## [Unreleased]` content is empty, the promoted `## [VERSION]` will also be empty — `release.yml` falls back to auto-generated notes (existing behavior preserved).
+- If `## [VERSION]` already exists (re-run, manual edit), the script skips with a log message — no overwrite.
+- The skill caller commits the change: `git add CHANGELOG.md && git commit -m "chore(changelog): promote [Unreleased] to [VERSION]"`
+
+This is **optional** — the skill's release-notes generation (Phases 1-4) works independently. Phase 5 only ensures CHANGELOG consistency for projects that maintain Keep a Changelog format.
+
 ## Integration
 
 This skill is designed to be used during the release process:
 
 ```
 /omcustom:npm-version patch|minor|major  ->  version bump
-/omcustom-release-notes {version}         ->  generate notes
+/omcustom-release-notes {version}         ->  generate notes + promote [Unreleased] (Phase 5)
 mgr-gitnerd: gh release create           ->  create release with notes
 ```
 
@@ -115,6 +153,8 @@ mgr-gitnerd: gh release create           ->  create release with notes
 - Uses git history and gh CLI for data gathering
 - Claude Code analyzes and generates notes in-context
 - Resource count changes auto-detected from CLAUDE.md history
+- Phase 5 promotion is idempotent — safe to re-run; skips if `## [VERSION]` exists
+- See `CONTRIBUTING.md` for [Unreleased] entry guidance during PR authoring
 
 ## Permission Mode
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,3 +31,4 @@
 - [ ] I have added tests that prove my fix/feature works
 - [ ] All tests pass with 100% coverage
 - [ ] My changes generate no new warnings
+- [ ] I have added a `## [Unreleased]` entry to `CHANGELOG.md` for user-visible changes (skip for internal/refactor-only PRs)

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.127.0",
-  "generatedAt": "2026-05-08T01:55:20.300Z",
-  "templateVersion": "0.127.0",
+  "generatorVersion": "0.128.0",
+  "generatedAt": "2026-05-08T03:51:42.475Z",
+  "templateVersion": "0.128.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "dc6ce94ab01e1c6abb76e0a1a33b472a47f21706921e63f61ce2fb43bab9a9cf",
@@ -800,8 +800,8 @@
       "component": "skills"
     },
     ".claude/skills/omcustom-release-notes/SKILL.md": {
-      "templateHash": "fe6aa62a2bb5c82a3e66ed7c0cf7be6a8d10f61dc1e329ba228a66112111f109",
-      "size": 3311,
+      "templateHash": "55e7e08b9f57dd22f17649e4a319efe52b4a258e01d2900b3cb00511af3b6086",
+      "size": 5218,
       "component": "skills"
     },
     ".claude/skills/omcustom-takeover/SKILL.md": {
@@ -1070,8 +1070,8 @@
       "component": "skills"
     },
     ".claude/skills/goal/SKILL.md": {
-      "templateHash": "4b2debf2b7ee0c2775ca22d09c605b972b8287e7ef6ba2797a13d6215b914517",
-      "size": 3979,
+      "templateHash": "ab1826c0aa396d37b6c2dc805fe2db6fffdf27070811322a2a7a0183a688a90c",
+      "size": 3994,
       "component": "skills"
     },
     ".claude/hooks/PARALLEL-GROUPS.md": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,21 @@ feature/another ──────┘                                           
    git branch -d feature/my-feature
    ```
 
+#### Update CHANGELOG.md
+
+When your PR introduces user-visible behavior changes, add a one-line entry under `## [Unreleased]` in `CHANGELOG.md`. Use [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) categories:
+
+- **Added** — new features
+- **Fixed** — bug fixes
+- **Changed** — non-breaking changes
+- **Removed** — removed features
+- **Deprecated** — soon-to-be-removed
+- **Security** — vulnerability fixes
+
+Skip this for internal-only changes (refactors, test-only commits, build tweaks).
+
+The release process automatically promotes `## [Unreleased]` to `## [vX.Y.Z]` via the `omcustom-release-notes` skill (Phase 5). See `.claude/skills/omcustom-release-notes/SKILL.md`.
+
 #### Release Process
 
 **Important: All npm publishing happens automatically via CI after PR merge. Never push tags or run `npm publish` manually.**
@@ -165,10 +180,12 @@ The release pipeline is fully automated:
    git checkout -b release/x.y.z
    ```
 
-2. **Bump version and update CHANGELOG:**
+2. **Bump version and promote CHANGELOG [Unreleased] section:**
    ```bash
    npm version [major|minor|patch]
-   # Update CHANGELOG.md
+   # Recommended: invoke /omcustom-release-notes <version> to auto-promote [Unreleased]
+   # Or manually: replace `## [Unreleased]` header with empty `## [Unreleased]`
+   # plus a new `## [vX.Y.Z] - YYYY-MM-DD` section containing the moved entries.
    git add .
    git commit -m "chore: prepare release x.y.z"
    ```

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2334,7 +2334,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.127.0",
+    version: "0.128.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2014,7 +2014,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.127.0",
+  version: "0.128.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.127.0",
+  "version": "0.128.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/omcustom-release-notes/SKILL.md
+++ b/templates/.claude/skills/omcustom-release-notes/SKILL.md
@@ -99,13 +99,51 @@ The generated notes can be:
 2. **File**: Written to `release_notes.md` for review before use
 3. **Update**: Used with `gh release edit v{VERSION} --notes "{notes}"`
 
+### Phase 5: Promote `## [Unreleased]` in CHANGELOG.md (Optional but Recommended)
+
+After generating release notes, promote any pending `## [Unreleased]` entries to a versioned section so `release.yml` (awk extract at line ~217) finds the authored notes instead of falling back to GitHub auto-generated content.
+
+```bash
+# Promote [Unreleased] to [VERSION] with today's date
+DATE=$(date -u +%Y-%m-%d)
+python3 - "$VERSION" "$DATE" <<'PY'
+import sys, re, pathlib
+version, date = sys.argv[1], sys.argv[2]
+path = pathlib.Path("CHANGELOG.md")
+text = path.read_text()
+header = f"## [{version}] - {date}"
+if re.search(rf"^## \[{re.escape(version)}\]", text, flags=re.M):
+    print(f"[skip] [{version}] section already exists — manual reconciliation needed")
+    sys.exit(0)
+new = re.sub(
+    r"^## \[Unreleased\]\s*\n",
+    f"## [Unreleased]\n\n{header}\n",
+    text,
+    count=1,
+    flags=re.M,
+)
+if new == text:
+    print("[error] [Unreleased] section not found — CHANGELOG.md format unexpected")
+    sys.exit(1)
+path.write_text(new)
+print(f"[ok] promoted [Unreleased] -> [{version}]")
+PY
+```
+
+Behavior:
+- If `## [Unreleased]` content is empty, the promoted `## [VERSION]` will also be empty — `release.yml` falls back to auto-generated notes (existing behavior preserved).
+- If `## [VERSION]` already exists (re-run, manual edit), the script skips with a log message — no overwrite.
+- The skill caller commits the change: `git add CHANGELOG.md && git commit -m "chore(changelog): promote [Unreleased] to [VERSION]"`
+
+This is **optional** — the skill's release-notes generation (Phases 1-4) works independently. Phase 5 only ensures CHANGELOG consistency for projects that maintain Keep a Changelog format.
+
 ## Integration
 
 This skill is designed to be used during the release process:
 
 ```
 /omcustom:npm-version patch|minor|major  ->  version bump
-/omcustom-release-notes {version}         ->  generate notes
+/omcustom-release-notes {version}         ->  generate notes + promote [Unreleased] (Phase 5)
 mgr-gitnerd: gh release create           ->  create release with notes
 ```
 
@@ -115,6 +153,8 @@ mgr-gitnerd: gh release create           ->  create release with notes
 - Uses git history and gh CLI for data gathering
 - Claude Code analyzes and generates notes in-context
 - Resource count changes auto-detected from CLAUDE.md history
+- Phase 5 promotion is idempotent — safe to re-run; skips if `## [VERSION]` exists
+- See `CONTRIBUTING.md` for [Unreleased] entry guidance during PR authoring
 
 ## Permission Mode
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.127.0",
+  "version": "0.128.0",
   "lastUpdated": "2026-04-24T07:30:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약

`omcustom-release-notes` 스킬에 Phase 5 추가 — 릴리스 시점에 `CHANGELOG.md`의 `## [Unreleased]` 섹션을 `## [vX.Y.Z] - YYYY-MM-DD`로 promote합니다. 멱등(idempotent), 빈 섹션은 안전하게 통과 (release.yml fallback 보존).

#1111 (CHANGELOG modernization)에서 Track A로 분할된 정책. Track B (v0.36.0~v0.127.0 92개 backfill)는 `--backfill` 모드 도구화가 선행돼야 하므로 별도로 추적.

Closes #1113

## 변경 파일

| 파일 | 변경 |
|------|------|
| `.claude/skills/omcustom-release-notes/SKILL.md` | Phase 5 추가 (+templates 미러 byte-equal) |
| `CONTRIBUTING.md` | "Update CHANGELOG.md" 하위 섹션 신규 + Release Process step 2 재작성 |
| `.github/PULL_REQUEST_TEMPLATE.md` | `[Unreleased]` 체크리스트 항목 추가 |
| `package.json`, `templates/manifest.json` | version 0.127.0 → 0.128.0 |
| `.omcustom.lock.json`, `dist/*` | 자동 생성 (src/ 무변경, 결정론적 재컴파일) |

## 검증 결과

- `bun test`: 1929 pass / 0 fail
- `bun run lint` (biome): 93 files, 0 issues
- `bun run typecheck` (tsc): clean
- `verify-template-sync.sh`: pass
- `verify-wiki-sync.sh`: pass (skills=117, missing=0)
- 스킬 `.claude/` ↔ `templates/.claude/` 미러: byte-equal

## Test plan

- [x] 로컬 빌드 통과
- [x] 로컬 테스트 통과
- [x] CI-mimic 스크립트 통과
- [ ] CI 8 checks 통과 (자동)
- [ ] 머지 후 auto-tag.yml v0.128.0 태그 생성 (자동)
- [ ] release.yml npm publish 완료 (자동)
- [ ] `npm view oh-my-customcode version` = 0.128.0 (검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)