### PR TITLE
release: v0.133.0 — Hook continueOnBlock tier (#1125) + args form review (#1124)

### DIFF
--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -411,7 +411,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/scripts/context-budget-advisor.sh"
+            "command": "bash .claude/hooks/scripts/context-budget-advisor.sh",
+            "continueOnBlock": true
           }
         ],
         "description": "Context budget advisor \u2014 track tool usage patterns and advise ecomode activation"
@@ -421,7 +422,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/scripts/stuck-detector.sh"
+            "command": "bash .claude/hooks/scripts/stuck-detector.sh",
+            "continueOnBlock": true
           }
         ],
         "description": "Detect repetitive failure loops and advise recovery strategies"
@@ -431,7 +433,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/scripts/cost-cap-advisor.sh"
+            "command": "bash .claude/hooks/scripts/cost-cap-advisor.sh",
+            "continueOnBlock": true
           }
         ],
         "description": "Advisory cost cap monitoring \u2014 warn when session cost approaches configurable limit"

--- a/.claude/hooks/scripts/context-budget-advisor.sh
+++ b/.claude/hooks/scripts/context-budget-advisor.sh
@@ -85,6 +85,20 @@ if [ "$tool_count" -gt 0 ] && [ $((tool_count % 25)) -eq 0 ]; then
   fi
 fi
 
+# continueOnBlock: emit conversation feedback when task-type threshold is reached (once per session)
+BLOCK_FILE="/tmp/.claude-budget-blocked-${PPID}"
+if [ "$tool_count" -ge "$THRESHOLD" ] && [ ! -f "$BLOCK_FILE" ]; then
+  touch "$BLOCK_FILE"
+  echo "[Context Budget] Threshold ${THRESHOLD}% reached for ${task_type} task — activate ecomode (R013)" >&2
+  HOOK_END=$(date +%s%N 2>/dev/null || echo 0)
+  if [ "$HOOK_START" != "0" ] && [ "$HOOK_END" != "0" ]; then
+    HOOK_MS=$(( (HOOK_END - HOOK_START) / 1000000 ))
+    echo "[Hook Perf] $(basename "$0"): ${HOOK_MS}ms" >> "/tmp/.claude-hook-perf-${PPID}.log"
+  fi
+  echo "$input"
+  exit 2
+fi
+
 # R010 compliance heartbeat (every 50 tool calls)
 if [ "$tool_count" -gt 0 ] && [ $((tool_count % 50)) -eq 0 ]; then
   echo "[Compliance] R007: Agent ID required | R008: Tool ID required | R010: Delegate writes" >&2

--- a/.claude/hooks/scripts/cost-cap-advisor.sh
+++ b/.claude/hooks/scripts/cost-cap-advisor.sh
@@ -54,6 +54,8 @@ if [ "$cost_pct" -ge 100 ] && [ "$last_level" != "100" ]; then
   echo "[Cost Cap] Session cost \$${cost_usd} has reached cap \$${COST_CAP} (${cost_pct}%)" >&2
   echo "[Cost Cap] Consider wrapping up or increasing CLAUDE_COST_CAP" >&2
   echo "100" > "$ADVISORY_FILE"
+  echo "$input"
+  exit 2
 elif [ "$cost_pct" -ge 90 ] && [ "$last_level" != "90" ] && [ "$last_level" != "100" ]; then
   echo "[Cost Cap] Session cost \$${cost_usd} at 90% of cap \$${COST_CAP}" >&2
   echo "[Cost Cap] Ecomode recommended — consider /compact" >&2

--- a/.claude/hooks/scripts/stuck-detector.sh
+++ b/.claude/hooks/scripts/stuck-detector.sh
@@ -186,7 +186,7 @@ if [ "$hard_block" = true ]; then
     HOOK_MS=$(( (HOOK_END - HOOK_START) / 1000000 ))
     echo "[Hook Perf] $(basename "$0"): ${HOOK_MS}ms" >> "/tmp/.claude-hook-perf-${PPID}.log"
   fi
-  exit 1
+  exit 2
 fi
 
 # Pass through

