### PR TITLE
release: v0.143.0 — ECC epic 종결 (#1170) + cross-harness 결정 archive (#1176)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.142.0",
+  "version": "0.143.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.142.0",
+  "version": "0.143.0",
   "lastUpdated": "2026-05-18T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약
auto-dev 묶음 batch — #1170 ECC epic 종결 + #1176 cross-harness 결정 rationale archive. 코드 변경 없음 (전략 archive + epic close).

## 변경 사항

### #1170 — ECC epic CLOSED
- 4 sub-issues 처리 결과 본문 갱신 + close
- 흡수: 3 (sec-agentshield-wrapper, instinct-extractor, manifest-install)
- 거부/지연: 1 (cross-harness #1176, standalone)

### #1176 — cross-harness 결정 archive
- \`guides/external-tools/ecc-absorption-decisions.md\` (232줄)
- **권고: REJECT** (DEFER 옵션 명시)
- 근거: compilation metaphor 보호, single-maintainer 비용, manifest-install로 진입로 해소
- DEFER 트리거: 한국어 50%+ + 외부 기여자 5+ 도달 시점

### 동기화
- R022 wiki sync (external-tools.md 갱신)
- templates/ 미러
- version 0.142.0 → 0.143.0
- 카운트 변동 없음

## R017 검증 ✓
- 카운트 정합 (skills 121, rules 23, guides 57, agents 49 — 변동 없음)
- 신규 가이드 frontmatter 유효
- cross-refs 정합

## #1176 표시
PR 본문에서 결정 내용 공개. 사용자 최종 결정 (REJECT vs DEFER vs partial-absorb)은 PR 머지 후 #1176 코멘트 또는 close로 표시.

## 잔여 (시퀀싱 deferred)
- **#1169 AgentMemory** — 1주 measure 가드 (routine trig_01JhfZvVikjC88QnzJTs6ZqN, 2026-05-25 09:00 KST 자동 reminder)
- **#1176 cross-harness** — 사용자 final decision (본 PR 권고: REJECT)

세션 진행률: 시작 4 verify-done → 종료 2 verify-done (#1169, #1176)

Closes #1170
Refs #1176

🤖 Generated with /pipeline auto-dev (묶음 batch: epic close + decision archive)