### PR TITLE
release: v0.129.0 — CHANGELOG.md historical backfill v0.36.0..v0.127.0 (#1111)

### DIFF
--- a/.claude/skills/omcustom-release-notes/SKILL.md
+++ b/.claude/skills/omcustom-release-notes/SKILL.md
@@ -3,7 +3,7 @@ name: omcustom-release-notes
 description: Generate structured release notes from git history and closed issues within Claude Code session
 scope: harness
 user-invocable: true
-argument-hint: "<version> [--previous-tag <tag>]"
+argument-hint: "<version> [--previous-tag <tag>] | --backfill <range>"
 ---
 
 # Release Notes Generator
@@ -19,6 +19,7 @@ Replaces the CI-based `release-notes.yml` workflow that previously used Claude A
 ```
 /omcustom-release-notes 0.36.0
 /omcustom-release-notes 0.36.0 --previous-tag v0.35.3
+/omcustom-release-notes --backfill v0.36.0..v0.127.0
 ```
 
 ## Workflow
@@ -137,6 +138,56 @@ Behavior:
 
 This is **optional** — the skill's release-notes generation (Phases 1-4) works independently. Phase 5 only ensures CHANGELOG consistency for projects that maintain Keep a Changelog format.
 
+## Backfill Mode
+
+For projects with historical CHANGELOG.md gaps (releases shipped without `[Unreleased]` promotion), the skill provides a deterministic batch backfill.
+
+### Usage
+
+```bash
+python3 scripts/backfill_changelog.py <START_TAG>..<END_TAG> [--output FILE]
+```
+
+Or invoked via skill: `/omcustom-release-notes --backfill v0.36.0..v0.127.0`
+
+### Behavior
+
+For each tag in range (in reverse semver order), the script:
+
+1. Determines previous tag (semver-immediately-before)
+2. Reads `git log <prev>..<tag> --pretty=%s --no-merges` to extract commit subjects
+3. Maps Conventional Commits prefix to Keep a Changelog category:
+   - `feat` → Added
+   - `fix` → Fixed
+   - `security` → Security
+   - `perf`, `refactor`, `chore`, `build`, `deps`, `revert` → Changed
+   - `docs`, `test`, `ci`, `style` → SKIPPED (internal-only, unless `!` breaking marker)
+   - Non-conventional → Changed (full subject as message)
+4. Special handling for `release:` / `chore(release):` commits — extracts description after version (e.g., `release: v0.127.0 — DESC` → DESC under Changed)
+5. Extracts issue refs (`#NNN`) and appends as `(#1, #2)` suffix
+6. Renders per-version section with categories sorted: Added, Changed, Fixed, Security, Removed, Deprecated
+7. Empty sections (zero qualifying commits) render as `_No user-visible changes (internal only)._`
+
+### Output
+
+Markdown text suitable for prepending to CHANGELOG.md between `## [Unreleased]` and the first existing version section.
+
+### When to Use
+
+- Adopting Keep a Changelog format on an existing project with N historical releases
+- Recovering after a CHANGELOG drift period
+- One-time bulk operation — afterward, use Phase 5 promotion (forward-looking) for ongoing maintenance
+
+### Limitations
+
+- Only as good as commit message quality. Squash-merge release commits typically contain only the PR title — backfill produces 1-2 lines per version, not exhaustive change lists
+- Non-conventional or pre-Conventional Commits adoption commits land in Changed
+- Manual curation may improve specific entries; the script provides the baseline
+
+### Tests
+
+`tests/scripts/test_backfill_changelog.py` covers parser correctness, semver sorting, category mapping, edge cases (40 tests).
+
 ## Integration
 
 This skill is designed to be used during the release process:
@@ -155,6 +206,7 @@ mgr-gitnerd: gh release create           ->  create release with notes
 - Resource count changes auto-detected from CLAUDE.md history
 - Phase 5 promotion is idempotent — safe to re-run; skips if `## [VERSION]` exists
 - See `CONTRIBUTING.md` for [Unreleased] entry guidance during PR authoring
+- For one-time historical backfill, see Backfill Mode above (script: `scripts/backfill_changelog.py`)
 
 ## Permission Mode
 

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.128.0",
-  "generatedAt": "2026-05-08T03:51:42.475Z",
-  "templateVersion": "0.128.0",
+  "generatorVersion": "0.129.0",
+  "generatedAt": "2026-05-08T04:15:55.057Z",
+  "templateVersion": "0.129.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "dc6ce94ab01e1c6abb76e0a1a33b472a47f21706921e63f61ce2fb43bab9a9cf",
@@ -800,8 +800,8 @@
       "component": "skills"
     },
     ".claude/skills/omcustom-release-notes/SKILL.md": {
-      "templateHash": "55e7e08b9f57dd22f17649e4a319efe52b4a258e01d2900b3cb00511af3b6086",
-      "size": 5218,
+      "templateHash": "3f597c2d4ce1d99e6855a03b76816e3300e11da8e218eadbb1fe427ca8a62d2d",
+      "size": 7637,
       "component": "skills"
     },
     ".claude/skills/omcustom-takeover/SKILL.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,1176 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.127.0] - 2026-05-08
