### PR TITLE
release: v0.132.0 — Web UI guides browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.132.0] - 2026-05-12
+
+### Added
+- Web UI guides browser routes — `/guides` 목록(검색·정렬) + `/guides/[name]` 상세 페이지. 기존 skill/guide creation 페이지(#469) 패턴과 일관 (`packages/serve/src/routes/guides/`)
+
 ## [0.131.0] - 2026-05-12
 
 > Note: v0.130.0 was published to npm from a stale `release` branch (containing the backfill_changelog work below). v0.131.0 unifies that lost work with the planned /goal rename + CC v2.1.139 docs work that was only on develop.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.131.0",
+  "version": "0.132.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.131.0",
+  "version": "0.132.0",
   "lastUpdated": "2026-04-24T07:30:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약

v0.132.0 minor release — Web UI guides browser feature publish.

## 포함 작업

- #1130 feat(serve): Web UI guides browser routes (`/guides`, `/guides/[name]`)

## 검증

- counts 변경 없음 (skills=117, agents=49, guides=49)
- 신규 파일은 packages/serve scope에 국한 (`.claude/` 영역 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)