### PR TITLE
release: v0.150.1 — installer tests/tsconfig.json 자동 복사 (#1213)

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.149.0",
-  "generatedAt": "2026-05-21T12:52:08.223Z",
-  "templateVersion": "0.149.0",
+  "generatorVersion": "0.150.1",
+  "generatedAt": "2026-05-21T13:07:31.492Z",
+  "templateVersion": "0.150.1",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "dc6ce94ab01e1c6abb76e0a1a33b472a47f21706921e63f61ce2fb43bab9a9cf",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.150.1] - 2026-05-21
+
+### Added
+- `src/core/installer.ts` `installTestsConfig` function — auto-copy `templates/tests/tsconfig.json` to new projects (#1213)
+- 4 new test cases in `tests/unit/core/installer.test.ts`
+
 ## [0.150.0] - 2026-05-21
 
 ### Added — R010/R015 강화 + tsconfig template + investigation memos (#1208 #1210 #1211 #1212)

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2334,7 +2334,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.149.0",
+    version: "0.150.1",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {
@@ -28090,6 +28090,22 @@ async function installStatusline(targetDir, options, _result) {
   await fs2.chmod(destPath, 493);
   debug("install.statusline_installed", {});
 }
+async function installTestsConfig(targetDir, options, _result) {
+  const srcPath = resolveTemplatePath(join8("tests", "tsconfig.json"));
+  const destPath = join8(targetDir, "tests", "tsconfig.json");
+  if (!await fileExists(srcPath)) {
+    debug("install.tests_config_not_found", { path: srcPath });
+    return;
+  }
+  if (await fileExists(destPath)) {
+    if (!options.force && !options.backup) {
+      debug("install.tests_config_skipped", { reason: "exists" });
+      return;
+    }
+  }
+  await copyFile(srcPath, destPath);
+  debug("install.tests_config_installed", {});
+}
 async function installSettingsLocal(targetDir, result) {
   const layout = getProviderLayout();
   const settingsPath = join8(targetDir, layout.rootDir, "settings.local.json");
@@ -28182,6 +28198,7 @@ async function install(options) {
     await verifyTemplateDirectory();
     await installAllComponents(options.targetDir, options, result);
     await installStatusline(options.targetDir, options, result);
+    await installTestsConfig(options.targetDir, options, result);
     await installSettingsLocal(options.targetDir, result);
     await installEntryDocWithTracking(options.targetDir, options, result);
     if (preservation) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1680,6 +1680,22 @@ async function installStatusline(targetDir, options, _result) {
   await fs.chmod(destPath, 493);
   debug("install.statusline_installed", {});
 }
+async function installTestsConfig(targetDir, options, _result) {
+  const srcPath = resolveTemplatePath(join5("tests", "tsconfig.json"));
+  const destPath = join5(targetDir, "tests", "tsconfig.json");
+  if (!await fileExists(srcPath)) {
+    debug("install.tests_config_not_found", { path: srcPath });
+    return;
+  }
+  if (await fileExists(destPath)) {
+    if (!options.force && !options.backup) {
+      debug("install.tests_config_skipped", { reason: "exists" });
+      return;
+    }
+  }
+  await copyFile(srcPath, destPath);
+  debug("install.tests_config_installed", {});
+}
 async function installSettingsLocal(targetDir, result) {
   const layout = getProviderLayout();
   const settingsPath = join5(targetDir, layout.rootDir, "settings.local.json");
@@ -1772,6 +1788,7 @@ async function install(options) {
     await verifyTemplateDirectory();
     await installAllComponents(options.targetDir, options, result);
     await installStatusline(options.targetDir, options, result);
+    await installTestsConfig(options.targetDir, options, result);
     await installSettingsLocal(options.targetDir, result);
     await installEntryDocWithTracking(options.targetDir, options, result);
     if (preservation) {
@@ -2014,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.149.0",
+  version: "0.150.1",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.150.0",
+  "version": "0.150.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,41 +1,25 @@
-# Release v0.150.0
+# Release v0.150.1
 
 ## Highlights
-- **R010 enforcement 강화** (#1208): 루트 메타 파일 위임 표준화 (`.gitignore`, `.editorconfig`, `README.md` 등) + Self-Check #5 + R015 push directive persistence 정책
-- **omcustom-init tests/tsconfig.json template** (#1211): 신규 프로젝트 부트스트랩 시 `tests/` 디렉토리 타입 추론 지원
-- **Investigation memos** (#1210 #1212): Agent Teams force shutdown + Background agent progress tracking 가이드 + CC upstream 추적 정착
+- **omcustom-init installer: tests/tsconfig.json 자동 설치** (#1213): v0.150.0에서 추가된 `templates/tests/tsconfig.json`을 신규 프로젝트 부트스트랩 시 `tests/tsconfig.json`으로 자동 복사
 
-## :wrench: Rules
-- **R010 (MUST-orchestrator-coordination)**: Root Meta-File Delegation 표 추가 (`.gitignore`/`.npmrc`/`README.md` 등 specialist 매핑) + Common Violations에 "1-line edit" 핑계 anti-pattern + Self-Check #5
-- **R015 (MUST-intent-transparency)**: Git Push Continuation 섹션 추가 — first-time strict, follow-up relaxed; 동일 세션 내 동일 브랜치 push directive persistence
+## :rocket: Features
+- `src/core/installer.ts`: `installTestsConfig` 함수 추가 (`installStatusline` 패턴 동일) — copyFile로 src→dst 복사, dst 존재 시 skip (force 옵션 시 덮어쓰기), src 미존재 시 silent skip
 
-## :books: Documentation
-- `guides/agent-teams/troubleshooting.md` (NEW): graceful shutdown 5단계 절차 + tmux kill-pane fallback + isActive flag 수동 해제
-- `guides/claude-code-tracking.md` (NEW): CC upstream API 추적 — Background Agent Progress API + Agent Teams Force Shutdown 후보 변경 키워드
-
-## :file_folder: Templates
-- `templates/tests/tsconfig.json` (NEW): bun-types 타입 + 상위 tsconfig.json 상속
-
-## :brain: Memory
-- `feedback_agent_teams_force_shutdown.md` (NEW): tmux kill-pane fallback 절차 — #1210
-- `feedback_background_agent_progress_tracking.md` (NEW): CC upstream API 부재, workarounds + monitoring — #1212
+## :test_tube: Tests
+- `tests/unit/core/installer.test.ts`: 4 new cases — src+dst-empty→copy, dst-exists+no-force→skip, dst-exists+force→overwrite, src-missing→warn
 
 ## Resource Changes
-| Resource | Before (v0.149.0) | After (v0.150.0) | Delta |
-|----------|-------------------|-------------------|-------|
-| Agents | 50 | 49 | -1 (count correction) |
+| Resource | Before | After | Delta |
+|----------|--------|-------|-------|
+| Agents | 49 | 49 | 0 |
 | Skills | 121 | 121 | 0 |
 | Rules | 23 | 23 | 0 |
-| Guides | 57 | 58 | +1 (agent-teams 디렉토리 — claude-code-tracking은 기존 claude-code/와 별개 단일 파일) |
+| Guides | 58 | 58 | 0 |
+| Tests | 1984 | 1988 | +4 |
 
 ## Closed Issues
-- #1208 — R010 violation: orchestrator direct .gitignore edit + main push policy inconsistency
-- #1210 — Agent Teams graceful shutdown + tmux kill fallback 표준화 (#1206 item 2)
-- #1211 — omcustom-init 템플릿에 tests/tsconfig.json 추가 (#1206 item 5)
-- #1212 — Background agent 진행 추적 (CC upstream tracking) (#1206 item 7)
-
-## Follow-up
-- #1213 — installer 로직 (tests/tsconfig.json 자동 설치) — #1211 follow-up
+- #1213 — omcustom-init installer: tests/tsconfig.json 자동 설치 로직 추가 (#1211 follow-up)
 
 ---
-_Release notes generated with Claude Code (oh-my-customcode auto-dev pipeline v2.1.0)_
+_Patch release — installer logic for tests/tsconfig.json template_

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -298,6 +298,33 @@ async function installStatusline(
 }
 
 /**
+ * Install tests/tsconfig.json to the target directory
+ */
+async function installTestsConfig(
+  targetDir: string,
+  options: InstallOptions,
+  _result: InstallResult
+): Promise<void> {
+  const srcPath = resolveTemplatePath(join('tests', 'tsconfig.json'));
+  const destPath = join(targetDir, 'tests', 'tsconfig.json');
+
+  if (!(await fileExists(srcPath))) {
+    debug('install.tests_config_not_found', { path: srcPath });
+    return;
+  }
+
+  if (await fileExists(destPath)) {
+    if (!options.force && !options.backup) {
+      debug('install.tests_config_skipped', { reason: 'exists' });
+      return;
+    }
+  }
+
+  await copyFile(srcPath, destPath);
+  debug('install.tests_config_installed', {});
+}
+
+/**
  * Create or merge settings.local.json with statusLine configuration
  */
 async function installSettingsLocal(targetDir: string, result: InstallResult): Promise<void> {
@@ -433,6 +460,7 @@ export async function install(options: InstallOptions): Promise<InstallResult> {
 
     await installAllComponents(options.targetDir, options, result);
     await installStatusline(options.targetDir, options, result);
+    await installTestsConfig(options.targetDir, options, result);
     await installSettingsLocal(options.targetDir, result);
     await installEntryDocWithTracking(options.targetDir, options, result);
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.150.0",
+  "version": "0.150.1",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",
@@ -52,12 +52,24 @@
     "minimal": {
       "description": "Essential assets only — core SW Engineers + Managers. Reduces deactivation cost on first use.",
       "include": {
-        "agents": ["mgr-*", "lang-*-expert", "sys-memory-keeper"],
-        "skills": [
-          {"scope": "core"},
-          {"scope": "harness"}
+        "agents": [
+          "mgr-*",
+          "lang-*-expert",
+          "sys-memory-keeper"
         ],
-        "guides": ["agent-design", "git-safety", "claude-code"]
+        "skills": [
+          {
+            "scope": "core"
+          },
+          {
+            "scope": "harness"
+          }
+        ],
+        "guides": [
+          "agent-design",
+          "git-safety",
+          "claude-code"
+        ]
       }
     },
     "full": {
@@ -82,7 +94,9 @@
           "mgr-*"
         ],
         "skills": [
-          {"scope": "core"},
+          {
+            "scope": "core"
+          },
           "react-best-practices",
           "typescript-best-practices",
           "fastapi-best-practices",
@@ -117,7 +131,9 @@
           "mgr-*"
         ],
         "skills": [
-          {"scope": "core"},
+          {
+            "scope": "core"
+          },
           "airflow-best-practices",
           "dbt-best-practices"
         ],
@@ -141,7 +157,9 @@
           "tracker-checkpoint"
         ],
         "skills": [
-          {"scope": "harness"}
+          {
+            "scope": "harness"
+          }
         ],
         "guides": [
           "agent-design",

--- a/tests/unit/core/installer.test.ts
+++ b/tests/unit/core/installer.test.ts
@@ -386,6 +386,70 @@ describe('installer', () => {
     });
   });
 
+  describe('tests/tsconfig.json installation', () => {
+    it('should install tests/tsconfig.json during init', async () => {
+      await install({ targetDir: tempDir, skipConfirm: true });
+      const testsConfigPath = join(tempDir, 'tests', 'tsconfig.json');
+      expect(await fileExists(testsConfigPath)).toBe(true);
+    });
+
+    it('should skip tests/tsconfig.json if already exists and no force', async () => {
+      // First install
+      await install({ targetDir: tempDir, skipConfirm: true });
+      const testsConfigPath = join(tempDir, 'tests', 'tsconfig.json');
+
+      // Modify to detect overwrite
+      const fs = await import('node:fs/promises');
+      await fs.writeFile(testsConfigPath, '{ "custom": true }', 'utf-8');
+
+      // Second install without force
+      await install({ targetDir: tempDir, skipConfirm: true });
+
+      // Should still be our custom content
+      const content = await fs.readFile(testsConfigPath, 'utf-8');
+      expect(content).toContain('"custom"');
+    });
+
+    it('should overwrite tests/tsconfig.json with force option', async () => {
+      // First install
+      await install({ targetDir: tempDir, skipConfirm: true });
+      const testsConfigPath = join(tempDir, 'tests', 'tsconfig.json');
+
+      // Modify to detect overwrite
+      const fs = await import('node:fs/promises');
+      await fs.writeFile(testsConfigPath, '{ "custom": true }', 'utf-8');
+
+      // Second install with force
+      await install({ targetDir: tempDir, force: true, skipConfirm: true });
+
+      // Should be overwritten (no longer custom)
+      const content = await fs.readFile(testsConfigPath, 'utf-8');
+      expect(content).not.toContain('"custom"');
+    });
+
+    it('should skip gracefully when tests/tsconfig.json template is missing', async () => {
+      // Mock fileExists to return false for tests/tsconfig.json template source
+      const originalFileExists = fsUtils.fileExists;
+      const fileExistsSpy = spyOn(fsUtils, 'fileExists').mockImplementation(async (path) => {
+        const pathStr = String(path);
+        if (pathStr.includes('templates') && pathStr.endsWith(join('tests', 'tsconfig.json'))) {
+          return false;
+        }
+        return originalFileExists(path);
+      });
+
+      const result = await install({
+        targetDir: tempDir,
+        skipConfirm: true,
+      });
+
+      // Install should still succeed even without the template
+      expect(result.success).toBe(true);
+
+      fileExistsSpy.mockRestore();
+    });
+  });
+
   describe('statusline installation', () => {
     it('should install statusline.sh during init', async () => {
       await install({ targetDir: tempDir, skipConfirm: true });


### PR DESCRIPTION
## 요약

#1211(v0.150.0)에서 추가한 `templates/tests/tsconfig.json` 템플릿을 신규 프로젝트 부트스트랩 시 자동으로 `tests/tsconfig.json`으로 복사하도록 installer 로직 보완.

## Closes
Closes #1213

## Test plan
- [x] bun test: 1988 pass / 0 fail (+4 new)
- [x] lint / typecheck / build: OK
- [x] verify-template-sync / verify-wiki-sync / verify-version-sync: OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)