### PR TITLE
release: v0.130.0 — /goal → omcustom:goal rename + CC v2.1.139 온보딩 docs

### DIFF
--- a/.claude/skills/goal/SKILL.md
+++ b/.claude/skills/goal/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: goal
+name: omcustom:goal
 description: Disciplined goal-to-execution workflow for any user task. Parses objective, asks only for materially missing requirements via ambiguity-gate, inspects repo via idea, plans via sdd-dev or deep-plan, executes safely under project conventions, verifies completion per R020, and reports changed files with evidence. Use when user invokes /goal <task>.
 version: 1.0.0
 scope: core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.130.0] - 2026-05-12
+
+### Changed
+- `goal` 스킬을 `omcustom:goal` namespace로 rename — CC v2.1.139 네이티브 `/goal` 명령과의 슬래시 라우팅 shadowing 해소 (#1123)
+
+### Added
+- CC v2.1.139 신규 명령 (`claude agents`, `/scroll-speed`, `claude plugin details`, `/mcp` reconnect 개선, transcript navigation, `/context all` 정확도 개선) 온보딩 가이드 추가 to `guides/claude-code/15-version-compatibility.md` (#1126)
+
+### Dependencies
+- @anthropic-ai/sdk: 0.92.0 → 0.95.2 (dev dependency, dependabot #1121)
+
+## [0.129.0] - 2026-05-08
+
+### Changed
+- CHANGELOG.md historical backfill v0.36.0..v0.127.0 (#1111, #1115)
+
+## [0.128.0] - 2026-05-08
+
+### Changed
+- forward-looking CHANGELOG [Unreleased] policy (#1113, #1114)
+
 ## [0.127.0] - 2026-05-08
 
 ### Changed

--- a/guides/claude-code/15-version-compatibility.md
+++ b/guides/claude-code/15-version-compatibility.md
@@ -1,7 +1,7 @@
 # Claude Code Version Compatibility
 
-> Updated: 2026-04-24
-> Source: Claude Code release notes (#967, #968, #969 auto-detected by claude-native skill)
+> Updated: 2026-05-12
+> Source: Claude Code release notes (#967, #968, #969, #1126 auto-detected by claude-native skill)
 
 ## Compatibility Baseline
 
@@ -43,6 +43,66 @@ oh-my-customcode v0.107.0 targets Claude Code v2.1.116+. All v2.1.117-119 additi
 
 **Action items**: Verify `--print` based CI scripts (if any) work correctly with restricted-tools agents like `arch-documenter` (which has `disallowedTools: [Bash]`).
 
+## v2.1.139 (2026-05-xx) — 신규 사용자 노출 명령
+
+> Issue: #1126 — CC v2.1.139 onboarding update
+
+### `claude agents` — Agent View (Research Preview)
+
+단일 화면에서 실행 중(running), 대기(blocked), 완료(done) 상태인 모든 CC 세션을 목록으로 확인합니다.
+
+```bash
+claude agents
+```
+
+**oh-my-customcode 연관**: R009 병렬 에이전트, R018 Agent Teams 운영 시 다중 세션 상태 가시성이 개선됩니다. 복잡한 병렬 워크플로우에서 어느 에이전트가 blocked 상태인지 즉시 파악 가능.
+
+### `claude plugin details <name>` — Plugin Inventory
+
+플러그인의 component inventory와 세션당 예상 token cost를 표시합니다.
+
+```bash
+claude plugin details oh-my-customcode
+claude plugin details superpowers
+```
+
+**oh-my-customcode 연관**: R013 ecomode token efficiency 검증 도구로 활용 가능합니다. 자체 빌드 결과(skill/agent count + 토큰 비용)를 정량 측정하여 `guides/claude-code/14-token-efficiency.md` 최적화 결정에 근거를 제공합니다.
+
+### `/scroll-speed` — 마우스 스크롤 속도 조정
+
+휠 스크롤 속도를 실시간 preview와 함께 튜닝합니다. 긴 transcript나 대용량 출력 검토 시 유용.
+
+```
+/scroll-speed
+```
+
+### `/mcp` Reconnect 개선
+
+`.mcp.json` 편집 후 CC 재시작 없이 `reconnect` 명령으로 변경사항을 반영합니다. 연결 실패 시 HTTP 상태 코드와 URL이 표시됩니다.
+
+**oh-my-customcode 연관**: `claude-mem`, `ontology-rag` 등 MCP 서버 설정 변경 시 재시작 없이 적용 — 긴 세션 중단 없이 R011 메모리 통합을 재설정할 수 있습니다.
+
+### Transcript View 네비게이션 단축키
+
+transcript view에서 다음 단축키를 사용할 수 있습니다:
+
+| 키 | 동작 |
+|----|------|
+| `?` | 전체 단축키 목록 표시 |
+| `{` | 이전 user prompt로 이동 |
+| `}` | 다음 user prompt로 이동 |
+| `v` | shortcut panel 표시/숨김 toggle |
+
+### `/context all` — Skill별 토큰 추정 정확도 개선
+
+모델 tokenizer 기반 추정값과 반올림 표시가 적용됩니다.
+
+**oh-my-customcode 연관**: R013 ecomode context budget 관리 (threshold: 80%)에서 각 skill이 소비하는 토큰을 더 정확히 파악할 수 있습니다. `context: fork` skill (현재 10/12 사용 중) 비용 모니터링에 직접 활용 가능.
+
+**Action items**: None — 모두 additive. `/context all`로 fork skill 비용 정기 점검 권장.
+
+---
+
 ## Action Items Summary
 
 | Version | oh-my-customcode action | Priority |
@@ -50,12 +110,15 @@ oh-my-customcode v0.107.0 targets Claude Code v2.1.116+. All v2.1.117-119 additi
 | v2.1.117 | None (additive) | — |
 | v2.1.118 | Evaluate hooks `type: mcp_tool` for R022/R011 | P3 follow-up |
 | v2.1.119 | Audit `--print` CI with disallowedTools agents | P3 follow-up |
+| v2.1.139 | None (additive). `/context all` fork skill 비용 모니터링 권장 | P3 follow-up |
 
 ## References
 
 - #967 — Claude Code v2.1.117 release note
 - #968 — Claude Code v2.1.118 release note
 - #969 — Claude Code v2.1.119 release note
+- #1126 — Claude Code v2.1.139 신규 명령 문서화
 - `.claude/skills/claude-native/` — auto-generation source
 - `.claude/rules/SHOULD-hud-statusline.md` — R012 statusline integration
 - `.claude/rules/MUST-agent-design.md` — R006 agent frontmatter spec
+- `guides/claude-code/14-token-efficiency.md` — token efficiency guide (관련: plugin details 활용)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.129.0",
+  "version": "0.130.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/goal/SKILL.md
+++ b/templates/.claude/skills/goal/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: goal
+name: omcustom:goal
 description: Disciplined goal-to-execution workflow for any user task. Parses objective, asks only for materially missing requirements via ambiguity-gate, inspects repo via idea, plans via sdd-dev or deep-plan, executes safely under project conventions, verifies completion per R020, and reports changed files with evidence. Use when user invokes /goal <task>.
 version: 1.0.0
 scope: core

--- a/templates/guides/claude-code/15-version-compatibility.md
+++ b/templates/guides/claude-code/15-version-compatibility.md
@@ -1,7 +1,7 @@
 # Claude Code Version Compatibility
 
-> Updated: 2026-04-24
-> Source: Claude Code release notes (#967, #968, #969 auto-detected by claude-native skill)
+> Updated: 2026-05-12
+> Source: Claude Code release notes (#967, #968, #969, #1126 auto-detected by claude-native skill)
 
 ## Compatibility Baseline
 
@@ -43,6 +43,66 @@ oh-my-customcode v0.107.0 targets Claude Code v2.1.116+. All v2.1.117-119 additi
 
 **Action items**: Verify `--print` based CI scripts (if any) work correctly with restricted-tools agents like `arch-documenter` (which has `disallowedTools: [Bash]`).
 
+## v2.1.139 (2026-05-xx) — 신규 사용자 노출 명령
+
+> Issue: #1126 — CC v2.1.139 onboarding update
+
+### `claude agents` — Agent View (Research Preview)
+
+단일 화면에서 실행 중(running), 대기(blocked), 완료(done) 상태인 모든 CC 세션을 목록으로 확인합니다.
+
+```bash
+claude agents
+```
+
+**oh-my-customcode 연관**: R009 병렬 에이전트, R018 Agent Teams 운영 시 다중 세션 상태 가시성이 개선됩니다. 복잡한 병렬 워크플로우에서 어느 에이전트가 blocked 상태인지 즉시 파악 가능.
+
+### `claude plugin details <name>` — Plugin Inventory
+
+플러그인의 component inventory와 세션당 예상 token cost를 표시합니다.
+
+```bash
+claude plugin details oh-my-customcode
+claude plugin details superpowers
+```
+
+**oh-my-customcode 연관**: R013 ecomode token efficiency 검증 도구로 활용 가능합니다. 자체 빌드 결과(skill/agent count + 토큰 비용)를 정량 측정하여 `guides/claude-code/14-token-efficiency.md` 최적화 결정에 근거를 제공합니다.
+
+### `/scroll-speed` — 마우스 스크롤 속도 조정
+
+휠 스크롤 속도를 실시간 preview와 함께 튜닝합니다. 긴 transcript나 대용량 출력 검토 시 유용.
+
+```
+/scroll-speed
+```
+
+### `/mcp` Reconnect 개선
+
+`.mcp.json` 편집 후 CC 재시작 없이 `reconnect` 명령으로 변경사항을 반영합니다. 연결 실패 시 HTTP 상태 코드와 URL이 표시됩니다.
+
+**oh-my-customcode 연관**: `claude-mem`, `ontology-rag` 등 MCP 서버 설정 변경 시 재시작 없이 적용 — 긴 세션 중단 없이 R011 메모리 통합을 재설정할 수 있습니다.
+
+### Transcript View 네비게이션 단축키
+
+transcript view에서 다음 단축키를 사용할 수 있습니다:
+
+| 키 | 동작 |
+|----|------|
+| `?` | 전체 단축키 목록 표시 |
+| `{` | 이전 user prompt로 이동 |
+| `}` | 다음 user prompt로 이동 |
+| `v` | shortcut panel 표시/숨김 toggle |
+
+### `/context all` — Skill별 토큰 추정 정확도 개선
+
+모델 tokenizer 기반 추정값과 반올림 표시가 적용됩니다.
+
+**oh-my-customcode 연관**: R013 ecomode context budget 관리 (threshold: 80%)에서 각 skill이 소비하는 토큰을 더 정확히 파악할 수 있습니다. `context: fork` skill (현재 10/12 사용 중) 비용 모니터링에 직접 활용 가능.
+
+**Action items**: None — 모두 additive. `/context all`로 fork skill 비용 정기 점검 권장.
+
+---
+
 ## Action Items Summary
 
 | Version | oh-my-customcode action | Priority |
@@ -50,12 +110,15 @@ oh-my-customcode v0.107.0 targets Claude Code v2.1.116+. All v2.1.117-119 additi
 | v2.1.117 | None (additive) | — |
 | v2.1.118 | Evaluate hooks `type: mcp_tool` for R022/R011 | P3 follow-up |
 | v2.1.119 | Audit `--print` CI with disallowedTools agents | P3 follow-up |
+| v2.1.139 | None (additive). `/context all` fork skill 비용 모니터링 권장 | P3 follow-up |
 
 ## References
 
 - #967 — Claude Code v2.1.117 release note
 - #968 — Claude Code v2.1.118 release note
 - #969 — Claude Code v2.1.119 release note
+- #1126 — Claude Code v2.1.139 신규 명령 문서화
 - `.claude/skills/claude-native/` — auto-generation source
 - `.claude/rules/SHOULD-hud-statusline.md` — R012 statusline integration
 - `.claude/rules/MUST-agent-design.md` — R006 agent frontmatter spec
+- `guides/claude-code/14-token-efficiency.md` — token efficiency guide (관련: plugin details 활용)

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.129.0",
+  "version": "0.130.0",
   "lastUpdated": "2026-04-24T07:30:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약

CC v2.1.139 release tracking (#1122) 분기에서 식별된 두 actionable 항목 처리.

## 포함 항목

- **#1123 (P2)**: `goal` 스킬을 `omcustom:goal` namespace로 rename — 네이티브 CC `/goal` interactive command와 슬래시 라우팅 shadow 해소. 디렉토리 유지 (frontmatter `name:` authoritative)
- **#1126 (P3)**: CC v2.1.139 신규 명령 온보딩 가이드 추가 (`claude agents`, `claude plugin details`, `/scroll-speed`, `/mcp` reconnect 개선, transcript navigation, `/context all` 정확도 개선)
- **#1121 (dependabot)**: `@anthropic-ai/sdk` dev dependency 0.92.0 → 0.95.2 (이미 develop에 머지됨, CHANGELOG에 기록)
- **CHANGELOG backfill**: v0.128.0 / v0.129.0 항목 추가

## Defer 항목

- **#1124 P3** (hook args[] migration) — \`next-release\`
- **#1125 P3** (PostToolUse continueOnBlock) — \`next-release\`

## 검증

- R017 sauron verification: **PASS**
  - frontmatter / orphan / counts (117/49/49) / template sync / CHANGELOG 포맷 ✓

## 비고

- wiki/skills/goal.md 동기화는 R022 advisory — 별도 commit 또는 다음 release에서

🤖 Generated with [Claude Code](https://claude.com/claude-code)