### PR TITLE
release: v0.138.0 — auto-dev G3~G7 + milestone auto-close + wiki sync + templates/README

### DIFF
--- a/.claude/skills/pipeline/labels.md
+++ b/.claude/skills/pipeline/labels.md
@@ -1,0 +1,52 @@
+# Pipeline Label Standards
+
+Canonical reference for GitHub issue label semantics in the auto-dev pipeline.
+Used by `scope-selection` to include/exclude issues and by `implement` for lifecycle management.
+
+## Label Definitions
+
+| Label | Meaning | scope-selection 처리 |
+|-------|---------|----------------------|
+| `verify-ready` | Triage 완료, 즉시 verify 가능 (자동화 후보) | INCLUDE (preferred) |
+| `verify-done` | Triage 완료했으나 deferred 또는 이미 처리됨 (이번 사이클 미포함) | EXCLUDE |
+| `in-progress` | 작업 진행 중 (다른 세션에서 claim됨) | EXCLUDE |
+| `needs-review` | 사람 검토 필요 (자동 파이프라인 진입 불가) | EXCLUDE |
+| `decision-needed` | 결정 필요 (보안, 정책 critical) | EXCLUDE |
+| `automated` | Auto-generated issue (claude-native skill 등) | INCLUDE if other criteria met |
+| `claude-code-release` | CC version compat docs trigger | INCLUDE (preferred) |
+| `documentation` | Docs scope | INCLUDE (preferred for docs-only release) |
+| `enhancement-yaml-only` | YAML/config-only scope change | INCLUDE (eligible for docs-only compression) |
+
+## Selection Rule
+
+```
+EXCLUDE if:
+  - blocked_by_decision == true
+  - labels ∩ {decision-needed, needs-review, verify-done, manual-action, in-progress} ≠ ∅
+
+INCLUDE (preferred tier):
+  - labels ∩ {verify-ready, claude-code-release, documentation} ≠ ∅
+
+INCLUDE (standard tier):
+  - P1/P2/P3 issues not in excluded set
+
+Tie-break priority: P1 > P2 > P3 > unclassified
+```
+
+## Compression Eligibility (G6)
+
+An issue is eligible for `docs-only` compression mode if its labels include at least one of:
+`documentation`, `automated`, `claude-code-release`, `enhancement-yaml-only`
+
+If ALL scoped issues are compression-eligible AND scope size ≤ 3, the pipeline MAY use
+`compression_mode=docs-only` (skip professor-triage / release-plan / deep-plan / deep-verify skill spawns).
+
+## Lifecycle Labels (set by `implement` step)
+
+| Transition | Action |
+|-----------|--------|
+| Work started | Add `in-progress`, assign @me |
+| Work succeeded | Remove `in-progress`, add `verify-ready` |
+| Work failed | Remove `in-progress`, add `needs-review` |
+| Released | Remove `verify-ready`, close with "Fixed in v{version}" |
+| Deferred | Add `verify-done`, label "Deferred from v{version}" |

--- a/.claude/skills/pipeline/workflows/auto-dev.yaml
+++ b/.claude/skills/pipeline/workflows/auto-dev.yaml
@@ -1,6 +1,6 @@
 name: auto-dev
 description: "Automated development pipeline — from issue triage to release"
-version: "2.0.0"
+version: "2.1.0"
 
 # Design rule: each pipeline run produces ONE bounded release unit (3-7 issues), not all open issues.
 # This pipeline is a project-agnostic template. Project-specific overrides belong in
@@ -31,7 +31,20 @@ steps:
          - Local HEAD: git rev-parse --short HEAD
          - Behind state: synced or 0
 
-      5. Cross-reference: compare latest tag with any "vX.Y.Z" version references in pipeline memory/context. Flag mismatches for awareness.
+      5. Cross-reference checks (advisory, do NOT halt):
+         a. Memory vs git consistency (G7):
+            - latest_tag=$(git tag --sort=-v:refname | head -1)
+            - Compare with "Last release" or equivalent line in pipeline memory/context
+            - If mismatch: stderr warning "[pre-triage] WARNING: memory says vX.Y.Z but git latest tag is vA.B.C — update memory after pipeline completion"
+            - Do NOT halt (advisory only — memory updates are session-end responsibility)
+
+         b. Issue body stale version references (G5):
+            - Retrieve open issues: gh issue list --state open --limit 100 --json number,body
+            - For each issue body, extract all vX.Y.Z patterns (regex: v\d+\.\d+\.\d+)
+            - Retrieve git tag list: git tag --list
+            - Flag any issue referencing a version not present in git tags:
+              "[pre-triage] WARNING: Issue #N references vX.Y.Z (not in git tags) — body may be stale"
+            - Output all warnings as advisory log; do NOT halt
 
       Phase 1 — Ensure required labels exist, then scan issues.
 
@@ -50,44 +63,95 @@ steps:
          - order: topological sort over dependencies
 
       4. Output: dependency-sorted issue table with blocked_by_decision flag.
-    description: "Ensure labels exist, scan issues, dependency-analyze"
+    description: "Sync remote, stale-version check, memory consistency check, scan issues"
 
   - name: scope-selection
     prompt: |
       Select a single bounded release scope (3-7 issues) for THIS pipeline run.
 
