### PR TITLE
release: v0.131.0 — 통합 복구 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.130.0] - 2026-05-12
+## [0.131.0] - 2026-05-12
+
+> Note: v0.130.0 was published to npm from a stale `release` branch (containing the backfill_changelog work below). v0.131.0 unifies that lost work with the planned /goal rename + CC v2.1.139 docs work that was only on develop.
 
 ### Changed
 - `goal` 스킬을 `omcustom:goal` namespace로 rename — CC v2.1.139 네이티브 `/goal` 명령과의 슬래시 라우팅 shadowing 해소 (#1123)
@@ -15,8 +17,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - CC v2.1.139 신규 명령 (`claude agents`, `/scroll-speed`, `claude plugin details`, `/mcp` reconnect 개선, transcript navigation, `/context all` 정확도 개선) 온보딩 가이드 추가 to `guides/claude-code/15-version-compatibility.md` (#1126)
 
+### Fixed
+- `scripts/backfill_changelog.py` robustness (H1 + M1-M3 + L1-L4) (#1116)
+- CHANGELOG.md backfill cosmetic polish (M1 + L1-L2) (#1117)
+
+### Maintenance
+- Claude Code v2.1.136 reviewed (#1118)
+- Claude Code v2.1.137 reviewed (#1119)
+- Claude Code v2.1.138 reviewed (#1120)
+- `.gitignore` cleanup — agent-memory, caches, plugin artifacts (#1128)
+
 ### Dependencies
 - @anthropic-ai/sdk: 0.92.0 → 0.95.2 (dev dependency, dependabot #1121)
+
+## [0.130.0] - 2026-05-12
+
+> Note: Published to npm from a stale `release` branch before develop merge. Content superseded by v0.131.0.
+
+### Fixed
+
+- **scripts/backfill_changelog.py robustness** (#1116)
+  - `_get_release_date` git fallback wrapped in try/except CalledProcessError — no more uncaught traceback on bad tags / detached HEAD / empty repo
+  - Unified non-semver tag sentinel to `(-1,-1,-1)` across `sort_tags_semver` and `_tags_in_range._semver` — pre-release tags like `v1.0.0-rc1` no longer leak into ranges unexpectedly
+  - gh jq null-string guard before recording `publishedAt`
+  - Empty `start_tag` validation in `main()` (no more silent `(0,0,0)` fallback)
+  - Python idioms: tuple-direct `startswith`, single-element tuple removal, bare annotation cleanup
+- **CHANGELOG.md backfill cosmetic polish** (#1117)
+  - `_RELEASE_PREP_RE` filters noise commits like "bump version to X.Y.Z" and "vX.Y.Z plan"
+  - `extract_issue_refs` deduplicates PR refs (`(#1083) (#1083)` → `#1083`)
+  - `_looks_like_addition` heuristic classifies "add"/"introduce" prefixed commits as `### Added` instead of `### Changed`
+
+### Maintenance
+
+- Claude Code v2.1.136 release reviewed (#1118) — no oh-my-customcode changes required
+- Claude Code v2.1.137 release reviewed (#1119) — no oh-my-customcode changes required
+- Claude Code v2.1.138 release reviewed (#1120) — no oh-my-customcode changes required
+
+### Tests
+
+- 57 unittest cases all pass (`tests/scripts/test_backfill_changelog.py`)
+- New test classes: `TestGetReleaseDate`, `TestMainRangeValidation`
+- Expanded coverage: `TestExtractIssueRefs`, `TestParseCommit`, `TestSortTagsSemver`
 
 ## [0.129.0] - 2026-05-08
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.130.0",
+  "version": "0.131.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/scripts/backfill_changelog.py
+++ b/scripts/backfill_changelog.py
@@ -78,6 +78,16 @@ _MERGE_PATTERNS: tuple[str, ...] = (
     "Merge branch",
 )
 
+#: Release-prep noise patterns to skip (both as start-of-line anchored regex).
+#: These are version-bump and plan commits that leak into changelogs.
+_RELEASE_PREP_RE = re.compile(
+    r"^(?:"
+    r"bump version to \d+\.\d+\.\d+"      # "bump version to X.Y.Z"
+    r"|v\d+\.\d+\.\d+ plan\b"             # "vX.Y.Z plan ..."
+    r")",
+    re.IGNORECASE,
+)
+
 
 # ---------------------------------------------------------------------------
 # Public helpers (importable by tests)
@@ -85,20 +95,28 @@ _MERGE_PATTERNS: tuple[str, ...] = (
 
 
 def extract_issue_refs(text: str) -> list[str]:
-    """Return all issue numbers (as strings) found in *text*.
+    """Return deduplicated issue numbers (as strings) found in *text*.
 
     Args:
         text: Arbitrary string, e.g. a commit subject.
 
     Returns:
-        Ordered list of issue number strings (no ``#`` prefix).
+        Ordered, deduplicated list of issue number strings (no ``#`` prefix).
 
     Example::
 
         >>> extract_issue_refs("fix crash (#42, #99)")
         ['42', '99']
+        >>> extract_issue_refs("thing (#42) (#42)")
+        ['42']
     """
-    return _ISSUE_REF_RE.findall(text)
+    seen: set[str] = set()
+    result: list[str] = []
+    for num in _ISSUE_REF_RE.findall(text):
+        if num not in seen:
+            seen.add(num)
+            result.append(num)
+    return result
 
 
 def parse_commit(subject: str) -> tuple[Optional[str], str, list[str]]:
@@ -114,14 +132,18 @@ def parse_commit(subject: str) -> tuple[Optional[str], str, list[str]]:
           ``None`` if the commit should be skipped entirely.
         * ``message`` — cleaned human-readable description.  Breaking
           changes are prefixed with ``**BREAKING**: ``.
-        * ``refs`` — list of issue numbers extracted from the subject.
+        * ``refs`` — deduplicated list of issue numbers extracted from the
+          subject.
 
     The caller is responsible for assembling the final formatted line.
     """
     # Skip merge commits unconditionally.
-    for pattern in _MERGE_PATTERNS:
-        if subject.startswith(pattern):
-            return None, subject, []
+    if subject.startswith(_MERGE_PATTERNS):
+        return None, subject, []
+
+    # Skip release-prep noise commits (version bumps, plan commits).
+    if _RELEASE_PREP_RE.match(subject):
+        return None, subject, []
 
     refs = extract_issue_refs(subject)
 
@@ -131,7 +153,7 @@ def parse_commit(subject: str) -> tuple[Optional[str], str, list[str]]:
         is_breaking = breaking == "!"
 
         # Handle release commits: extract human description after version stamp.
-        if commit_type in ("release",) or (
+        if commit_type == "release" or (
             commit_type == "chore" and _scope in ("(release)",)
         ):
             desc = _RELEASE_VERSION_RE.sub("", raw_desc, count=1)
@@ -148,6 +170,10 @@ def parse_commit(subject: str) -> tuple[Optional[str], str, list[str]]:
         if category is None:
             # Unknown conventional prefix → treat as Changed.
             category = "Changed"
+
+        # Classify "add"/"introduce" keywords as "Added" when not already mapped.
+        if category == "Changed" and _looks_like_addition(raw_desc):
+            category = "Added"
 
         # Strip issue refs from raw_desc; they are returned separately.
         desc = _strip_issue_refs(raw_desc)
@@ -226,7 +252,7 @@ def sort_tags_semver(tags: list[str]) -> list[str]:
         try:
             return tuple(int(p) for p in parts)
         except ValueError:
-            # Non-semver sorts last (treated as version 0.0.0).
+            # Non-semver sorts last (sentinel matches _tags_in_range).
             return (-1, -1, -1)
 
     return sorted(tags, key=_key, reverse=True)
@@ -235,6 +261,16 @@ def sort_tags_semver(tags: list[str]) -> list[str]:
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
+
+
+def _looks_like_addition(desc: str) -> bool:
+    """Return True if *desc* reads like a new feature/skill introduction.
+
+    Heuristic: subjects starting with "add " or "introduce " should map to
+    "Added" rather than the default "Changed" category.
+    """
+    lower = desc.strip().lower()
+    return lower.startswith(("add ", "introduce ", "adds ", "introduces "))
 
 
 def _strip_issue_refs(text: str) -> str:
@@ -272,6 +308,9 @@ def _get_release_date(tag: str) -> str:
 
     Falls back to ``git log`` author date if ``gh`` is unavailable or the
     release does not exist on GitHub.
+
+    If the git fallback also fails (e.g., invalid tag, detached HEAD, empty
+    repo), prints a warning and returns ``"UNKNOWN-DATE"``.
     """
     try:
         raw = subprocess.check_output(
@@ -283,16 +322,34 @@ def _get_release_date(tag: str) -> str:
             stderr=subprocess.DEVNULL,
             text=True,
         ).strip()
-        if raw:
+        # jq outputs the literal string "null" when the field is absent.
+        if raw and raw != "null":
             return raw[:10]
     except (subprocess.CalledProcessError, FileNotFoundError):
         pass
 
-    raw = subprocess.check_output(
-        ["git", "log", "-1", "--format=%aI", tag],
-        text=True,
-    ).strip()
-    return raw[:10]
+    # Git fallback — guard against invalid tags / detached HEAD / empty repo.
+    try:
+        raw = subprocess.check_output(
+            ["git", "log", "-1", "--format=%aI", tag],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+        if raw:
+            return raw[:10]
+        print(
+            f"Warning: git log returned empty output for tag {tag!r}. "
+            "Using UNKNOWN-DATE.",
+            file=sys.stderr,
+        )
+        return "UNKNOWN-DATE"
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"Warning: could not determine date for tag {tag!r}: {exc}. "
+            "Using UNKNOWN-DATE.",
+            file=sys.stderr,
+        )
+        return "UNKNOWN-DATE"
 
 
 def _get_commits_in_range(prev_tag: str, tag: str) -> list[str]:
@@ -321,13 +378,15 @@ def _tags_in_range(all_tags: list[str], start: str, end: str) -> list[str]:
     sorted_all = sort_tags_semver(all_tags)
 
     # Build a semver-comparable key for boundary comparison.
+    # Sentinel (-1,-1,-1) matches sort_tags_semver's non-semver fallback,
+    # ensuring consistent treatment across both functions.
     def _semver(tag: str) -> tuple[int, ...]:
         cleaned = tag.lstrip("v")
         parts = cleaned.split(".")
         try:
             return tuple(int(p) for p in parts[:3])
         except ValueError:
-            return (0, 0, 0)
+            return (-1, -1, -1)
 
     start_key = _semver(start)
     end_key = _semver(end)
@@ -412,6 +471,13 @@ def main(argv: Optional[list[str]] = None) -> None:
 
     start_tag, end_tag = args.range.split("..", 1)
 
+    # Validate that neither side of the range is empty.
+    if not start_tag or not end_tag:
+        sys.exit(
+            f"Error: both START and END must be non-empty in range, "
+            f"got: {args.range!r}"
+        )
+
     all_tags = _list_all_tags()
     sorted_all = sort_tags_semver(all_tags)
 
@@ -435,7 +501,6 @@ def main(argv: Optional[list[str]] = None) -> None:
         date = _get_release_date(tag)
         version = tag.lstrip("v")
 
-        subjects: list[str]
         if prev_ref:
             subjects = _get_commits_in_range(prev_ref, tag)
         else:

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.130.0",
+  "version": "0.131.0",
   "lastUpdated": "2026-04-24T07:30:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/tests/scripts/test_backfill_changelog.py
+++ b/tests/scripts/test_backfill_changelog.py
@@ -6,7 +6,7 @@ Run with:
 """
 
 import sys
-import types
+import subprocess
 import unittest
 from unittest.mock import patch
 
@@ -29,6 +29,9 @@ from scripts.backfill_changelog import (  # noqa: E402
     extract_issue_refs,
     sort_tags_semver,
     CATEGORY_ORDER,
+    _get_release_date,
+    _tags_in_range,
+    main,
 )
 
 
@@ -145,6 +148,40 @@ class TestParseCommit(unittest.TestCase):
         self.assertIn("add pagination endpoint", msg)
         self.assertEqual(refs, ["55"])
 
+    # --- New addition-heuristic tests (#1117-L2) ---
+
+    def test_chore_with_add_keyword_maps_to_added(self):
+        """chore: commits whose description starts with 'add' should map to Added."""
+        cat, msg, refs = parse_commit("chore(skill): add version frontmatter (#42)")
+        self.assertEqual(cat, "Added")
+
+    def test_chore_with_introduce_keyword_maps_to_added(self):
+        """chore: commits whose description starts with 'introduce' → Added."""
+        cat, msg, refs = parse_commit("chore: introduce new logging framework")
+        self.assertEqual(cat, "Added")
+
+    def test_chore_without_add_keyword_stays_changed(self):
+        """Regular chore commits without addition keywords stay Changed."""
+        cat, msg, refs = parse_commit("chore: update CI config")
+        self.assertEqual(cat, "Changed")
+
+    # --- Release-prep noise skip tests (#1117-M1) ---
+
+    def test_release_prep_bump_version_skipped(self):
+        """'bump version to X.Y.Z' should be silently skipped."""
+        cat, msg, refs = parse_commit("bump version to 0.125.0")
+        self.assertIsNone(cat)
+
+    def test_release_prep_plan_skipped(self):
+        """'vX.Y.Z plan ...' should be silently skipped."""
+        cat, msg, refs = parse_commit("v0.125.0 plan + permissions.defaultMode")
+        self.assertIsNone(cat)
+
+    def test_release_prep_plan_case_insensitive(self):
+        """Release-prep pattern match is case-insensitive."""
+        cat, msg, refs = parse_commit("Bump version to 0.130.0")
+        self.assertIsNone(cat)
+
 
 # ---------------------------------------------------------------------------
 # extract_issue_refs tests
@@ -175,6 +212,19 @@ class TestExtractIssueRefs(unittest.TestCase):
         refs = extract_issue_refs("do something (#1) (#2)")
         self.assertIn("1", refs)
         self.assertIn("2", refs)
+
+    # --- Deduplication test (#1117-L1) ---
+
+    def test_duplicate_refs_deduplicated(self):
+        """Duplicate PR refs like (#1083) (#1083) must be deduplicated."""
+        refs = extract_issue_refs("some change (#1083) (#1083)")
+        self.assertEqual(refs, ["1083"])
+        self.assertEqual(len(refs), 1)
+
+    def test_duplicate_refs_in_single_parens(self):
+        """Duplicates within a single paren group are also collapsed."""
+        refs = extract_issue_refs("thing (#42, #42)")
+        self.assertEqual(refs, ["42"])
 
 
 # ---------------------------------------------------------------------------
@@ -276,12 +326,122 @@ class TestSortTagsSemver(unittest.TestCase):
         # Valid semver tags appear first in descending order
         self.assertEqual(result[0], "v2.0.0")
         self.assertEqual(result[1], "v1.0.0")
+        # Non-semver tag lands at the end
+        self.assertEqual(result[2], "not-a-version")
+
+    def test_non_semver_excluded_from_range(self):
+        """Non-semver tags with sentinel (-1,-1,-1) must NOT be included in ranges."""
+        all_tags = ["v1.0.0", "v2.0.0", "not-a-version"]
+        result = _tags_in_range(all_tags, "v1.0.0", "v2.0.0")
+        self.assertIn("v2.0.0", result)
+        self.assertNotIn("not-a-version", result)
+
+    def test_prerelease_tag_tolerated(self):
+        """Tags like v1.0.0-rc1 (non-pure-semver) are tolerated without crashing."""
+        tags = ["v1.0.0", "v1.0.0-rc1", "v2.0.0"]
+        result = sort_tags_semver(tags)
+        self.assertEqual(result[0], "v2.0.0")
+        self.assertEqual(result[1], "v1.0.0")
+        # Pre-release tag sorts last (non-semver sentinel)
+        self.assertEqual(result[2], "v1.0.0-rc1")
 
     def test_empty_list(self):
         self.assertEqual(sort_tags_semver([]), [])
 
     def test_single_tag(self):
         self.assertEqual(sort_tags_semver(["v1.2.3"]), ["v1.2.3"])
+
+
+# ---------------------------------------------------------------------------
+# _get_release_date safety tests (#1116-H1, #1116-M2)
+# ---------------------------------------------------------------------------
+
+
+class TestGetReleaseDate(unittest.TestCase):
+    """Tests for _get_release_date error handling."""
+
+    def test_gh_null_publishedAt_falls_back_to_git(self):
+        """When gh returns 'null', should fall back to git log."""
+        def fake_check_output(cmd, **kwargs):
+            if cmd[0] == "gh":
+                return "null\n"
+            # git log fallback
+            return "2026-01-15T10:00:00+00:00\n"
+
+        with patch("subprocess.check_output", side_effect=fake_check_output):
+            date = _get_release_date("v1.0.0")
+        self.assertEqual(date, "2026-01-15")
+
+    def test_gh_empty_publishedAt_falls_back_to_git(self):
+        """When gh returns empty string, should fall back to git log."""
+        def fake_check_output(cmd, **kwargs):
+            if cmd[0] == "gh":
+                return "\n"
+            return "2026-02-20T00:00:00+00:00\n"
+
+        with patch("subprocess.check_output", side_effect=fake_check_output):
+            date = _get_release_date("v1.0.0")
+        self.assertEqual(date, "2026-02-20")
+
+    def test_git_log_failure_returns_unknown_date(self):
+        """CalledProcessError from git log should return UNKNOWN-DATE, not crash."""
+        def fake_check_output(cmd, **kwargs):
+            if cmd[0] == "gh":
+                raise subprocess.CalledProcessError(1, cmd)
+            # git also fails
+            raise subprocess.CalledProcessError(128, cmd)
+
+        with patch("subprocess.check_output", side_effect=fake_check_output):
+            date = _get_release_date("v-invalid-tag")
+        self.assertEqual(date, "UNKNOWN-DATE")
+
+    def test_git_log_empty_output_returns_unknown_date(self):
+        """Empty git log output should return UNKNOWN-DATE safely."""
+        def fake_check_output(cmd, **kwargs):
+            if cmd[0] == "gh":
+                raise FileNotFoundError
+            # git returns empty string (e.g., detached HEAD, wrong tag)
+            return "\n"
+
+        with patch("subprocess.check_output", side_effect=fake_check_output):
+            date = _get_release_date("v0.0.0")
+        self.assertEqual(date, "UNKNOWN-DATE")
+
+    def test_gh_valid_date_used_directly(self):
+        """Valid gh publishedAt date is used without falling back to git."""
+        call_count = {"git": 0}
+
+        def fake_check_output(cmd, **kwargs):
+            if cmd[0] == "gh":
+                return "2026-03-10T08:30:00Z\n"
+            call_count["git"] += 1
+            return "2020-01-01T00:00:00Z\n"
+
+        with patch("subprocess.check_output", side_effect=fake_check_output):
+            date = _get_release_date("v1.2.3")
+        self.assertEqual(date, "2026-03-10")
+        self.assertEqual(call_count["git"], 0)
+
+
+# ---------------------------------------------------------------------------
+# main() empty-range validation test (#1116-M3)
+# ---------------------------------------------------------------------------
+
+
+class TestMainRangeValidation(unittest.TestCase):
+    """Tests for main() argument validation."""
+
+    def test_empty_start_tag_exits(self):
+        """'..v1.0.0' (empty start) should exit with an error, not silently include all tags."""
+        with self.assertRaises(SystemExit) as ctx:
+            main(["..v1.0.0"])
+        self.assertNotEqual(ctx.exception.code, 0)
+
+    def test_empty_end_tag_exits(self):
+        """'v1.0.0..' (empty end) should exit with an error."""
+        with self.assertRaises(SystemExit) as ctx:
+            main(["v1.0.0.."])
+        self.assertNotEqual(ctx.exception.code, 0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 요약

이전 stale `release` 브랜치가 v0.130.0 tag/npm publish를 점유한 사이, 별도 머지의 #1123 + #1126 작업은 develop에만 머물러 npm 배포 누락. v0.131.0으로 양쪽 작업을 통합 publish.

## 포함 작업

| 출처 | 내용 | 이슈 |
|------|------|------|
| #1127 머지 | /goal → omcustom:goal rename | #1123 |
| #1127 머지 | CC v2.1.139 신규 명령 온보딩 docs | #1126 |
| Lost release branch (cherry-pick) | backfill_changelog.py robustness | #1116, #1117 |
| Lost release branch (cherry-pick) | CC v2.1.136-138 review | #1118-#1120 |
| #1121 dependabot | @anthropic-ai/sdk 0.92.0 → 0.95.2 | — |
| #1128 chore | .gitignore cleanup | — |

## 배경

v0.130.0 tag/npm은 stale release 브랜치 기반으로 publish됨 (의도 외). v0.131.0이 unified publish로 정상화.

## 검증

- counts: skills=117, agents=49, guides=49 (변경 없음)
- /goal frontmatter: name: omcustom:goal ✓
- CHANGELOG: v0.131.0 + v0.130.0 historical 둘 다 유지

## Followups (R016)

- stale branch 즉시 삭제 정책 재검토 — checkpoint 확인 없이 삭제 시 작업 손실 위험
- wiki/skills/goal.md → wiki/skills/omcustom-goal.md 갱신 (R022 advisory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)