--- a/.claude/rules/MUST-enforcement-policy.md
+++ b/.claude/rules/MUST-enforcement-policy.md
@@ -12,6 +12,7 @@ oh-my-customcode uses an **advisory-first enforcement model**. Most rules are en
 |------|-----------|-------|----------|
 | Hard Block | PreToolUse hook, exit 2 | stage-blocker, dev-server tmux, rule-deletion-guard | Prevents tool execution |
 | Soft Block | Stop hook prompt | R011 session-end saves | Auto-performs then approves |
+| Conversation Block | PostToolUse hook + `continueOnBlock` (CC v2.1.139+), exit 2 | stuck-detector, context-budget-advisor, cost-cap-advisor | Feeds rejection reason into conversation; Claude continues with awareness |
 | Advisory | PostToolUse hooks | R007, R008, R009, R010, R018 | Warns via stderr, never blocks |
 | Prompt-based | CLAUDE.md + rules/ + PostCompact | All MUST rules | Behavioral guidance in context |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.133.0] - 2026-05-13
+
+### Added
+- R021 Enforcement Tiers에 `Conversation Block` tier 추가 — PostToolUse hook + `continueOnBlock` (CC v2.1.139+) 패턴 문서화 (#1125)
+- `continueOnBlock: true` 적용 to 3 PostToolUse advisory hooks:
+  - `stuck-detector.sh` — HARD_BLOCK_THRESHOLD 도달 시 stderr-only → conversation feedback (exit 2)
+  - `context-budget-advisor.sh` — task-type threshold 도달 시 ecomode 활성화 신호 (R013 통합)
+  - `cost-cap-advisor.sh` — cost cap 100% 도달 시 wrap-up 신호
+
+### Changed
+- `stuck-detector.sh` hard block exit code: `exit 1` → `exit 2` (CC hook rejection 규약 정렬, continueOnBlock 페어링)
+
+### Investigated
+- Hook `args: string[]` exec form 마이그레이션 검토 (#1124): 현재 hooks.json은 jq 추출 패턴으로 path-safety 모범 사례 준수 — 마이그레이션 실효 후보 ZERO. 신규 hook 작성 가이드라인만 향후 추가 권고.
+
 ## [0.132.0] - 2026-05-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.132.0",
+  "version": "0.133.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/hooks/hooks.json
+++ b/templates/.claude/hooks/hooks.json
@@ -411,7 +411,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/scripts/context-budget-advisor.sh"
+            "command": "bash .claude/hooks/scripts/context-budget-advisor.sh",
+            "continueOnBlock": true
           }
         ],
         "description": "Context budget advisor \u2014 track tool usage patterns and advise ecomode activation"
@@ -421,7 +422,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/scripts/stuck-detector.sh"
+            "command": "bash .claude/hooks/scripts/stuck-detector.sh",
+            "continueOnBlock": true
           }
         ],
         "description": "Detect repetitive failure loops and advise recovery strategies"
@@ -431,7 +433,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash .claude/hooks/scripts/cost-cap-advisor.sh"
+            "command": "bash .claude/hooks/scripts/cost-cap-advisor.sh",
+            "continueOnBlock": true
           }
         ],
         "description": "Advisory cost cap monitoring \u2014 warn when session cost approaches configurable limit"

--- a/templates/.claude/hooks/scripts/context-budget-advisor.sh
+++ b/templates/.claude/hooks/scripts/context-budget-advisor.sh
@@ -85,6 +85,20 @@ if [ "$tool_count" -gt 0 ] && [ $((tool_count % 25)) -eq 0 ]; then
   fi
 fi
 