-      Selection rules:
+      ## Step 0 — Milestone state pre-check (G3)
+
+      Before creating a milestone for version vX.Y.Z:
+      1. Query all milestones (open and closed):
+         existing=$(gh api 'repos/{owner}/{repo}/milestones?state=all&per_page=100' --jq '.[] | select(.title == "vX.Y.Z") | "\(.number)|\(.state)"')
+      2. Evaluate:
+         - If existing && state=closed:
+           HALT with "[scope-selection] BLOCKED: milestone vX.Y.Z already exists and is closed. Bump version or reopen milestone manually."
+         - If existing && state=open:
+           Use existing milestone as-is (do not create new)
+         - If not existing:
+           Create new milestone: gh api repos/{owner}/{repo}/milestones --method POST --field title="vX.Y.Z"
+
+      ## Step 1 — Label-based filtering (G4)
+
+      Reference label semantics: .claude/skills/pipeline/labels.md
+
+      Apply filter rules:
+      - EXCLUDE: blocked_by_decision == true OR labels ∩ {decision-needed, needs-review, verify-done, manual-action, in-progress} ≠ ∅
+      - INCLUDE (preferred): labels ∩ {verify-ready, claude-code-release, documentation} ≠ ∅
+      - INCLUDE (standard): P1/P2/P3 issues not in excluded set
+      - Tie-break: P1 > P2 > P3 > unclassified
+
+      ## Step 2 — Selection rules
+
       1. Determine release tier:
          - No tags yet → v0.1.0
          - Otherwise: highest-priority open tier (bug → chore → feature)
