### PR TITLE
release: v0.144.0 — #1169 Phase 1 (COEXIST) prep

### DIFF
--- a/.claude/rules/SHOULD-memory-integration.md
+++ b/.claude/rules/SHOULD-memory-integration.md
@@ -381,3 +381,45 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 - MCP saves are **non-blocking**: memory failure MUST NOT prevent session from ending
 - If claude-mem unavailable: skip, log warning
 - episodic-memory: no action needed (auto-indexed after session)
+
+## Dual-Backend Advisory (AgentMemory + claude-mem)
+
+#1169 Phase 1 (COEXIST) 단계에서 두 memory backend 동시 활성 가능:
+
+| 상황 | 권장 |
+|------|------|
+| claude-mem 단독 | 기본값 — 현 운영 유지 |
+| AgentMemory 단독 | Phase 2 (SWITCH) 이후 진행 |
+| 둘 다 활성 (COEXIST) | Phase 1 한정 — `memory-aggregator`가 결과 병합 |
+
+### 충돌 감지
+
+`.mcp.json`에 두 서버(`claude-mem`, `agentmemory`) 동시 등록 시 첫 호출 시점에 advisory 출력 권장:
+
+```
+[Advisory] Dual memory backend detected (Phase 1 COEXIST)
+  - claude-mem: active (Chroma)
+  - agentmemory: active (SQLite)
+  Phase 2 SWITCH 진입 전까지 두 backend 유지
+  가이드: guides/agentmemory-migration/phase-1-coexist.md
+```
+
+이 advisory는 경고가 아닙니다. Phase 1 COEXIST에서는 정상 상태입니다.
+
+### Session-End Self-Check (COEXIST 확장)
+
+Phase 1 COEXIST 기간 중 세션 종료 시:
+
+1. sys-memory-keeper가 MEMORY.md 갱신? → YES: 계속
+2. claude-mem 저장 시도? → YES (기존 항목)
+3. AgentMemory 저장 시도? → YES (COEXIST 추가)
+세 단계 모두 완료 후 사용자에게 확인. 둘 중 하나 실패해도 비차단.
+
+### Phase 2 진입 전 필수 조건
+
+- 1주 measure 결과 (`scripts/measure-claude-mem-usage.sh`) GO 판정
+- 자산 처리표 사용자 검토 완료 (12 plugin skill 처리 방향 결정)
+- 30분 롤백 절차 검증 (Chroma 백업 + 복원 테스트)
+
+Refs: #1169 본문 조치 3 (택1 강제), 조치 4 (롤백 절차),
+      `guides/agentmemory-migration/phase-1-coexist.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,8 @@ Claude Code의 Agent Teams 기능이 활성화되어 있으면 (`CLAUDE_CODE_EXP
 
 | 서버 | 용도 |
 |------|------|