+
+### Changed
+- add /goal thin wrapper skill (#1109, #1110)
+
+## [0.126.1] - 2026-05-07
+
+### Changed
+- CC tracking issues consolidation (#1104, #1105, #1106, #1107)
+
+## [0.126.0] - 2026-05-02
+
+### Changed
+- R010 /tmp deprecation + manifest sync gate (#1098, #1101, #1099, #1102)
+- deps(dev)(deps-dev): bump @anthropic-ai/sdk from 0.90.0 to 0.92.0 in the development-dependencies group across 1 directory (#1083) (#1083)
+
+## [0.125.1] - 2026-05-01
+
+### Changed
+- sync templates/manifest.json
+
+## [0.125.0] - 2026-05-01
+
+### Changed
+- bump version to 0.125.0
+- v0.125.0 plan + permissions.defaultMode
+- regenerate architecture diagrams via Eraser MCP for v0.124.0 (#1092)
+
+### Fixed
+- R007/R008 multi-turn self-check + enforcement candidate
+- arch-documenter Output Constraints + R018 TaskUpdate discipline
+
+## [0.124.0] - 2026-04-28
+
+### Changed
+- single-agent giant prompt anti-pattern (R009/R018) + arch-documenter token threshold (#1086)
+
+## [0.123.0] - 2026-04-27
+
+### Changed
+- memory MCP server + skill profile loader (#1079, #1080)
+
+## [0.122.0] - 2026-04-27
+
+### Changed
+- memory persistence service (#1077)
+
+## [0.121.0] - 2026-04-27
+
+### Changed
+- memory aggregation + dedup layer (#1073)
+
+## [0.120.0] - 2026-04-27
+
+### Changed
+- memory unification adapters (#1070, #1071, #1072)
+
+## [0.119.0] - 2026-04-27
+
+### Changed
+- OTEL trajectory mode + memory_records table (#1035, #1069)
+
+## [0.118.3] - 2026-04-27
+
+### Changed
+- memory unification docs (#1065, #1066, #1067)
+
+## [0.118.2] - 2026-04-27
+
+### Changed
+- manager/system agent inline /tmp directive (#1062)
+
+## [0.118.1] - 2026-04-27
+
+### Changed
+- wiki sync + R006 skills advisory note ( follow-up) (#1055, #1063)
+
+## [0.118.0] - 2026-04-27
+
+### Changed
+- init auto-setup + fork skill split + token observability (#1048, #1054, #1057, #1060)
+
+## [0.117.0] - 2026-04-27
+
+### Changed
+- context optimization batch (#1045, #1053, #1056)
+
+## [0.116.2] - 2026-04-27
+
+### Changed
+- universal /tmp script bypass directive (#1052, #1058)
+
+## [0.116.1] - 2026-04-27
+
+### Added
+- trigger Airflow issue_triage DAG on issue open (#1049)
+
+### Changed
+- fix delegation chain sensitive-path directive loss (#1043, #1046)
+
+## [0.116.0] - 2026-04-27
+
+### Changed
+- eval-core schema 확장 (drizzle migration, ) (#1036)
+
+## [0.115.0] - 2026-04-26
+
+### Changed
+- LangChain harness/middleware 통합 가이드 (#1021, #1022, #1024, #1026)
+
+## [0.114.0] - 2026-04-26
+
+### Changed
+- R020 정량 evidence advisory + Phased Opt-in Gate 일관화 + 클러스터 정리
+
+## [0.113.0] - 2026-04-26
+
+### Changed
+- agent-eval-framework 4-metric internalization (#1025)
+
+## [0.112.0] - 2026-04-25
+
+### Changed
+- Codex Browser Verify 루프 패턴 (#1009)
+
+## [0.111.1] - 2026-04-25
+
+### Changed
+- v0.111.1 hotfix — Write→/tmp NOTE 정정 (#1016)
+
+## [0.111.0] - 2026-04-25
+
+### Changed
+- sensitive-path Write-tool directive 강제 (#1014)
+
+## [0.110.0] - 2026-04-25
+
+### Changed
+- Output Styles + roundtable-debate anti-groupthink 패턴 (#1003, #1007)
+
+## [0.109.0] - 2026-04-24
+
+### Changed
+- auto-dev /tmp bypass pattern + R006 fork cross-validation (#1000, #1001)
+
+### Fixed
+- resolve context fork cap documentation drift (#984)
+
+## [0.108.0] - 2026-04-24
+
+### Changed
+- 5 P3 bundle: ontology/harness/socratic/sample/google (#993, #994, #986, #975, #971)
+
+## [0.107.0] - 2026-04-24
+
+### Changed
+- R006 refactor + PAL analysis + CI/docs batch (#982, #989, #990, #991, #992, #967, #968, #969)
+
+## [0.106.1] - 2026-04-24
+
+### Changed
+- sdd-dev DR template +  tracker-checkpoint agent (#985, #983)
+
+## [0.106.0] - 2026-04-24
+
+### Changed
+- caveman plugin docs +  ouroboros Ralph Loop guide (#964, #966)
+
+## [0.105.1] - 2026-04-24
+
+### Changed
+- R006 sensitive-path scope extension to Write/Edit tools (#981)
+
+### Fixed
+- correct r006 broken cross-ref and ambiguous wording
+
+## [0.105.0] - 2026-04-24
+
+### Changed
+- Deep Insight 내재화 + 경량 외부 통합 묶음 (#963, #970, #972, #973, #974, #976, #977, #980)
+
+## [0.104.1] - 2026-04-24
+
+### Changed
+- skill mkdir sensitive-path rule fix + regression guard (#978)
+
+## [0.104.0] - 2026-04-21
+
+### Changed
+- CC v2.1.116 compatibility + .claude/ sensitive path fix (#959, #960, #961)
+- sync bun lockfile for @anthropic-ai/sdk 0.90.0
+- deps(dev)(deps-dev): bump @anthropic-ai/sdk
+
+## [0.103.0] - 2026-04-20
+
+### Changed
+- tech stack version updates + bypassPermissions universal mandate (#954, #955)
+
+## [0.102.0] - 2026-04-19
+
+### Changed
+- playwright-compress skill + product-strategy skill + design-shotgun skill + browser-automation guide (#949, #948)
+
+## [0.101.0] - 2026-04-19
+
+### Changed
+- routing accuracy improvement with skill/guide triggers and wiki-rag enrichment (#946)
+
+## [0.100.1] - 2026-04-19
+
+### Changed
+- bypassPermissions propagation fix (#947)
+
+## [0.100.0] - 2026-04-19
+
+### Changed
+- token-efficiency-audit skill + pre-generation-arch-check skill + DCP pruning transparency (#938, #935)
+
+## [0.99.3] - 2026-04-19
+
+### Changed
+- claude-design wiki page fix
+
+### Fixed
+- add claude-design guide wiki page
+
+## [0.99.2] - 2026-04-18
+
+### Changed
+- statusline fix + cleanRegistry + Claude Design guide (#931, #928, #924)
+
+## [0.99.1] - 2026-04-18
+
+### Changed
+- bypassPermissions enforcement + /idea skill (#926, #930)
+
+### Fixed
+- update skill count 106→107 in README and README_ko
+- enforce bypassPermissions on all agent spawns, add /idea skill
+
+## [0.99.0] - 2026-04-18
+
+### Changed
+- auto-dev pipeline CI-mimic local verification (#927)
+
+## [0.98.0] - 2026-04-18
+
+### Changed
+- OpenHarness patterns internalization (#922)
+
+### Fixed
+- correct template sync paths for hooks
+
+## [0.97.1] - 2026-04-18
+
+### Added
+- add hada-scout v2.0 with LLM pre-scout filtering
+
+### Changed
+- hada-scout v2.0 LLM pre-scout filtering (#912)
+
+## [0.97.0] - 2026-04-18
+
+### Changed
+- ouroboros capability graph pattern integration (#909, #910)
+
+## [0.96.0] - 2026-04-18
+
+### Changed
+- CC v2.1.113-v2.1.114 호환성 문서화 (#905)
+
+## [0.95.0] - 2026-04-18
+
+### Changed
+- rules context token optimization (#889)
+
+## [0.94.0] - 2026-04-18
+
+### Changed
+- cc-release-monitor workflow removal (Airflow DAG migration) (#894)
+
+## [0.93.0] - 2026-04-18
+
+### Changed
+- Airflow 3.1.8 에이전트/스킬/가이드 업데이트 (#890)
+
+## [0.92.0] - 2026-04-18
+
+### Changed
+- cc-token-saver integration + harness-synthesizer skill (#886, #888)
+
+## [0.91.0] - 2026-04-17
+
+### Changed
+- CC v2.1.111-v2.1.112 compat (#881)
+
+## [0.90.0] - 2026-04-16
+
+### Changed
+- CC v2.1.110 compat (#877)
+
+## [0.89.0] - 2026-04-15
+
+### Changed
+- CC v2.1.97-v2.1.108 compat (#871)
+
+## [0.88.1] - 2026-04-14
+
+### Changed
+- Rule safety expansion  (R020/R015/R011) (#869, #867)
+
+## [0.88.0] - 2026-04-14
+
+### Changed
+- registry 격리  + re-exec 후속 번들 (#859, #867, #868)
+
+## [0.87.3] - 2026-04-14
+
+### Fixed
+- omcustom update self-update + re-exec 클러스터 v0.87.3 (#862, #863, #864, #865, #866)
+
+## [0.87.2] - 2026-04-14
+
+### Fixed
+- omcustom update --all --hard 핫픽스 v0.87.2 (#860, #861)
+
+## [0.87.1] - 2026-04-14
+
+_No user-visible changes (internal only)._
+
+## [0.87.0] - 2026-04-14
+
+### Changed
+- Claude Code v2.1.105 feature docs (#856)
+
+## [0.86.1] - 2026-04-13
+
+### Added
+- add skill-count-sync advisory hook (#853)
+
+### Changed
+- deps update + skill-count-sync hook
+- regenerate bun.lock for marked 18.0.0
+- regenerate bun.lock for @anthropic-ai/sdk 0.88.0
+- deps(dev)(deps-dev): bump @anthropic-ai/sdk
+- bump marked from 17.0.6 to 18.0.0
+
+### Fixed
+- sync skill-count-reminder hook to templates/.claude/hooks/
+
+## [0.86.0] - 2026-04-13
+
+### Changed
+- hada-scout automation (#841)
+
+### Fixed
+- sync all README.md skill counts to 105
+- sync README.md skill count to 105
+- sync templates/CLAUDE.md skill count to 105
+- sync manifest.json version to 0.86.0
+
+## [0.85.0] - 2026-04-12
+
+### Changed
+- homedir project filter + parallel narrative format + blocker triage
+
+### Fixed
+- sync manifest.json version to 0.85.0
+
+## [0.84.0] - 2026-04-12
+
+### Changed
+- MemKraft bridge + Multica reference integration
+
+## [0.83.0] - 2026-04-12
+
+### Changed
+- Session Auto-Fix hook for previous session issue detection
+
+## [0.82.0] - 2026-04-12
+
+### Changed
+- statusLine refreshInterval fix + multi-agent coding guides
+
+### Fixed
+- add missing wiki pages for 3 new guides
+
+## [0.81.0] - 2026-04-12
+
+### Added
+- v0.81.0 — Wiki system, Adaptive Harness, wiki-rag, R022
+
+### Fixed
+- update README.md counts — agents 48, skills 104, rules 22
+- update manifest.json and CLAUDE.md counts for v0.81.0
+- printf octal interpretation bug in wiki-sync.yml
+- add .claude/rules/ to gitignore exceptions, include SHOULD-wiki-sync.md
+- CI failures — missing rule, grep macOS compat, wiki pages
+
+## [0.80.0] - 2026-04-11
+
+### Added
+- add rule updates and release plan for v0.80.0
+- v0.80.0 release — Stop hook fix, R000/R002/R006/R012 updates, CC v2.1.97-101 compatibility
+
+### Changed
+- sync manifest.json version to 0.80.0
+- bump version to 0.80.0
+
+## [0.79.5] - 2026-04-09
+
+### Changed
+- bump version to 0.79.5
+
+### Fixed
+- align skills with R010 Protected Paths routing
+
+## [0.79.4] - 2026-04-09
+
+### Changed
+- bump version to 0.79.4
+
+### Fixed
+- strengthen R010 with Protected Paths for agent/skill/guide creation
+
+## [0.79.3] - 2026-04-09
+
+### Changed
+- bump version to 0.79.3
+
+### Fixed
+- resolve CI failures for v0.79.3 release
+- clean up stale E2E test registry entries
+
+## [0.79.2] - 2026-04-09
+
+### Added
+- v0.79.2 — registry-based project detection  + update self-update (#812, #811)
+
+### Fixed
+- remove mock.module usage to prevent cross-file test pollution
+- isolate mock.module test to prevent cross-file pollution
+- v0.79.2 CI failures — lint, version sync, test isolation
+
+## [0.79.1] - 2026-04-08
+
+### Fixed
+- v0.79.1 — ARCHITECTURE_ko.md sync (counts, hook table, translations)
+
+## [0.79.0] - 2026-04-08
+
+### Added
+- add geeknews-scout CronJob for GeekNews RSS monitoring
+- add CC release collector CronJob and rule deletion protection hook
+
+### Changed
+- bump version to 0.79.0
+- env-based deploy abstraction for cc-release-collector
+
+### Fixed
+- sync rule-deletion-guard.sh and hooks.json to templates
+- deep-verify findings — SSH injection, hook bypasses, dead code
+
+## [0.78.3] - 2026-04-06
+
+### Changed
+- deps(dev)(deps-dev): bump @anthropic-ai/sdk
+- deps(dev)(deps-dev): bump @types/nodemailer from 7.0.11 to 8.0.0
+
+### Fixed
+- v0.78.3 — dependency updates (@anthropic-ai/sdk 0.82.0, @types/nodemailer 8.0.0)
+
+## [0.78.2] - 2026-04-06
+
+### Added
+- v0.78.2 — slack-cli-expert agent for Slack workspace automation (#794)
+
+## [0.78.1] - 2026-04-06
+
+### Fixed
+- sync hook-data-flow guide to templates and update guide counts 31 → 32
+- v0.78.1 — hook data flow docs + inline hook extraction (#791, #792)
+
+## [0.78.0] - 2026-04-06
+
+### Added
+- v0.78.0 — stall detection hook + task-decomposition granularity integration (#788, #789)
+
+### Fixed
+- sync new hook scripts to templates for CI template-sync check
+
+## [0.77.0] - 2026-04-06
+
+### Added
+- v0.77.0 — adaptive parallel splitting pattern (#786)
+
+## [0.76.2] - 2026-04-06
+
+### Fixed
+- v0.76.2 — rename agora skill to omcustom:agora namespace
+
+## [0.76.1] - 2026-04-06
+
+### Added
+- v0.76.1 — agora multi-LLM adversarial consensus skill
+
+### Fixed
+- update README skill counts 100 → 101 for v0.76.1
+
+## [0.76.0] - 2026-04-05
+
+### Added
+- v0.76.0 — deep-plan dependency gate and R009 hard cap expansion (#782, #783)
+
+## [0.75.0] - 2026-04-05
+
+### Added
+- v0.75.0 — pre-commit DX and pipeline parallel execution (#778, #779)
+
+## [0.74.0] - 2026-04-05
+
+### Added
+- v0.74.0 — ROBOCO CLI feature gaps internalization (#773)
+
+## [0.73.0] - 2026-04-05
+
+### Added
+- v0.73.0 — Hermes Agent internalization (skill-extractor, User Model, agentskills.io) (#762)
+
+### Fixed
+- auto-close linked issues and delete release branch on merge (#776)
+
+## [0.72.1] - 2026-04-03
+
+### Fixed
+- remove deprecated sync-server-repo.yml — server decommissioned since 2026-03-18
+
+## [0.72.0] - 2026-04-03
+
+### Added
+- v0.72.0 — Korean localization for analysis skill templates (#767)
+
+## [0.71.0] - 2026-04-03
+
+### Added
+- v0.71.0 — pipeline skill migration, claude-native release monitor (#758, #759)
+
+### Fixed
+- delete deprecated pr-analysis.yml — Airflow endpoint dead since 2026-03-18
+
+## [0.70.0] - 2026-04-01
+
+### Added
+- v0.70.0 — Codex auto-install, SessionStart auto-update, Airflow dead code removal (#752, #754, #756)
+
+### Fixed
+- sync omcustom-auto-update hook to templates — fix Template Sync CI
+
+## [0.69.0] - 2026-04-01
+
+### Added
+- professor-triage v2.1 multi-perspective analysis + default filter fix (#753, #755)
+
+### Changed
+- professor-triage v2.0 — internalize codebase analysis, remove omc_issue_analyzer dependency
+
+## [0.68.2] - 2026-03-31
+
+### Added
+- RTK auto-install in init/update/doctor (#742)
+
+## [0.68.1] - 2026-03-31
+
+### Fixed
+- self-update cache phantom version guard (#741)
+
+## [0.68.0] - 2026-03-31
+
+### Added
+- CC v2.1.88 compat + RTK PreToolUse auto-intercept (#741, #746)
+
+## [0.67.0] - 2026-03-31
+
+### Added
+- add rtk-exec skill for RTK CLI proxy integration (#742)
+
+## [0.66.0] - 2026-03-30
+
+### Added
+- add gemini-exec skill for native Gemini CLI execution (#739)
+
+## [0.65.2] - 2026-03-30
+
+### Added
+- TypeScript 6.0 upgrade release v0.65.2
+
+### Changed
+- update bun.lock for typescript v6
+- deps(dev)(deps-dev): bump typescript from 5.9.3 to 6.0.2
+- update bun.lockb for i18next v26
+- bump i18next from 25.10.10 to 26.0.2
+
+## [0.65.1] - 2026-03-30
+
+### Added
+- CC v2.1.87 compatibility + auto-dev pre-triage step (#733)
+
+## [0.65.0] - 2026-03-29
+
+### Added
+- hook registry expansion + CC feature integration (#725)
+
+## [0.64.3] - 2026-03-28
+
+### Added
+- internalize Anthropic harness design insights — evaluator calibration, conditional evaluator, context reset (#728)
+
+## [0.64.2] - 2026-03-28
+
+### Added
+- permissionMode tier-based adoption for all 46 agents (#719)
+
+## [0.64.1] - 2026-03-28
+
+### Added
+- agent guardrails (maxTurns/limitations/disallowedTools) + harness-eval template sync (#720, #722)
+
+## [0.64.0] - 2026-03-28
+
+### Added
+- R002 tool modernization (9→30) + R006 frontmatter sync + Fast Mode (#724, #727)
+
+## [0.63.1] - 2026-03-28
+
+### Fixed
+- skill metadata consistency — user-invocable audit, CLAUDE.md sync, effort fix (#718)
+
+## [0.63.0] - 2026-03-28
+
+### Added
+- internalize Chroma Context-1 insights — context pruning, retrieval-reasoning separation, recall bias (#714)
+
+## [0.62.5] - 2026-03-28
+
+_No user-visible changes (internal only)._
+
+## [0.62.4] - 2026-03-28
+
+### Added
+- graph accessibility — circular nav, aria-live, skip link, focus-visible (#706, #707, #708, #709)
+
+### Fixed
+- pass complete PR context to Airflow DAG for accurate analysis
+
+## [0.62.3] - 2026-03-28
+
+### Added
+- graph keyboard accessibility & zoom UX improvements (#699, #700)
+
+## [0.62.2] - 2026-03-28
+
+### Fixed
+- set config.version in updateInstallConfig after init (#696)
+
+## [0.62.1] - 2026-03-28
+
+### Added
+- CI lockfile-sync gate + R016 defect response matrix (#701, #702)
+
+## [0.62.0] - 2026-03-28
+
+### Added
+- Web UI dependency graph visualization (#670)
+
+### Changed
+- update bun.lockb for d3 dependency
+
+## [0.61.0] - 2026-03-27
+
+### Added
+- Permission Mode Guidance + CLI self-update check (#690, #681)
+
+## [0.60.1] - 2026-03-27
+
+### Added
+- action-validator + peer-messaging skills, monitoring-setup inspector docs (#684, #685, #686)
+
+## [0.60.0] - 2026-03-27
+
+### Added
+- CC v2.1.83-85 compatibility + harness design internalization (#683, #682, #676, #687)
+
+### Fixed
+- unify workflow command namespace to /omcustom:workflow
+
+## [0.59.1] - 2026-03-27
+
+### Fixed
+- enforce mandatory triage comment posting (#689)
+
+## [0.59.0] - 2026-03-27
+
+### Added
+- token optimization via HTML comments in rules/ (#688)
+
+## [0.58.6] - 2026-03-25
+
+### Fixed
+- add validation tests, deduplicate CLAUDE.md (#661, #662)
+
+## [0.58.5] - 2026-03-25
+
+### Fixed
+- track guides/ directory in git (#665)
+- track 7 untracked rule files in git (#665)
+
+## [0.58.4] - 2026-03-25
+
+_No user-visible changes (internal only)._
+
+## [0.58.3] - 2026-03-25
+
+### Fixed
+- repair feedback-collector, cost-cap-advisor TSV, updater.ts CRLF (#664, #666, #667)
+
+## [0.58.2] - 2026-03-25
+
+### Added
+- show RL/WL renewal countdown in statusline (#674)
+
+### Changed
+- include build artifact for v0.58.2
+
+## [0.58.1] - 2026-03-24
+
+### Added
+- add post-release-followup step to omcustom-dev workflow
+
+### Changed
+- bump version to v0.58.1
+
+### Fixed
+- add PR feedback source to followup skill, remove package-lock.json
+
+## [0.58.0] - 2026-03-23
+
+### Added
+- v0.58.0 — Impeccable design language integration (#663)
+
+## [0.57.0] - 2026-03-23
+
+### Added
+- v0.57.0 — update --hard namespace sync, Web UI fixes, auto-improve skill, eval pipeline
+
+## [0.56.0] - 2026-03-23
+
+### Added
+- v0.56.0 — PostCompact R000 enforcement, workflow --list, statusline WL sync, dependency updates
+
+## [0.55.0] - 2026-03-23
+
+### Added
+- v0.55.0 — eraser workflow, weekly rate limit statusline
+
+## [0.54.0] - 2026-03-23
+
+### Added
+- v0.54.0 — ARCHITECTURE.md v0.53.1 sync, release-plan fix, Eraser diagrams
+
+## [0.53.1] - 2026-03-23
+
+### Fixed
+- v0.53.1 — auto-tagging fix, workflow rename, custom workflow templates
+
+## [0.53.0] - 2026-03-23
+
+### Added
+- v0.53.0 — dashboard cleanup, project detail, eval-core DB, user feedback
+
+## [0.52.0] - 2026-03-21
+
+### Fixed
+- correct README skill counts for v0.52.0 release validation
+- v0.52.0 — feedback collector hook, routing miss analysis, improve-report skill, R018 scope constraint
+
+## [0.51.2] - 2026-03-21
+
+### Changed
+- bump version to 0.51.2
+
+### Fixed
+- v0.51.2 — R018 advisor batch detection, dashboard cleanup, Projects removal
+
+## [0.51.1] - 2026-03-21
+
+### Changed
+- bump version to 0.51.1
+
+### Fixed
+- v0.51.1 — migration transaction, npm fallback test, CI optimization, Drizzle lesson
+
+## [0.51.0] - 2026-03-21
+
+### Added
+- add /scout skill for external URL analysis and project fit evaluation (#616)
+
+### Changed
+- bump version to 0.51.0
+
+## [0.50.0] - 2026-03-21
+
+### Added
+- lockfile-based smart protection for update + systematic-debugging skill
+
+### Changed
+- bump version to 0.50.0
+
+### Fixed
+- apply deep-verify findings — template CLAUDE.md skill count (84→90)
+
+## [0.49.0] - 2026-03-21
+
+### Added
+- add workflow engine with /workflow:omcustom-dev (#605, #606, #607, #608, #609)
+
+### Changed
+- bump version to 0.49.0
+- update skill count to 89 and register workflow commands
+
+### Fixed
+- apply deep-verify findings — README commands, category count, path validation
+
+## [0.48.5] - 2026-03-21
+
+### Added
+- add /release-plan skill for release-unit planning (#603)
+
+### Changed
+- bump version to 0.48.5
+- bump version to 0.48.5
+- update skill count to 86 after release-plan addition
+
+### Fixed
+- apply deep-verify findings — scope, security, commands table (#603, #611)
+- add bypassPermissions advisory to PostCompact hook (#611)
+
+## [0.48.4] - 2026-03-21
+
+### Added
+- add stale-todo-scanner SessionStart hook (#602)
+
+### Changed
+- bump version to 0.48.4
+
+### Fixed
+- add git add keyword to git-delegation-guard.sh (#600)
+- whitelist .claude/hooks/ in .gitignore and track hook scripts (#602)
+
+## [0.48.3] - 2026-03-21
+
+### Changed
+- bump version to 0.48.3
+
+### Fixed
+- use .claude/* glob pattern for proper gitignore negation (#596)
+- whitelist .claude/skills/ in .gitignore and track script files (#596)
+
+## [0.48.2] - 2026-03-21
+
+### Added
+- add professor-triage intent-detection trigger (#598)
+
+### Changed
+- bump version to 0.48.2 with professor-triage template sync
+
+## [0.48.1] - 2026-03-21
+
+### Added
+- expand /deep-verify with philosophy gate and add web-scraping guide (#593)
+
+### Changed
+- bump version to 0.48.1
+
+## [0.48.0] - 2026-03-21
+
+### Added
+- v0.48.0 — conflict resolution, dashboard cleanup, CI optimization (#586)
+
+### Changed
+- bump version to 0.48.0
+
+## [0.47.2] - 2026-03-20
+
+### Changed
+- bump version to 0.47.2
+
+### Fixed
+- prevent version downgrade and unify version display sources (#584)
+
+## [0.47.1] - 2026-03-20
+
+### Changed
+- bump version to 0.47.1
+
+### Fixed
+- remove auto-start serve from init to prevent orphan servers (#580)
+
+## [0.47.0] - 2026-03-20
+
+### Added
+- add feedback analysis engine and improvement tracking (#545)
+- add omcustom-loop skill with SubagentStop prompt hook (#556)
+- add omcustom web CLI command with start/stop/status/open (#538, #540)
+- add anonymous feedback option and remove gh hard dependency (#547, #555)
+- automate release tag creation after PR merge (#533, #551)
+- redesign main dashboard to project statistics view (#536, #539)
+- session auto-collection with projects and feedback schema (#534, #542)
+
+### Changed
+- bump version to 0.47.0
+- rebuild dist after json_group_array fix
+
+### Fixed
+- replace group_concat with json_group_array for delimiter safety
+- address all deep review findings and resolve test failures
+- add cwd and parent dir to projects search path (#546, #553)
+- align slash command names with actual skill names (#550, #554)
+- resolve empty project page when accessing /projects?project=slug (#537, #541)
+- improve statusline CTX accuracy with fallback calculation and atomic write (#543, #549)
+- add worktree detection to pre-commit hook for lightweight checks (#544, #548)
+
+## [0.46.1] - 2026-03-20
+
+### Fixed
+- statusline RL segment ANSI escape codes rendered as raw text
+- rename OMCUSTOM_PROJECT_ROOT to OMX_PROJECT_ROOT (#530)
+- commit missing sync-source-lockfile.ts and bump to v0.46.1 (#529)
+
+## [0.46.0] - 2026-03-20
+
+### Added
+- v0.46.0 — CC v2.1.80 compat, multi-project Web UI, batch update UI, docs refresh
+
+## [0.45.3] - 2026-03-20
+
+### Fixed
+- version comparison inconsistency between projects and updater (#525)
+
+## [0.45.2] - 2026-03-20
+
+### Changed
+- bump version to 0.45.2
+
+## [0.45.1] - 2026-03-19
+
+### Added
+- add omcustom update --all and interactive multi-project update (#518)
+
+### Changed
+- bump version to 0.45.1
+
+## [0.45.0] - 2026-03-19
+
+### Added
+- add PR analysis workflow with Airflow JWT auth (#515)
+- add ambiguity-gate skill — ouroboros-inspired pre-routing analysis (#507)
+- add /omcustom:feedback skill for GitHub issue submission (#498)
+- add omcustom projects command with lock file infrastructure (#495)
+- add SDD (Spec-Driven Development) skill (#506)
+- add argument-hint to 5 user-invocable skills (#494)
+
+### Changed
+- bump version to 0.45.0
+
+### Fixed
+- sync guides count in manifest and README (#507)
+- sync skill count to 77 in manifest and README (#494)
+
+## [0.44.6] - 2026-03-19
+
+### Changed
+- bump version to 0.44.6
+
+### Fixed
+- migrate Airflow CI workflows to JWT token auth for Airflow 3.x
+
+## [0.44.5] - 2026-03-19
+
+### Added
+- add Alembic migration expert agent, skill, and guide
+
+## [0.44.4] - 2026-03-19
+
+### Changed
+- bump version to 0.44.4
+
+### Fixed
+- update issue-analyzer workflow for Docker-based Airflow
+
+## [0.44.3] - 2026-03-19
+
+### Changed
+- bump version to 0.44.3
+
+### Fixed
+- make GitHub Packages verification non-blocking in verify-release
+
+## [0.44.2] - 2026-03-19
+
+### Added
+- autonomous execution mode and long-session compliance improvements (#485, #483)
+
+### Changed
+- bump version to 0.44.2
+
+## [0.44.1] - 2026-03-18
+
+### Changed
+- bump version to 0.44.1
+
+### Fixed
+- make verify-release non-blocking and increase GHP retry count
+
+## [0.44.0] - 2026-03-18
+
+### Added
+- add evaluations table and Web UI evaluation pages (#467, #481)
+- add sidebar Core category and dashboard analytics (#470, #480)
+- add /omcustom:web interactive toggle, remove SessionStart auto-serve (#476, #479)
+- add verify-release job to release workflow (#474, #477)
+
+### Changed
+- bump version to 0.44.0
+
+### Fixed
+- replace truncate with line-clamp-2 for description readability (#475, #478)
+- update docs-sync.yml to macos-latest — nuc13 runner removed (#474)
+
+## [0.43.1] - 2026-03-18
+
+### Added
+- add skill/guide creation pages and SessionStart auto-serve (#469)
+
+### Changed
+- bump version to 0.43.1
+- move lightweight jobs to GitHub-hosted runners (#471, #472)
+
+### Fixed
+- inline issue number in SSH script to fix JSON parse error
+
+## [0.43.0] - 2026-03-18
+
+### Added
+- add omcustom serve/serve-stop commands with auto-start (#466)
+- add built-in Web UI — SvelteKit agent/skill/guide/rule explorer (#466)
+- add issue analyzer webhook trigger
+
+### Changed
+- bump version to 0.43.0
+
+## [0.42.3] - 2026-03-18
+
+### Added
+- add git worktree workflow guide + .gitignore update (#463)
+- add CLI native modules — scope-filter, lockfile-hasher, file-tree-scanner (#421)
+
+### Changed
+- bump version to 0.42.3
+
+### Fixed
+- code review fixes — Domain Copy/FromStr/Database, extension_filter rename, bench bug (#421)
+
+## [0.42.2] - 2026-03-18
+
+### Changed
+- sauron auto-fix — skill count, context:fork list, template sync
+- bump version to 0.42.2
+
+### Fixed
+- add sequential-dependency guidance and blocked agent behavior (#457, #461)
+
+## [0.42.1] - 2026-03-16
+
+### Fixed
+- v0.42.1 — fix README skill count for release validation
+- update skill count 74→75 in README files
+
+## [0.42.0] - 2026-03-16
+
+### Added
+- v0.42.0 — Performance
+
+## [0.41.0] - 2026-03-16
+
+### Added
+- v0.41.0 — Skills & DX
+
+## [0.40.0] - 2026-03-16
+
+### Added
+- v0.40.0 — Rule Clarity & Testing
+
+## [0.39.0] - 2026-03-16
+
+### Added
+- v0.39.0 — Quick Fixes & Dependencies
+
+### Changed
+- bump drizzle-orm in the production-dependencies group
+- deps(dev)(deps-dev): bump drizzle-kit
+
+### Fixed
+- sync templates with source hooks for v0.39.0
+- sync bun.lock for drizzle-orm update
+- sync bun.lock for drizzle-kit update
+
+## [0.38.0] - 2026-03-16
+
+### Added
+- upgrade to v0.38.0 — README/ARCHITECTURE rewrite + version bump
+- CC v2.1.72~v2.1.74 compatibility updates
+- Claude Code v2.1.76 compatibility — PostCompact hook + R006 sync
+- add @omcustom/eval-core MVP with bun workspace
+- add interactive init wizard with @clack/prompts
+
+### Fixed
+- final audit — guide sync, version, context:fork cap, skill categories, code cleanup
+- force-add untracked template rule file (MUST-completion-verification.md)
+- audit follow-up — template sync + code cleanup + test alignment
+- deep audit findings — hooks integrity + eval-core parser safety
+- sync templates with source — R011 memory sections + session-env-check CI block
+- security audit CI compatibility with bun workspaces
+
+## [0.37.2] - 2026-03-16
+
+### Added
+- remove Claude Native Check CI workflow
+
+## [0.37.1] - 2026-03-16
+
+### Added
+- activate codex-exec auto-delegation in research and routing skills
+
+### Changed
+- bump version to 0.37.1
+
+## [0.37.0] - 2026-03-16
+
+### Added
+- v0.37.0 structure optimization — 6 issues across token efficiency and workflow
+
+## [0.36.2] - 2026-03-15
+
+### Fixed
+- sync missing hook scripts and hooks.json to templates
+- add template-sync CI job to catch .claude/ <-> templates/ desync (#382)
+
+## [0.36.1] - 2026-03-15
+
+### Added
+- replace Claude API release-notes CI with in-session skill
+
+### Fixed
+- add missing skills to templates for validate-docs CI
+
+## [0.36.0] - 2026-03-15
+
+### Added
+- release v0.36.0 — 26 issues across Harness Engineering + codespeak patterns
+
 ## [0.35.0] - 2026-03-14
 
 ### Added

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,10 @@
+"""Root conftest.py — adds the project root to sys.path for all tests."""
+import sys
+import os
+
+# Ensure project root is importable as the top-level package namespace.
+# This allows `from scripts.backfill_changelog import ...` to work regardless
+# of how pytest resolves the rootdir.
+_ROOT = os.path.dirname(os.path.abspath(__file__))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2334,7 +2334,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.128.0",
+    version: "0.129.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2014,7 +2014,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.128.0",
+  version: "0.129.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.128.0",
+  "version": "0.129.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/scripts/backfill_changelog.py
+++ b/scripts/backfill_changelog.py
@@ -1,0 +1,463 @@
+#!/usr/bin/env python3
+"""Deterministic CHANGELOG.md backfill tool.
+
+Generate a Keep-a-Changelog formatted history for a tag range by reading
+git history and GitHub release metadata.
+
+Usage
+-----
+    python3 scripts/backfill_changelog.py <START>..<END> [--output FILE]
+
+Example
+-------
+    python3 scripts/backfill_changelog.py v0.36.0..v0.127.0 --output backfill.md
+
+The range is exclusive of START_TAG and inclusive of END_TAG.
+Output is ordered newest-first (reverse semver).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Keep-a-Changelog canonical category order.
+CATEGORY_ORDER: list[str] = [
+    "Added",
+    "Changed",
+    "Fixed",
+    "Security",
+    "Removed",
+    "Deprecated",
+]
+
+#: Conventional Commit prefix → changelog category.
+_PREFIX_TO_CATEGORY: dict[str, str] = {
+    "feat": "Added",
+    "fix": "Fixed",
+    "security": "Security",
+    "perf": "Changed",
+    "refactor": "Changed",
+    "chore": "Changed",
+    "build": "Changed",
+    "deps": "Changed",
+    "revert": "Changed",
+}
+
+#: Conventional Commit prefixes whose commits are silently skipped
+#: UNLESS they carry a breaking-change marker (!).
+_SKIP_PREFIXES: frozenset[str] = frozenset({"docs", "test", "ci", "style"})
+
+#: Regex for Conventional Commits.
+#: Groups: (type)(scope?)(breaking?)(subject)
+_CONV_COMMIT_RE = re.compile(
+    r"^([a-z]+)"          # type
+    r"(\([^)]+\))?"       # optional scope
+    r"(!)?"               # optional breaking marker
+    r":\s*"               # colon + whitespace
+    r"(.+)$"              # subject
+)
+
+#: Regex for issue references like #123.
+_ISSUE_REF_RE = re.compile(r"#(\d+)")
+
+#: Regex to strip version prefix from release/chore(release) descriptions.
+#: Matches: "v0.127.0 — rest of message" or "v0.127.0 - rest of message"
+_RELEASE_VERSION_RE = re.compile(r"^v\d+\.\d+\.\d+\s*[—-]\s*")
+
+#: Merge commit patterns to skip.
+_MERGE_PATTERNS: tuple[str, ...] = (
+    "Merge pull request",
+    "Merge branch",
+)
+
+
+# ---------------------------------------------------------------------------
+# Public helpers (importable by tests)
+# ---------------------------------------------------------------------------
+
+
+def extract_issue_refs(text: str) -> list[str]:
+    """Return all issue numbers (as strings) found in *text*.
+
+    Args:
+        text: Arbitrary string, e.g. a commit subject.
+
+    Returns:
+        Ordered list of issue number strings (no ``#`` prefix).
+
+    Example::
+
+        >>> extract_issue_refs("fix crash (#42, #99)")
+        ['42', '99']
+    """
+    return _ISSUE_REF_RE.findall(text)
+
+
+def parse_commit(subject: str) -> tuple[Optional[str], str, list[str]]:
+    """Classify a commit subject into a changelog entry.
+
+    Args:
+        subject: Raw git commit subject line.
+
+    Returns:
+        A 3-tuple ``(category, message, refs)``:
+
+        * ``category`` — one of the :data:`CATEGORY_ORDER` strings, or
+          ``None`` if the commit should be skipped entirely.
+        * ``message`` — cleaned human-readable description.  Breaking
+          changes are prefixed with ``**BREAKING**: ``.
+        * ``refs`` — list of issue numbers extracted from the subject.
+
+    The caller is responsible for assembling the final formatted line.
+    """
+    # Skip merge commits unconditionally.
+    for pattern in _MERGE_PATTERNS:
+        if subject.startswith(pattern):
+            return None, subject, []
+
+    refs = extract_issue_refs(subject)
+
+    m = _CONV_COMMIT_RE.match(subject)
+    if m:
+        commit_type, _scope, breaking, raw_desc = m.groups()
+        is_breaking = breaking == "!"
+
+        # Handle release commits: extract human description after version stamp.
+        if commit_type in ("release",) or (
+            commit_type == "chore" and _scope in ("(release)",)
+        ):
+            desc = _RELEASE_VERSION_RE.sub("", raw_desc, count=1)
+            # Strip issue refs from desc; they are returned separately.
+            desc = _strip_issue_refs(desc)
+            message = _build_message(desc, is_breaking)
+            return "Changed", message, refs
+
+        # Normally-skipped prefixes are kept only when breaking.
+        if commit_type in _SKIP_PREFIXES and not is_breaking:
+            return None, subject, []
+
+        category = _PREFIX_TO_CATEGORY.get(commit_type)
+        if category is None:
+            # Unknown conventional prefix → treat as Changed.
+            category = "Changed"
+
+        # Strip issue refs from raw_desc; they are returned separately.
+        desc = _strip_issue_refs(raw_desc)
+        message = _build_message(desc, is_breaking)
+        return category, message, refs
+
+    # Non-conventional commit → Changed, full subject as message.
+    return "Changed", subject, refs
+
+
+def format_section(
+    version: str,
+    date: str,
+    categories: dict[str, list[str]],
+) -> str:
+    """Render a single changelog section in Keep-a-Changelog format.
+
+    Args:
+        version: Semver version string without ``v`` prefix (e.g. ``"0.42.0"``).
+        date: ISO date string ``YYYY-MM-DD``.
+        categories: Mapping of category name → list of formatted entry strings.
+            Only categories present in :data:`CATEGORY_ORDER` are rendered.
+
+    Returns:
+        Markdown-formatted changelog section string.
+
+    Example::
+
+        >>> print(format_section("1.0.0", "2026-01-01", {"Added": ["new thing"]}))
+        ## [1.0.0] - 2026-01-01
+        <BLANKLINE>
+        ### Added
+        - new thing
+        <BLANKLINE>
+    """
+    lines: list[str] = [f"## [{version}] - {date}", ""]
+
+    has_entries = any(
+        entries
+        for cat, entries in categories.items()
+        if cat in CATEGORY_ORDER
+    )
+
+    if not has_entries:
+        lines.append("_No user-visible changes (internal only)._")
+        lines.append("")
+        return "\n".join(lines)
+
+    for cat in CATEGORY_ORDER:
+        entries = categories.get(cat)
+        if not entries:
+            continue
+        lines.append(f"### {cat}")
+        for entry in entries:
+            lines.append(f"- {entry}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def sort_tags_semver(tags: list[str]) -> list[str]:
+    """Sort tag strings in descending semver order (newest first).
+
+    Non-semver tags are placed at the end of the list in their original
+    relative order (they do not raise errors).
+
+    Args:
+        tags: List of git tag strings, optionally prefixed with ``v``.
+
+    Returns:
+        New sorted list.
+    """
+    def _key(tag: str) -> tuple[int, ...]:
+        cleaned = tag.lstrip("v")
+        parts = cleaned.split(".")
+        try:
+            return tuple(int(p) for p in parts)
+        except ValueError:
+            # Non-semver sorts last (treated as version 0.0.0).
+            return (-1, -1, -1)
+
+    return sorted(tags, key=_key, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _strip_issue_refs(text: str) -> str:
+    """Remove all issue references and resulting empty parens from *text*.
+
+    For example::
+
+        "fix crash (#42)" → "fix crash"
+        "thing (#10, #20)" → "thing"
+        "no refs here" → "no refs here"
+    """
+    # Remove individual #NNN occurrences.
+    cleaned = _ISSUE_REF_RE.sub("", text)
+    # Remove empty or whitespace-only parentheses left behind, e.g. "(, )" or "()".
+    cleaned = re.sub(r"\(\s*[,\s]*\)", "", cleaned)
+    # Strip trailing commas, spaces.
+    return cleaned.rstrip(" ,")
+
+
+def _build_message(desc: str, is_breaking: bool) -> str:
+    """Combine description with optional breaking prefix.
+
+    Issue refs are NOT appended here — they are returned separately by
+    ``parse_commit`` and composed into the final entry by the caller
+    (e.g., ``_build_categories``).
+    """
+    desc = desc.strip()
+    if is_breaking:
+        desc = f"**BREAKING**: {desc}"
+    return desc
+
+
+def _get_release_date(tag: str) -> str:
+    """Return YYYY-MM-DD for *tag*, preferring GitHub release metadata.
+
+    Falls back to ``git log`` author date if ``gh`` is unavailable or the
+    release does not exist on GitHub.
+    """
+    try:
+        raw = subprocess.check_output(
+            [
+                "gh", "release", "view", tag,
+                "--json", "publishedAt",
+                "--jq", ".publishedAt",
+            ],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        if raw:
+            return raw[:10]
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+
+    raw = subprocess.check_output(
+        ["git", "log", "-1", "--format=%aI", tag],
+        text=True,
+    ).strip()
+    return raw[:10]
+
+
+def _get_commits_in_range(prev_tag: str, tag: str) -> list[str]:
+    """Return raw commit subjects between *prev_tag* and *tag* (no merges)."""
+    output = subprocess.check_output(
+        ["git", "log", f"{prev_tag}..{tag}", "--pretty=%s", "--no-merges"],
+        text=True,
+    )
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def _list_all_tags() -> list[str]:
+    """Return all git tags in the repository."""
+    output = subprocess.check_output(
+        ["git", "tag", "--list"],
+        text=True,
+    )
+    return [t.strip() for t in output.splitlines() if t.strip()]
+
+
+def _tags_in_range(all_tags: list[str], start: str, end: str) -> list[str]:
+    """Return tags strictly after *start* and up to and including *end*.
+
+    Returns tags in descending semver order (newest first).
+    """
+    sorted_all = sort_tags_semver(all_tags)
+
+    # Build a semver-comparable key for boundary comparison.
+    def _semver(tag: str) -> tuple[int, ...]:
+        cleaned = tag.lstrip("v")
+        parts = cleaned.split(".")
+        try:
+            return tuple(int(p) for p in parts[:3])
+        except ValueError:
+            return (0, 0, 0)
+
+    start_key = _semver(start)
+    end_key = _semver(end)
+
+    result = []
+    for tag in sorted_all:
+        k = _semver(tag)
+        if start_key < k <= end_key:
+            result.append(tag)
+    return result
+
+
+def _previous_tag(sorted_all: list[str], tag: str) -> Optional[str]:
+    """Return the semver-immediately-prior tag to *tag* in *sorted_all*.
+
+    *sorted_all* must be in **descending** semver order.
+    Returns ``None`` if *tag* is the earliest.
+    """
+    try:
+        idx = sorted_all.index(tag)
+    except ValueError:
+        return None
+    # Descending order → next index is the older tag.
+    if idx + 1 < len(sorted_all):
+        return sorted_all[idx + 1]
+    return None
+
+
+def _build_categories(subjects: list[str]) -> dict[str, list[str]]:
+    """Parse commit subjects and group entries by changelog category.
+
+    Each entry is a formatted string ``"description (#ref1, #ref2)"``
+    ready for direct inclusion in the changelog.
+    """
+    categories: dict[str, list[str]] = {}
+    for subject in subjects:
+        cat, msg, refs = parse_commit(subject)
+        if cat is None:
+            continue
+        entry = msg
+        if refs:
+            entry = f"{msg} ({', '.join('#' + r for r in refs)})"
+        categories.setdefault(cat, []).append(entry)
+    return categories
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a Keep-a-Changelog backfill for a git tag range.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Example:\n"
+            "  python3 scripts/backfill_changelog.py v0.36.0..v0.127.0 "
+            "--output backfill.md"
+        ),
+    )
+    parser.add_argument(
+        "range",
+        metavar="START..END",
+        help="Tag range in git log notation (START exclusive, END inclusive).",
+    )
+    parser.add_argument(
+        "--output",
+        metavar="FILE",
+        default=None,
+        help="Write output to FILE instead of stdout.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    """CLI entry point."""
+    args = _parse_args(argv)
+
+    if ".." not in args.range:
+        sys.exit(f"Error: range must be in START..END format, got: {args.range!r}")
+
+    start_tag, end_tag = args.range.split("..", 1)
+
+    all_tags = _list_all_tags()
+    sorted_all = sort_tags_semver(all_tags)
+
+    tags_to_process = _tags_in_range(all_tags, start_tag, end_tag)
+
+    if not tags_to_process:
+        sys.exit(
+            f"No tags found in range {start_tag!r}..{end_tag!r}. "
+            "Check that both tags exist."
+        )
+
+    sections: list[str] = []
+    for tag in tags_to_process:
+        prev = _previous_tag(sorted_all, tag)
+        if prev is None:
+            # No earlier tag — use git root commit as base.
+            prev_ref = ""
+        else:
+            prev_ref = prev
+
+        date = _get_release_date(tag)
+        version = tag.lstrip("v")
+
+        subjects: list[str]
+        if prev_ref:
+            subjects = _get_commits_in_range(prev_ref, tag)
+        else:
+            # Range from first commit to tag.
+            first = subprocess.check_output(
+                ["git", "rev-list", "--max-parents=0", "HEAD"],
+                text=True,
+            ).strip()
+            subjects = _get_commits_in_range(first, tag)
+
+        categories = _build_categories(subjects)
+        sections.append(format_section(version, date, categories))
+
+    output = "\n".join(sections).rstrip() + "\n"
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as fh:
+            fh.write(output)
+        print(f"Written to {args.output}")
+    else:
+        sys.stdout.write(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/.claude/skills/omcustom-release-notes/SKILL.md
+++ b/templates/.claude/skills/omcustom-release-notes/SKILL.md
@@ -3,7 +3,7 @@ name: omcustom-release-notes
 description: Generate structured release notes from git history and closed issues within Claude Code session
 scope: harness
 user-invocable: true
-argument-hint: "<version> [--previous-tag <tag>]"
+argument-hint: "<version> [--previous-tag <tag>] | --backfill <range>"
 ---
 
 # Release Notes Generator
@@ -19,6 +19,7 @@ Replaces the CI-based `release-notes.yml` workflow that previously used Claude A
 ```
 /omcustom-release-notes 0.36.0
 /omcustom-release-notes 0.36.0 --previous-tag v0.35.3
+/omcustom-release-notes --backfill v0.36.0..v0.127.0
 ```
 
 ## Workflow
@@ -137,6 +138,56 @@ Behavior:
 
 This is **optional** — the skill's release-notes generation (Phases 1-4) works independently. Phase 5 only ensures CHANGELOG consistency for projects that maintain Keep a Changelog format.
 
+## Backfill Mode
+
+For projects with historical CHANGELOG.md gaps (releases shipped without `[Unreleased]` promotion), the skill provides a deterministic batch backfill.
+
+### Usage
+
+```bash
+python3 scripts/backfill_changelog.py <START_TAG>..<END_TAG> [--output FILE]
+```
+
+Or invoked via skill: `/omcustom-release-notes --backfill v0.36.0..v0.127.0`
+
+### Behavior
+
+For each tag in range (in reverse semver order), the script:
+
+1. Determines previous tag (semver-immediately-before)
+2. Reads `git log <prev>..<tag> --pretty=%s --no-merges` to extract commit subjects
+3. Maps Conventional Commits prefix to Keep a Changelog category:
+   - `feat` → Added
+   - `fix` → Fixed
+   - `security` → Security
+   - `perf`, `refactor`, `chore`, `build`, `deps`, `revert` → Changed
+   - `docs`, `test`, `ci`, `style` → SKIPPED (internal-only, unless `!` breaking marker)
+   - Non-conventional → Changed (full subject as message)
+4. Special handling for `release:` / `chore(release):` commits — extracts description after version (e.g., `release: v0.127.0 — DESC` → DESC under Changed)
+5. Extracts issue refs (`#NNN`) and appends as `(#1, #2)` suffix
+6. Renders per-version section with categories sorted: Added, Changed, Fixed, Security, Removed, Deprecated
+7. Empty sections (zero qualifying commits) render as `_No user-visible changes (internal only)._`
+
+### Output
+
+Markdown text suitable for prepending to CHANGELOG.md between `## [Unreleased]` and the first existing version section.
+
+### When to Use
+
+- Adopting Keep a Changelog format on an existing project with N historical releases
+- Recovering after a CHANGELOG drift period
+- One-time bulk operation — afterward, use Phase 5 promotion (forward-looking) for ongoing maintenance
+
+### Limitations
+
+- Only as good as commit message quality. Squash-merge release commits typically contain only the PR title — backfill produces 1-2 lines per version, not exhaustive change lists
+- Non-conventional or pre-Conventional Commits adoption commits land in Changed
+- Manual curation may improve specific entries; the script provides the baseline
+
+### Tests
+
+`tests/scripts/test_backfill_changelog.py` covers parser correctness, semver sorting, category mapping, edge cases (40 tests).
+
 ## Integration
 
 This skill is designed to be used during the release process:
@@ -155,6 +206,7 @@ mgr-gitnerd: gh release create           ->  create release with notes
 - Resource count changes auto-detected from CLAUDE.md history
 - Phase 5 promotion is idempotent — safe to re-run; skips if `## [VERSION]` exists
 - See `CONTRIBUTING.md` for [Unreleased] entry guidance during PR authoring
+- For one-time historical backfill, see Backfill Mode above (script: `scripts/backfill_changelog.py`)
 
 ## Permission Mode
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.128.0",
+  "version": "0.129.0",
   "lastUpdated": "2026-04-24T07:30:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/tests/scripts/test_backfill_changelog.py
+++ b/tests/scripts/test_backfill_changelog.py
@@ -1,0 +1,302 @@
+"""
+Tests for scripts/backfill_changelog.py
+
+Run with:
+    python3 -m pytest tests/scripts/test_backfill_changelog.py -v
+"""
+
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+# ---------------------------------------------------------------------------
+# Import the module under test.
+# The script lives at scripts/backfill_changelog.py; add the project root to
+# sys.path so we can import it as `scripts.backfill_changelog`.
+# ---------------------------------------------------------------------------
+import importlib
+import os
+
+# Ensure project root is on sys.path regardless of how pytest is invoked.
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from scripts.backfill_changelog import (  # noqa: E402
+    format_section,
+    parse_commit,
+    extract_issue_refs,
+    sort_tags_semver,
+    CATEGORY_ORDER,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_commit tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseCommit(unittest.TestCase):
+    """Unit tests for parse_commit()."""
+
+    def test_parse_commit_feat(self):
+        cat, msg, refs = parse_commit("feat: add new skill (#42)")
+        self.assertEqual(cat, "Added")
+        self.assertEqual(msg, "add new skill")
+        self.assertEqual(refs, ["42"])
+
+    def test_parse_commit_fix_with_scope(self):
+        cat, msg, refs = parse_commit("fix(skills): resolve memory leak")
+        self.assertEqual(cat, "Fixed")
+        self.assertIn("resolve memory leak", msg)
+        self.assertEqual(refs, [])
+
+    def test_parse_commit_chore_release_with_desc(self):
+        cat, msg, refs = parse_commit(
+            "chore(release): v0.127.0 — /goal thin wrapper skill (#1109)"
+        )
+        self.assertEqual(cat, "Changed")
+        self.assertIn("/goal thin wrapper skill", msg)
+        self.assertIn("1109", refs)
+
+    def test_parse_commit_skip_docs(self):
+        cat, msg, refs = parse_commit("docs: update README")
+        self.assertIsNone(cat)
+
+    def test_parse_commit_skip_test(self):
+        cat, msg, refs = parse_commit("test: add coverage")
+        self.assertIsNone(cat)
+
+    def test_parse_commit_skip_ci(self):
+        cat, msg, refs = parse_commit("ci: update GitHub Actions workflow")
+        self.assertIsNone(cat)
+
+    def test_parse_commit_skip_style(self):
+        cat, msg, refs = parse_commit("style: reformat imports")
+        self.assertIsNone(cat)
+
+    def test_parse_commit_breaking_keeps_test(self):
+        """Breaking changes must NOT be skipped even for normally-skipped prefixes."""
+        cat, msg, refs = parse_commit("feat!: breaking API change")
+        self.assertEqual(cat, "Added")
+        self.assertTrue(msg.startswith("**BREAKING**:"))
+
+    def test_parse_commit_breaking_docs_not_skipped(self):
+        """docs! (breaking) should surface as Changed/Added, not be silently dropped."""
+        cat, msg, refs = parse_commit("docs!: remove legacy endpoint docs")
+        self.assertIsNotNone(cat)
+        self.assertTrue(msg.startswith("**BREAKING**:"))
+
+    def test_parse_commit_non_conventional(self):
+        cat, msg, refs = parse_commit("Random commit message")
+        self.assertEqual(cat, "Changed")
+        self.assertEqual(msg, "Random commit message")
+
+    def test_parse_commit_merge_skipped(self):
+        cat, msg, refs = parse_commit("Merge pull request #1 from foo/bar")
+        self.assertIsNone(cat)
+
+    def test_parse_commit_merge_branch_skipped(self):
+        cat, msg, refs = parse_commit("Merge branch 'develop' into feature/xyz")
+        self.assertIsNone(cat)
+
+    def test_parse_commit_perf_maps_to_changed(self):
+        cat, msg, refs = parse_commit("perf: speed up query execution")
+        self.assertEqual(cat, "Changed")
+
+    def test_parse_commit_security_maps_correctly(self):
+        cat, msg, refs = parse_commit("security: patch XSS vulnerability (#99)")
+        self.assertEqual(cat, "Security")
+        self.assertIn("99", refs)
+
+    def test_parse_commit_refactor_maps_to_changed(self):
+        cat, msg, refs = parse_commit("refactor: simplify routing logic")
+        self.assertEqual(cat, "Changed")
+
+    def test_parse_commit_release_plain(self):
+        """release: commit should extract description after version pattern."""
+        cat, msg, refs = parse_commit("release: v0.42.0 — new release (#100)")
+        self.assertEqual(cat, "Changed")
+        self.assertIn("new release", msg)
+        self.assertIn("100", refs)
+
+    def test_parse_commit_deps_maps_to_changed(self):
+        cat, msg, refs = parse_commit("deps: bump lodash from 4.17.20 to 4.17.21")
+        self.assertEqual(cat, "Changed")
+
+    def test_parse_commit_multiple_issue_refs(self):
+        cat, msg, refs = parse_commit("fix: resolve crash (#10, #20)")
+        self.assertEqual(cat, "Fixed")
+        self.assertIn("10", refs)
+        self.assertIn("20", refs)
+
+    def test_parse_commit_revert_maps_to_changed(self):
+        cat, msg, refs = parse_commit("revert: undo bad migration")
+        self.assertEqual(cat, "Changed")
+
+    def test_parse_commit_build_maps_to_changed(self):
+        cat, msg, refs = parse_commit("build: update Dockerfile base image")
+        self.assertEqual(cat, "Changed")
+
+    def test_parse_commit_feat_with_scope_and_ref(self):
+        cat, msg, refs = parse_commit("feat(api): add pagination endpoint (#55)")
+        self.assertEqual(cat, "Added")
+        self.assertIn("add pagination endpoint", msg)
+        self.assertEqual(refs, ["55"])
+
+
+# ---------------------------------------------------------------------------
+# extract_issue_refs tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractIssueRefs(unittest.TestCase):
+    """Unit tests for extract_issue_refs()."""
+
+    def test_single_ref(self):
+        self.assertEqual(extract_issue_refs("fix crash (#42)"), ["42"])
+
+    def test_multiple_refs(self):
+        refs = extract_issue_refs("closes (#10, #20, #30)")
+        self.assertIn("10", refs)
+        self.assertIn("20", refs)
+        self.assertIn("30", refs)
+
+    def test_no_ref(self):
+        self.assertEqual(extract_issue_refs("no issue here"), [])
+
+    def test_inline_ref(self):
+        refs = extract_issue_refs("mentioned in #99 and done")
+        self.assertIn("99", refs)
+
+    def test_strips_trailing_parens_from_message(self):
+        """Trailing paren refs are part of the string — ensure extraction is complete."""
+        refs = extract_issue_refs("do something (#1) (#2)")
+        self.assertIn("1", refs)
+        self.assertIn("2", refs)
+
+
+# ---------------------------------------------------------------------------
+# format_section tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSection(unittest.TestCase):
+    """Unit tests for format_section()."""
+
+    def test_format_section_with_categories(self):
+        section = format_section(
+            "0.42.0",
+            "2026-04-01",
+            {
+                "Added": ["new feature (#1)"],
+                "Fixed": ["a bug (#2)"],
+            },
+        )
+        self.assertIn("## [0.42.0] - 2026-04-01", section)
+        self.assertIn("### Added", section)
+        self.assertIn("### Fixed", section)
+        self.assertIn("- new feature (#1)", section)
+        # Order: Added before Fixed
+        self.assertLess(section.index("### Added"), section.index("### Fixed"))
+
+    def test_format_section_empty(self):
+        section = format_section("0.42.0", "2026-04-01", {})
+        self.assertIn("_No user-visible changes", section)
+
+    def test_format_section_category_order(self):
+        """Categories appear in canonical Keep-a-Changelog order."""
+        section = format_section(
+            "1.0.0",
+            "2026-01-01",
+            {
+                "Fixed": ["bug fix"],
+                "Added": ["new thing"],
+                "Security": ["cve patch"],
+                "Changed": ["updated api"],
+            },
+        )
+        added_idx = section.index("### Added")
+        changed_idx = section.index("### Changed")
+        fixed_idx = section.index("### Fixed")
+        security_idx = section.index("### Security")
+        self.assertLess(added_idx, changed_idx)
+        self.assertLess(changed_idx, fixed_idx)
+        self.assertLess(fixed_idx, security_idx)
+
+    def test_format_section_header_format(self):
+        section = format_section("1.2.3", "2025-06-15", {"Changed": ["tweak"]})
+        # Must match Keep-a-Changelog header style
+        self.assertIn("## [1.2.3] - 2025-06-15", section)
+
+    def test_format_section_no_unknown_categories(self):
+        """Only known CATEGORY_ORDER categories appear in section headers."""
+        section = format_section(
+            "1.0.0", "2026-01-01", {"Added": ["x"], "Unknown": ["y"]}
+        )
+        # Unknown category should either not appear or be shown — test that
+        # known ones appear correctly.
+        self.assertIn("### Added", section)
+
+    def test_format_section_entry_format(self):
+        """Each entry is formatted as a markdown list item."""
+        section = format_section("2.0.0", "2026-02-01", {"Added": ["alpha", "beta"]})
+        self.assertIn("- alpha", section)
+        self.assertIn("- beta", section)
+
+
+# ---------------------------------------------------------------------------
+# sort_tags_semver tests
+# ---------------------------------------------------------------------------
+
+
+class TestSortTagsSemver(unittest.TestCase):
+    """Unit tests for sort_tags_semver()."""
+
+    def test_basic_sort_descending(self):
+        tags = ["v0.1.0", "v0.3.0", "v0.2.0"]
+        result = sort_tags_semver(tags)
+        self.assertEqual(result, ["v0.3.0", "v0.2.0", "v0.1.0"])
+
+    def test_major_version_ordering(self):
+        tags = ["v1.0.0", "v2.0.0", "v10.0.0"]
+        result = sort_tags_semver(tags)
+        self.assertEqual(result, ["v10.0.0", "v2.0.0", "v1.0.0"])
+
+    def test_patch_version_ordering(self):
+        tags = ["v0.1.1", "v0.1.10", "v0.1.2"]
+        result = sort_tags_semver(tags)
+        self.assertEqual(result, ["v0.1.10", "v0.1.2", "v0.1.1"])
+
+    def test_non_semver_tags_tolerated(self):
+        """Non-semver tags should not crash the sort — they sort after valid tags."""
+        tags = ["v1.0.0", "not-a-version", "v2.0.0"]
+        result = sort_tags_semver(tags)
+        # Valid semver tags appear first in descending order
+        self.assertEqual(result[0], "v2.0.0")
+        self.assertEqual(result[1], "v1.0.0")
+
+    def test_empty_list(self):
+        self.assertEqual(sort_tags_semver([]), [])
+
+    def test_single_tag(self):
+        self.assertEqual(sort_tags_semver(["v1.2.3"]), ["v1.2.3"])
+
+
+# ---------------------------------------------------------------------------
+# CATEGORY_ORDER constant test
+# ---------------------------------------------------------------------------
+
+
+class TestCategoryOrder(unittest.TestCase):
+    def test_standard_categories_present(self):
+        for cat in ("Added", "Changed", "Fixed", "Security", "Removed", "Deprecated"):
+            self.assertIn(cat, CATEGORY_ORDER)
+
+    def test_added_is_first(self):
+        self.assertEqual(CATEGORY_ORDER[0], "Added")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

`CHANGELOG.md` 92→0.127.0 backfill 자동화 도구 추가 + 173 versioned sections 일괄 backfill.

`scripts/backfill_changelog.py` (463 LOC, stdlib only, 40 tests) — Conventional Commits prefix 결정론적 파싱으로 Keep a Changelog 1.1.0 형식 섹션 생성. LLM 비용 0.

Track A (#1113, v0.128.0)에서 Phase 5 forward-looking promotion 정책을 ship한 후, 본 PR은 Track B (과거 92 release backfill 도구화 + 적용)로 #1111 종결.

Closes #1111

## 변경 파일

| 파일 | 변경 |
|------|------|
| `scripts/backfill_changelog.py` (신규) | 463 LOC 결정론적 파서 |
| `scripts/__init__.py` (신규) | 패키지 마커 |
| `tests/scripts/test_backfill_changelog.py` (신규) | 40 단위 테스트 |
| `conftest.py` (신규) | pytest sys.path 설정 |
| `CHANGELOG.md` | +1170줄 (173 versioned sections) |
| `.claude/skills/omcustom-release-notes/SKILL.md` (+미러) | Backfill Mode 섹션 + frontmatter argument-hint 갱신 |
| `package.json`, `templates/manifest.json` | 0.128.0 → 0.129.0 |
| `.omcustom.lock.json`, `dist/*` | 자동 생성 |

## 검증 결과

| 검사 | 결과 |
|------|------|
| `python3 -m pytest tests/scripts/` | 40/40 pass |
| `bun test` | 1929 pass / 0 fail |
| `bun run lint` (biome) | 93 files, 0 issues |
| `bun run typecheck` (tsc) | clean |
| `verify-template-sync.sh` | pass |
| `verify-wiki-sync.sh` | pass (skills=117, missing=0) |
| Regression Guard 1 (sensitive-path Bash) | pass |
| Regression Guard 2 (artifact /tmp bypass) | pass |
| 스킬 미러 byte-equality | pass |
| deep-verify (2-agent focused review) | READY (1 HIGH content fix applied; script robustness deferred to follow-up) |

## Backfill 결과

- 173 versioned sections (v0.36.0 ~ v0.127.0)
- 카테고리 분포: 104 Changed, 74 Added, 66 Fixed
- 날짜 단조감소 검증: pass (234 dated sections, 0 violations)

## 알려진 한계 (follow-up 후보)

- 일부 release commit이 단일 squash 메시지만 남겨 1-2줄로 요약됨 (예: 0.125.0 노이즈)
- /goal 같은 신규 스킬이 `Changed`로 분류됨 (release: prefix → conservative mapping). 수동 보정 가능
- Python script `_get_release_date` git fallback uncaught (이번 run에 영향 없음, 후속 robustness 개선)

## Test plan

- [x] 로컬 테스트 통과
- [x] CI-mimic 스크립트 통과
- [ ] CI 8 checks 통과 (자동)
- [ ] 머지 후 v0.129.0 태그 생성 (자동)
- [ ] release.yml npm publish 완료 (자동)
- [ ] `npm view oh-my-customcode version` = 0.129.0 (검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)