-      2. Exclude:
-         - blocked_by_decision == true
-         - Issues requiring manual/human action
+      2. Apply Step 1 filter (label-based exclusion and preference)
       3. Sort by dependency: prerequisites before dependents
       4. Cap at 7 issues; if priority issues < 7, stop at that priority (don't mix tiers)
       5. Minimum 1 issue; if 0 eligible, halt with "no eligible issues for auto-dev run"
 
-      Create release milestone and assign scoped issues.
+      Assign scoped issues to milestone.
       Output markdown release manifest:
-        | order | # | title | prerequisite | effort |
+        | order | # | title | prerequisite | effort | labels |
 
       Persist manifest as pipeline state for subsequent steps.
-    description: "Pick 3-7 issues as v{X.Y.Z} scope, create milestone"
+    description: "Milestone state pre-check, label filter, pick 3-7 issues as v{X.Y.Z} scope"
     depends_on: pre-triage
+
+  - name: compression-mode-eval
+    prompt: |
+      Evaluate whether this pipeline run qualifies for docs-only compression mode (G6).
+
+      ## Compression Eligibility Check
+
+      Reference: .claude/skills/pipeline/labels.md — "Compression Eligibility" section
+
+      Conditions for compression_mode=docs-only:
+      1. scope size ≤ 3 (number of issues in release manifest)
+      2. ALL scoped issues have labels ∩ {documentation, automated, claude-code-release, enhancement-yaml-only} ≠ ∅
+
+      ## Decision
+
+      If BOTH conditions met → set compression_mode=docs-only
+        - triage step: skip professor-triage skill; perform direct manifest summary instead
+        - plan step: skip release-plan skill; single-response plan instead
+        - deep-plan step: skip deep-plan skill; single-response implementation notes instead
+        - deep-verify step: skip deep-verify skill; perform self-review checklist instead
+        - Log: "[compression-mode] docs-only compression activated (scope={n}, all docs/yaml labels)"
+
+      Otherwise → set compression_mode=standard
+        - All pipeline steps execute normally with full skill spawns
+        - Log: "[compression-mode] standard mode (scope={n}, mixed labels or large scope)"
+
+      Output: compression_mode value as pipeline state for downstream steps.
+    description: "Evaluate docs-only compression eligibility; set compression_mode state"
+    depends_on: scope-selection
 
   - name: triage
     skill: professor-triage
-    description: "Cross-analysis triage with priority assessment (scoped to release manifest)"
-    depends_on: scope-selection
+    description: "Cross-analysis triage with priority assessment (scoped to release manifest) — skipped if compression_mode=docs-only"
+    depends_on: compression-mode-eval
 
   - name: plan
     skill: release-plan
-    description: "Release unit plan from triaged issues"
+    description: "Release unit plan from triaged issues — skipped if compression_mode=docs-only"
     depends_on: triage
 
   - name: deep-plan
     skill: deep-plan
-    description: "Research-validated implementation plan (research → plan → verify)"
+    description: "Research-validated implementation plan (research → plan → verify) — skipped if compression_mode=docs-only"
     depends_on: plan
 
   - name: implement
@@ -165,7 +229,7 @@ steps:
 
   - name: deep-verify
     skill: deep-verify
-    description: "Multi-angle release quality verification"
+    description: "Multi-angle release quality verification — self-review checklist only if compression_mode=docs-only"
     depends_on: verify-build
 
   - name: release

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -76,6 +76,35 @@ jobs:
               --repo "$REPO" || echo "⚠ Failed to close #$ISSUE"
           done
 
+      - name: Close milestone if all issues closed
+        if: steps.check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Ensure milestone title starts with "v"
+          [[ "$TAG" =~ ^v ]] && milestone_title="$TAG" || milestone_title="v$TAG"
+
+          # Find open milestone with matching title
+          milestone_number=$(gh api "repos/$REPO/milestones?state=open&per_page=100" \
+            --jq ".[] | select(.title == \"$milestone_title\") | .number")
+
+          if [ -z "$milestone_number" ]; then
+            echo "Milestone $milestone_title not found (open) — skip"
+            exit 0
+          fi
+
+          # Check open issues count
+          open_issues=$(gh api "repos/$REPO/milestones/$milestone_number" --jq '.open_issues')
+
+          if [ "$open_issues" -eq 0 ]; then
+            gh api -X PATCH "repos/$REPO/milestones/$milestone_number" -f state=closed
+            echo "Milestone $milestone_title closed (0 open issues)"
+          else
+            echo "Milestone $milestone_title has $open_issues open issues — skip close (will require manual close)"
+          fi
+
       - name: Delete merged release branch
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.138.0] - 2026-05-15
+
+### Added
+- 신규 `.claude/skills/pipeline/labels.md` — 파이프라인 라벨 의미 표준 정의 (`verify-ready`, `verify-done`, `in-progress`, `needs-review`, `decision-needed`, `automated`, `claude-code-release`, `documentation` semantics) (#1161 G4)
+- 신규 `templates/README.md` — `omcustom init` distribution 구조 + 컴포넌트 카운트 heading (Agents 49, Skills 117, Rules 22, Guides 50, Hooks 34) (#1157)
+- `.github/workflows/auto-tag.yml`에 milestone auto-close step 추가 — release PR merge 후 마일스톤 open_issues == 0이면 자동 close (#1163)
+
+### Changed
+- `/pipeline auto-dev` 강화 (#1161 G3~G7):
+  - **G3**: scope-selection에 closed milestone re-use pre-check 추가 — `gh api .../milestones?state=all`로 state별 분기 처리 (closed → halt + bump 권고, open → 그대로 사용)
+  - **G4**: labels.md 표준 참조 + 필터 로직 명시 (`verify-ready` preferred, `verify-done`/`needs-review`/`decision-needed` exclude)
+  - **G5**: pre-triage Phase 0에 본문 vX.Y.Z 참조 vs git tag 일치 검증 추가 (warning only, do not halt)
+  - **G6**: compression_mode 분기 명문화 — scope size ≤ 3 + docs/automated/claude-code-release labels → triage/plan/deep-plan/deep-verify 압축 모드
+  - **G7**: pre-triage Phase 0에 메모리 vs git latest tag 일치 비교 추가 (advisory only; hook 자동 감지는 future scope)
+- 위키 동기화 (#1164):
+  - `wiki/skills/pipeline.md` — auto-dev Phase 0 Sync + verify-build bun test 변경 반영
+  - `wiki/guides/claude-code.md` — v2.1.142 섹션 + Known Limitations 반영
+  - `wiki/agents/mgr-gitnerd.md` — rustup symlink 교훈 학습 반영
+
+### Maintenance
+- Templates 동기화: `templates/.claude/skills/pipeline/workflows/auto-dev.yaml`, `templates/.claude/skills/pipeline/labels.md`
+- Agent Teams (`v0138-release`) 사용 — 4 멤버 병렬 (workflow-engineer, wiki-engineer, skill-engineer, readme-writer)
+- /pipeline auto-dev G1 (#1159) 자기-개량 검증 — release/v0.137.0 stale ref 자동 cleanup 확인됨
+
 ## [0.137.0] - 2026-05-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.137.0",
+  "version": "0.138.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/pipeline/labels.md
+++ b/templates/.claude/skills/pipeline/labels.md
@@ -1,0 +1,52 @@
+# Pipeline Label Standards
+
+Canonical reference for GitHub issue label semantics in the auto-dev pipeline.
+Used by `scope-selection` to include/exclude issues and by `implement` for lifecycle management.
+
+## Label Definitions
+
+| Label | Meaning | scope-selection 처리 |
+|-------|---------|----------------------|
+| `verify-ready` | Triage 완료, 즉시 verify 가능 (자동화 후보) | INCLUDE (preferred) |
+| `verify-done` | Triage 완료했으나 deferred 또는 이미 처리됨 (이번 사이클 미포함) | EXCLUDE |
+| `in-progress` | 작업 진행 중 (다른 세션에서 claim됨) | EXCLUDE |
+| `needs-review` | 사람 검토 필요 (자동 파이프라인 진입 불가) | EXCLUDE |
+| `decision-needed` | 결정 필요 (보안, 정책 critical) | EXCLUDE |
+| `automated` | Auto-generated issue (claude-native skill 등) | INCLUDE if other criteria met |
+| `claude-code-release` | CC version compat docs trigger | INCLUDE (preferred) |
+| `documentation` | Docs scope | INCLUDE (preferred for docs-only release) |
+| `enhancement-yaml-only` | YAML/config-only scope change | INCLUDE (eligible for docs-only compression) |
+
+## Selection Rule
+
+```
+EXCLUDE if:
+  - blocked_by_decision == true
+  - labels ∩ {decision-needed, needs-review, verify-done, manual-action, in-progress} ≠ ∅
+
+INCLUDE (preferred tier):
+  - labels ∩ {verify-ready, claude-code-release, documentation} ≠ ∅
+
+INCLUDE (standard tier):
+  - P1/P2/P3 issues not in excluded set
+
+Tie-break priority: P1 > P2 > P3 > unclassified
+```
+
+## Compression Eligibility (G6)
+
+An issue is eligible for `docs-only` compression mode if its labels include at least one of:
+`documentation`, `automated`, `claude-code-release`, `enhancement-yaml-only`
+
+If ALL scoped issues are compression-eligible AND scope size ≤ 3, the pipeline MAY use
+`compression_mode=docs-only` (skip professor-triage / release-plan / deep-plan / deep-verify skill spawns).
+
+## Lifecycle Labels (set by `implement` step)
+
+| Transition | Action |
+|-----------|--------|
+| Work started | Add `in-progress`, assign @me |
+| Work succeeded | Remove `in-progress`, add `verify-ready` |
+| Work failed | Remove `in-progress`, add `needs-review` |
+| Released | Remove `verify-ready`, close with "Fixed in v{version}" |
+| Deferred | Add `verify-done`, label "Deferred from v{version}" |

--- a/templates/.claude/skills/pipeline/workflows/auto-dev.yaml
+++ b/templates/.claude/skills/pipeline/workflows/auto-dev.yaml
@@ -1,6 +1,6 @@
 name: auto-dev
 description: "Automated development pipeline — from issue triage to release"
-version: "2.0.0"
+version: "2.1.0"
 
 # Design rule: each pipeline run produces ONE bounded release unit (3-7 issues), not all open issues.
 # This pipeline is a project-agnostic template. Project-specific overrides belong in
@@ -31,7 +31,20 @@ steps:
          - Local HEAD: git rev-parse --short HEAD
          - Behind state: synced or 0
 
-      5. Cross-reference: compare latest tag with any "vX.Y.Z" version references in pipeline memory/context. Flag mismatches for awareness.
+      5. Cross-reference checks (advisory, do NOT halt):
+         a. Memory vs git consistency (G7):
+            - latest_tag=$(git tag --sort=-v:refname | head -1)
+            - Compare with "Last release" or equivalent line in pipeline memory/context
+            - If mismatch: stderr warning "[pre-triage] WARNING: memory says vX.Y.Z but git latest tag is vA.B.C — update memory after pipeline completion"
+            - Do NOT halt (advisory only — memory updates are session-end responsibility)
+
+         b. Issue body stale version references (G5):
+            - Retrieve open issues: gh issue list --state open --limit 100 --json number,body
+            - For each issue body, extract all vX.Y.Z patterns (regex: v\d+\.\d+\.\d+)
+            - Retrieve git tag list: git tag --list
+            - Flag any issue referencing a version not present in git tags:
+              "[pre-triage] WARNING: Issue #N references vX.Y.Z (not in git tags) — body may be stale"
+            - Output all warnings as advisory log; do NOT halt
 
       Phase 1 — Ensure required labels exist, then scan issues.
 
@@ -50,44 +63,95 @@ steps:
          - order: topological sort over dependencies
 
       4. Output: dependency-sorted issue table with blocked_by_decision flag.
-    description: "Ensure labels exist, scan issues, dependency-analyze"
+    description: "Sync remote, stale-version check, memory consistency check, scan issues"
 
   - name: scope-selection
     prompt: |
       Select a single bounded release scope (3-7 issues) for THIS pipeline run.
 
-      Selection rules:
+      ## Step 0 — Milestone state pre-check (G3)
+
+      Before creating a milestone for version vX.Y.Z:
+      1. Query all milestones (open and closed):
+         existing=$(gh api 'repos/{owner}/{repo}/milestones?state=all&per_page=100' --jq '.[] | select(.title == "vX.Y.Z") | "\(.number)|\(.state)"')
+      2. Evaluate:
+         - If existing && state=closed:
+           HALT with "[scope-selection] BLOCKED: milestone vX.Y.Z already exists and is closed. Bump version or reopen milestone manually."
+         - If existing && state=open:
+           Use existing milestone as-is (do not create new)
+         - If not existing:
+           Create new milestone: gh api repos/{owner}/{repo}/milestones --method POST --field title="vX.Y.Z"
+
+      ## Step 1 — Label-based filtering (G4)
+
+      Reference label semantics: .claude/skills/pipeline/labels.md
+
+      Apply filter rules:
+      - EXCLUDE: blocked_by_decision == true OR labels ∩ {decision-needed, needs-review, verify-done, manual-action, in-progress} ≠ ∅
+      - INCLUDE (preferred): labels ∩ {verify-ready, claude-code-release, documentation} ≠ ∅
+      - INCLUDE (standard): P1/P2/P3 issues not in excluded set
+      - Tie-break: P1 > P2 > P3 > unclassified
+
+      ## Step 2 — Selection rules
+
       1. Determine release tier:
          - No tags yet → v0.1.0
          - Otherwise: highest-priority open tier (bug → chore → feature)
-      2. Exclude:
-         - blocked_by_decision == true
-         - Issues requiring manual/human action
+      2. Apply Step 1 filter (label-based exclusion and preference)
       3. Sort by dependency: prerequisites before dependents
       4. Cap at 7 issues; if priority issues < 7, stop at that priority (don't mix tiers)
       5. Minimum 1 issue; if 0 eligible, halt with "no eligible issues for auto-dev run"
 
-      Create release milestone and assign scoped issues.
+      Assign scoped issues to milestone.
       Output markdown release manifest:
-        | order | # | title | prerequisite | effort |
+        | order | # | title | prerequisite | effort | labels |
 
       Persist manifest as pipeline state for subsequent steps.
-    description: "Pick 3-7 issues as v{X.Y.Z} scope, create milestone"
+    description: "Milestone state pre-check, label filter, pick 3-7 issues as v{X.Y.Z} scope"
     depends_on: pre-triage
+
+  - name: compression-mode-eval
+    prompt: |
+      Evaluate whether this pipeline run qualifies for docs-only compression mode (G6).
+
+      ## Compression Eligibility Check
+
+      Reference: .claude/skills/pipeline/labels.md — "Compression Eligibility" section
+
+      Conditions for compression_mode=docs-only:
+      1. scope size ≤ 3 (number of issues in release manifest)
+      2. ALL scoped issues have labels ∩ {documentation, automated, claude-code-release, enhancement-yaml-only} ≠ ∅
+
+      ## Decision
+
+      If BOTH conditions met → set compression_mode=docs-only
+        - triage step: skip professor-triage skill; perform direct manifest summary instead
+        - plan step: skip release-plan skill; single-response plan instead
+        - deep-plan step: skip deep-plan skill; single-response implementation notes instead
+        - deep-verify step: skip deep-verify skill; perform self-review checklist instead
+        - Log: "[compression-mode] docs-only compression activated (scope={n}, all docs/yaml labels)"
+
+      Otherwise → set compression_mode=standard
+        - All pipeline steps execute normally with full skill spawns
+        - Log: "[compression-mode] standard mode (scope={n}, mixed labels or large scope)"
+
+      Output: compression_mode value as pipeline state for downstream steps.
+    description: "Evaluate docs-only compression eligibility; set compression_mode state"
+    depends_on: scope-selection
 
   - name: triage
     skill: professor-triage
-    description: "Cross-analysis triage with priority assessment (scoped to release manifest)"
-    depends_on: scope-selection
+    description: "Cross-analysis triage with priority assessment (scoped to release manifest) — skipped if compression_mode=docs-only"
+    depends_on: compression-mode-eval
 
   - name: plan
     skill: release-plan
-    description: "Release unit plan from triaged issues"
+    description: "Release unit plan from triaged issues — skipped if compression_mode=docs-only"
     depends_on: triage
 
   - name: deep-plan
     skill: deep-plan
-    description: "Research-validated implementation plan (research → plan → verify)"
+    description: "Research-validated implementation plan (research → plan → verify) — skipped if compression_mode=docs-only"
     depends_on: plan
 
   - name: implement
@@ -165,7 +229,7 @@ steps:
 
   - name: deep-verify
     skill: deep-verify
-    description: "Multi-angle release quality verification"
+    description: "Multi-angle release quality verification — self-review checklist only if compression_mode=docs-only"
     depends_on: verify-build
 
   - name: release

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,195 @@
+# templates/
+
+> **oh-my-customcode 배포 디렉토리**
+>
+> `omcustom init` 실행 시 새 프로젝트에 복사되는 파일들의 소스입니다.
+
+---
+
+## 목적 (Purpose)
+
+`templates/`는 oh-my-customcode의 **배포 구조(distribution structure)**입니다.
+
+사용자가 새 프로젝트에서 `omcustom init`을 실행하면, 이 디렉토리의 내용이 대상 프로젝트 루트로 복사됩니다. 즉, 이 디렉토리는 oh-my-customcode가 제공하는 에이전트 시스템의 **완성된 스냅샷**입니다.
+
+```
+oh-my-customcode 소스 레포
+  └── templates/                   ← 배포 소스 (이 디렉토리)
+        ├── .claude/
+        ├── guides/
+        └── CLAUDE.md
+
+사용자 프로젝트 (omcustom init 후)
+  └── your-project/
+        ├── .claude/               ← templates/.claude/ 에서 복사
+        ├── guides/                ← templates/guides/ 에서 복사
+        └── CLAUDE.md              ← templates/CLAUDE.md 에서 복사
+```
+
+---
+
+## 메인 README와의 관계
+
+| 문서 | 대상 | 설명 |
+|------|------|------|
+| [`/README.md`](../README.md) | oh-my-customcode **자체** | 프로젝트 소개, 철학, 설치 가이드 |
+| `templates/README.md` (이 파일) | **배포 콘텐츠** | 배포되는 파일 구조와 카운트 |
+
+메인 README는 oh-my-customcode라는 도구를 설명합니다. 이 파일은 그 도구가 배포하는 내용물을 설명합니다.
+
+---
+
+## 디렉토리 구조
+
+```
+templates/
+├── README.md                        # 이 파일 (배포 콘텐츠 문서)
+├── CLAUDE.md                        # 에이전트 시스템 진입점
+├── manifest.json                    # 배포 컴포넌트 카운트 및 메타데이터
+├── .claude/
+│   ├── agents/                      # 에이전트 정의 파일 (*.md, 49개)
+│   ├── skills/                      # 스킬 모듈 (각 디렉토리에 SKILL.md, 117개)
+│   ├── rules/                       # 전역 규칙 (R000–R022, 22개)
+│   ├── hooks/
+│   │   ├── hooks.json               # 훅 이벤트 설정 (PreToolUse/PostToolUse 등)
+│   │   └── scripts/                 # 훅 셸 스크립트 (34개)
+│   ├── contexts/                    # 컨텍스트 설정 파일 (ecomode 등)
+│   └── ontology/                    # Ontology-RAG 지식 그래프
+└── guides/                          # 레퍼런스 문서 디렉토리 (50개)
+```
+
+---
+
+## 컴포넌트 (Components)
+
+아래 카운트는 `templates/manifest.json`과 동기화됩니다.
+CI의 `verify-template-sync.sh`가 소스와 templates/ 간 일치를 검증합니다.
+
+### Agents (49)
+
+`.claude/agents/*.md` — 에이전트 정의 파일.
+
+각 파일은 단일 전문가 에이전트를 정의합니다. frontmatter에 `name`, `description`, `model`, `tools`가 필수 포함됩니다.
+
+| 카테고리 | 수량 |
+|----------|------|
+| SW Engineer / Language | 6 |
+| SW Engineer / Backend | 6 |
+| SW Engineer / Frontend | 5 |
+| SW Engineer / Tooling | 4 |
+| DE Engineer | 6 |
+| SW Engineer / Database | 4 |
+| Security | 1 |
+| SW Architect | 2 |
+| Infra Engineer | 2 |
+| QA Team | 3 |
+| Manager | 6 |
+| System | 4 |
+
+### Skills (117)
+
+`.claude/skills/*/SKILL.md` — 재사용 가능한 스킬 모듈.
+
+각 스킬 디렉토리에 `SKILL.md`가 있으며, 필요에 따라 `scripts/` 서브디렉토리를 포함합니다.
+
+스킬 범위(`scope`):
+- `core` — 범용 개발 도구 (init 시 배포됨)
+- `harness` — 에이전트/스킬/룰 유지보수 도구 (init 시 배포됨)
+- `package` — 패키지 특화 도구 (선택 배포)
+
+### Rules (22)
+
+`.claude/rules/*.md` — 에이전트 행동 규칙 (R000–R022, R014 없음).
+
+파일명 형식: `{PRIORITY}-{name}.md` (예: `MUST-agent-identification.md`)
+
+| 우선순위 | 의미 | 예 |
+|----------|------|-----|
+| `MUST` | 절대 준수 | R007 에이전트 식별, R009 병렬 실행 |
+| `SHOULD` | 강력 권장 | R003 상호작용, R013 Ecomode |
+| `MAY` | 선택 | R005 최적화 |
+
+### Guides (50)
+
+`guides/*/` — 레퍼런스 문서 디렉토리.
+
+각 디렉토리는 단일 토픽에 대한 best practices, 튜토리얼, 또는 설계 가이드를 담습니다. 에이전트가 작업 중 참조합니다 (R006 관심사 분리).
+
+### Hooks (34)
+
+`.claude/hooks/scripts/*.sh` — 라이프사이클 훅 스크립트.
+
+`hooks.json`에 정의된 이벤트(PreToolUse, PostToolUse, Stop 등)에 반응합니다.
+
+주요 훅 스크립트:
+
+| 스크립트 | 역할 |
+|----------|------|
+| `secret-filter.sh` | API 키/시크릿 노출 방지 |
+| `stage-blocker.sh` | 스테이지 게이트 강제 |
+| `rule-deletion-guard.sh` | 규칙 파일 삭제 차단 |
+| `stuck-detector.sh` | 에이전트 무한루프 감지 |
+| `context-budget-advisor.sh` | 컨텍스트 예산 경고 |
+| `cost-cap-advisor.sh` | 비용 한도 초과 경고 |
+
+---
+
+## 사용 방법 (Usage)
+
+### omcustom init
+
+```bash
+# 전역 설치
+npm install -g oh-my-customcode
+
+# 프로젝트에 oh-my-customcode 초기화
+cd your-project
+omcustom init
+```
+
+`omcustom init`은 이 `templates/` 디렉토리의 내용을 대상 프로젝트에 복사합니다:
+1. `.claude/` 전체 (agents, skills, rules, hooks, contexts, ontology)
+2. `guides/` 전체
+3. `CLAUDE.md` (프로젝트 진입점)
+
+### 선택적 업데이트
+
+이미 초기화된 프로젝트를 최신 버전으로 업데이트할 때:
+
+```bash
+omcustom update
+```
+
+---
+
+## 동기화 검증
+
+소스(`.claude/`, `guides/`)와 `templates/` 간 동기화는 CI에서 자동 검증됩니다.
+
+```bash
+# 로컬 검증
+bash .github/scripts/verify-template-sync.sh
+```
+
+검증 항목:
+- 스킬 수 일치 (`.claude/skills/` ↔ `templates/.claude/skills/`)
+- 에이전트 수 일치
+- 룰 수 일치
+- 가이드 수 일치
+- 훅 스크립트 수 일치
+- `manifest.json` 카운트 일치
+
+소스에 새 파일을 추가할 때는 반드시 `templates/`에도 동기화해야 합니다.
+`manifest.json`의 카운트도 함께 업데이트하세요.
+
+---
+
+## 기여 가이드 참조
+
+에이전트, 스킬, 룰 추가/수정 시 3중 동기화가 필요합니다:
+
+1. **원본**: `.claude/agents/`, `.claude/skills/`, `.claude/rules/`, `guides/`
+2. **templates 복사**: `templates/.claude/agents/`, `templates/.claude/skills/` 등
+3. **카운트 업데이트**: `templates/manifest.json`, `README.md`, `CLAUDE.md` 등
+
+자세한 내용은 프로젝트 루트의 기여 가이드 및 `guides/` 참조 문서를 확인하세요.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.137.0",
+  "version": "0.138.0",
   "lastUpdated": "2026-05-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/wiki/agents/mgr-gitnerd.md
+++ b/wiki/agents/mgr-gitnerd.md
@@ -78,7 +78,17 @@ The local `release` branch (file ref) conflicts with `release/v*` directory ref 
 - **Mitigation**: auto-dev.yaml release step prepends item 0 to force-delete the stale local branch before tag/branch operations. Unpushed commits are warned but force-delete proceeds.
 - **Memory**: see `.claude/agent-memory/mgr-gitnerd/MEMORY.md` (locally untracked per project policy).
 
+### rustup symlink multiplexer is not cache poisoning (#1148, v0.137.0)
+
+`readlink -f $(which cargo) | grep -q "rustup-init"` returning true is **normal** rustup behavior — NOT an indicator of cache poisoning or misconfiguration.
+
+- **Why**: rustup uses a single binary (`rustup-init`) with argv[0]-based multiplexing. All tool symlinks (`cargo`, `rustc`, etc.) resolve to `rustup-init` by design.
+- **Anti-pattern**: Binary identity checks (`readlink`) for cargo verification — these produce false positives and caused PR #1143 CI failure (v0.136.0).
+- **Correct approach**: Functional verification — `cargo --list | grep test` (subcommand existence). The actual #1140 regression symptom was `cargo test` returning `error: unexpected argument 'test' found`, not symlink mismatch.
+- **Rule**: Use functional output verification, never binary identity path checks, for tool environment guards.
+
 ## Sources
 
 - `.claude/agents/mgr-gitnerd.md` — agent definition
 - Issue #1146 — v0.136.0 working tree loss incident (origin of expanded Safety Rules)
+- Issue #1148 — rustup symlink false-positive CI failure (v0.137.0)

--- a/wiki/guides/claude-code.md
+++ b/wiki/guides/claude-code.md
@@ -1,11 +1,15 @@
 ---
 title: "Claude Code Guide"
 type: guide
-updated: 2026-04-12
+updated: 2026-05-15
 sources:
   - guides/claude-code/01-overview.md
+  - guides/claude-code/15-version-compatibility.md
 related:
   - [[mgr-claude-code-bible]]
+  - [[r010]]
+  - [[r012]]
+  - [[r013]]
 ---
 
 # Claude Code Guide
@@ -26,12 +30,55 @@ Covers Claude's advanced API features for building Claude Code-compatible applic
 - Citations and search results for RAG applications
 - Token counting and effort control
 
+## Version Compatibility
+
+oh-my-customcode v0.107.0+ targets CC v2.1.116+. See `guides/claude-code/15-version-compatibility.md` for full per-version notes.
+
+### v2.1.142 (2026-05-14) — Key Changes
+
+> Issue: #1158
+
+- **`claude agents` new flags**: `--add-dir`, `--settings`, `--mcp-config`, `--plugin-dir`, `--permission-mode`, `--model`, `--effort`, `--dangerously-skip-permissions` — enables CLI-level override of R006 agent frontmatter values. Useful for CI/unattended R010 bypassPermissions flows.
+- **Fast Mode default model → Opus 4.7**: `model: opus` agents + Fast Mode now use Opus 4.7. Pin with `CLAUDE_CODE_OPUS_4_6_FAST_MODE_OVERRIDE=1` if needed.
+- **Plugin root-level SKILL.md**: `SKILL.md` at plugin root (no `skills/` subdir) now exposes as skill — no impact on oh-my-customcode's `.claude/skills/<name>/SKILL.md` pattern.
+- **`MCP_TOOL_TIMEOUT` fix**: Now correctly raises per-request fetch timeout for remote HTTP/SSE MCP servers (was capped at 60s). Relevant for R011 `claude-mem` / R019 `ontology-rag` timeout issues.
+- **BG + git worktree Edit fix**: Background sessions can now edit files in existing git worktrees — stabilizes R009 parallel worktree workflows.
+- **BG macOS sleep/wake fix**: Background sessions survive macOS sleep/wake — improves R018 Agent Teams long-running session stability.
+- **`--dangerously-skip-permissions` retention**: Persists across retire/wake cycles — R010 unattended execution more reliable.
+
+**Action items**: Confirm Fast Mode Opus 4.7 impact; set `MCP_TOOL_TIMEOUT` if needed for MCP server latency.
+
+### v2.1.141 (2026-05-13) — Key Changes
+
+> Issue: #1137
+
+- **`/bg` permission mode preservation**: Background agents (`/bg` or `←←`) now retain current session's permission mode — `bypassPermissions` no longer drops on detach. R010 universal bypassPermissions on Agent tool calls still required.
+- **Hook `terminalSequence` field**: Hooks can emit window title changes or terminal bells without terminal control — R012 HUD complement.
+- **`claude agents --cwd <path>`**: Filter session list by directory — reduces noise in multi-project R009 monitoring.
+- **Rewind "Summarize up to here"**: Manual context compression complementing R013 ecomode.
+
+### Earlier Versions
+
+See `guides/claude-code/15-version-compatibility.md` for v2.1.117–v2.1.140 notes.
+
+## Known Limitations
+
+### `.gitignore` Nested `.md` Pattern (#1147)
+
+```gitignore
+docs/superpowers/plans/*
+!docs/superpowers/plans/*.md
+```
+
+This pattern tracks only **direct-child** `.md` files. Git semantics prevent `!` negation patterns from working inside already-excluded (`*`) parent directories. Nested paths like `docs/superpowers/plans/subdir/plan.md` are not tracked. **Current impact**: none — `release-plan` skill only creates flat-path plans. Fix if nested tracking is needed: add explicit `!docs/superpowers/plans/<subdir>/*.md` lines.
+
 ## Relationships
 
 - **Used by agents**: [[mgr-claude-code-bible]]
 - **Related skills**: [[claude-native]]
-- **See also**: [[skill-bundle-design]], [[hook-data-flow]]
+- **See also**: [[skill-bundle-design]], [[hook-data-flow]], [[r010]], [[r012]]
 
 ## Sources
 
 - `guides/claude-code/01-overview.md` — feature overview, tool catalog, API capabilities
+- `guides/claude-code/15-version-compatibility.md` — per-version compatibility notes (v2.1.117–v2.1.142)

--- a/wiki/skills/pipeline.md
+++ b/wiki/skills/pipeline.md
@@ -1,13 +1,16 @@
 ---
 title: Pipeline
 type: skill
-updated: 2026-04-12
+updated: 2026-05-15
 sources:
   - .claude/skills/pipeline/SKILL.md
+  - .claude/skills/pipeline/workflows/auto-dev.yaml
 related:
   - [[dag-orchestration]]
   - [[pipeline-guards]]
   - [[task-decomposition]]
+  - [[professor-triage]]
+  - [[deep-verify]]
 ---
 
 # Pipeline
@@ -27,12 +30,47 @@ YAML-based pipeline executor. In list mode, scans `workflows/*.yaml` and display
 - **Argument hint**: `<pipeline-name> | resume | (no args to list available)`
 - **Source**: external (github: baekenough/baekenough-skills v1.0.0)
 
+## auto-dev Pipeline Steps
+
+The `auto-dev` workflow runs a full release cycle: `pre-triage → scope-selection → triage → plan → deep-plan → implement → verify-build → deep-verify → release → ci-check → post-release-followup`.
+
+### Phase 0: Sync (G1 — #1159, v0.137.0)
+
+`pre-triage` now begins with a mandatory local-remote sync before scanning issues:
+
+1. `git fetch --all --tags --prune` — pull all remote state
+2. Detect `behind` count vs `origin/<current_branch>`
+3. If behind > 0 AND working tree **clean** → `git pull --ff-only` and report synced commits
+4. If behind > 0 AND working tree **dirty** → **HALT** with manual reconcile required message
+5. Report: latest tag, local HEAD SHA, behind state, and flag any tag/context version mismatch
+
+**Purpose**: Prevents stale session memory (from previous session's git state) from causing incorrect version selection or duplicate issue processing. Resolves the pattern where pipeline memory held an old version while git HEAD had already advanced.
+
+### verify-build: bun test with Baseline Delta Guard (G2 — #1160, #1156, v0.137.0)
+
+`verify-build` now mandates `bun test` with dynamic baseline tracking:
+
+1. `bun install` — lockfile sync check (halt on drift)
+2. `bun run lint` (if script exists)
+3. `bun run typecheck` (if available)
+4. **`bun test` — MANDATORY, no silent skip**
+   - Baseline: adopt prior version's pass/fail count (dynamic, not hardcoded)
+   - Historical note: #1156 documented 86 failures; v0.136.2 resolved them → current baseline = 0
+   - If current FAIL count **>** baseline → new regression detected → halt + report failure list
+   - If current FAIL count **≤** baseline → continue with advisory `"X failures (baseline {n}, delta {d})"`
+5. Build script (if exists)
+
+**Halt conditions**: lint errors, typecheck errors, NEW test failures (regression from baseline), build failure, lockfile drift.
+
+**Purpose**: Catches unit test regressions that static checks miss. Addresses the v0.133.0 pattern where hook script exit code changes introduced test regressions not detected by lint/typecheck alone.
+
 ## Relationships
 
 - **Used by agents**: orchestrator
-- **Related skills**: [[dag-orchestration]], [[pipeline-guards]], [[task-decomposition]]
+- **Related skills**: [[dag-orchestration]], [[pipeline-guards]], [[task-decomposition]], [[professor-triage]], [[deep-verify]]
 - **See also**: [[R009]], [[R010]]
 
 ## Sources
 
 - `.claude/skills/pipeline/SKILL.md` — skill definition
+- `.claude/skills/pipeline/workflows/auto-dev.yaml` — auto-dev workflow YAML (G1/G2 added v0.137.0)


### PR DESCRIPTION
## v0.138.0 릴리즈

### Added
- 신규 `.claude/skills/pipeline/labels.md` — 파이프라인 라벨 의미 표준 정의 (`verify-ready`, `verify-done`, `in-progress`, `needs-review`, `decision-needed`, `automated`, `claude-code-release`, `documentation` semantics) (#1161 G4)
- 신규 `templates/README.md` — `omcustom init` distribution 구조 + 컴포넌트 카운트 heading (Agents 49, Skills 117, Rules 22, Guides 50, Hooks 34) (#1157)
- `.github/workflows/auto-tag.yml`에 milestone auto-close step 추가 — release PR merge 후 마일스톤 open_issues == 0이면 자동 close (#1163)

### Changed
- `/pipeline auto-dev` 강화 (#1161 G3~G7):
  - **G3**: scope-selection에 closed milestone re-use pre-check 추가 — `gh api .../milestones?state=all`로 state별 분기 처리
  - **G4**: labels.md 표준 참조 + 필터 로직 명시 (`verify-ready` preferred, `verify-done`/`needs-review`/`decision-needed` exclude)
  - **G5**: pre-triage Phase 0에 본문 vX.Y.Z 참조 vs git tag 일치 검증 추가 (warning only)
  - **G6**: compression_mode 분기 명문화 — scope size ≤ 3 + docs/automated/claude-code-release labels → 압축 모드
  - **G7**: pre-triage Phase 0에 메모리 vs git latest tag 일치 비교 추가 (advisory only)
- 위키 동기화 (#1164): `wiki/skills/pipeline.md`, `wiki/guides/claude-code.md`, `wiki/agents/mgr-gitnerd.md`

### Maintenance
- Templates 동기화: `templates/.claude/skills/pipeline/workflows/auto-dev.yaml`, `templates/.claude/skills/pipeline/labels.md`
- Agent Teams (`v0138-release`) 사용 — 4 멤버 병렬 검증

### Closes
- Closes #1161 (auto-dev G3~G7)
- Closes #1163 (milestone auto-close)
- Closes #1164 (wiki sync)
- Closes #1157 (templates/README.md)

### Pre-commit 결과
- Tests: 1945 pass / 0 fail
- Function coverage: 98.67% / Line coverage: 98.33% (threshold: 98%)
- verify-version-sync: exit 0 (0.138.0)
- verify-template-sync: exit 0
- verify-wiki-sync: exit 0 (268 pages, 0 missing)