+# continueOnBlock: emit conversation feedback when task-type threshold is reached (once per session)
+BLOCK_FILE="/tmp/.claude-budget-blocked-${PPID}"
+if [ "$tool_count" -ge "$THRESHOLD" ] && [ ! -f "$BLOCK_FILE" ]; then
+  touch "$BLOCK_FILE"
+  echo "[Context Budget] Threshold ${THRESHOLD}% reached for ${task_type} task — activate ecomode (R013)" >&2
+  HOOK_END=$(date +%s%N 2>/dev/null || echo 0)
+  if [ "$HOOK_START" != "0" ] && [ "$HOOK_END" != "0" ]; then
+    HOOK_MS=$(( (HOOK_END - HOOK_START) / 1000000 ))
+    echo "[Hook Perf] $(basename "$0"): ${HOOK_MS}ms" >> "/tmp/.claude-hook-perf-${PPID}.log"
+  fi
+  echo "$input"
+  exit 2
+fi
+
 # R010 compliance heartbeat (every 50 tool calls)
 if [ "$tool_count" -gt 0 ] && [ $((tool_count % 50)) -eq 0 ]; then
   echo "[Compliance] R007: Agent ID required | R008: Tool ID required | R010: Delegate writes" >&2

--- a/templates/.claude/hooks/scripts/cost-cap-advisor.sh
+++ b/templates/.claude/hooks/scripts/cost-cap-advisor.sh
@@ -54,6 +54,8 @@ if [ "$cost_pct" -ge 100 ] && [ "$last_level" != "100" ]; then
   echo "[Cost Cap] Session cost \$${cost_usd} has reached cap \$${COST_CAP} (${cost_pct}%)" >&2
   echo "[Cost Cap] Consider wrapping up or increasing CLAUDE_COST_CAP" >&2
   echo "100" > "$ADVISORY_FILE"
+  echo "$input"
+  exit 2
 elif [ "$cost_pct" -ge 90 ] && [ "$last_level" != "90" ] && [ "$last_level" != "100" ]; then
   echo "[Cost Cap] Session cost \$${cost_usd} at 90% of cap \$${COST_CAP}" >&2
   echo "[Cost Cap] Ecomode recommended — consider /compact" >&2

--- a/templates/.claude/hooks/scripts/stuck-detector.sh
+++ b/templates/.claude/hooks/scripts/stuck-detector.sh
@@ -186,7 +186,7 @@ if [ "$hard_block" = true ]; then
     HOOK_MS=$(( (HOOK_END - HOOK_START) / 1000000 ))
     echo "[Hook Perf] $(basename "$0"): ${HOOK_MS}ms" >> "/tmp/.claude-hook-perf-${PPID}.log"
   fi
-  exit 1
+  exit 2
 fi
 
 # Pass through

--- a/templates/.claude/rules/MUST-enforcement-policy.md
+++ b/templates/.claude/rules/MUST-enforcement-policy.md
@@ -12,6 +12,7 @@ oh-my-customcode uses an **advisory-first enforcement model**. Most rules are en
 |------|-----------|-------|----------|
 | Hard Block | PreToolUse hook, exit 2 | stage-blocker, dev-server tmux, rule-deletion-guard | Prevents tool execution |
 | Soft Block | Stop hook prompt | R011 session-end saves | Auto-performs then approves |
+| Conversation Block | PostToolUse hook + `continueOnBlock` (CC v2.1.139+), exit 2 | stuck-detector, context-budget-advisor, cost-cap-advisor | Feeds rejection reason into conversation; Claude continues with awareness |
 | Advisory | PostToolUse hooks | R007, R008, R009, R010, R018 | Warns via stderr, never blocks |
 | Prompt-based | CLAUDE.md + rules/ + PostCompact | All MUST rules | Behavioral guidance in context |
 
@@ -22,7 +23,7 @@ oh-my-customcode uses an **advisory-first enforcement model**. Most rules are en
 3. **Composability**: External skills and internal rules can coexist without deadlocks
 4. **PostCompact reinforcement**: R007/R008/R009/R010/R018 are re-injected after context compaction
 
-## Hard Enforcement Candidates — R010 git-delegation-guard (conditional), R007/R008 (conditional). Promoted: rule-deletion-guard.sh (2026-04-08). See details via Read tool.
+## Hard Enforcement Candidates — R010 git-delegation-guard (conditional), R007/R008 UserPromptSubmit/PreToolUse hook (multi-turn gap candidate, #1096). Promoted: rule-deletion-guard.sh (2026-04-08). See details via Read tool.
 
 <!-- DETAIL: Hard Enforcement Candidates (Future)
 If advisory enforcement proves insufficient for specific rules, these are candidates for promotion to hard-block:

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.132.0",
+  "version": "0.133.0",
   "lastUpdated": "2026-04-24T07:30:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/tests/unit/core/stuck-detector.test.ts