-| claude-mem | 세션 메모리 영속성 (Chroma 기반) — Phase β 이후 AgentMemory로 교체 예정 (#1169) |
+| claude-mem | 세션 메모리 영속성 (Chroma 기반) — Phase β (#1169) COEXIST 진행 중 |
+| **agentmemory** | claude-mem 대체 후보 (SQLite 기반, 4-tier consolidation) — Phase 1 COEXIST (#1169) |
 | code-review-graph | Token-efficient AST 기반 context retrieval (8.2× 토큰 절감) — wrapper: `crg-integration` 스킬 (#1171) |
 | semble | Semantic code search via embeddings (98% 토큰 절감, NDCG@10=0.854) — wrapper: `semble-integration` 스킬 (#1173) |
 
@@ -263,6 +264,12 @@ Claude Code의 Agent Teams 기능이 활성화되어 있으면 (`CLAUDE_CODE_EXP
 # MCP 설정 (claude-mem)
 npm install -g claude-mem
 claude-mem setup
+
+# AgentMemory MCP 설치 (claude-mem 대체 후보, COEXIST)
+pip install agentmemory
+claude mcp add agentmemory -- agentmemory mcp
+# 또는 .mcp.json 수동 편집 (R001 auto-install 금지)
+# Phase 1 COEXIST 가이드: guides/agentmemory-migration/phase-1-coexist.md
 
 # CRG MCP 설치 (token efficiency)
 pipx install code-review-graph

--- a/guides/agentmemory-migration/phase-1-coexist.md
+++ b/guides/agentmemory-migration/phase-1-coexist.md
@@ -1,0 +1,261 @@
+# AgentMemory Migration — Phase 1: COEXIST (Week 1-2)
+
+> **상태**: 활성 — 2026-05-18 시작 (#1169)
+> **다음 단계**: Phase 2 SWITCH (measure 결과 후 GO/NO-GO 결정)
+> **이전 단계**: [measure-step-zero.md](./measure-step-zero.md)
+
+---
+
+## 1. 개요
+
+Phase 1 (COEXIST)는 claude-mem과 AgentMemory를 **동시에 운영**하는 단계입니다.
+이 단계에서는 어떤 destructive 변경도 발생하지 않습니다:
+
+- claude-mem 기존 Chroma 데이터 유지
+- 12 plugin skill 폐기 없음
+- 어댑터 코드 활성화 없음 (STUB 상태 유지)
+- 자산 처리표 적용 없음
+
+목표는 1주간 실제 사용 데이터를 수집하고, AgentMemory 설치와 공존 운영에 익숙해지는 것입니다.
+
+| 항목 | Phase 1 (COEXIST) | Phase 2 (SWITCH) |
+|------|-------------------|------------------|
+| claude-mem | 활성 (기존 운영) | 비활성화 예정 |
+| AgentMemory | 설치 후 병렬 활성 | 단독 운영 |
+| 데이터 마이그레이션 | 없음 | 선택적 (측정 후 결정) |
+| 어댑터 코드 | STUB 유지 | 활성화 |
+| 자산 처리표 | 적용 보류 | 사용자 검토 후 적용 |
+
+---
+
+## 2. AgentMemory 설치
+
+> **R001 주의**: auto-install 금지. 아래 명령어를 사용자 로컬에서 수동으로 실행합니다.
+
+### 2-1. 패키지 설치
+
+```bash
+# 옵션 A: pip
+pip install agentmemory
+
+# 옵션 B: pipx (격리 환경 권장)
+pipx install agentmemory
+
+# 옵션 C: uvx (uv 사용 시)
+uvx agentmemory
+```
+
+### 2-2. MCP 서버 등록
+
+```bash
+# Claude Code CLI로 등록
+claude mcp add agentmemory -- agentmemory mcp
+
+# 또는 .mcp.json 수동 편집 (R001 auto-install 금지)
+# {
+#   "mcpServers": {
+#     "agentmemory": {
+#       "command": "agentmemory",
+#       "args": ["mcp"]
+#     }
+#   }
+# }
+```
+
+### 2-3. 등록 확인
+
+```bash
+claude mcp list
+# 출력에 agentmemory 서버가 표시되어야 합니다
+```
+
+---
+
+## 3. COEXIST 정책
+
+Phase 1 기간 동안 두 backend는 다음 정책에 따라 공존합니다.
+
+### 3-1. 기본 운영 방식
+
+| 작업 | 우선 backend | 비고 |
+|------|-------------|------|
+| 기존 메모리 조회 | claude-mem | 기존 Chroma 데이터 유지 |
+| 신규 메모리 저장 | 둘 다 | COEXIST 기간 중 병렬 저장 권장 |
+| 세션 종료 시 저장 | 둘 다 | R011 Session-End Self-Check 참조 |
+
+### 3-2. 쿼리 병합 (memory-aggregator)
+
+두 backend에서 결과가 반환될 경우 `memory-aggregator` 스킬이 결과를 병합합니다:
+
+```
+claude-mem.search(query)    →  결과 A
+AgentMemory.search(query)   →  결과 B
+memory-aggregator           →  A + B 중복 제거 후 반환
+```
+
+`memory-aggregator` 스킬이 없는 경우, 두 결과를 순서대로 제시하고 사용자가 선택합니다.
+
+### 3-3. 충돌 방지 원칙
+
+- claude-mem 기존 데이터를 AgentMemory로 자동 복사하지 않음
+- 두 backend에 동일 키로 저장 시 별개 항목으로 취급
+- 강제 동기화 없음 — Phase 2에서 마이그레이션 여부 결정
+
+---
+
+## 4. Dual-Backend 충돌 Advisory
+
+`.mcp.json`에 두 서버가 동시 등록된 상태를 감지하면 다음 advisory를 출력합니다.
+
+### 4-1. 감지 조건
+
+```
+.mcp.json 내 서버 목록:
+  - "claude-mem" (또는 관련 tool prefix)
+  - "agentmemory"
+  → 두 개 동시 존재 시 Phase 1 COEXIST 상태로 간주
+```
+
+### 4-2. Advisory 메시지
+
+```
+[Advisory] Dual memory backend detected (Phase 1 COEXIST)
+  - claude-mem: active (Chroma)
+  - agentmemory: active (SQLite)
+  현재 Phase 1 COEXIST 정책 적용 중 — 두 backend 병렬 운영
+  Phase 2 SWITCH 진입 전까지 두 backend 유지
+  가이드: guides/agentmemory-migration/phase-1-coexist.md
+```
+
+이 advisory는 경고가 아닙니다. Phase 1에서는 정상 상태입니다.
+
+### 4-3. 강제 선택 (사용자 명시 시)
+
+사용자가 명시적으로 "agentmemory만 사용" 또는 "claude-mem만 사용"을 요청하는 경우,
+해당 요청을 따르되 자산 처리표 적용 및 어댑터 활성화는 Phase 2 GO 결정 후 진행합니다.
+
+---
+
+## 5. 사용자 행동 계획
+
+### 5-1. 1주 measure 루틴 (자동 트리거: 2026-05-25)
+
+`scripts/measure-claude-mem-usage.sh` 스크립트를 1주간 실행합니다:
+
+```bash
+# 수동 실행 (필요 시)
+bash scripts/measure-claude-mem-usage.sh
+
+# 결과는 .claude/outputs/sessions/ 에 저장됩니다
+```
+
+측정 항목:
+- 일별 호출 횟수 (claude-mem vs AgentMemory)
+- 응답 지연 (p50, p95)
+- 저장 성공/실패율
+- 메모리 용량 (Chroma vs SQLite)
+
+### 5-2. GO/NO-GO 결정 기준 (2026-05-25 예정)
+
+| 지표 | GO 조건 | NO-GO 조건 |
+|------|---------|------------|
+| 응답 지연 | AgentMemory ≤ claude-mem × 1.2 | AgentMemory > claude-mem × 2.0 |
+| 저장 성공률 | ≥ 99% | < 95% |
+| 운영 안정성 | 1주 무장애 | 크래시 또는 데이터 손실 |
+| 호환성 | 기존 메모리 포맷 읽기 가능 | 포맷 비호환으로 검색 실패 |
+
+### 5-3. 지금 할 수 있는 것
+
+- AgentMemory 설치 및 MCP 등록 (위 섹션 2 참조)
+- 신규 세션에서 AgentMemory로도 저장해보기 (실험적)
+- measure 스크립트 결과 관찰
+- 자산 처리표 (`guides/agentmemory-migration/asset-disposition.md`) 검토 준비
+
+---
+
+## 6. Phase 2 진입 조건
+
+다음 조건이 모두 충족된 경우에만 Phase 2 (SWITCH)로 진행합니다.
+
+### 필수 조건
+
+- [ ] 1주 measure 결과 GO 판정 (5-2 기준 충족)
+- [ ] 자산 처리표 사용자 검토 완료 (12 plugin skill 처리 방향 결정)
+- [ ] 30분 롤백 절차 검증 완료
+
+### 롤백 절차 검증 (Phase 2 진입 전 필수)
+
+```bash
+# 1. Chroma 백업 생성
+cp -r ~/.local/share/claude-mem/chroma ~/.local/share/claude-mem/chroma.bak.$(date +%Y%m%d)
+
+# 2. 백업에서 복원 가능 여부 확인
+# (실제 복원 수행하지 않고 절차만 검증)
+ls -la ~/.local/share/claude-mem/chroma.bak.*
+
+# 3. AgentMemory SQLite 백업
+cp ~/.local/share/agentmemory/memories.db ~/.local/share/agentmemory/memories.db.bak.$(date +%Y%m%d)
+```
+
+롤백 소요 시간이 30분 이내임을 확인한 후 Phase 2 진행.
+
+---
+
+## 7. 현 단계 한계 및 금지 사항
+
+### 7-1. STUB 상태 유지 (변경 금지)
+
+```
+packages/eval-core/src/adapters/agentmemory.ts  ← STUB, 활성화 금지
+packages/eval-core/src/db/schema.ts              ← 변경 금지
+```
+
+이 파일들은 Phase 2 GO 결정 후 별도 사이클에서 수정합니다.
+
+### 7-2. 자산 처리표 적용 보류
+
+12 plugin skill의 폐기/유지 결정은 measure 결과를 확인한 후 진행합니다:
+
+```
+.claude/skills/memory-*/  ← 폐기 여부 보류
+.claude/skills/claude-mem-*/  ← 폐기 여부 보류
+```
+
+### 7-3. 데이터 마이그레이션 금지
+
+Phase 1에서는 claude-mem Chroma 데이터를 AgentMemory SQLite로 이전하지 않습니다.
+이전은 Phase 2에서 사용자가 명시적으로 승인한 경우에만 진행합니다.
+
+---
+
+## 8. R011과의 관계
+
+Phase 1 COEXIST 기간 중 R011 (SHOULD-memory-integration) 적용:
+
+| R011 항목 | COEXIST 수정 사항 |
+|-----------|-----------------|
+| Primary: Native auto memory | 변경 없음 |
+| Supplementary: claude-mem | 변경 없음 (계속 사용) |
+| Session-End Self-Check | claude-mem + AgentMemory 둘 다 저장 시도 |
+| Failure Policy | 둘 중 하나 실패해도 비차단 |
+
+세션 종료 시 자가 점검 (COEXIST 확장):
+
+```
+1. sys-memory-keeper가 MEMORY.md 갱신? → YES
+2. claude-mem 저장 시도? → YES (기존)
+3. AgentMemory 저장 시도? → YES (COEXIST 추가)
+모두 완료 후 사용자에게 확인
+```
+
+---
+
+## 9. 참고
+
+- **이슈**: #1169 (AgentMemory 마이그레이션 계획)
+- **이전 단계**: [measure-step-zero.md](./measure-step-zero.md)
+- **R011**: `.claude/rules/SHOULD-memory-integration.md` (Dual-Backend Advisory 섹션)
+- **관련 기억**: [[project-sequencing-alpha-beta-gamma]]
+- **자산 처리표**: `guides/agentmemory-migration/asset-disposition.md` (Phase 2 전 검토 필요)
+- **measure 스크립트**: `scripts/measure-claude-mem-usage.sh`
+- **롤백 가이드**: #1169 본문 조치 4 (30분 롤백 절차)

--- a/guides/external-tools/ecc-absorption-decisions.md
+++ b/guides/external-tools/ecc-absorption-decisions.md
@@ -1,0 +1,232 @@
+# ECC 흡수 결정 아카이브
+
+> **목적**: ECC (Everything Claude Code) 패턴 흡수 검토 이력 보존.
+> 미래 기여자가 "왜 흡수했는가 / 왜 거부했는가"를 재검토 없이 파악할 수 있도록 합니다.
+>
+> 관련 Epic: #1170 (closed), 분리 이슈: #1176
+
+---
+
+## 1. 개요
+
+oh-my-customcode는 **compilation metaphor**를 핵심 아키텍처 철학으로 채택합니다.
+ECC (Everything Claude Code) 등 외부 도구의 패턴을 흡수할 때, 이 철학과의 정합성이
+흡수 여부의 1차 판단 기준입니다.
+
+| 판단 기준 | 설명 |
+|----------|------|
+| metaphor 정합성 | `.claude/` 구조를 컴파일러 metaphor로 강화하는가 |
+| single-maintainer 비용 | 외부 의존성 추적 부담이 감당 가능한가 |
+| 사용자 가치 | 기존 사용자 워크플로우를 개선하는가 |
+| 차별점 영향 | ECC와 직접 경쟁(zero-sum)이 되는가 |
+
+본 문서는 v0.142.0 ~ v0.143.0 기간에 검토된 4개 패턴의 결정을 기록합니다.
+
+---
+
+## 2. 흡수된 패턴 (v0.142.0)
+
+### 2-1. sec-agentshield-wrapper (sub-issue #1174)
+
+| 항목 | 내용 |
+|------|------|
+| 릴리즈 | v0.142.0 |
+| 흡수 형태 | pre-flight 보안 wrapper skill |
+| 차별점 영향 | **보완** — post-write 자산(CodeQL 등)과 시점 분리 |
+
+**결정: ACCEPT**
+
+ECC의 `agentshield-wrapper`는 실행 전 입력 검증 레이어를 제공합니다.
+oh-my-customcode의 `sec-codeql-expert`가 post-write 단계에 집중하므로,
+pre-flight 단계를 담당하는 이 패턴은 compilation pipeline을 완성하는
+`compiler → linker → loader` 구조에 자연스럽게 편입됩니다.
+유지보수 비용: 외부 harness 의존 없음, 내부 skill로 완전 소유.
+
+---
+
+### 2-2. instinct-extractor (sub-issue #1175)
+
+| 항목 | 내용 |
+|------|------|
+| 릴리즈 | v0.142.0 |
+| 흡수 형태 | cross-session 패턴 채굴 skill |
+| 차별점 영향 | **보완** — `skill-extractor`와 trigger 분리 |
+
+**결정: ACCEPT**
+
+`skill-extractor`가 현재 세션의 행동 패턴을 skill로 승격한다면,
+`instinct-extractor`는 누적 세션에서 반복 패턴을 자동 감지합니다.
+두 도구는 trigger가 다릅니다 (단일 세션 vs 누적 히스토리).
+R016 Continuous Improvement 루프를 강화하며, 내부 구조(agent-memory + claude-mem)로
+구현 가능하므로 외부 의존성이 없습니다.
+
+---
+
+### 2-3. manifest-install --profile (sub-issue #1177)
+
+| 항목 | 내용 |
+|------|------|
+| 릴리즈 | v0.142.0 |
+| 흡수 형태 | manifest profiles 5종 |
+| 차별점 영향 | **보완** — deactivation 비용 축소 |
+
+**결정: ACCEPT**
+
+신규 사용자의 진입 비용을 낮추는 profile 기반 설치 패턴입니다.
+`--profile minimal`, `--profile de`, `--profile qa` 등 도메인별 subset을
+한 번에 활성화합니다. deactivation 비용 문제(한 번 설치된 skill이 불필요해도
+삭제 경로가 불명확)를 profile 전환으로 해소합니다.
+cross-harness export 거부(#1176)로 발생하는 진입로 공백을 부분 보완합니다.
+
+---
+
+## 3. 거부된 패턴 — Cross-harness Export (#1176)
+
+### 3-1. 개요
+
+ECC는 oh-my-customcode의 `.claude/` 구조를 Cursor, Aider, Codex, Opencode 등
+8개 외부 harness 포맷으로 export하는 기능을 제공합니다.
+이 패턴을 oh-my-customcode가 흡수할 경우, 내부에 cross-harness export 레이어가
+추가됩니다.
+
+---
+
+### 3-2. 분석
+
+**R006 compilation metaphor 영향**
+
+oh-my-customcode의 아키텍처는 다음 매핑을 따릅니다:
+
+```
+Source code     → .claude/skills/
+Build artifacts → .claude/agents/
+Compiler        → mgr-sauron (R017)
+Spec            → .claude/rules/
+```
+
+cross-harness export를 흡수하면 이 compiler가 N개의 target backend(Cursor,
+Aider, Codex 등)를 추가로 지원해야 합니다. 이는 **단일 target 컴파일러에서
+multi-target 크로스 컴파일러로의 전환**을 의미합니다.
+
+multi-target 전환의 결과:
+- 각 외부 harness의 구조 변경이 oh-my-customcode build system에 직접 영향
+- metaphor의 순수성 훼손 (compiler가 external spec을 추적해야 함)
+- mgr-sauron (R017) 검증 범위가 외부 harness 포맷으로 확장
+
+**single-maintainer 비용**
+
+외부 harness들은 변동성이 높습니다:
+
+| Harness | 변동 리스크 |
+|---------|------------|
+| Cursor | 에이전트 폴더 구조 자주 변경 |
+| Aider | `.aider` 설정 포맷 semi-annual 변경 |
+| Codex | OpenAI 정책 변경 직접 반영 |
+| Opencode | 초기 단계, 구조 unstable |
+
+각 harness의 breaking change가 발생할 때마다 R016 (Continuous Improvement)
+워크플로우가 트리거됩니다. single-maintainer 환경에서 이는 **core feature
+개발 시간의 경쟁 비용**이 됩니다.
+
+**사용자 가치 trade-off**
+
+| 가치 | 유형 |
+|------|------|
+| 신규 사용자 진입로 확장 | 신규 사용자 |
+| 기존 harness 자산 재활용 | 멀티 harness 사용자 |
+| ECC와 기능 중복 | zero-sum 경쟁 |
+
+신규 사용자 진입로 문제는 `manifest-install --profile`(#1177)으로 부분 해소됩니다.
+멀티 harness 사용자는 ECC를 직접 사용하는 것이 더 효과적입니다.
+
+---
+
+### 3-3. 결정: REJECT (DEFER 옵션 존재)
+
+**권고: REJECT**
+
+거부 사유 (우선순위 순):
+
+1. **compilation metaphor 순수성 보호**
+   cross-harness export는 oh-my-customcode의 핵심 차별점인 compilation metaphor를
+   직접 훼손합니다. 이 metaphor는 관심사 분리(R006)의 철학적 기반입니다.
+
+2. **ECC와의 zero-sum 경쟁 회피**
+   ECC는 이미 이 패턴의 원천(export source)입니다. 흡수하면 동일 기능으로
+   경쟁하는 구조가 되며, 두 도구의 차별화가 희석됩니다.
+
+3. **single-maintainer R016 부담**
+   외부 harness 8개의 변동을 추적하는 비용이 core feature R016 루프에 경쟁합니다.
+   현재 기여자 구성(single-maintainer)에서는 감당 불가 수준으로 판단됩니다.
+
+4. **진입로 문제 대체 해소**
+   #1177 `manifest-install --profile`이 신규 사용자 진입 비용을 낮추는 대안으로
+   이미 흡수되었습니다.
+
+---
+
+### 3-4. 대안 경로 (DEFER 시나리오)
+
+다음 조건이 충족될 때 재검토를 권장합니다:
+
+| 조건 | 임계값 | 현재 (2026-05-18) |
+|------|--------|------------------|
+| 한국어 사용자 비율 | 50%+ | 미집계 |
+| 외부 기여자 수 | 5명 이상 | 미집계 |
+
+DEFER 기간 동안의 cross-tool integration 우회 경로:
+
+- **RTK proxy skill**: 기존 infra 활용, Cursor 등에서 oh-my-customcode skill 호출
+- **Codex/Gemini exec skill**: 외부 LLM executor를 skill로 래핑, harness 종속성 없음
+
+이 우회 경로는 full export와 동일한 가치를 제공하지 않지만,
+R016 부담 없이 80% 이상의 use case를 커버합니다.
+
+---
+
+## 4. Cross-harness 거부의 의도된 결과
+
+이 결정으로 두 도구의 포지셔닝이 명확해집니다:
+
+| 도구 | 포지션 |
+|------|--------|
+| **oh-my-customcode** | compilation metaphor pure-play — `.claude/` 생태계 전문화 |
+| **ECC** | cross-harness pragmatist — 다양한 harness 간 이식성 제공 |
+
+사용자는 목적에 따라 도구를 선택할 수 있습니다:
+- compilation metaphor 기반 체계적 에이전트 구축 → oh-my-customcode
+- 기존 harness 자산의 이식/통합 → ECC
+
+두 도구가 동일한 기능을 제공할 필요가 없으며,
+이 차별화가 각 도구의 장기 지속성에 기여합니다.
+
+---
+
+## 5. KPI 모니터링
+
+DEFER 조건 모니터링을 위한 내부 KPI 메모:
+
+> 내부 메모: `.claude/agent-memory/sys-memory-keeper/project_ecc_kpi_internal_metrics.md`
+
+| KPI | 6개월 목표 | 1년 목표 |
+|-----|-----------|---------|
+| 외부 기여자 수 | 2명 | 5명 |
+| 한국어 사용자 비율 | 30% | 50% |
+| cross-harness export 요청 수 | 10회 이상 → DEFER 재검토 | 30회 이상 → ACCEPT 재검토 |
+
+KPI 미달 시: REJECT 유지, 대안 경로 개선 검토.
+KPI 초과 달성 시: R016 워크플로우로 재검토 트리거.
+
+---
+
+## 6. 참고
+
+| 항목 | 링크 |
+|------|------|
+| ECC 흡수 Epic | #1170 (closed) |
+| Cross-harness 이슈 | #1176 (standalone, decision-needed) |
+| sec-agentshield-wrapper | #1174 |
+| instinct-extractor | #1175 |
+| manifest-install --profile | #1177 |
+| 시퀀싱 메모 | `.claude/agent-memory/sys-memory-keeper/` → `[[project-sequencing-alpha-beta-gamma]]` |
+| R006 compilation metaphor | `.claude/rules/MUST-agent-design.md` |

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.143.0",
+  "version": "0.144.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/SHOULD-memory-integration.md
+++ b/templates/.claude/rules/SHOULD-memory-integration.md
@@ -381,3 +381,45 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 - MCP saves are **non-blocking**: memory failure MUST NOT prevent session from ending
 - If claude-mem unavailable: skip, log warning
 - episodic-memory: no action needed (auto-indexed after session)
+
+## Dual-Backend Advisory (AgentMemory + claude-mem)
+
+#1169 Phase 1 (COEXIST) 단계에서 두 memory backend 동시 활성 가능:
+
+| 상황 | 권장 |
+|------|------|
+| claude-mem 단독 | 기본값 — 현 운영 유지 |
+| AgentMemory 단독 | Phase 2 (SWITCH) 이후 진행 |
+| 둘 다 활성 (COEXIST) | Phase 1 한정 — `memory-aggregator`가 결과 병합 |
+
+### 충돌 감지
+
+`.mcp.json`에 두 서버(`claude-mem`, `agentmemory`) 동시 등록 시 첫 호출 시점에 advisory 출력 권장:
+
+```
+[Advisory] Dual memory backend detected (Phase 1 COEXIST)
+  - claude-mem: active (Chroma)
+  - agentmemory: active (SQLite)
+  Phase 2 SWITCH 진입 전까지 두 backend 유지
+  가이드: guides/agentmemory-migration/phase-1-coexist.md
+```
+
+이 advisory는 경고가 아닙니다. Phase 1 COEXIST에서는 정상 상태입니다.
+
+### Session-End Self-Check (COEXIST 확장)
+
+Phase 1 COEXIST 기간 중 세션 종료 시:
+
+1. sys-memory-keeper가 MEMORY.md 갱신? → YES: 계속
+2. claude-mem 저장 시도? → YES (기존 항목)
+3. AgentMemory 저장 시도? → YES (COEXIST 추가)
+세 단계 모두 완료 후 사용자에게 확인. 둘 중 하나 실패해도 비차단.
+
+### Phase 2 진입 전 필수 조건
+
+- 1주 measure 결과 (`scripts/measure-claude-mem-usage.sh`) GO 판정
+- 자산 처리표 사용자 검토 완료 (12 plugin skill 처리 방향 결정)
+- 30분 롤백 절차 검증 (Chroma 백업 + 복원 테스트)
+
+Refs: #1169 본문 조치 3 (택1 강제), 조치 4 (롤백 절차),
+      `guides/agentmemory-migration/phase-1-coexist.md`.

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -245,7 +245,8 @@ Claude Code의 Agent Teams 기능이 활성화되어 있으면 (`CLAUDE_CODE_EXP
 
 | 서버 | 용도 |
 |------|------|
-| claude-mem | 세션 메모리 영속성 (Chroma 기반) |
+| claude-mem | 세션 메모리 영속성 (Chroma 기반) — Phase β (#1169) COEXIST 진행 중 |
+| **agentmemory** | claude-mem 대체 후보 (SQLite 기반, 4-tier consolidation) — Phase 1 COEXIST (#1169) |
 | code-review-graph | Token-efficient AST 기반 context retrieval (8.2× 토큰 절감) — wrapper: `crg-integration` 스킬 (#1171) |
 | semble | Semantic code search via embeddings (98% 토큰 절감, NDCG@10=0.854) — wrapper: `semble-integration` 스킬 (#1173) |
 
@@ -263,6 +264,12 @@ Claude Code의 Agent Teams 기능이 활성화되어 있으면 (`CLAUDE_CODE_EXP
 # MCP 설정 (claude-mem)
 npm install -g claude-mem
 claude-mem setup
+
+# AgentMemory MCP 설치 (claude-mem 대체 후보, COEXIST)
+pip install agentmemory
+claude mcp add agentmemory -- agentmemory mcp
+# 또는 .mcp.json 수동 편집 (R001 auto-install 금지)
+# Phase 1 COEXIST 가이드: guides/agentmemory-migration/phase-1-coexist.md
 
 # CRG MCP 설치 (token efficiency)
 pipx install code-review-graph

--- a/templates/guides/agentmemory-migration/phase-1-coexist.md
+++ b/templates/guides/agentmemory-migration/phase-1-coexist.md
@@ -1,0 +1,261 @@
+# AgentMemory Migration — Phase 1: COEXIST (Week 1-2)
+
+> **상태**: 활성 — 2026-05-18 시작 (#1169)
+> **다음 단계**: Phase 2 SWITCH (measure 결과 후 GO/NO-GO 결정)
+> **이전 단계**: [measure-step-zero.md](./measure-step-zero.md)
+
+---
+
+## 1. 개요
+
+Phase 1 (COEXIST)는 claude-mem과 AgentMemory를 **동시에 운영**하는 단계입니다.
+이 단계에서는 어떤 destructive 변경도 발생하지 않습니다:
+
+- claude-mem 기존 Chroma 데이터 유지
+- 12 plugin skill 폐기 없음
+- 어댑터 코드 활성화 없음 (STUB 상태 유지)
+- 자산 처리표 적용 없음
+
+목표는 1주간 실제 사용 데이터를 수집하고, AgentMemory 설치와 공존 운영에 익숙해지는 것입니다.
+
+| 항목 | Phase 1 (COEXIST) | Phase 2 (SWITCH) |
+|------|-------------------|------------------|
+| claude-mem | 활성 (기존 운영) | 비활성화 예정 |
+| AgentMemory | 설치 후 병렬 활성 | 단독 운영 |
+| 데이터 마이그레이션 | 없음 | 선택적 (측정 후 결정) |
+| 어댑터 코드 | STUB 유지 | 활성화 |
+| 자산 처리표 | 적용 보류 | 사용자 검토 후 적용 |
+
+---
+
+## 2. AgentMemory 설치
+
+> **R001 주의**: auto-install 금지. 아래 명령어를 사용자 로컬에서 수동으로 실행합니다.
+
+### 2-1. 패키지 설치
+
+```bash
+# 옵션 A: pip
+pip install agentmemory
+
+# 옵션 B: pipx (격리 환경 권장)
+pipx install agentmemory
+
+# 옵션 C: uvx (uv 사용 시)
+uvx agentmemory
+```
+
+### 2-2. MCP 서버 등록
+
+```bash
+# Claude Code CLI로 등록
+claude mcp add agentmemory -- agentmemory mcp
+
+# 또는 .mcp.json 수동 편집 (R001 auto-install 금지)
+# {
+#   "mcpServers": {
+#     "agentmemory": {
+#       "command": "agentmemory",
+#       "args": ["mcp"]
+#     }
+#   }
+# }
+```
+
+### 2-3. 등록 확인
+
+```bash
+claude mcp list
+# 출력에 agentmemory 서버가 표시되어야 합니다
+```
+
+---
+
+## 3. COEXIST 정책
+
+Phase 1 기간 동안 두 backend는 다음 정책에 따라 공존합니다.
+
+### 3-1. 기본 운영 방식
+
+| 작업 | 우선 backend | 비고 |
+|------|-------------|------|
+| 기존 메모리 조회 | claude-mem | 기존 Chroma 데이터 유지 |
+| 신규 메모리 저장 | 둘 다 | COEXIST 기간 중 병렬 저장 권장 |
+| 세션 종료 시 저장 | 둘 다 | R011 Session-End Self-Check 참조 |
+
+### 3-2. 쿼리 병합 (memory-aggregator)
+
+두 backend에서 결과가 반환될 경우 `memory-aggregator` 스킬이 결과를 병합합니다:
+
+```
+claude-mem.search(query)    →  결과 A
+AgentMemory.search(query)   →  결과 B
+memory-aggregator           →  A + B 중복 제거 후 반환
+```
+
+`memory-aggregator` 스킬이 없는 경우, 두 결과를 순서대로 제시하고 사용자가 선택합니다.
+
+### 3-3. 충돌 방지 원칙
+
+- claude-mem 기존 데이터를 AgentMemory로 자동 복사하지 않음
+- 두 backend에 동일 키로 저장 시 별개 항목으로 취급
+- 강제 동기화 없음 — Phase 2에서 마이그레이션 여부 결정
+
+---
+
+## 4. Dual-Backend 충돌 Advisory
+
+`.mcp.json`에 두 서버가 동시 등록된 상태를 감지하면 다음 advisory를 출력합니다.
+
+### 4-1. 감지 조건
+
+```
+.mcp.json 내 서버 목록:
+  - "claude-mem" (또는 관련 tool prefix)
+  - "agentmemory"
+  → 두 개 동시 존재 시 Phase 1 COEXIST 상태로 간주
+```
+
+### 4-2. Advisory 메시지
+
+```
+[Advisory] Dual memory backend detected (Phase 1 COEXIST)
+  - claude-mem: active (Chroma)
+  - agentmemory: active (SQLite)
+  현재 Phase 1 COEXIST 정책 적용 중 — 두 backend 병렬 운영
+  Phase 2 SWITCH 진입 전까지 두 backend 유지
+  가이드: guides/agentmemory-migration/phase-1-coexist.md
+```
+
+이 advisory는 경고가 아닙니다. Phase 1에서는 정상 상태입니다.
+
+### 4-3. 강제 선택 (사용자 명시 시)
+
+사용자가 명시적으로 "agentmemory만 사용" 또는 "claude-mem만 사용"을 요청하는 경우,
+해당 요청을 따르되 자산 처리표 적용 및 어댑터 활성화는 Phase 2 GO 결정 후 진행합니다.
+
+---
+
+## 5. 사용자 행동 계획
+
+### 5-1. 1주 measure 루틴 (자동 트리거: 2026-05-25)
+
+`scripts/measure-claude-mem-usage.sh` 스크립트를 1주간 실행합니다:
+
+```bash
+# 수동 실행 (필요 시)
+bash scripts/measure-claude-mem-usage.sh
+
+# 결과는 .claude/outputs/sessions/ 에 저장됩니다
+```
+
+측정 항목:
+- 일별 호출 횟수 (claude-mem vs AgentMemory)
+- 응답 지연 (p50, p95)
+- 저장 성공/실패율
+- 메모리 용량 (Chroma vs SQLite)
+
+### 5-2. GO/NO-GO 결정 기준 (2026-05-25 예정)
+
+| 지표 | GO 조건 | NO-GO 조건 |
+|------|---------|------------|
+| 응답 지연 | AgentMemory ≤ claude-mem × 1.2 | AgentMemory > claude-mem × 2.0 |
+| 저장 성공률 | ≥ 99% | < 95% |
+| 운영 안정성 | 1주 무장애 | 크래시 또는 데이터 손실 |
+| 호환성 | 기존 메모리 포맷 읽기 가능 | 포맷 비호환으로 검색 실패 |
+
+### 5-3. 지금 할 수 있는 것
+
+- AgentMemory 설치 및 MCP 등록 (위 섹션 2 참조)
+- 신규 세션에서 AgentMemory로도 저장해보기 (실험적)
+- measure 스크립트 결과 관찰
+- 자산 처리표 (`guides/agentmemory-migration/asset-disposition.md`) 검토 준비
+
+---
+
+## 6. Phase 2 진입 조건
+
+다음 조건이 모두 충족된 경우에만 Phase 2 (SWITCH)로 진행합니다.
+
+### 필수 조건
+
+- [ ] 1주 measure 결과 GO 판정 (5-2 기준 충족)
+- [ ] 자산 처리표 사용자 검토 완료 (12 plugin skill 처리 방향 결정)
+- [ ] 30분 롤백 절차 검증 완료
+
+### 롤백 절차 검증 (Phase 2 진입 전 필수)
+
+```bash
+# 1. Chroma 백업 생성
+cp -r ~/.local/share/claude-mem/chroma ~/.local/share/claude-mem/chroma.bak.$(date +%Y%m%d)
+
+# 2. 백업에서 복원 가능 여부 확인
+# (실제 복원 수행하지 않고 절차만 검증)
+ls -la ~/.local/share/claude-mem/chroma.bak.*
+
+# 3. AgentMemory SQLite 백업
+cp ~/.local/share/agentmemory/memories.db ~/.local/share/agentmemory/memories.db.bak.$(date +%Y%m%d)
+```
+
+롤백 소요 시간이 30분 이내임을 확인한 후 Phase 2 진행.
+
+---
+
+## 7. 현 단계 한계 및 금지 사항
+
+### 7-1. STUB 상태 유지 (변경 금지)
+
+```
+packages/eval-core/src/adapters/agentmemory.ts  ← STUB, 활성화 금지
+packages/eval-core/src/db/schema.ts              ← 변경 금지
+```
+
+이 파일들은 Phase 2 GO 결정 후 별도 사이클에서 수정합니다.
+
+### 7-2. 자산 처리표 적용 보류
+
+12 plugin skill의 폐기/유지 결정은 measure 결과를 확인한 후 진행합니다:
+
+```
+.claude/skills/memory-*/  ← 폐기 여부 보류
+.claude/skills/claude-mem-*/  ← 폐기 여부 보류
+```
+
+### 7-3. 데이터 마이그레이션 금지
+
+Phase 1에서는 claude-mem Chroma 데이터를 AgentMemory SQLite로 이전하지 않습니다.
+이전은 Phase 2에서 사용자가 명시적으로 승인한 경우에만 진행합니다.
+
+---
+
+## 8. R011과의 관계
+
+Phase 1 COEXIST 기간 중 R011 (SHOULD-memory-integration) 적용:
+
+| R011 항목 | COEXIST 수정 사항 |
+|-----------|-----------------|
+| Primary: Native auto memory | 변경 없음 |
+| Supplementary: claude-mem | 변경 없음 (계속 사용) |
+| Session-End Self-Check | claude-mem + AgentMemory 둘 다 저장 시도 |
+| Failure Policy | 둘 중 하나 실패해도 비차단 |
+
+세션 종료 시 자가 점검 (COEXIST 확장):
+
+```
+1. sys-memory-keeper가 MEMORY.md 갱신? → YES
+2. claude-mem 저장 시도? → YES (기존)
+3. AgentMemory 저장 시도? → YES (COEXIST 추가)
+모두 완료 후 사용자에게 확인
+```
+
+---
+
+## 9. 참고
+
+- **이슈**: #1169 (AgentMemory 마이그레이션 계획)
+- **이전 단계**: [measure-step-zero.md](./measure-step-zero.md)
+- **R011**: `.claude/rules/SHOULD-memory-integration.md` (Dual-Backend Advisory 섹션)
+- **관련 기억**: [[project-sequencing-alpha-beta-gamma]]
+- **자산 처리표**: `guides/agentmemory-migration/asset-disposition.md` (Phase 2 전 검토 필요)
+- **measure 스크립트**: `scripts/measure-claude-mem-usage.sh`
+- **롤백 가이드**: #1169 본문 조치 4 (30분 롤백 절차)

--- a/templates/guides/external-tools/ecc-absorption-decisions.md
+++ b/templates/guides/external-tools/ecc-absorption-decisions.md
@@ -1,0 +1,232 @@
+# ECC 흡수 결정 아카이브
+
+> **목적**: ECC (Everything Claude Code) 패턴 흡수 검토 이력 보존.
+> 미래 기여자가 "왜 흡수했는가 / 왜 거부했는가"를 재검토 없이 파악할 수 있도록 합니다.
+>
+> 관련 Epic: #1170 (closed), 분리 이슈: #1176
+
+---
+
+## 1. 개요
+
+oh-my-customcode는 **compilation metaphor**를 핵심 아키텍처 철학으로 채택합니다.
+ECC (Everything Claude Code) 등 외부 도구의 패턴을 흡수할 때, 이 철학과의 정합성이
+흡수 여부의 1차 판단 기준입니다.
+
+| 판단 기준 | 설명 |
+|----------|------|
+| metaphor 정합성 | `.claude/` 구조를 컴파일러 metaphor로 강화하는가 |
+| single-maintainer 비용 | 외부 의존성 추적 부담이 감당 가능한가 |
+| 사용자 가치 | 기존 사용자 워크플로우를 개선하는가 |
+| 차별점 영향 | ECC와 직접 경쟁(zero-sum)이 되는가 |
+
+본 문서는 v0.142.0 ~ v0.143.0 기간에 검토된 4개 패턴의 결정을 기록합니다.
+
+---
+
+## 2. 흡수된 패턴 (v0.142.0)
+
+### 2-1. sec-agentshield-wrapper (sub-issue #1174)
+
+| 항목 | 내용 |
+|------|------|
+| 릴리즈 | v0.142.0 |
+| 흡수 형태 | pre-flight 보안 wrapper skill |
+| 차별점 영향 | **보완** — post-write 자산(CodeQL 등)과 시점 분리 |
+
+**결정: ACCEPT**
+
+ECC의 `agentshield-wrapper`는 실행 전 입력 검증 레이어를 제공합니다.
+oh-my-customcode의 `sec-codeql-expert`가 post-write 단계에 집중하므로,
+pre-flight 단계를 담당하는 이 패턴은 compilation pipeline을 완성하는
+`compiler → linker → loader` 구조에 자연스럽게 편입됩니다.
+유지보수 비용: 외부 harness 의존 없음, 내부 skill로 완전 소유.
+
+---
+
+### 2-2. instinct-extractor (sub-issue #1175)
+
+| 항목 | 내용 |
+|------|------|
+| 릴리즈 | v0.142.0 |
+| 흡수 형태 | cross-session 패턴 채굴 skill |
+| 차별점 영향 | **보완** — `skill-extractor`와 trigger 분리 |
+
+**결정: ACCEPT**
+
+`skill-extractor`가 현재 세션의 행동 패턴을 skill로 승격한다면,
+`instinct-extractor`는 누적 세션에서 반복 패턴을 자동 감지합니다.
+두 도구는 trigger가 다릅니다 (단일 세션 vs 누적 히스토리).
+R016 Continuous Improvement 루프를 강화하며, 내부 구조(agent-memory + claude-mem)로
+구현 가능하므로 외부 의존성이 없습니다.
+
+---
+
+### 2-3. manifest-install --profile (sub-issue #1177)
+
+| 항목 | 내용 |
+|------|------|
+| 릴리즈 | v0.142.0 |
+| 흡수 형태 | manifest profiles 5종 |
+| 차별점 영향 | **보완** — deactivation 비용 축소 |
+
+**결정: ACCEPT**
+
+신규 사용자의 진입 비용을 낮추는 profile 기반 설치 패턴입니다.
+`--profile minimal`, `--profile de`, `--profile qa` 등 도메인별 subset을
+한 번에 활성화합니다. deactivation 비용 문제(한 번 설치된 skill이 불필요해도
+삭제 경로가 불명확)를 profile 전환으로 해소합니다.
+cross-harness export 거부(#1176)로 발생하는 진입로 공백을 부분 보완합니다.
+
+---
+
+## 3. 거부된 패턴 — Cross-harness Export (#1176)
+
+### 3-1. 개요
+
+ECC는 oh-my-customcode의 `.claude/` 구조를 Cursor, Aider, Codex, Opencode 등
+8개 외부 harness 포맷으로 export하는 기능을 제공합니다.
+이 패턴을 oh-my-customcode가 흡수할 경우, 내부에 cross-harness export 레이어가
+추가됩니다.
+
+---
+
+### 3-2. 분석
+
+**R006 compilation metaphor 영향**
+
+oh-my-customcode의 아키텍처는 다음 매핑을 따릅니다:
+
+```
+Source code     → .claude/skills/
+Build artifacts → .claude/agents/
+Compiler        → mgr-sauron (R017)
+Spec            → .claude/rules/
+```
+
+cross-harness export를 흡수하면 이 compiler가 N개의 target backend(Cursor,
+Aider, Codex 등)를 추가로 지원해야 합니다. 이는 **단일 target 컴파일러에서
+multi-target 크로스 컴파일러로의 전환**을 의미합니다.
+
+multi-target 전환의 결과:
+- 각 외부 harness의 구조 변경이 oh-my-customcode build system에 직접 영향
+- metaphor의 순수성 훼손 (compiler가 external spec을 추적해야 함)
+- mgr-sauron (R017) 검증 범위가 외부 harness 포맷으로 확장
+
+**single-maintainer 비용**
+
+외부 harness들은 변동성이 높습니다:
+
+| Harness | 변동 리스크 |
+|---------|------------|
+| Cursor | 에이전트 폴더 구조 자주 변경 |
+| Aider | `.aider` 설정 포맷 semi-annual 변경 |
+| Codex | OpenAI 정책 변경 직접 반영 |
+| Opencode | 초기 단계, 구조 unstable |
+
+각 harness의 breaking change가 발생할 때마다 R016 (Continuous Improvement)
+워크플로우가 트리거됩니다. single-maintainer 환경에서 이는 **core feature
+개발 시간의 경쟁 비용**이 됩니다.
+
+**사용자 가치 trade-off**
+
+| 가치 | 유형 |
+|------|------|
+| 신규 사용자 진입로 확장 | 신규 사용자 |
+| 기존 harness 자산 재활용 | 멀티 harness 사용자 |
+| ECC와 기능 중복 | zero-sum 경쟁 |
+
+신규 사용자 진입로 문제는 `manifest-install --profile`(#1177)으로 부분 해소됩니다.
+멀티 harness 사용자는 ECC를 직접 사용하는 것이 더 효과적입니다.
+
+---
+
+### 3-3. 결정: REJECT (DEFER 옵션 존재)
+
+**권고: REJECT**
+
+거부 사유 (우선순위 순):
+
+1. **compilation metaphor 순수성 보호**
+   cross-harness export는 oh-my-customcode의 핵심 차별점인 compilation metaphor를
+   직접 훼손합니다. 이 metaphor는 관심사 분리(R006)의 철학적 기반입니다.
+
+2. **ECC와의 zero-sum 경쟁 회피**
+   ECC는 이미 이 패턴의 원천(export source)입니다. 흡수하면 동일 기능으로
+   경쟁하는 구조가 되며, 두 도구의 차별화가 희석됩니다.
+
+3. **single-maintainer R016 부담**
+   외부 harness 8개의 변동을 추적하는 비용이 core feature R016 루프에 경쟁합니다.
+   현재 기여자 구성(single-maintainer)에서는 감당 불가 수준으로 판단됩니다.
+
+4. **진입로 문제 대체 해소**
+   #1177 `manifest-install --profile`이 신규 사용자 진입 비용을 낮추는 대안으로
+   이미 흡수되었습니다.
+
+---
+
+### 3-4. 대안 경로 (DEFER 시나리오)
+
+다음 조건이 충족될 때 재검토를 권장합니다:
+
+| 조건 | 임계값 | 현재 (2026-05-18) |
+|------|--------|------------------|
+| 한국어 사용자 비율 | 50%+ | 미집계 |
+| 외부 기여자 수 | 5명 이상 | 미집계 |
+
+DEFER 기간 동안의 cross-tool integration 우회 경로:
+
+- **RTK proxy skill**: 기존 infra 활용, Cursor 등에서 oh-my-customcode skill 호출
+- **Codex/Gemini exec skill**: 외부 LLM executor를 skill로 래핑, harness 종속성 없음
+
+이 우회 경로는 full export와 동일한 가치를 제공하지 않지만,
+R016 부담 없이 80% 이상의 use case를 커버합니다.
+
+---
+
+## 4. Cross-harness 거부의 의도된 결과
+
+이 결정으로 두 도구의 포지셔닝이 명확해집니다:
+
+| 도구 | 포지션 |
+|------|--------|
+| **oh-my-customcode** | compilation metaphor pure-play — `.claude/` 생태계 전문화 |
+| **ECC** | cross-harness pragmatist — 다양한 harness 간 이식성 제공 |
+
+사용자는 목적에 따라 도구를 선택할 수 있습니다:
+- compilation metaphor 기반 체계적 에이전트 구축 → oh-my-customcode
+- 기존 harness 자산의 이식/통합 → ECC
+
+두 도구가 동일한 기능을 제공할 필요가 없으며,
+이 차별화가 각 도구의 장기 지속성에 기여합니다.
+
+---
+
+## 5. KPI 모니터링
+
+DEFER 조건 모니터링을 위한 내부 KPI 메모:
+
+> 내부 메모: `.claude/agent-memory/sys-memory-keeper/project_ecc_kpi_internal_metrics.md`
+
+| KPI | 6개월 목표 | 1년 목표 |
+|-----|-----------|---------|
+| 외부 기여자 수 | 2명 | 5명 |
+| 한국어 사용자 비율 | 30% | 50% |
+| cross-harness export 요청 수 | 10회 이상 → DEFER 재검토 | 30회 이상 → ACCEPT 재검토 |
+
+KPI 미달 시: REJECT 유지, 대안 경로 개선 검토.
+KPI 초과 달성 시: R016 워크플로우로 재검토 트리거.
+
+---
+
+## 6. 참고
+
+| 항목 | 링크 |
+|------|------|
+| ECC 흡수 Epic | #1170 (closed) |
+| Cross-harness 이슈 | #1176 (standalone, decision-needed) |
+| sec-agentshield-wrapper | #1174 |
+| instinct-extractor | #1175 |
+| manifest-install --profile | #1177 |
+| 시퀀싱 메모 | `.claude/agent-memory/sys-memory-keeper/` → `[[project-sequencing-alpha-beta-gamma]]` |
+| R006 compilation metaphor | `.claude/rules/MUST-agent-design.md` |

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.143.0",
+  "version": "0.144.0",
   "lastUpdated": "2026-05-18T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/wiki/guides/agentmemory-migration.md
+++ b/wiki/guides/agentmemory-migration.md
@@ -1,9 +1,10 @@
 ---
-title: "AgentMemory Migration — Step 0: MEASURE"
+title: "AgentMemory Migration Guide"
 type: guide
 updated: 2026-05-18
 sources:
   - guides/agentmemory-migration/measure-step-zero.md
+  - guides/agentmemory-migration/phase-1-coexist.md
 related:
   - [[r011]]
   - [[r013]]
@@ -12,60 +13,93 @@ related:
   - [[token-efficiency]]
 ---
 
-# AgentMemory Migration — Step 0: MEASURE
+# AgentMemory Migration Guide
 
-claude-mem → native AgentMemory 마이그레이션 Phase 1(COEXIST) 진입 전 실사용 빈도를 측정하는 단계 0 가이드.
+claude-mem → native AgentMemory 마이그레이션 단계별 가이드. 현재 Phase 1 (COEXIST) 활성 중 (#1169).
 
-관련 이슈: [#1169](https://github.com) | 참고 메모리: `feedback_claude_mem_maintenance`, `project_sequencing_alpha_beta_gamma`
+관련 이슈: #1169 | 참고 메모리: `feedback_claude_mem_maintenance`, `project_sequencing_alpha_beta_gamma`
 
-## 목적
+## 마이그레이션 단계
 
-마이그레이션 계획의 폐기 후보 5종(`make-plan`, `do`, `babysit`, `wowerpoint`, `knowledge-agent`, `pathfinder`)이 "미사용 또는 저빈도"라는 가설에 기반한다. 실측 없이 Phase 1에 진입하면 실제 사용 중인 skill이 제거되어 워크플로우가 깨질 수 있다.
+| 단계 | 이름 | 상태 | 소스 |
+|------|------|------|------|
+| 0 | MEASURE | 완료 | `guides/agentmemory-migration/measure-step-zero.md` |
+| 1 | COEXIST | **활성** (2026-05-18~) | `guides/agentmemory-migration/phase-1-coexist.md` |
+| 2 | SWITCH | 대기 (GO/NO-GO 후) | — |
 
-## 실행 방법
+---
+
+## Step 0: MEASURE
+
+Phase 1 진입 전 실사용 빈도를 측정하는 단계.
+
+폐기 후보(`make-plan`, `do`, `babysit`, `wowerpoint`, `knowledge-agent`, `pathfinder`)의 "미사용 가설"을 실측으로 검증한다. 미측정 진입 시 실제 사용 중인 skill이 제거되어 워크플로우가 깨질 수 있다.
 
 ```bash
-# 기본 (최근 7일, ~/.claude/measure-claude-mem-usage-YYYY-MM-DD.md 저장)
-bash scripts/measure-claude-mem-usage.sh
-
-# 1주 3-포인트 수집
-bash scripts/measure-claude-mem-usage.sh --output ~/.claude/claude-mem-day1.md
-bash scripts/measure-claude-mem-usage.sh --days 4 --output ~/.claude/claude-mem-day4.md
 bash scripts/measure-claude-mem-usage.sh --days 7 --output ~/.claude/claude-mem-day7.md
 ```
 
-스캔 대상: `~/.claude-mem/archives/` (claude-mem 아카이브) + `~/.claude/projects/*/session-*.jsonl` (Claude Code 세션 로그). 어느 한쪽이 없으면 silent skip.
+**해석 기준**: 호출 수 0 → 폐기 안전 | 1–3 → wrapper 매핑 | 4+ → 대체 도구 명확화 필수
 
-## 해석 기준
+---
 
-| 호출 수 | 신호 | 권장 조치 |
-|---------|------|----------|
-| 0 | 미사용 | 폐기 안전 |
-| 1–3 | 가끔 사용 | wrapper 또는 대체 도구 매핑 |
-| 4+ | 정기 사용 | 대체 도구 명확화 필수 |
+## Phase 1: COEXIST
 
-## Phase 1 GO/NO-GO 결정
+claude-mem과 AgentMemory를 **동시에 운영**하는 단계. 어떤 destructive 변경도 발생하지 않는다.
 
-| 조건 | 결정 |
-|------|------|
-| 폐기 후보 전부 호출 수 0 | GO |
-| 폐기 후보 중 1개 이상 1–3 | CONDITIONAL GO (대체 매핑 완료 후) |
-| 폐기 후보 중 1개 이상 4+ | NO-GO (처리표 재설계 후 재측정) |
+### 설치 (수동, R001 auto-install 금지)
 
-## 결과 활용
+```bash
+pip install agentmemory
+claude mcp add agentmemory -- agentmemory mcp
+```
 
-측정 완료 후:
-1. `gh issue comment 1169 --body-file ~/.claude/claude-mem-day7.md` — #1169에 리포트 첨부
-2. `feedback_claude_mem_maintenance.md` 자산 처리표 "처리 방향" 열 실측값으로 갱신
-3. GO 결정 시 Phase 1(COEXIST) 진입
+### 운영 정책
+
+| 작업 | 우선 backend |
+|------|-------------|
+| 기존 메모리 조회 | claude-mem (Chroma) |
+| 신규 메모리 저장 | 둘 다 (병렬 저장) |
+| 세션 종료 시 저장 | 둘 다 (R011 Session-End Self-Check 확장) |
+
+두 backend에서 결과가 반환될 경우 `memory-aggregator` 스킬이 중복 제거 후 병합한다.
+
+### Dual-Backend Advisory
+
+`.mcp.json`에 `claude-mem` + `agentmemory` 동시 존재 감지 시:
+
+```
+[Advisory] Dual memory backend detected (Phase 1 COEXIST)
+  현재 Phase 1 COEXIST 정책 적용 중 — 두 backend 병렬 운영
+  가이드: guides/agentmemory-migration/phase-1-coexist.md
+```
+
+Phase 1에서 정상 상태이며 경고가 아니다.
+
+### Phase 2 GO/NO-GO 기준 (2026-05-25 예정)
+
+| 지표 | GO | NO-GO |
+|------|-----|-------|
+| 응답 지연 | ≤ claude-mem × 1.2 | > claude-mem × 2.0 |
+| 저장 성공률 | ≥ 99% | < 95% |
+| 운영 안정성 | 1주 무장애 | 크래시 또는 데이터 손실 |
+
+### 금지 사항 (Phase 1)
+
+- `packages/eval-core/src/adapters/agentmemory.ts` STUB 활성화 금지
+- claude-mem Chroma → AgentMemory SQLite 데이터 이전 금지
+- 12 plugin skill 폐기 보류
+
+---
 
 ## Cross-References
 
-- [[r011]] — native auto-memory 구조, memory scope (`user`/`project`/`local`)
-- [[r013]] — ecomode, context budget (R013이 과도한 claude-mem 호출을 압박함)
+- [[r011]] — Dual-Backend Advisory 섹션, memory scope, Session-End Self-Check 확장
+- [[r013]] — ecomode context budget (과도한 claude-mem 호출 압박)
 - [[memory-management]], [[memory-save]], [[memory-recall]] — claude-mem skill 군
-- `scripts/measure-claude-mem-usage.sh` — 측정 스크립트 (wiki 별도 페이지 없음, 도구)
+- `scripts/measure-claude-mem-usage.sh` — 측정 스크립트
 
 ## Sources
 
-- `guides/agentmemory-migration/measure-step-zero.md` — 원본 가이드 (1주 계획, 한계 사항, 전체 해석 기준)
+- `guides/agentmemory-migration/measure-step-zero.md` — Step 0 원본 가이드
+- `guides/agentmemory-migration/phase-1-coexist.md` — Phase 1 COEXIST 상세 가이드

--- a/wiki/guides/external-tools.md
+++ b/wiki/guides/external-tools.md
@@ -1,19 +1,22 @@
 ---
 title: External Tools Guide
 type: guide
-updated: 2026-04-24
+updated: 2026-05-18
 sources:
   - guides/external-tools/graphify-integration.md
+  - guides/external-tools/ecc-absorption-decisions.md
 related:
   - [[skills/wiki-rag]]
   - [[skills/ontology-rag]]
   - [[R019]]
+  - [[R006]]
   - [[guides/hook-data-flow]]
+  - [[concepts/compilation-metaphor]]
 ---
 
 # External Tools Guide
 
-oh-my-customcode 스택과 연동 가능한 외부 도구 참조 가이드. 현재 graphify 통합 레퍼런스 포함.
+oh-my-customcode 스택과 연동 가능한 외부 도구 참조 가이드. graphify 통합 레퍼런스 및 ECC 패턴 흡수 결정 아카이브 포함.
 
 ## graphify Integration
 
@@ -51,6 +54,53 @@ graphify는 code/docs/paper corpus를 queryable knowledge graph로 전환하는 
 - **Skills**: [[skills/wiki-rag]], [[skills/ontology-rag]]
 - **Background**: issue #977 (scout:integrate)
 
+## ECC Absorption Decisions
+
+ECC (Everything Claude Code) 패턴 흡수 결정 이력. v0.142.0–v0.143.0 기간 4개 패턴 검토.
+
+### 흡수 기준
+
+| 기준 | 설명 |
+|------|------|
+| metaphor 정합성 | [[concepts/compilation-metaphor]] (R006) 강화 여부 |
+| single-maintainer 비용 | 외부 의존성 추적 부담 |
+| 사용자 가치 | 기존 워크플로우 개선 |
+| 차별점 영향 | ECC와 zero-sum 경쟁 여부 |
+
+### 흡수된 패턴 (v0.142.0, #1170)
+
+| 패턴 | 결정 | 이유 |
+|------|------|------|
+| `sec-agentshield-wrapper` (#1174) | ACCEPT | pre-flight 단계 — CodeQL post-write와 시점 분리, compilation pipeline 완성 |
+| `instinct-extractor` (#1175) | ACCEPT | 누적 세션 패턴 채굴 — skill-extractor(단일)와 trigger 분리, R016 강화 |
+| `manifest-install --profile` (#1177) | ACCEPT | 도메인별 설치 profile 5종 — deactivation 비용 해소, 진입 장벽 낮춤 |
+
+### 거부된 패턴 — Cross-harness Export (#1176)
+
+ECC의 8개 외부 harness(Cursor/Aider/Codex/Opencode 등) export 기능.
+
+**REJECT** (3가지 이유):
+1. compilation metaphor 순수성 보호 — single-target → multi-target 전환은 R006 핵심 훼손
+2. ECC와 zero-sum 경쟁 회피 — 동일 기능 중복 시 차별화 희석
+3. single-maintainer R016 부담 — 8개 harness 변동 추적이 core 개발과 경쟁
+
+**대안**: `manifest-install --profile` (#1177)이 신규 진입 문제를 부분 해소. DEFER 재검토 조건: 외부 기여자 5명+ OR 한국어 사용자 50%+.
+
+**포지셔닝 결과**:
+
+| 도구 | 포지션 |
+|------|--------|
+| oh-my-customcode | compilation metaphor pure-play |
+| ECC | cross-harness pragmatist |
+
+### KPI 모니터링
+
+내부 메트릭: `.claude/agent-memory/sys-memory-keeper/` → `[[project-ecc-kpi-internal-metrics]]`
+
+- 외부 기여자 5명 이상 → DEFER 재검토
+- cross-harness export 요청 30회 이상 → ACCEPT 재검토
+
 ## Sources
 
 - `guides/external-tools/graphify-integration.md` — graphify 개요 및 스택 관계 레퍼런스
+- `guides/external-tools/ecc-absorption-decisions.md` — ECC 패턴 흡수 결정 아카이브 (#1170, #1176)

--- a/wiki/index.yaml
+++ b/wiki/index.yaml
@@ -662,7 +662,7 @@ pages:
       summary: "Reference documentation for clear, concise writing based on Strunk's classic style guide"
     - file: guides/external-tools.md
       title: "External Tools Guide"
-      summary: "Reference for external tools that integrate with oh-my-customcode — currently covers graphify as a Layer-3 RAG enrichment candidate"
+      summary: "Reference for external tools integrating with oh-my-customcode — graphify (Layer-3 RAG candidate) and ECC absorption decision archive (v0.142.0: 3 ACCEPT, 1 REJECT cross-harness export #1176)"
     - file: guides/fastapi.md
       title: "FastAPI Guide"
       summary: "Reference documentation for FastAPI high-performance Python web API patterns"
@@ -778,8 +778,8 @@ pages:
       title: "Deep Plan Guide"
       summary: "Research-validated 3-phase planning (Discovery Research → Reality-Check Planning → Plan Verification) that eliminates assumption-reality gaps before implementation begins"
     - file: guides/agentmemory-migration.md
-      title: "AgentMemory Migration — Step 0: MEASURE"
-      summary: "claude-mem → native AgentMemory 마이그레이션 Phase 1 진입 전 실사용 빈도 측정 가이드. 1주 3-포인트 수집 계획, 해석 기준(0/1-3/4+), GO/NO-GO 결정 매트릭스. #1169"
+      title: "AgentMemory Migration Guide"
+      summary: "claude-mem → native AgentMemory 마이그레이션 단계별 가이드. Phase 1 COEXIST 활성 중 (2026-05-18~): 두 backend 병렬 운영, Dual-Backend Advisory, GO/NO-GO 기준(2026-05-25). #1169"
     - file: guides/security-agentshield-pre-flight.md
       title: "Security — AgentShield Pre-flight Guide"
       summary: "Pre-write security analysis pattern guide — full security asset timeline (pre/post-write), standard pipeline, scenario-based advisory examples, and CRG integration for trust boundary analysis"

--- a/wiki/rules/r011.md
+++ b/wiki/rules/r011.md
@@ -1,7 +1,7 @@
 ---
 title: "R011: Memory Integration Rules"
 type: rule
-updated: 2026-04-27
+updated: 2026-05-18
 sources:
   - .claude/rules/SHOULD-memory-integration.md
 related:
@@ -9,6 +9,7 @@ related:
   - [[r013]]
   - [[r020]]
   - [[r021]]
+  - [[agentmemory-migration]]
 ---
 
 # R011: Memory Integration Rules
@@ -70,6 +71,24 @@ Save memory IMMEDIATELY upon surprising discovery — do not defer to session en
 
 **Anti-pattern**: "I'll batch all learnings at session end" — by then you'll have forgotten WHY each one mattered, and further violations may have occurred using the un-saved pattern.
 
+## Dual-Backend Advisory (Phase 1 COEXIST)
+
+claude-mem + AgentMemory 동시 운영 기간(Phase 1 COEXIST) 동안 R011 적용 확장:
+
+| R011 항목 | COEXIST 수정 사항 |
+|-----------|-----------------|
+| Primary: Native auto memory | 변경 없음 |
+| Supplementary: claude-mem | 변경 없음 (계속 사용) |
+| Session-End Self-Check | claude-mem + AgentMemory 둘 다 저장 시도 |
+| Failure Policy | 둘 중 하나 실패해도 비차단 |
+
+세션 종료 시 자가 점검 (COEXIST 확장):
+1. sys-memory-keeper가 MEMORY.md 갱신? → YES
+2. claude-mem 저장 시도? → YES
+3. AgentMemory 저장 시도? → YES (COEXIST 추가)
+
+`.mcp.json`에 두 서버가 동시 등록된 상태는 Phase 1에서 정상이다 — Advisory 메시지가 출력되지만 경고가 아니다. 상세: [[agentmemory-migration]].
+
 ## Enforcement
 
 Prompt-based + Stop hook (soft block for session-end saves) per [[r021]].
@@ -82,5 +101,6 @@ Prompt-based + Stop hook (soft block for session-end saves) per [[r021]].
 
 ## Sources
 
-- `.claude/rules/SHOULD-memory-integration.md` — rule definition (HTML detail uplift #1053)
+- `.claude/rules/SHOULD-memory-integration.md` — rule definition (HTML detail uplift #1053, Dual-Backend Advisory 추가 v0.144.0)
 - Issue #869 — mid-session immediate save triggers (2026-04-15)
+- Issue #1169 — AgentMemory 마이그레이션 계획 (Phase 1 COEXIST)


### PR DESCRIPTION
## 요약
#1169 AgentMemory 마이그레이션 Phase 1 (COEXIST) **NON-DESTRUCTIVE** prep. 사용자가 1주 measure 가드 prep 부분 우회 명시 — 운영 가이드 + advisory 추가만, 어댑터 활성화 + 자산 처리는 보류.

## 변경 사항

### #1169 — Phase 1 prep (NON-DESTRUCTIVE)
- `guides/agentmemory-migration/phase-1-coexist.md` (261줄) — COEXIST 운영 9 섹션
- R011 SHOULD-memory-integration — Dual-Backend Advisory 섹션 추가
- CLAUDE.md — agentmemory MCP 권장 행 + 설치 명령어

### Boundary (의도적 제외)
| 항목 | 상태 | 진입 조건 |
|------|------|----------|
| eval-core agentmemory.ts | STUB 유지 | 사용자 MCP 설치 + 검증 후 |
| 12 plugin claude-mem skill 폐기 | 보류 | measure 결과 + 사용자 검토 후 |
| Phase 2 (SWITCH) | 미진입 | measure GO 결정 후 |

### 동기화
- R022 wiki (agentmemory-migration, r011)
- templates/ 미러
- version 0.143.0 → 0.144.0
- counts 변동 없음

## R017 ✓
카운트 정합 (skills 121, rules 23, guides 57, agents 49 — 모두 unchanged)
cross-refs 정합

## 사용자 행동 (다음 단계)

### 즉시 가능
1. `pip install agentmemory` + `claude mcp add agentmemory -- agentmemory mcp` (R001 수동)
2. `.mcp.json`에 등록 후 dual-backend 경고 advisory 확인
3. COEXIST 운영 시작 (claude-mem 기존 데이터 유지)

### 1주 후 (2026-05-25 자동 reminder)
1. `bash scripts/measure-claude-mem-usage.sh --days 7`
2. 결과 `gh issue comment 1169 --body-file <report>`
3. 자산 처리표 검토 → Phase 2 GO/NO-GO

Refs #1169

🤖 Generated with [Claude Code](https://claude.com/claude-code)