### PR TITLE
chore: gitignore cleanup — agent-memory, caches, plugin artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,36 @@ CLAUDE.md
 .mcp.json
 test-validator.ts
 
+# Stray agent-memory directories from subproject execution
+**/agent-memory/
+!.claude/agent-memory/
+!.claude/agent-memory-local/
+
+# Agent memory subdirs (per-agent session artifacts) — except tracked ones
+.claude/agent-memory/arch-documenter/
+.claude/agent-memory/de-pipeline-expert/
+.claude/agent-memory/fe-svelte-agent/
+.claude/agent-memory/lang-rust-expert/
+.claude/agent-memory/lang-typescript-expert/
+.claude/agent-memory/mgr-creator/
+.claude/agent-memory/mgr-gitnerd/
+.claude/agent-memory/sys-memory-keeper/
+
+# Python caches
+__pycache__/
+**/__pycache__/
+
+# Test output artifacts
+test-results/
+packages/*/test-results/
+
+# Superpowers plugin session artifacts
+docs/superpowers/plans/
+docs/superpowers/specs/
+
+# claude-mem MCP context injection file
+AGENTS.md
+
 # Git worktrees
 .worktrees/
 
@@ -57,3 +87,4 @@ target/
 *.so
 *.pyd
 *.dylib
+.omx/


### PR DESCRIPTION
## 요약

작업트리 정리. `.gitignore`에 다음 패턴 추가:

- agent-memory subdirectories (per-agent session artifacts)
- Python __pycache__
- test-results
- superpowers plugin plans/specs (session artifacts)
- AGENTS.md (claude-mem MCP injection file)

## 결과

`git status --short` count: ~70 → 2 (사용자 작업으로 의심되는 Svelte routes 2개는 보존)

## 비고

별도 PR로 분리하여 v0.130.0 release scope를 좁게 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)