+++ b/tests/unit/core/stuck-detector.test.ts
@@ -229,8 +229,8 @@ describe('stuck-detector.sh', () => {
       const input = makeErrorInput();
       const results = await runNTimesAll(input, 3);
       const third = results[2];
-      // At threshold=3, hard-block fires (exit 1). Advisory fires first (in stderr), then hard-block.
-      expect(third.exitCode).toBe(1);
+      // At threshold=3, hard-block fires (exit 2). Advisory fires first (in stderr), then hard-block.
+      expect(third.exitCode).toBe(2);
       expect(third.stderr).toContain('[Stuck Detection] HARD BLOCK');
     });
 
@@ -255,13 +255,13 @@ describe('stuck-detector.sh', () => {
     it('should hard-block at 4 consecutive identical errors (threshold=3)', async () => {
       const input = makeErrorInput();
       const result = await runNTimes(input, 4);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
     });
 
-    it('should hard-block (exit 1) when same error hash appears 3 consecutive times', async () => {
+    it('should hard-block (exit 2) when same error hash appears 3 consecutive times', async () => {
       const input = makeErrorInput();
       const result = await runNTimes(input, 3);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
     });
 
     it('should emit HARD BLOCK message to stderr on 3rd consecutive same-error', async () => {
@@ -279,7 +279,7 @@ describe('stuck-detector.sh', () => {
     it('should still pass stdin to stdout even when hard-blocking', async () => {
       const input = makeErrorInput();
       const result = await runNTimes(input, 3);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stdout.trim()).toBe(input);
     });
 
@@ -342,8 +342,8 @@ describe('stuck-detector.sh', () => {
       const input = makeEditInput();
       const results = await runNTimesAll(input, 3);
       const third = results[2];
-      // At threshold=3, hard-block fires (exit 1).
-      expect(third.exitCode).toBe(1);
+      // At threshold=3, hard-block fires (exit 2).
+      expect(third.exitCode).toBe(2);
       expect(third.stderr).toContain('[Stuck Detection] HARD BLOCK');
     });
 
@@ -367,10 +367,10 @@ describe('stuck-detector.sh', () => {
       expect(result.stderr).toContain('3');
     });
 
-    it('should hard-block (exit 1) when same file edited 3 consecutive times', async () => {
+    it('should hard-block (exit 2) when same file edited 3 consecutive times', async () => {
       const input = makeEditInput();
       const result = await runNTimes(input, 3);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
     });
 
     it('should emit HARD BLOCK message when same file edited 3 consecutive times', async () => {
@@ -389,7 +389,7 @@ describe('stuck-detector.sh', () => {
       const input = makeEditInput();
       const result = await runNTimes(input, 4);
       // 4 >= HARD_BLOCK_THRESHOLD=3, so hard block
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
     });
 
     it('should also trigger advisory for Write tool on same file', async () => {
@@ -422,13 +422,13 @@ describe('stuck-detector.sh', () => {
     it('should hard-block on 4 consecutive same tool+target calls (threshold=3)', async () => {
       const input = makeBashInput();
       const result = await runNTimes(input, 4);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
     });
 
-    it('should hard-block (exit 1) on 3 consecutive same tool+target calls', async () => {
+    it('should hard-block (exit 2) on 3 consecutive same tool+target calls', async () => {
       const input = makeBashInput();
       const result = await runNTimes(input, 3);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
     });
 
     it('should emit HARD BLOCK message on 3rd consecutive same tool+target', async () => {
@@ -592,30 +592,30 @@ describe('stuck-detector.sh', () => {
       expect(result.exitCode).toBe(0);
     });
 
-    it('should hard-block (exit 1) at count=3 (same file) — at threshold', async () => {
+    it('should hard-block (exit 2) at count=3 (same file) — at threshold', async () => {
       const input = makeInput({ tool_name: 'Edit', file_path: '/src/app.ts' });
       const result = await runNTimes(input, 3);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
     });
 
-    it('should hard-block (exit 1) at count=4 (same file) — above threshold', async () => {
+    it('should hard-block (exit 2) at count=4 (same file) — above threshold', async () => {
       const input = makeInput({ tool_name: 'Edit', file_path: '/src/app.ts' });
       const result = await runNTimes(input, 4);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
     });
 
     it('should emit HARD BLOCK (not just advisory) at count=3', async () => {
       const input = makeInput({ tool_name: 'Edit', file_path: '/src/app.ts' });
       const results = await runNTimesAll(input, 3);
       const third = results[2];
-      expect(third.exitCode).toBe(1);
+      expect(third.exitCode).toBe(2);
       expect(third.stderr).toContain('[Stuck Detection] HARD BLOCK');
     });
 
     it('should emit HARD BLOCK at count=4', async () => {
       const input = makeInput({ tool_name: 'Edit', file_path: '/src/app.ts' });
       const result = await runNTimes(input, 4);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('[Stuck Detection] HARD BLOCK');
     });
 
@@ -637,10 +637,10 @@ describe('stuck-detector.sh', () => {
   // -----------------------------------------------------------------
 
   describe('at threshold behavior (count = 3)', () => {
-    it('should hard-block (exit 1) at count=3 for same file consecutive edits', async () => {
+    it('should hard-block (exit 2) at count=3 for same file consecutive edits', async () => {
       const input = makeInput({ tool_name: 'Edit', file_path: '/src/stuck.ts' });
       const result = await runNTimes(input, 3);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
     });
 
     it('should emit HARD BLOCK header to stderr at count=3', async () => {
@@ -682,14 +682,14 @@ describe('stuck-detector.sh', () => {
         output: 'ReferenceError: x is not defined',
       });
       const result = await runNTimes(input, 3);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
     });
 
     it('should hard-block at count=3 for same tool+target', async () => {
       // Bash with a command (resolves as file_path fallback for tool_input.command)
       const input = makeInput({ tool_name: 'Bash', file_path: '/scripts/deploy.sh' });
       const result = await runNTimes(input, 3);
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(2);
     });
 
     it('should transition from no-block to hard-block between count=2 and count=3', async () => {
@@ -700,8 +700,8 @@ describe('stuck-detector.sh', () => {
       expect(results[1].exitCode).toBe(0);
       expect(results[1].stderr).not.toContain('HARD BLOCK');
 
-      // count=3: hard-block (exit 1)
-      expect(results[2].exitCode).toBe(1);
+      // count=3: hard-block (exit 2)
+      expect(results[2].exitCode).toBe(2);
       expect(results[2].stderr).toContain('[Stuck Detection] HARD BLOCK');
     });
   });


### PR DESCRIPTION
## Summary
- **#1125**: PostToolUse hook `continueOnBlock` (CC v2.1.139+) 활용 — 3개 advisory hook (stuck/budget/cost)을 stderr-only → conversation feedback 전환
- **#1124**: Hook `args: string[]` exec form 마이그레이션 검토 — 현재 hooks.json은 jq 추출 패턴으로 path-safety 모범 사례 준수, 마이그레이션 실효 후보 없음 → 코드 변경 없이 close
- 신규 R021 Enforcement Tier `Conversation Block` 문서화
- templates/ 동기화 + version 0.133.0 + CHANGELOG 프로모션
- stuck-detector.sh exit 1 → exit 2 (CC hook rejection 규약 정렬) + 테스트 기대값 업데이트

## Test plan
- [x] bun test stuck-detector PASS (78 pass, 0 fail)
- [x] bun test 전체 PASS (1945 pass, 0 fail)
- [x] verify-template-sync 대상 파일 templates/ 동기화 확인
- [x] JSON 유효성 + bash 구문 검증 PASS
- [ ] CI 7/7 PASS
- [ ] auto-tag.yml v0.133.0 태그 생성
- [ ] npm publish 0.133.0

Fixes #1124
Fixes #1125

🤖 Generated with [Claude Code](https://claude.com/claude-code)