### PR TITLE
release: v0.149.0 — 피드백 룰 강화 + CC v2.1.146 docs + claude-mem advisory hook

### DIFF
--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -185,6 +185,16 @@
           }
         ],
         "description": "Auto-detect and fix previous session issues at start (#838)"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/scripts/plugin-cache-check.sh"
+          }
+        ],
+        "description": "Advisory check for plugin cache directories missing node_modules (#1207)"
       }
     ],
     "UserPromptSubmit": [

--- a/.claude/hooks/scripts/plugin-cache-check.sh
+++ b/.claude/hooks/scripts/plugin-cache-check.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# plugin-cache-check.sh — SessionStart advisory hook
+# Detects shared plugin caches with package.json but missing node_modules.
+# Always exit 0 (non-blocking). Output advisory to stderr only.
+# Issue: #1207 — claude-mem v13.3.0 plugin node_modules missing (zod/v3 module error)
+
+set -euo pipefail
+
+# Read and pass stdin through unchanged
+input=$(cat)
+
+PLUGIN_CACHE="${HOME}/.claude/shared-plugins/cache"
+
+if [ ! -d "$PLUGIN_CACHE" ]; then
+  echo "$input"
+  exit 0
+fi
+
+missing=()
+while IFS= read -r pkg; do
+  dir=$(dirname "$pkg")
+  if [ ! -d "$dir/node_modules" ]; then
+    missing+=("$dir")
+  fi
+done < <(find "$PLUGIN_CACHE" -maxdepth 4 -name package.json 2>/dev/null)
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "[Advisory] Plugin cache missing node_modules (run \`(cd <dir> && bun install)\` per directory):" >&2
+  for d in "${missing[@]}"; do
+    echo "  - $d" >&2
+  done
+fi
+
+echo "$input"
+exit 0

--- a/.claude/rules/MUST-agent-teams.md
+++ b/.claude/rules/MUST-agent-teams.md
@@ -38,14 +38,18 @@ These are distinct mechanisms. Agent Teams `SendMessage` requires `TeamCreate` a
 ## Self-Check (Before Agent Tool)
 
 Before using Agent tool for 2+ agent tasks, complete this check:
-Quick rule: 3+ agents OR review cycle → use Agent Teams. Sequential deps / scaffolding → Agent Tool. 2+ issues in same batch → prefer Agent Teams.
+Quick rule: User explicitly preferred plain subagents this session? → use Agent Tool (R000 user instructions > R018). Otherwise: 3+ agents OR review cycle → use Agent Teams. Sequential deps / scaffolding → Agent Tool. 2+ issues in same batch → prefer Agent Teams.
 
 <!-- DETAIL: Self-Check (Before Agent Tool)
 ╔══════════════════════════════════════════════════════════════════╗
 ║  BEFORE USING Agent TOOL FOR 2+ AGENTS:                          ║
 ║                                                                   ║
+║  0. Has user explicitly preferred plain subagents this session?  ║
+║     YES → Use Agent tool (R000 user instructions > R018)         ║
+║     NO  → Continue to #1                                          ║
+║                                                                   ║
 ║  1. Is Agent Teams available?                                    ║
-║     YES → check criteria #2-#4                                  ║
+║     YES → check criteria #2-#5                                  ║
 ║     NO  → Proceed with Agent tool                               ║
 ║                                                                   ║
 ║  2. Will 3+ agents be involved?                                  ║

--- a/.claude/rules/MUST-continuous-improvement.md
+++ b/.claude/rules/MUST-continuous-improvement.md
@@ -80,7 +80,7 @@ Before first implementation commit on external contribution:
 
 Reference issues: #1188 item #5, #1188 item #7, #1198 item #5.
 
-## Anti-Patterns — 4 patterns: "I'll update later", "one-time exception", "doesn't cover this", "finish task first". See table via Read tool.
+## Anti-Patterns — 5 patterns: "I'll update later", "one-time exception", "doesn't cover this", "finish task first", "calibration during action-oriented tone". See table via Read tool.
 
 <!-- DETAIL: Anti-Patterns
 | Anti-Pattern | Why It's Wrong | Correct Action |
@@ -89,6 +89,7 @@ Reference issues: #1188 item #5, #1188 item #7, #1198 item #5.
 | "This is a one-time exception" | Exceptions become patterns | If the rule is wrong, fix it; if it's right, follow it |
 | "The rule doesn't cover this case" | Missing coverage = rule gap | Add the case to the rule immediately |
 | "Let me finish the task first" | Rule violations compound | Fix rule first (5 min), then continue (prevents N future violations) |
+| "Calibration/humility during action-oriented tone (auto mode, ㄱㄱ, 계속해)" | Self-questioning wastes time when user signals action; action-mode preempts meta-reflection | Defer calibration to post-task feedback memory; respond with short action confirmation |
 -->
 
 ## Timing — Rule updates MUST happen before continuing original task, in the same session.

--- a/.claude/rules/SHOULD-memory-integration.md
+++ b/.claude/rules/SHOULD-memory-integration.md
@@ -351,7 +351,7 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 
 ### Session-End Self-Check (MANDATORY)
 
-(1) sys-memory-keeper updated MEMORY.md? (2) claude-mem save attempted? Both required before confirming to user. See full self-check via Read tool.
+(1) sys-memory-keeper updated MEMORY.md? (2) claude-mem save attempted? (3) If `omcustom-feedback` skill is active, prompt user to trigger it? All three required before confirming to user. See full self-check via Read tool.
 
 <!-- DETAIL: Session-End Self-Check (MANDATORY)
 ```
@@ -366,10 +366,15 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 ║     YES → Continue (even if it failed)                           ║
 ║     NO  → ToolSearch + save now                                  ║
 ║                                                                   ║
+║  3. Is omcustom-feedback skill available in this project?        ║
+║     YES → Ask user: "이번 세션 피드백을 omcustom-feedback로     ║
+║          기록하시겠습니까?" — accept skip                        ║
+║     NO  → Skip                                                    ║
+║                                                                   ║
 ║  Note: episodic-memory auto-indexes conversations after session  ║
 ║  ends. No manual action needed — do NOT search as "verification" ║
 ║                                                                   ║
-║  BOTH steps must be completed before confirming to user.         ║
+║  ALL steps must be completed before confirming to user.          ║
 ║  "Attempted" means called the tool — failure is OK, skipping     ║
 ║  is NOT.                                                          ║
 ╚══════════════════════════════════════════════════════════════════╝
@@ -413,7 +418,8 @@ Phase 1 COEXIST 기간 중 세션 종료 시:
 1. sys-memory-keeper가 MEMORY.md 갱신? → YES: 계속
 2. claude-mem 저장 시도? → YES (기존 항목)
 3. AgentMemory 저장 시도? → YES (COEXIST 추가)
-세 단계 모두 완료 후 사용자에게 확인. 둘 중 하나 실패해도 비차단.
+4. omcustom-feedback 권유? → YES (활성 시) / 스킵 (비활성 시)
+네 단계 모두 완료 후 사용자에게 확인. 둘 중 하나 실패해도 비차단.
 
 ### Phase 2 진입 전 필수 조건
 

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.146.0",
-  "generatedAt": "2026-05-20T02:06:52.156Z",
-  "templateVersion": "0.146.0",
+  "generatorVersion": "0.148.0",
+  "generatedAt": "2026-05-21T12:07:25.759Z",
+  "templateVersion": "0.148.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "dc6ce94ab01e1c6abb76e0a1a33b472a47f21706921e63f61ce2fb43bab9a9cf",
@@ -15,13 +15,13 @@
       "component": "rules"
     },
     ".claude/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "7bf5ad55d2fc6494e00ef04f9f53e7faab3e9f188156ddd25832e830b99d5970",
-      "size": 22335,
+      "templateHash": "09f69bab659d2b40d93f93df9cb0f24b4ff590947085599758c0719225011d09",
+      "size": 23707,
       "component": "rules"
     },
     ".claude/rules/MUST-intent-transparency.md": {
-      "templateHash": "339f659795c8c88d6a2752c7972bcd2b988adee3e0180b15d9311fe513aab8c8",
-      "size": 4090,
+      "templateHash": "64b1fd69a87d211d374b9368c35b5c9e70e72c5ecd6fd7d0f2124bffc9dddf03",
+      "size": 4634,
       "component": "rules"
     },
     ".claude/rules/SHOULD-error-handling.md": {
@@ -45,8 +45,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-language-policy.md": {
-      "templateHash": "e48bfda6d2c7d8414999fba0c87f46ddfed3748c4c264ad7fd35ddbc22746ada",
-      "size": 745,
+      "templateHash": "afb21d6e1b068a45e356191edf452c50b1018403dd4168664ffc8daee1316def",
+      "size": 1612,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
@@ -55,8 +55,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
-      "templateHash": "98b1bd947038a6065029994d8ae6c6a1a4d547fea6b23f69486517cfbac7300a",
-      "size": 2981,
+      "templateHash": "24f5d22a536d7fc201a497d3dec3755360552acf6dc02e088ced5bb311b2f0e0",
+      "size": 3432,
       "component": "rules"
     },
     ".claude/rules/MUST-sync-verification.md": {
@@ -65,8 +65,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-teams.md": {
-      "templateHash": "79d179c9b17f6c175a39cad8848bb5a67b1311a2cc5b2edb91f58b3b8b4f89e9",
-      "size": 16974,
+      "templateHash": "81dd35b6b43c2052cbedece0a9c60204a61d37bc38e1458da8c03739337a75d9",
+      "size": 17391,
       "component": "rules"
     },
     ".claude/rules/MAY-optimization.md": {
@@ -75,8 +75,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-continuous-improvement.md": {
-      "templateHash": "fa057ee2468b06ba71973f52982d00a5ae60b39eed778889b66c134ceea09183",
-      "size": 3271,
+      "templateHash": "b9c4d96418cec2f9d73697d3835b8203890648ff6cdfe9c64be15d55881da96b",
+      "size": 4854,
       "component": "rules"
     },
     ".claude/rules/MUST-permissions.md": {
@@ -95,8 +95,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-tool-identification.md": {
-      "templateHash": "920fb33b8c73de68943bd706fbb84c63f8b79938f19b20dcbbec8489be240873",
-      "size": 3531,
+      "templateHash": "ada0c458d27a593c85c3187db8145311d1eb30caaec385f7dbe64741e625ed08",
+      "size": 3935,
       "component": "rules"
     },
     ".claude/rules/SHOULD-verification-ladder.md": {
@@ -105,8 +105,8 @@
       "component": "rules"
     },
     ".claude/rules/SHOULD-memory-integration.md": {
-      "templateHash": "7f8109124ad32392de93d8b843b3df101f099f3497ff2518dc1f8420c5643099",
-      "size": 17534,
+      "templateHash": "e52ce7e12ef888e30d0b24c9d9ff94af053c580c31732888e2d7cc6ab74edcd1",
+      "size": 18074,
       "component": "rules"
     },
     ".claude/rules/MUST-enforcement-policy.md": {
@@ -120,8 +120,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-completion-verification.md": {
-      "templateHash": "dc28039aafff2011a6fcccf3c93dcd25db47e981bc373248f7bee16ff4583e33",
-      "size": 7175,
+      "templateHash": "6cf25e28123cd6158e10012c5814895fff0ac80afb5abbfb8b566a88e0c10202",
+      "size": 7808,
       "component": "rules"
     },
     ".claude/agents/be-springboot-expert.md": {
@@ -1139,6 +1139,11 @@
       "size": 1347,
       "component": "hooks"
     },
+    ".claude/hooks/scripts/plugin-cache-check.sh": {
+      "templateHash": "606ecfd7fa5e4435bb34f4904d67e474999ea4b68820991457d7b1d8172a4f6b",
+      "size": 916,
+      "component": "hooks"
+    },
     ".claude/hooks/scripts/rule-deletion-guard.sh": {
       "templateHash": "a06097f9d245bd39194498452f1dac3c2df46f14939d52fe20fc31c634b61ca9",
       "size": 2374,
@@ -1165,8 +1170,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/session-reflection.sh": {
-      "templateHash": "3f995ec64bad24212f60bffcad6a7a522be883df08b0c426025dace062a5988b",
-      "size": 6084,
+      "templateHash": "0c9c224368c7a1fb13818c1981b7c7da10bde6f8c7e4c8ca83decdc077207162",
+      "size": 8409,
       "component": "hooks"
     },
     ".claude/hooks/scripts/user-prompt-preprocessor.sh": {
@@ -1315,8 +1320,8 @@
       "component": "hooks"
     },
     ".claude/hooks/hooks.json": {
-      "templateHash": "0c542afa181064ff2989a6a5e48b12c68ab4ae1cbb4912c83c30950ba42791bd",
-      "size": 27907,
+      "templateHash": "0aab01683cd30a6776041558fb6a8ea0ae0133d226bd58b9a1965e060d888c70",
+      "size": 28205,
       "component": "hooks"
     },
     ".claude/contexts/ecomode.md": {
@@ -1425,8 +1430,8 @@
       "component": "guides"
     },
     "guides/claude-code/15-version-compatibility.md": {
-      "templateHash": "5cd6b8359241dc3217ceaa3a5d4420c99262183ed4ee03bb083dc3032f9d7fe2",
-      "size": 37472,
+      "templateHash": "dcd4e37fd6c83c1e2b02dc0f473a273693748c87db98cbad484c3e72ca302b78",
+      "size": 42387,
       "component": "guides"
     },
     "guides/claude-code/11-sub-agents.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.149.0] - 2026-05-21
+
+### Added — 룰 강화 + CC v2.1.146 + claude-mem hook (#1205 #1206 #1207)
+- R018 (`MUST-agent-teams`): Self-Check #0 user explicit subagent preference (R000 > R018) — #1206 item #1
+- R011 (`SHOULD-memory-integration`): Session-End Self-Check에 omcustom-feedback 권유 (3 places) — #1206 item #3
+- R016 (`MUST-continuous-improvement`): Anti-Pattern 5번째 row — calibration during action-oriented tone — #1206 item #4
+- `.claude/hooks/scripts/plugin-cache-check.sh`: plugin cache `node_modules` 누락 SessionStart advisory hook (비차단, exit 0) — #1207
+- `guides/claude-code/15-version-compatibility.md`: CC v2.1.146 호환성 섹션 — #1205
+
+### Changed
+- 룰 3건 + 1 hook 신규 등록 + templates/ 동기화
+
+### Memory
+- feedback_r010_root_metafile_exception_rejected (신규): R010 약화 제안 거부 — #1206 item #6
+- feedback_plugin_node_modules_missing: v0.149.0/#1207 자동 감지 hook note append
+
 ## [0.148.0] - 2026-05-20
 
 ### Added — CC v2.1.145 follow-up

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2334,7 +2334,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.146.0",
+    version: "0.148.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {
@@ -2382,7 +2382,7 @@ var init_package = __esm(() => {
       yaml: "^2.8.2"
     },
     devDependencies: {
-      "@anthropic-ai/sdk": "^0.95.1",
+      "@anthropic-ai/sdk": "^0.97.1",
       "@biomejs/biome": "^2.3.12",
       "@types/bun": "^1.3.6",
       "@types/js-yaml": "^4.0.9",

--- a/dist/index.js
+++ b/dist/index.js
@@ -2014,7 +2014,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.146.0",
+  version: "0.148.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {
@@ -2062,7 +2062,7 @@ var package_default = {
     yaml: "^2.8.2"
   },
   devDependencies: {
-    "@anthropic-ai/sdk": "^0.95.1",
+    "@anthropic-ai/sdk": "^0.97.1",
     "@biomejs/biome": "^2.3.12",
     "@types/bun": "^1.3.6",
     "@types/js-yaml": "^4.0.9",

--- a/guides/claude-code/15-version-compatibility.md
+++ b/guides/claude-code/15-version-compatibility.md
@@ -486,6 +486,7 @@ docs/superpowers/plans/**
 | v2.1.143 | 직접 변경 불필요. `worktree.bgIsolation: "none"` opt-in 시 파일 소유권 규율 필수. Stop hook 8회 block cap 인지. | P3 follow-up |
 | v2.1.144 | 호환 가능. CLAUDE.md `omcustomMinClaudeCode` v2.1.121 유지. macOS bg session FDA crash fix 확인. | None |
 | v2.1.145 | docs-only. `claude agents --json` HUD 강화, Stop/SubagentStop hook `background_tasks`/`session_crons` 활용, status line GitHub PR 통합 — 별도 follow-up 권장. | P3 follow-up |
+| v2.1.146 | docs-only. `/simplify`→`/code-review` 리네임 + effort level, AskUserQuestion auto-mode normalization, MCP pagination 안정성, `CLAUDE_CODE_SUBAGENT_MODEL` 자식 프로세스 전파 fix. | None |
 
 ## v2.1.144 (2026-05-19) — 호환성 점검
 
@@ -640,6 +641,76 @@ Agent Teams 멤버 이름에 non-ASCII 문자(한국어 포함)가 포함된 경
 
 ---
 
+## v2.1.146 (2026-05-21) — 호환성 점검
+
+> Issue: #1205 — Claude Code v2.1.146 compatibility documentation
+
+### `/simplify` → `/code-review` 리네임 (+ effort level)
+
+기존 `/simplify` 슬래시 커맨드가 `/code-review`로 리네임되었습니다. effort level을 인수로 지정할 수 있습니다 (예: `/code-review high`).
+
+**oh-my-customcode 연관**: 내부 `dev-review` 스킬과 명칭이 다르며 충돌 없음. 사용자가 네이티브 `/code-review`와 omcustom `dev-review` 스킬을 혼동하지 않도록 구분 안내가 필요할 수 있습니다 (별도 follow-up 후보). 직접 harness 변경 불필요.
+
+### Auto mode `AskUserQuestion` 억제 해제
+
+Auto mode에서 user 또는 skill이 명시적으로 요청한 경우 `AskUserQuestion` 호출이 더 이상 억제되지 않습니다.
+
+**oh-my-customcode 연관**: R015 intent transparency의 ambiguity-gate 패턴이 정상 작동합니다. 신뢰도 < 70% 구간에서 `AskUserQuestion`을 통한 명시적 확인 요청이 auto mode에서도 동작하므로 R015 오탐(ambiguous routing 무음 처리)이 감소합니다. 호환, 개선.
+
+### MCP `resources/list`, `resources/templates/list`, `prompts/list` 페이지네이션 수정
+
+1페이지 이후의 항목이 누락되던 버그가 수정되었습니다.
+
+**oh-my-customcode 연관**: `ListMcpResourcesTool` 페이지네이션 안정성이 개선됩니다. `claude-mem`, `ontology-rag` 등 R011/R019 MCP 서버에서 리소스 목록이 많은 경우 전체 항목이 정상 조회됩니다. 호환, 개선.
+
+### `CLAUDE_CODE_SUBAGENT_MODEL` 자식 프로세스 전파 수정
+
+`CLAUDE_CODE_SUBAGENT_MODEL` 환경 변수가 다중 에이전트 세션의 자식 프로세스에 전파되지 않던 버그가 수정되었습니다.
+
+**oh-my-customcode 연관**: R010 + R018 Agent Teams 멤버 모델 일관성에 직접 영향. `CLAUDE_CODE_SUBAGENT_MODEL`을 설정한 환경에서 Agent Teams 멤버가 지정 모델을 올바르게 사용하는지 v2.1.146 업그레이드 후 검증 권장. 호환, 검증 권장.
+
+### Windows 관련 수정 (macOS 영향 없음)
+
+- Windows PowerShell `pwsh` winget/Store 설치 실패 fix (v2.1.124 regression)
+- Windows Terminal background session strobing fix
+- Windows NTFS junction background-job worktree 안전성 개선
+- GNOME Terminal right/middle-click paste fix
+
+**oh-my-customcode 연관**: macOS 개발 환경에는 직접 영향 없음.
+
+### 기타 수정
+
+- `/background` skill-or-custom-slash-only 입력 수용 fix → `/bg` 플로우(R010 Universal bypassPermissions) 개선
+- Backgrounded sessions tool permission "don't ask again" 재요청 fix → R010 bypassPermissions 안정성 개선
+- Auto-updater 상태줄 fail 시 현재 버전 표시 fix → R012 statusline 영향 없음 (별도)
+- Agent SDK 스트리밍 세션 종료 시 uncaught exception fix → agent-sdk-* 플러그인 영향 가능, 모니터 권장
+- `forceLoginOrgUUID`/`forceLoginMethod` managed-settings enforcement fix → R002 직접 영향 없음
+- Auto-updater 일시적 네트워크 실패 retry 개선
+- 대용량 파일 편집 diff 렌더링 성능 개선
+- `/theme` color editor + "New custom theme" Esc 미응답 fix
+
+### oh-my-customcode 연관 평가
+
+| 변경 | oh-my-customcode 영향 | 조치 |
+|------|----------------------|------|
+| `/simplify` → `/code-review` 리네임 + effort level | 내부 `dev-review` skill과 명칭 다름, 충돌 없음 | 호환, 별도 조치 없음 |
+| Auto mode `AskUserQuestion` 억제 해제 | R015 intent transparency, ambiguity-gate 정상 작동 | 호환, 개선 |
+| MCP 페이지네이션 수정 | `ListMcpResourcesTool` 페이지네이션 안정성 | 호환, 개선 |
+| `CLAUDE_CODE_SUBAGENT_MODEL` 자식 프로세스 전파 fix | R010 + R018 Agent Teams 멤버 모델 일관성 개선 | 호환, 검증 권장 |
+| `/background` 입력 수용 fix | `/bg` 플로우 개선 | 호환, 개선 |
+| Backgrounded sessions permission "don't ask again" fix | R010 bypassPermissions 안정성 | 호환, 개선 |
+| Agent SDK 스트리밍 uncaught exception fix | agent-sdk-* 플러그인 영향 가능 | 호환, 모니터 |
+| Windows/터미널 관련 수정 | macOS 환경 직접 영향 없음 | 호환 |
+
+**Action items**:
+- 본 릴리스에서 코드 변경 없음 (docs-only)
+- 후속 follow-up 후보:
+  - `CLAUDE_CODE_SUBAGENT_MODEL` 전파 동작 검증 (R018 Agent Teams 멤버 모델 일관성)
+  - 외부 `/code-review`와 내부 `dev-review` skill 구분 안내 (CLAUDE.md 또는 dev-review skill 본문)
+  - Agent SDK 스트리밍 fix가 agent-sdk-dev 플러그인에 미치는 영향 모니터
+
+---
+
 ## References
 
 - #967 — Claude Code v2.1.117 release note
@@ -652,6 +723,7 @@ Agent Teams 멤버 이름에 non-ASCII 문자(한국어 포함)가 포함된 경
 - #1147 — .gitignore nested .md pattern limitation note
 - #1187 — Claude Code v2.1.144 compatibility documentation
 - #1191 — Claude Code v2.1.145 compatibility documentation
+- #1205 — Claude Code v2.1.146 compatibility documentation
 - `.claude/skills/claude-native/` — auto-generation source
 - `.claude/rules/SHOULD-hud-statusline.md` — R012 statusline integration
 - `.claude/rules/MUST-agent-design.md` — R006 agent frontmatter spec

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.148.0",
+  "version": "0.149.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,43 +1,36 @@
-# Release v0.110.0
+# Release v0.149.0
 
 ## Highlights
-
-- **Output Styles 레이어 도입** — Claude Code 네이티브 시스템 프롬프트 레이어로 R007/R008/R000 강제력 격상 (#1003)
-- **roundtable-debate 스킬 신설** — Devil's Advocate + 소수의견 보호 + 2라운드 하드캡으로 다중 에이전트 토론의 anti-groupthink 메커니즘 내재화 (#1007)
-- **agora 보강** — Anti-Groupthink Mode 옵션 추가, 수렴 vs 발산 보존 패턴 구분 명확화
-
-## :rocket: Features
-
-- **Output Styles 도입** (#1003): `.claude/output-styles/korean-engineer.md` 신규 작성 — Korean-first 출력 + R007/R008 에이전트 식별 + R003 balanced 스타일을 시스템 프롬프트로 격상. R003 SHOULD-interaction.md에 Session-Level Style Enforcement 위임 섹션 추가, settings.local.json `outputStyle` 활성화.
-- **roundtable-debate 스킬** (#1007): 발산 보존(divergence preservation)을 목표로 하는 다중 에이전트 구조화 토론 스킬. context: fork (10/12), 핵심 메커니즘 4종(Independent-first parallel analysis, Devil's Advocate 강제 주입, 소수의견 보호 프로토콜, 2라운드 하드캡). cc-roundtable 패턴 attribution.
-- **agora Anti-Groupthink Mode** (#1007): 기존 만장일치 수렴 워크플로우에 옵션 모드 추가 — Devil's Advocate slot + minority opinion protection + round soft cap. `--mode anti-groupthink` 플래그로 활성화.
+- **세션 피드백 내재화** (#1206): R018/R011/R016 룰 강화 — 사용자 명시적 subagent 선호 우선, omcustom-feedback 세션 종료 권유, calibration 억제 anti-pattern 추가
+- **claude-mem plugin cache advisory hook** (#1207): SessionStart에서 `~/.claude/shared-plugins/cache/**` `node_modules` 누락 자동 감지, stderr advisory 출력 (비차단)
+- **Claude Code v2.1.146 호환성** (#1205): `/code-review` 리네임, AskUserQuestion auto-mode normalization, `CLAUDE_CODE_SUBAGENT_MODEL` 전파 fix 등 문서화
 
 ## :books: Documentation
+- **CC v2.1.146 호환성 문서** (#1205): `guides/claude-code/15-version-compatibility.md` — 16개 변경 사항 분석 및 oh-my-customcode 영향 평가, 후속 follow-up 후보 명시
 
-- **multi-agent-debate-patterns 가이드 신설** (#1007): 3대 고질병(Anchoring/Groupthink/Degeneration of Thought) 정의 + agora vs roundtable-debate 선택 매트릭스 + 연구 근거.
-- **CLAUDE.md 권장 플러그인** (#1007): cc-roundtable 외부 플러그인 항목 추가 — 패턴 내재화 후에도 원본 직접 사용 경로 보존.
-- **wiki R022 동기화**: 신규 페이지 3종(roundtable-debate, multi-agent-debate-patterns, output-styles) + 업데이트 3종(agora, R003, R006), wiki/index.yaml 갱신.
+## :wrench: Rules
+- **R018 (MUST-agent-teams)** (#1206 item 1): Self-Check `#0 — 사용자가 명시적으로 일반 subagent 선호?` prepend, R000 user instructions > R018 명시
+- **R011 (SHOULD-memory-integration)** (#1206 item 3): Session-End Self-Check에 `omcustom-feedback` skill 활성 시 사용자 권유 단계 추가 (visible + HTML detail + COEXIST 확장 3곳)
+- **R016 (MUST-continuous-improvement)** (#1206 item 4): Anti-Patterns에 "Calibration/humility during action-oriented tone" 5번째 row 추가
 
-## :wrench: Other Changes
+## :bug: Bug Fixes
+- **plugin-cache-check.sh advisory hook** (#1207): SessionStart에서 plugin cache `node_modules` 미설치 감지. v0.132.0 zod/v3 동일 재발 패턴 방지. 비차단(exit 0), stderr advisory only
 
-- ARCHITECTURE.md fork count drift 보정 (9 → 10), Workflow/orchestration skills 카운트 5 → 6.
-- 7곳 카운트 동기화: skills 113→114, guides 44→45, version 0.109.0→0.110.0.
-- templates/ 3중 동기화 검증: verify-template-sync.sh / verify-wiki-sync.sh / verify-fork-list.sh 모두 통과.
+## :recycle: Other Changes
+- **Memory: R010 root metafile exception rejected** (#1206 item 6): R010 약화 제안 거부 근거 기록. orchestrator 직접 작성 금지 일관 유지
 
 ## Resource Changes
+| Resource | Before (v0.148.0) | After (v0.149.0) | Delta |
+|----------|-------------------|-------------------|-------|
+| Agents | 49 | 50 | +1 |
+| Skills | 121 | 121 | 0 |
+| Rules | 23 | 23 | 0 |
+| Guides | 57 | 57 | 0 |
 
-| Resource | Before | After | Delta |
-|----------|--------|-------|-------|
-| Rules | 22 | 22 | 0 (R003/R006 본문 갱신) |
-| Skills | 113 | 114 | +1 (roundtable-debate) |
-| Agents | 49 | 49 | 0 |
-| Guides | 44 | 45 | +1 (multi-agent-debate-patterns) |
-| Wiki pages | 257 | 260 | +3 |
-| Fork context (cap 12) | 9 | 10 | +1 |
-
-## Breaking Changes
-
-없음. Output Styles는 비파괴 신규 레이어, roundtable-debate는 신규 스킬, agora는 옵션 모드 추가(기본 동작 변동 없음).
+## Closed Issues
+- #1205 — Claude Code v2.1.146
+- #1206 — 세션 찐빠 보고 (items 1/3/4/6 internalized; items 2/5/7 별도 issue로 분리 예정)
+- #1207 — claude-mem v13.3.0 plugin node_modules 미설치
 
 ---
-_Release notes generated with Claude Code_
+_Release notes generated with Claude Code (oh-my-customcode auto-dev pipeline v2.1.0)_

--- a/templates/.claude/hooks/hooks.json
+++ b/templates/.claude/hooks/hooks.json
@@ -185,6 +185,16 @@
           }
         ],
         "description": "Auto-detect and fix previous session issues at start (#838)"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/scripts/plugin-cache-check.sh"
+          }
+        ],
+        "description": "Advisory check for plugin cache directories missing node_modules (#1207)"
       }
     ],
     "UserPromptSubmit": [

--- a/templates/.claude/hooks/scripts/plugin-cache-check.sh
+++ b/templates/.claude/hooks/scripts/plugin-cache-check.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# plugin-cache-check.sh — SessionStart advisory hook
+# Detects shared plugin caches with package.json but missing node_modules.
+# Always exit 0 (non-blocking). Output advisory to stderr only.
+# Issue: #1207 — claude-mem v13.3.0 plugin node_modules missing (zod/v3 module error)
+
+set -euo pipefail
+
+# Read and pass stdin through unchanged
+input=$(cat)
+
+PLUGIN_CACHE="${HOME}/.claude/shared-plugins/cache"
+
+if [ ! -d "$PLUGIN_CACHE" ]; then
+  echo "$input"
+  exit 0
+fi
+
+missing=()
+while IFS= read -r pkg; do
+  dir=$(dirname "$pkg")
+  if [ ! -d "$dir/node_modules" ]; then
+    missing+=("$dir")
+  fi
+done < <(find "$PLUGIN_CACHE" -maxdepth 4 -name package.json 2>/dev/null)
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "[Advisory] Plugin cache missing node_modules (run \`(cd <dir> && bun install)\` per directory):" >&2
+  for d in "${missing[@]}"; do
+    echo "  - $d" >&2
+  done
+fi
+
+echo "$input"
+exit 0

--- a/templates/.claude/rules/MUST-agent-teams.md
+++ b/templates/.claude/rules/MUST-agent-teams.md
@@ -38,14 +38,18 @@ These are distinct mechanisms. Agent Teams `SendMessage` requires `TeamCreate` a
 ## Self-Check (Before Agent Tool)
 
 Before using Agent tool for 2+ agent tasks, complete this check:
-Quick rule: 3+ agents OR review cycle → use Agent Teams. Sequential deps / scaffolding → Agent Tool. 2+ issues in same batch → prefer Agent Teams.
+Quick rule: User explicitly preferred plain subagents this session? → use Agent Tool (R000 user instructions > R018). Otherwise: 3+ agents OR review cycle → use Agent Teams. Sequential deps / scaffolding → Agent Tool. 2+ issues in same batch → prefer Agent Teams.
 
 <!-- DETAIL: Self-Check (Before Agent Tool)
 ╔══════════════════════════════════════════════════════════════════╗
 ║  BEFORE USING Agent TOOL FOR 2+ AGENTS:                          ║
 ║                                                                   ║
+║  0. Has user explicitly preferred plain subagents this session?  ║
+║     YES → Use Agent tool (R000 user instructions > R018)         ║
+║     NO  → Continue to #1                                          ║
+║                                                                   ║
 ║  1. Is Agent Teams available?                                    ║
-║     YES → check criteria #2-#4                                  ║
+║     YES → check criteria #2-#5                                  ║
 ║     NO  → Proceed with Agent tool                               ║
 ║                                                                   ║
 ║  2. Will 3+ agents be involved?                                  ║
@@ -305,3 +309,22 @@ Agent Teams actively preferred for qualifying collaborative tasks. Use Agent too
 Do NOT avoid Agent Teams solely for cost reasons when criteria are met.
 
 **Active preference rule**: When Agent Teams is available, default to using it for any multi-step or multi-issue work. Only fall back to Agent tool for truly simple, single-issue tasks with no verification needs.
+
+## Member TaskUpdate Discipline
+
+Agent Teams 멤버는 long-running 작업 중 진행 상태를 TaskUpdate 로 명시적으로 알려야 한다. 침묵은 코디네이터가 죽었거나 멤버가 막혔다고 오인하게 만든다.
+
+| 시점 | 호출 |
+|------|------|
+| 작업 시작 | TaskUpdate(taskId, status: "in_progress") |
+| 의미 있는 진행 (≥30s 분기/체크포인트) | TaskUpdate(taskId, description 업데이트 또는 메타데이터) |
+| 완료 | TaskUpdate(taskId, status: "completed") |
+| 차단 시 | TaskUpdate(taskId, description: 차단 사유) — 그 후 SendMessage |
+
+### Common Violations
+
+- 30초 이상 작업하면서 in_progress 미설정 → 다른 멤버가 task 를 claim 시도해 충돌
+- 완료 후 status 미갱신 → 후속 작업이 영원히 blocked
+- 차단 사유를 SendMessage 로만 보내고 task description 업데이트 누락 → TaskList 만 보는 멤버는 사유를 모름
+
+Reference issue: #1087.

--- a/templates/.claude/rules/MUST-continuous-improvement.md
+++ b/templates/.claude/rules/MUST-continuous-improvement.md
@@ -33,6 +33,7 @@ Update the relevant rule rather than just acknowledging the violation.
 | Process gap (workflow hole) | ✅ | ✅ | ✅ | ⚠️ (패턴 3회 이상 반복 시) |
 | Repeatable system bug | — | ✅ | ✅ | ⚠️ (수정이 구조적일 경우, 일회성 아닐 때) |
 | Agent selection failure (wrong agent routed) | — | ✅ | — | ✅ (라우팅 스킬 업데이트 후보) |
+| External repo convention miss | ✅ | ✅ | — | ⚠️ (3회 이상 반복 시) |
 
 **Skill Promotion**: feedback memory가 동일 패턴으로 3회 이상 반복되면 "failure pattern"으로 승격. skill-extractor의 `--mode failure` 플래그로 스킬 후보 분석 가능 (Skillify 내재화, #972).
 
@@ -50,7 +51,36 @@ When repeating agent failures or suboptimal routing is detected:
 
 This connects R016's continuous improvement loop with the adaptive-harness skill's learning capability.
 
-## Anti-Patterns — 4 patterns: "I'll update later", "one-time exception", "doesn't cover this", "finish task first". See table via Read tool.
+## External Repo Contribution Pre-Check
+
+Before starting work on contributing to an external repository (skill submission, agent contribution, plugin development), MUST read these files in the target repo FIRST round:
+
+| File | Purpose |
+|------|---------|
+| `CONTRIBUTING.md` | Submission rules, PR conventions |
+| `AGENTS.md` | Agent contribution guide (if applicable) |
+| `docs/adding-a-*.md` | Domain-specific add guide (e.g., `adding-a-skill.md`) |
+| Domain-specific checklist | Frontmatter conventions, metadata enums |
+| `package.json` scripts | Validation commands (e.g., `npm run ci`) |
+
+### Self-Check
+
+Before first implementation commit on external contribution:
+- [ ] Read CONTRIBUTING / AGENTS / skill-checklist
+- [ ] Identified frontmatter convention + metadata enums
+- [ ] Identified validation commands
+- [ ] Confirmed domain fit (does this contribution match the target repo's domain?)
+
+### Common Violation
+
+```
+❌ WRONG: Start implementation → discover frontmatter convention mid-session → rewrite
+✓ CORRECT: First round read CONTRIBUTING/AGENTS → identify conventions → then implement
+```
+
+Reference issues: #1188 item #5, #1188 item #7, #1198 item #5.
+
+## Anti-Patterns — 5 patterns: "I'll update later", "one-time exception", "doesn't cover this", "finish task first", "calibration during action-oriented tone". See table via Read tool.
 
 <!-- DETAIL: Anti-Patterns
 | Anti-Pattern | Why It's Wrong | Correct Action |
@@ -59,6 +89,7 @@ This connects R016's continuous improvement loop with the adaptive-harness skill
 | "This is a one-time exception" | Exceptions become patterns | If the rule is wrong, fix it; if it's right, follow it |
 | "The rule doesn't cover this case" | Missing coverage = rule gap | Add the case to the rule immediately |
 | "Let me finish the task first" | Rule violations compound | Fix rule first (5 min), then continue (prevents N future violations) |
+| "Calibration/humility during action-oriented tone (auto mode, ㄱㄱ, 계속해)" | Self-questioning wastes time when user signals action; action-mode preempts meta-reflection | Defer calibration to post-task feedback memory; respond with short action confirmation |
 -->
 
 ## Timing — Rule updates MUST happen before continuing original task, in the same session.

--- a/templates/.claude/rules/SHOULD-memory-integration.md
+++ b/templates/.claude/rules/SHOULD-memory-integration.md
@@ -351,7 +351,7 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 
 ### Session-End Self-Check (MANDATORY)
 
-(1) sys-memory-keeper updated MEMORY.md? (2) claude-mem save attempted? Both required before confirming to user. See full self-check via Read tool.
+(1) sys-memory-keeper updated MEMORY.md? (2) claude-mem save attempted? (3) If `omcustom-feedback` skill is active, prompt user to trigger it? All three required before confirming to user. See full self-check via Read tool.
 
 <!-- DETAIL: Session-End Self-Check (MANDATORY)
 ```
@@ -366,10 +366,15 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 ║     YES → Continue (even if it failed)                           ║
 ║     NO  → ToolSearch + save now                                  ║
 ║                                                                   ║
+║  3. Is omcustom-feedback skill available in this project?        ║
+║     YES → Ask user: "이번 세션 피드백을 omcustom-feedback로     ║
+║          기록하시겠습니까?" — accept skip                        ║
+║     NO  → Skip                                                    ║
+║                                                                   ║
 ║  Note: episodic-memory auto-indexes conversations after session  ║
 ║  ends. No manual action needed — do NOT search as "verification" ║
 ║                                                                   ║
-║  BOTH steps must be completed before confirming to user.         ║
+║  ALL steps must be completed before confirming to user.          ║
 ║  "Attempted" means called the tool — failure is OK, skipping     ║
 ║  is NOT.                                                          ║
 ╚══════════════════════════════════════════════════════════════════╝
@@ -413,7 +418,8 @@ Phase 1 COEXIST 기간 중 세션 종료 시:
 1. sys-memory-keeper가 MEMORY.md 갱신? → YES: 계속
 2. claude-mem 저장 시도? → YES (기존 항목)
 3. AgentMemory 저장 시도? → YES (COEXIST 추가)
-세 단계 모두 완료 후 사용자에게 확인. 둘 중 하나 실패해도 비차단.
+4. omcustom-feedback 권유? → YES (활성 시) / 스킵 (비활성 시)
+네 단계 모두 완료 후 사용자에게 확인. 둘 중 하나 실패해도 비차단.
 
 ### Phase 2 진입 전 필수 조건
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.148.0",
+  "version": "0.149.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약

- **R018 / R011 / R016 룰 강화** (#1206 items 1/3/4): 사용자 명시 subagent 선호 우선, omcustom-feedback 세션 종료 권유, calibration anti-pattern
- **claude-mem plugin cache advisory hook** (#1207): SessionStart에서 plugin cache `node_modules` 누락 자동 감지 (비차단)
- **Claude Code v2.1.146 호환성 문서** (#1205): 16개 변경 사항 분석

## 변경 사항

- 룰 3건 업데이트 (R018/R011/R016) + templates 동기화
- `.claude/hooks/scripts/plugin-cache-check.sh` 신규 등록 (SessionStart, exit 0 advisory)
- `guides/claude-code/15-version-compatibility.md` v2.1.146 섹션 추가
- Memory: `feedback_r010_root_metafile_exception_rejected` (신규) + `feedback_plugin_node_modules_missing` 갱신

## Closes

Closes #1205
Closes #1206
Closes #1207

## Test plan

- [x] bun test: 1984 pass / 0 fail (baseline 유지)
- [x] bun run lint: OK
- [x] bun run typecheck: OK
- [x] bun run build: OK (1.22MB CLI + 182KB index)
- [x] .github/scripts/verify-template-sync.sh: OK
- [x] .github/scripts/verify-wiki-sync.sh: OK
- [x] scripts/verify-version-sync.sh: OK (package + manifest 동기화)
- [x] hook syntax + smoke test: exit 0, stdin passthrough

## 후속 follow-up 분리 등록 예정

- #1206 Item 2: Agent Teams graceful shutdown + tmux kill fallback
- #1206 Item 5: omcustom-init tests/tsconfig.json 템플릿
- #1206 Item 7: Background agent 진행 추적 (CC upstream tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)