### PR TITLE
release: v0.151.0 — CC v2.1.147–v2.1.150 호환성 문서 + R020/R017 룰 강화

### DIFF
--- a/.claude/rules/MUST-completion-verification.md
+++ b/.claude/rules/MUST-completion-verification.md
@@ -73,6 +73,15 @@ Never accept "pre-existing" without direct base-branch evidence. A false "pre-ex
 
 ## Common False Completion Patterns — 8 anti-patterns including "Command executed" without exit code check, "Waiting for manual publish" when CI auto-publishes, "UI changes done" without browser render. See full table via Read tool.
 
+### Test-Skip Is Not Completion (#1217 item #5)
+
+테스트 실패를 `describe.skip`/`xfail`/`it.skip` + coverage threshold 하향으로 회피하는 것은 완료가 아니다. 근본 원인 분석 없이 그린 빌드를 만드는 회피는 기술 부채를 다음 마이너로 이월시킨다.
+
+| 금지 | 필수 |
+|------|------|
+| 실패 테스트 skip + threshold 하향으로 그린 빌드 | 근본 원인 분석 후 수정, 불가 시 명시적 deferral + 이슈 등록 |
+| "다음 버전 TODO" 주석만 남기고 머지 | skip 사유·복구 조건·추적 이슈를 함께 기록 |
+
 <!-- DETAIL: Common False Completion Patterns
 
 | Pattern | Reality | Fix |
@@ -142,6 +151,25 @@ Related memory records:
 | "사과만 짧게" | 부족 — plan 재정렬 후속 필수 |
 
 Reference issues: #1188 item #8.
+
+## Diagnostic Hypothesis Verification
+
+진단 단계에서 채택한 가설로 워크플로우/인프라/설정을 **영구 변경하기 전**, 가설을 실제 증거로 검증해야 한다. "그럴듯한 가설"을 검증 없이 영구 변경에 적용하면 잘못된 추정이 영구 부채로 남는다.
+
+| 상황 | 금지 | 필수 |
+|------|------|------|
+| 에러 원인 추정 | 첫 가설로 워크플로우/설정 영구 수정 | 가설을 좁은 범위에서 검증 후 변경 |
+| CI/publish 실패 | 추정 기반 우회 커밋 머지 | 에러 메시지/로그로 실제 원인 확정 |
+| 권한/토큰 오류 | 플래그/옵션 변경으로 우회 시도 | 권한 범위·토큰 종류 직접 확인 |
+
+### Common Violation (#1217 item #4)
+npm publish E403을 `--provenance` attestation 충돌로 오진단 → release workflow에서 `--provenance` 제거 커밋 머지 → 2차 시도 동일 실패 → 실제 원인은 NPM_TOKEN 권한(Automation token 필요). 잘못된 추정으로 릴리즈 워크플로우를 영구 변경.
+
+### Self-Check (영구 변경 전)
+1. 가설을 뒷받침하는 직접 증거(로그/에러 코드/문서)가 있는가?
+2. 비파괴적 방법으로 가설을 검증할 수 있는가?
+3. 변경이 되돌리기 쉬운가? (영구 워크플로우 변경 vs 일회성 시도)
+하나라도 NO면 검증을 먼저 수행한다. 근본 원인 진단은 `superpowers:systematic-debugging` 참조.
 
 ## Integration
 

--- a/.claude/rules/MUST-sync-verification.md
+++ b/.claude/rules/MUST-sync-verification.md
@@ -81,6 +81,27 @@ Wiki verification is also enforced by CI (`.github/workflows/wiki-sync.yml`).
 
 Any change to: agents, agent frontmatter, skills, guides, routing patterns, rules, wiki pages.
 
+## Structural Migration Verification
+
+디렉토리 재구조화, 템플릿 평탄화(flat templates), 브랜치 전략 변경 등 **구조 마이그레이션** 시, 경로 참조와 파일 존재성 회귀를 사전 검사해야 한다. 표준 5-round 검증이 콘텐츠 정합성에 집중하는 반면, 구조 마이그레이션은 경로·존재성 회귀를 별도로 점검한다.
+
+| 마이그레이션 유형 | 검사 항목 |
+|------------------|-----------|
+| 디렉토리 재구조화 | 모든 경로 참조(스크립트, 테스트, CI workflow)가 새 경로로 업데이트되었는가 |
+| 템플릿 평탄화 | validate-docs/sync 스크립트가 새 경로를 참조하는가 |
+| 브랜치 전략 변경 | CI trigger 경로, 파일 git tracked 상태가 일관되는가 |
+| 파일 존재성 | 테스트가 read하는 파일이 CI 체크아웃 환경(clean clone)에 존재(git tracked)하는가 |
+
+### Common Violations (#1217 items #2/#3/#7)
+- flat templates 마이그레이션 후 `validate-docs.ts`가 옛 경로 참조 → G1 CI 실패
+- `CLAUDE.md` untracked → strict allowlist `.gitignore`와 결합되어 CI 체크아웃 환경에서 ENOENT
+- release/develop 듀얼 브랜치 전환 시 `verify-template-sync.sh`가 임시 skip 상태로 머지
+
+### Self-Check (구조 마이그레이션 커밋 전)
+1. `grep`으로 옛 경로 참조 잔존을 확인했는가?
+2. 테스트가 읽는 파일의 git tracked 상태를 확인했는가? (`git ls-files` 대조)
+3. 임시 skip된 검증 스크립트/테스트가 남아있지 않은가?
+
 ## Quick Verification Commands — agent/skill/guide/wiki counts via ls/find/wc. See commands via Read tool.
 
 <!-- DETAIL: Quick Verification Commands

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.150.1",
-  "generatedAt": "2026-05-21T13:07:31.492Z",
-  "templateVersion": "0.150.1",
+  "generatorVersion": "0.151.0",
+  "generatedAt": "2026-05-24T03:09:54.617Z",
+  "templateVersion": "0.151.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "dc6ce94ab01e1c6abb76e0a1a33b472a47f21706921e63f61ce2fb43bab9a9cf",
@@ -60,8 +60,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-sync-verification.md": {
-      "templateHash": "b83793f4438ed686d0e0b2404b866ab2ffa2816779cd82bbba4fa2e5ffbe6dc3",
-      "size": 6518,
+      "templateHash": "1c740e3a4a4b402bf674727db961cb6df46c4c64ccc6a9dc0dba1653db5c3fd6",
+      "size": 8073,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-teams.md": {
@@ -120,8 +120,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-completion-verification.md": {
-      "templateHash": "6cf25e28123cd6158e10012c5814895fff0ac80afb5abbfb8b566a88e0c10202",
-      "size": 7808,
+      "templateHash": "198560ce7eb6352ce4698aa2573bbf5c4c1489ac667f71cd3ac0d3c9f1ab0594",
+      "size": 9839,
       "component": "rules"
     },
     ".claude/agents/be-springboot-expert.md": {
@@ -1430,8 +1430,8 @@
       "component": "guides"
     },
     "guides/claude-code/15-version-compatibility.md": {
-      "templateHash": "dcd4e37fd6c83c1e2b02dc0f473a273693748c87db98cbad484c3e72ca302b78",
-      "size": 42387,
+      "templateHash": "be3e1e7e0cd6146bd8a1e1c4b515620448f233a5cd1e5a3beaf7e357edb58157",
+      "size": 52342,
       "component": "guides"
     },
     "guides/claude-code/11-sub-agents.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.151.0] - 2026-05-24
+
+### Added — CC v2.1.147–v2.1.150 호환성 문서화 (#1216 #1218 #1219 #1220)
+- `guides/claude-code/15-version-compatibility.md`: CC v2.1.147–v2.1.150 호환성 섹션
+  - v2.1.147: `Workflow` 도구(`CLAUDE_CODE_WORKFLOWS=1`) 도입, `/simplify`→`/code-review` 슬래시 커맨드 개명, plugin agent 복수 `Agent()` 타입 fix (#1216)
+  - v2.1.148: Bash 도구 exit 127 regression 수정 (#1218)
+  - v2.1.149: `/usage` per-category breakdown, GFM 체크박스 지원, worktree sandbox fix, `find` macOS crash fix (#1219)
+  - v2.1.150: 내부 인프라 개선만, 별도 조치 불필요 (#1220)
+
+### Changed — 룰 강화 (#1217)
+- R020 (`MUST-completion-verification`): `Diagnostic Hypothesis Verification` 섹션 추가 — 진단 가설을 영구 변경 전 검증 (npm publish E403 오진단 재발 방지)
+- R020 (`MUST-completion-verification`): `Test-Skip Is Not Completion` 섹션 추가 — 테스트 skip + threshold 하향 회피 금지
+- R017 (`MUST-sync-verification`): `Structural Migration Verification` 섹션 추가 — 디렉토리 재구조화·템플릿 평탄화·브랜치 전략 변경 시 경로/존재성 회귀 사전 검사
+
 ## [0.150.1] - 2026-05-21
 
 ### Added

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2334,7 +2334,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.150.1",
+    version: "0.151.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.150.1",
+  version: "0.151.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/guides/claude-code/15-version-compatibility.md
+++ b/guides/claude-code/15-version-compatibility.md
@@ -487,6 +487,10 @@ docs/superpowers/plans/**
 | v2.1.144 | 호환 가능. CLAUDE.md `omcustomMinClaudeCode` v2.1.121 유지. macOS bg session FDA crash fix 확인. | None |
 | v2.1.145 | docs-only. `claude agents --json` HUD 강화, Stop/SubagentStop hook `background_tasks`/`session_crons` 활용, status line GitHub PR 통합 — 별도 follow-up 권장. | P3 follow-up |
 | v2.1.146 | docs-only. `/simplify`→`/code-review` 리네임 + effort level, AskUserQuestion auto-mode normalization, MCP pagination 안정성, `CLAUDE_CODE_SUBAGENT_MODEL` 자식 프로세스 전파 fix. | None |
+| v2.1.147 | `Workflow` 도구(`CLAUDE_CODE_WORKFLOWS=1`) 추가 — /pipeline과 개념 중첩, 통합 검토 후보. `/simplify`→`/code-review` 개명. plugin agent 복수 `Agent()` 타입 fix. | P3 follow-up |
+| v2.1.148 | Bash 도구 exit 127 regression(v2.1.147 도입) 수정 — v2.1.147 사용 시 즉시 업그레이드 권장. | None |
+| v2.1.149 | `/usage` per-category(skills/subagents/plugins/MCP) breakdown, GFM 체크박스 렌더링, worktree sandbox allowlist fix, `find` macOS vnode crash fix. | P3 follow-up |
+| v2.1.150 | 내부 인프라 개선만, 사용자 대면 변경 없음. 조치 불필요. | None |
 
 ## v2.1.144 (2026-05-19) — 호환성 점검
 
@@ -711,6 +715,180 @@ Auto mode에서 user 또는 skill이 명시적으로 요청한 경우 `AskUserQu
 
 ---
 
+## v2.1.147 (2026-05-21) — 호환성 점검
+
+> Issue: #1216 — Claude Code v2.1.147 compatibility documentation
+
+### `Workflow` 도구 추가 (기본 off)
+
+deterministic multi-agent orchestration을 위한 새 `Workflow` 도구가 추가되었습니다. `CLAUDE_CODE_WORKFLOWS=1` 환경 변수로 활성화할 수 있으며, 기본값은 비활성입니다.
+
+**oh-my-customcode 연관**: oh-my-customcode `/pipeline` 스킬(workflows/*.yaml 기반)과 개념적으로 중첩됩니다. 향후 네이티브 `Workflow` 도구 통합 검토 후보이나, 현재 기본 off이므로 영향 없음. 호환.
+
+### `/simplify` → `/code-review` 개명 (+ effort level, `--comment`)
+
+기존 `/simplify` 슬래시 커맨드가 `/code-review`로 개명되었습니다. 선택한 effort 수준으로 correctness 버그를 보고하며(`/code-review high`), `--comment` 플래그로 inline PR 코멘트를 게시할 수 있습니다. 기존 cleanup-and-fix 동작은 제거되었습니다.
+
+**oh-my-customcode 연관**: CC 빌트인 `/code-review`와 내부 `dev-review`/`code-review` 스킬의 명칭 혼동 방지 안내가 필요합니다. v2.1.146에서 최초 리네임된 내용의 연속입니다. `.claude/skills/intent-detection/patterns/agent-triggers.yaml`의 `skill-simplify` 라우팅 엔트리는 내부 스킬 라우팅이므로 CC 빌트인 제거와 무관하나, 명명 혼동 방지를 위해 점검이 권장됩니다.
+
+### REPL 및 Workflow 도구 샌드박스 강화
+
+prototype-pollution 및 thenable 기반 escape에 대한 샌드박스 보안이 강화되었습니다.
+
+**oh-my-customcode 연관**: R001 안전 규칙과 정합. 보안 강화이므로 호환, 개선.
+
+### plugin agent 복수 `Agent(...)` 타입 fix
+
+plugin agents가 `tools:` frontmatter에 복수 `Agent(...)` 타입을 선언 시 마지막 항목만 남기고 나머지를 드롭하던 버그가 수정되었습니다.
+
+**oh-my-customcode 연관**: oh-my-customcode 에이전트 frontmatter에서 `tools:`에 복수 Agent() 타입을 선언하는 경우 이전에는 마지막만 인식되었습니다. 영향 점검이 권장됩니다.
+
+### hook `if` 조건 매칭 버그 수정
+
+hook `if` 조건(예: `PowerShell(git push*)`)이 매칭되지 않던 버그가 수정되었습니다 (`PowerShell(*)`만 동작했음).
+
+**oh-my-customcode 연관**: `.claude/hooks/` 내 조건부 hook(`if` 필드 사용)의 정확한 매칭이 보장됩니다. R001 안전 규칙의 stage-blocker hook 신뢰성이 향상됩니다. 호환, 개선.
+
+### 기타 수정
+
+- auto-updater 개선: transient 네트워크 실패 재시도, OS 에러 코드 보고
+- diff 렌더링 성능 개선
+- prompt history 연속 중복 제거
+- enterprise login 제한 강제 수정
+
+**oh-my-customcode 연관**: 일반 안정성 개선. 직접 영향 없음.
+
+### oh-my-customcode 연관 평가
+
+| 변경 | oh-my-customcode 영향 | 조치 |
+|------|----------------------|------|
+| `Workflow` 도구 추가 (기본 off) | `/pipeline` 스킬과 개념 중첩, 향후 통합 후보 | 호환, follow-up 후보 |
+| `/simplify` → `/code-review` 개명 | 내부 `dev-review` 스킬과 명칭 혼동 주의 | 호환, agent-triggers.yaml 점검 권장 |
+| REPL/Workflow 샌드박스 강화 | R001 보안 강화 | 호환, 개선 |
+| plugin agent 복수 Agent() 타입 fix | frontmatter `tools:` 복수 Agent() 선언 영향 점검 | 호환, 영향 점검 권장 |
+| hook `if` 조건 매칭 fix | stage-blocker hook 신뢰성 향상 | 호환, 개선 |
+| auto-updater / diff / history 개선 | 일반 안정성 | 호환 |
+
+**Action items**:
+- 본 릴리스에서 코드 변경 없음 (docs-only)
+- 후속 follow-up 후보:
+  1. CC 빌트인 `/code-review`와 내부 `dev-review` skill 구분 안내 보강
+  2. `agent-triggers.yaml`의 `skill-simplify` 엔트리 명명 혼동 방지 점검
+  3. plugin agent frontmatter `tools:` 복수 Agent() 선언 영향 점검
+  4. `Workflow` 도구와 `/pipeline` 스킬 통합 가능성 연구 (중장기)
+
+---
+
+## v2.1.148 (2026-05-22) — 호환성 점검
+
+> Issue: #1218 — Claude Code v2.1.148 compatibility documentation
+
+### Bash 도구 exit code 127 regression 수정 (긴급)
+
+v2.1.147에서 도입된 regression으로, 일부 사용자에게서 Bash 도구가 모든 명령에 대해 exit code 127을 반환하던 버그가 수정되었습니다.
+
+**oh-my-customcode 연관**: Bash 도구를 사용하는 gh, git, 빌드/테스트 명령 등 oh-my-customcode 워크플로우 전반에 영향을 줍니다. v2.1.147을 사용 중이라면 v2.1.148로 즉시 업그레이드가 권장됩니다.
+
+### oh-my-customcode 연관 평가
+
+| 변경 | oh-my-customcode 영향 | 조치 |
+|------|----------------------|------|
+| Bash exit code 127 regression fix | 모든 Bash 도구 사용 워크플로우 복구 | 즉시 업그레이드 권장 |
+
+**Action items**:
+- v2.1.147 사용 중이면 v2.1.148로 즉시 업그레이드
+- 본 릴리스에서 코드 변경 없음 (docs-only)
+
+---
+
+## v2.1.149 (2026-05-22) — 호환성 점검
+
+> Issue: #1219 — Claude Code v2.1.149 compatibility documentation
+
+### `/usage` per-category 사용량 분석
+
+`/usage`가 limits 사용량 분석을 카테고리별로 표시합니다: skills, subagents, plugins, per-MCP-server 비용 세분화.
+
+**oh-my-customcode 연관**: R013 ecomode 토큰 추적, R012 statusline, `token-efficiency-audit` 스킬과 연관됩니다. per-MCP 비용 가시성 덕분에 `claude-mem`, `ontology-rag` 등 R011/R019 MCP 서버의 비용을 모니터링할 수 있습니다. 호환, 개선.
+
+### `/diff` 키보드 스크롤 지원
+
+`/diff` 상세 뷰에서 키보드 스크롤이 지원됩니다 (arrows, j/k, PgUp/PgDn, Space, Home/End).
+
+**oh-my-customcode 연관**: 코드 리뷰 워크플로우의 UX 향상. 직접 harness 변경 불필요.
+
+### GFM 체크박스 렌더링
+
+Markdown 출력이 GFM task list 체크박스(`- [ ]`/`- [x]`)를 일반 bullet 대신 체크박스로 렌더링합니다.
+
+**oh-my-customcode 연관**: 에이전트 작업 목록(`- [ ]`/`- [x]`) 출력 가독성이 향상됩니다. 호환, 개선.
+
+### git worktree 샌드박스 write allowlist 수정
+
+git worktree에서 sandbox write allowlist가 main repo root 전체 대신 공유 `.git` 디렉토리만 커버하도록 수정되었습니다 (hooks/, config는 deny).
+
+**oh-my-customcode 연관**: `EnterWorktree` 사용 시 보안이 강화됩니다. R001 안전 규칙과 정합. 호환, 보안 개선.
+
+### Bash `find` macOS 크래시 버그 수정
+
+Bash 도구의 `find` 명령이 macOS system file/vnode table을 소진하여 호스트를 크래시시키던 버그가 수정되었습니다.
+
+**oh-my-customcode 연관**: Bash 도구로 대형 디렉토리를 탐색하는 oh-my-customcode 워크플로우의 호스트 안정성이 향상됩니다. 중요한 수정이므로 업그레이드가 권장됩니다.
+
+### `/ultraplan` 및 remote session 생성 수정
+
+작업 트리에 실제 변경이 없을 때 "Could not capture uncommitted changes"로 실패하던 버그가 수정되었습니다.
+
+**oh-my-customcode 연관**: `/ultraplan` 및 remote session 기반 워크플로우 안정성이 향상됩니다. 호환, 개선.
+
+### 기타 수정
+
+- enterprise `allowAllClaudeAiMcps` managed setting 추가
+- PowerShell 권한 우회 수정 (built-in `cd` 함수): macOS 환경 직접 영향 없음
+
+**oh-my-customcode 연관**: macOS 개발 환경에는 직접 영향 없음.
+
+### oh-my-customcode 연관 평가
+
+| 변경 | oh-my-customcode 영향 | 조치 |
+|------|----------------------|------|
+| `/usage` per-category breakdown | R013 ecomode / R012 statusline / MCP 비용 가시성 | 호환, 개선 |
+| `/diff` 키보드 스크롤 | 코드 리뷰 UX 향상 | 호환, 개선 |
+| GFM 체크박스 렌더링 | 에이전트 작업 목록 가독성 향상 | 호환, 개선 |
+| worktree sandbox write allowlist fix | EnterWorktree 보안 강화 | 호환, 보안 개선 |
+| Bash `find` macOS 크래시 fix | 대형 디렉토리 탐색 호스트 안정성 향상 | 업그레이드 권장 |
+| `/ultraplan` 생성 fix | remote session 워크플로우 안정성 | 호환, 개선 |
+| PowerShell `cd` 권한 fix | macOS 영향 없음 | 호환 |
+
+**Action items**:
+- 본 릴리스에서 코드 변경 없음 (docs-only)
+- 후속 follow-up 후보:
+  1. `/usage` per-MCP-server 비용 데이터를 `token-efficiency-audit` 스킬에 통합 검토
+  2. R012 statusline에 per-category usage 표시 강화 검토
+
+---
+
+## v2.1.150 (2026-05-23) — 호환성 점검
+
+> Issue: #1220 — Claude Code v2.1.150 compatibility documentation
+
+### 내부 인프라 개선
+
+내부 인프라 개선으로, 사용자 대면 변경 사항은 없습니다.
+
+**oh-my-customcode 연관**: 코드 및 문서 변경 불필요. 추적 기록용 docs-only 항목입니다.
+
+### oh-my-customcode 연관 평가
+
+| 변경 | oh-my-customcode 영향 | 조치 |
+|------|----------------------|------|
+| 내부 인프라 개선 | 사용자 대면 변경 없음 | 조치 불필요 |
+
+**Action items**:
+- 코드 및 문서 변경 불필요 (추적 기록용 docs-only)
+
+---
+
 ## References
 
 - #967 — Claude Code v2.1.117 release note
@@ -724,6 +902,10 @@ Auto mode에서 user 또는 skill이 명시적으로 요청한 경우 `AskUserQu
 - #1187 — Claude Code v2.1.144 compatibility documentation
 - #1191 — Claude Code v2.1.145 compatibility documentation
 - #1205 — Claude Code v2.1.146 compatibility documentation
+- #1216 — Claude Code v2.1.147 compatibility documentation
+- #1218 — Claude Code v2.1.148 compatibility documentation
+- #1219 — Claude Code v2.1.149 compatibility documentation
+- #1220 — Claude Code v2.1.150 compatibility documentation
 - `.claude/skills/claude-native/` — auto-generation source
 - `.claude/rules/SHOULD-hud-statusline.md` — R012 statusline integration
 - `.claude/rules/MUST-agent-design.md` — R006 agent frontmatter spec

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.150.1",
+  "version": "0.151.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-completion-verification.md
+++ b/templates/.claude/rules/MUST-completion-verification.md
@@ -73,6 +73,15 @@ Never accept "pre-existing" without direct base-branch evidence. A false "pre-ex
 
 ## Common False Completion Patterns — 8 anti-patterns including "Command executed" without exit code check, "Waiting for manual publish" when CI auto-publishes, "UI changes done" without browser render. See full table via Read tool.
 
+### Test-Skip Is Not Completion (#1217 item #5)
+
+테스트 실패를 `describe.skip`/`xfail`/`it.skip` + coverage threshold 하향으로 회피하는 것은 완료가 아니다. 근본 원인 분석 없이 그린 빌드를 만드는 회피는 기술 부채를 다음 마이너로 이월시킨다.
+
+| 금지 | 필수 |
+|------|------|
+| 실패 테스트 skip + threshold 하향으로 그린 빌드 | 근본 원인 분석 후 수정, 불가 시 명시적 deferral + 이슈 등록 |
+| "다음 버전 TODO" 주석만 남기고 머지 | skip 사유·복구 조건·추적 이슈를 함께 기록 |
+
 <!-- DETAIL: Common False Completion Patterns
 
 | Pattern | Reality | Fix |
@@ -130,6 +139,37 @@ Related memory records:
 - `feedback_github_workflows_inventory.md` — original incident (v0.87.2~v0.88.0 session)
 - `feedback_subagent_pre_existing_claims.md` — subagent false-positive pattern
 -->
+
+## Interrupt Priority Re-Ordering
+
+사용자 인터럽트 / 새 요청 / 룰 위반 지적 동시 수신 시, 사과 한 줄 후 즉시 작업 통합 plan 재정렬. "사과만 짧게 + 기존 흐름 유지" 패턴 금지.
+
+| 시나리오 | Required 행동 |
+|---------|--------------|
+| 새 작업 + 룰 위반 지적 동시 | (1) 룰 위반 즉시 수정 (2) 새 작업 통합 plan 제시 (3) 사용자 확인 후 진행 |
+| 인터럽트 후 기존 작업 진행 | 인터럽트 내용 통합 또는 명시적 deferral 후 진행 |
+| "사과만 짧게" | 부족 — plan 재정렬 후속 필수 |
+
+Reference issues: #1188 item #8.
+
+## Diagnostic Hypothesis Verification
+
+진단 단계에서 채택한 가설로 워크플로우/인프라/설정을 **영구 변경하기 전**, 가설을 실제 증거로 검증해야 한다. "그럴듯한 가설"을 검증 없이 영구 변경에 적용하면 잘못된 추정이 영구 부채로 남는다.
+
+| 상황 | 금지 | 필수 |
+|------|------|------|
+| 에러 원인 추정 | 첫 가설로 워크플로우/설정 영구 수정 | 가설을 좁은 범위에서 검증 후 변경 |
+| CI/publish 실패 | 추정 기반 우회 커밋 머지 | 에러 메시지/로그로 실제 원인 확정 |
+| 권한/토큰 오류 | 플래그/옵션 변경으로 우회 시도 | 권한 범위·토큰 종류 직접 확인 |
+
+### Common Violation (#1217 item #4)
+npm publish E403을 `--provenance` attestation 충돌로 오진단 → release workflow에서 `--provenance` 제거 커밋 머지 → 2차 시도 동일 실패 → 실제 원인은 NPM_TOKEN 권한(Automation token 필요). 잘못된 추정으로 릴리즈 워크플로우를 영구 변경.
+
+### Self-Check (영구 변경 전)
+1. 가설을 뒷받침하는 직접 증거(로그/에러 코드/문서)가 있는가?
+2. 비파괴적 방법으로 가설을 검증할 수 있는가?
+3. 변경이 되돌리기 쉬운가? (영구 워크플로우 변경 vs 일회성 시도)
+하나라도 NO면 검증을 먼저 수행한다. 근본 원인 진단은 `superpowers:systematic-debugging` 참조.
 
 ## Integration
 

--- a/templates/.claude/rules/MUST-sync-verification.md
+++ b/templates/.claude/rules/MUST-sync-verification.md
@@ -81,6 +81,27 @@ Wiki verification is also enforced by CI (`.github/workflows/wiki-sync.yml`).
 
 Any change to: agents, agent frontmatter, skills, guides, routing patterns, rules, wiki pages.
 
+## Structural Migration Verification
+
+디렉토리 재구조화, 템플릿 평탄화(flat templates), 브랜치 전략 변경 등 **구조 마이그레이션** 시, 경로 참조와 파일 존재성 회귀를 사전 검사해야 한다. 표준 5-round 검증이 콘텐츠 정합성에 집중하는 반면, 구조 마이그레이션은 경로·존재성 회귀를 별도로 점검한다.
+
+| 마이그레이션 유형 | 검사 항목 |
+|------------------|-----------|
+| 디렉토리 재구조화 | 모든 경로 참조(스크립트, 테스트, CI workflow)가 새 경로로 업데이트되었는가 |
+| 템플릿 평탄화 | validate-docs/sync 스크립트가 새 경로를 참조하는가 |
+| 브랜치 전략 변경 | CI trigger 경로, 파일 git tracked 상태가 일관되는가 |
+| 파일 존재성 | 테스트가 read하는 파일이 CI 체크아웃 환경(clean clone)에 존재(git tracked)하는가 |
+
+### Common Violations (#1217 items #2/#3/#7)
+- flat templates 마이그레이션 후 `validate-docs.ts`가 옛 경로 참조 → G1 CI 실패
+- `CLAUDE.md` untracked → strict allowlist `.gitignore`와 결합되어 CI 체크아웃 환경에서 ENOENT
+- release/develop 듀얼 브랜치 전환 시 `verify-template-sync.sh`가 임시 skip 상태로 머지
+
+### Self-Check (구조 마이그레이션 커밋 전)
+1. `grep`으로 옛 경로 참조 잔존을 확인했는가?
+2. 테스트가 읽는 파일의 git tracked 상태를 확인했는가? (`git ls-files` 대조)
+3. 임시 skip된 검증 스크립트/테스트가 남아있지 않은가?
+
 ## Quick Verification Commands — agent/skill/guide/wiki counts via ls/find/wc. See commands via Read tool.
 
 <!-- DETAIL: Quick Verification Commands

--- a/templates/guides/claude-code/15-version-compatibility.md
+++ b/templates/guides/claude-code/15-version-compatibility.md
@@ -486,6 +486,11 @@ docs/superpowers/plans/**
 | v2.1.143 | 직접 변경 불필요. `worktree.bgIsolation: "none"` opt-in 시 파일 소유권 규율 필수. Stop hook 8회 block cap 인지. | P3 follow-up |
 | v2.1.144 | 호환 가능. CLAUDE.md `omcustomMinClaudeCode` v2.1.121 유지. macOS bg session FDA crash fix 확인. | None |
 | v2.1.145 | docs-only. `claude agents --json` HUD 강화, Stop/SubagentStop hook `background_tasks`/`session_crons` 활용, status line GitHub PR 통합 — 별도 follow-up 권장. | P3 follow-up |
+| v2.1.146 | docs-only. `/simplify`→`/code-review` 리네임 + effort level, AskUserQuestion auto-mode normalization, MCP pagination 안정성, `CLAUDE_CODE_SUBAGENT_MODEL` 자식 프로세스 전파 fix. | None |
+| v2.1.147 | `Workflow` 도구(`CLAUDE_CODE_WORKFLOWS=1`) 추가 — /pipeline과 개념 중첩, 통합 검토 후보. `/simplify`→`/code-review` 개명. plugin agent 복수 `Agent()` 타입 fix. | P3 follow-up |
+| v2.1.148 | Bash 도구 exit 127 regression(v2.1.147 도입) 수정 — v2.1.147 사용 시 즉시 업그레이드 권장. | None |
+| v2.1.149 | `/usage` per-category(skills/subagents/plugins/MCP) breakdown, GFM 체크박스 렌더링, worktree sandbox allowlist fix, `find` macOS vnode crash fix. | P3 follow-up |
+| v2.1.150 | 내부 인프라 개선만, 사용자 대면 변경 없음. 조치 불필요. | None |
 
 ## v2.1.144 (2026-05-19) — 호환성 점검
 
@@ -640,6 +645,250 @@ Agent Teams 멤버 이름에 non-ASCII 문자(한국어 포함)가 포함된 경
 
 ---
 
+## v2.1.146 (2026-05-21) — 호환성 점검
+
+> Issue: #1205 — Claude Code v2.1.146 compatibility documentation
+
+### `/simplify` → `/code-review` 리네임 (+ effort level)
+
+기존 `/simplify` 슬래시 커맨드가 `/code-review`로 리네임되었습니다. effort level을 인수로 지정할 수 있습니다 (예: `/code-review high`).
+
+**oh-my-customcode 연관**: 내부 `dev-review` 스킬과 명칭이 다르며 충돌 없음. 사용자가 네이티브 `/code-review`와 omcustom `dev-review` 스킬을 혼동하지 않도록 구분 안내가 필요할 수 있습니다 (별도 follow-up 후보). 직접 harness 변경 불필요.
+
+### Auto mode `AskUserQuestion` 억제 해제
+
+Auto mode에서 user 또는 skill이 명시적으로 요청한 경우 `AskUserQuestion` 호출이 더 이상 억제되지 않습니다.
+
+**oh-my-customcode 연관**: R015 intent transparency의 ambiguity-gate 패턴이 정상 작동합니다. 신뢰도 < 70% 구간에서 `AskUserQuestion`을 통한 명시적 확인 요청이 auto mode에서도 동작하므로 R015 오탐(ambiguous routing 무음 처리)이 감소합니다. 호환, 개선.
+
+### MCP `resources/list`, `resources/templates/list`, `prompts/list` 페이지네이션 수정
+
+1페이지 이후의 항목이 누락되던 버그가 수정되었습니다.
+
+**oh-my-customcode 연관**: `ListMcpResourcesTool` 페이지네이션 안정성이 개선됩니다. `claude-mem`, `ontology-rag` 등 R011/R019 MCP 서버에서 리소스 목록이 많은 경우 전체 항목이 정상 조회됩니다. 호환, 개선.
+
+### `CLAUDE_CODE_SUBAGENT_MODEL` 자식 프로세스 전파 수정
+
+`CLAUDE_CODE_SUBAGENT_MODEL` 환경 변수가 다중 에이전트 세션의 자식 프로세스에 전파되지 않던 버그가 수정되었습니다.
+
+**oh-my-customcode 연관**: R010 + R018 Agent Teams 멤버 모델 일관성에 직접 영향. `CLAUDE_CODE_SUBAGENT_MODEL`을 설정한 환경에서 Agent Teams 멤버가 지정 모델을 올바르게 사용하는지 v2.1.146 업그레이드 후 검증 권장. 호환, 검증 권장.
+
+### Windows 관련 수정 (macOS 영향 없음)
+
+- Windows PowerShell `pwsh` winget/Store 설치 실패 fix (v2.1.124 regression)
+- Windows Terminal background session strobing fix
+- Windows NTFS junction background-job worktree 안전성 개선
+- GNOME Terminal right/middle-click paste fix
+
+**oh-my-customcode 연관**: macOS 개발 환경에는 직접 영향 없음.
+
+### 기타 수정
+
+- `/background` skill-or-custom-slash-only 입력 수용 fix → `/bg` 플로우(R010 Universal bypassPermissions) 개선
+- Backgrounded sessions tool permission "don't ask again" 재요청 fix → R010 bypassPermissions 안정성 개선
+- Auto-updater 상태줄 fail 시 현재 버전 표시 fix → R012 statusline 영향 없음 (별도)
+- Agent SDK 스트리밍 세션 종료 시 uncaught exception fix → agent-sdk-* 플러그인 영향 가능, 모니터 권장
+- `forceLoginOrgUUID`/`forceLoginMethod` managed-settings enforcement fix → R002 직접 영향 없음
+- Auto-updater 일시적 네트워크 실패 retry 개선
+- 대용량 파일 편집 diff 렌더링 성능 개선
+- `/theme` color editor + "New custom theme" Esc 미응답 fix
+
+### oh-my-customcode 연관 평가
+
+| 변경 | oh-my-customcode 영향 | 조치 |
+|------|----------------------|------|
+| `/simplify` → `/code-review` 리네임 + effort level | 내부 `dev-review` skill과 명칭 다름, 충돌 없음 | 호환, 별도 조치 없음 |
+| Auto mode `AskUserQuestion` 억제 해제 | R015 intent transparency, ambiguity-gate 정상 작동 | 호환, 개선 |
+| MCP 페이지네이션 수정 | `ListMcpResourcesTool` 페이지네이션 안정성 | 호환, 개선 |
+| `CLAUDE_CODE_SUBAGENT_MODEL` 자식 프로세스 전파 fix | R010 + R018 Agent Teams 멤버 모델 일관성 개선 | 호환, 검증 권장 |
+| `/background` 입력 수용 fix | `/bg` 플로우 개선 | 호환, 개선 |
+| Backgrounded sessions permission "don't ask again" fix | R010 bypassPermissions 안정성 | 호환, 개선 |
+| Agent SDK 스트리밍 uncaught exception fix | agent-sdk-* 플러그인 영향 가능 | 호환, 모니터 |
+| Windows/터미널 관련 수정 | macOS 환경 직접 영향 없음 | 호환 |
+
+**Action items**:
+- 본 릴리스에서 코드 변경 없음 (docs-only)
+- 후속 follow-up 후보:
+  - `CLAUDE_CODE_SUBAGENT_MODEL` 전파 동작 검증 (R018 Agent Teams 멤버 모델 일관성)
+  - 외부 `/code-review`와 내부 `dev-review` skill 구분 안내 (CLAUDE.md 또는 dev-review skill 본문)
+  - Agent SDK 스트리밍 fix가 agent-sdk-dev 플러그인에 미치는 영향 모니터
+
+---
+
+## v2.1.147 (2026-05-21) — 호환성 점검
+
+> Issue: #1216 — Claude Code v2.1.147 compatibility documentation
+
+### `Workflow` 도구 추가 (기본 off)
+
+deterministic multi-agent orchestration을 위한 새 `Workflow` 도구가 추가되었습니다. `CLAUDE_CODE_WORKFLOWS=1` 환경 변수로 활성화할 수 있으며, 기본값은 비활성입니다.
+
+**oh-my-customcode 연관**: oh-my-customcode `/pipeline` 스킬(workflows/*.yaml 기반)과 개념적으로 중첩됩니다. 향후 네이티브 `Workflow` 도구 통합 검토 후보이나, 현재 기본 off이므로 영향 없음. 호환.
+
+### `/simplify` → `/code-review` 개명 (+ effort level, `--comment`)
+
+기존 `/simplify` 슬래시 커맨드가 `/code-review`로 개명되었습니다. 선택한 effort 수준으로 correctness 버그를 보고하며(`/code-review high`), `--comment` 플래그로 inline PR 코멘트를 게시할 수 있습니다. 기존 cleanup-and-fix 동작은 제거되었습니다.
+
+**oh-my-customcode 연관**: CC 빌트인 `/code-review`와 내부 `dev-review`/`code-review` 스킬의 명칭 혼동 방지 안내가 필요합니다. v2.1.146에서 최초 리네임된 내용의 연속입니다. `.claude/skills/intent-detection/patterns/agent-triggers.yaml`의 `skill-simplify` 라우팅 엔트리는 내부 스킬 라우팅이므로 CC 빌트인 제거와 무관하나, 명명 혼동 방지를 위해 점검이 권장됩니다.
+
+### REPL 및 Workflow 도구 샌드박스 강화
+
+prototype-pollution 및 thenable 기반 escape에 대한 샌드박스 보안이 강화되었습니다.
+
+**oh-my-customcode 연관**: R001 안전 규칙과 정합. 보안 강화이므로 호환, 개선.
+
+### plugin agent 복수 `Agent(...)` 타입 fix
+
+plugin agents가 `tools:` frontmatter에 복수 `Agent(...)` 타입을 선언 시 마지막 항목만 남기고 나머지를 드롭하던 버그가 수정되었습니다.
+
+**oh-my-customcode 연관**: oh-my-customcode 에이전트 frontmatter에서 `tools:`에 복수 Agent() 타입을 선언하는 경우 이전에는 마지막만 인식되었습니다. 영향 점검이 권장됩니다.
+
+### hook `if` 조건 매칭 버그 수정
+
+hook `if` 조건(예: `PowerShell(git push*)`)이 매칭되지 않던 버그가 수정되었습니다 (`PowerShell(*)`만 동작했음).
+
+**oh-my-customcode 연관**: `.claude/hooks/` 내 조건부 hook(`if` 필드 사용)의 정확한 매칭이 보장됩니다. R001 안전 규칙의 stage-blocker hook 신뢰성이 향상됩니다. 호환, 개선.
+
+### 기타 수정
+
+- auto-updater 개선: transient 네트워크 실패 재시도, OS 에러 코드 보고
+- diff 렌더링 성능 개선
+- prompt history 연속 중복 제거
+- enterprise login 제한 강제 수정
+
+**oh-my-customcode 연관**: 일반 안정성 개선. 직접 영향 없음.
+
+### oh-my-customcode 연관 평가
+
+| 변경 | oh-my-customcode 영향 | 조치 |
+|------|----------------------|------|
+| `Workflow` 도구 추가 (기본 off) | `/pipeline` 스킬과 개념 중첩, 향후 통합 후보 | 호환, follow-up 후보 |
+| `/simplify` → `/code-review` 개명 | 내부 `dev-review` 스킬과 명칭 혼동 주의 | 호환, agent-triggers.yaml 점검 권장 |
+| REPL/Workflow 샌드박스 강화 | R001 보안 강화 | 호환, 개선 |
+| plugin agent 복수 Agent() 타입 fix | frontmatter `tools:` 복수 Agent() 선언 영향 점검 | 호환, 영향 점검 권장 |
+| hook `if` 조건 매칭 fix | stage-blocker hook 신뢰성 향상 | 호환, 개선 |
+| auto-updater / diff / history 개선 | 일반 안정성 | 호환 |
+
+**Action items**:
+- 본 릴리스에서 코드 변경 없음 (docs-only)
+- 후속 follow-up 후보:
+  1. CC 빌트인 `/code-review`와 내부 `dev-review` skill 구분 안내 보강
+  2. `agent-triggers.yaml`의 `skill-simplify` 엔트리 명명 혼동 방지 점검
+  3. plugin agent frontmatter `tools:` 복수 Agent() 선언 영향 점검
+  4. `Workflow` 도구와 `/pipeline` 스킬 통합 가능성 연구 (중장기)
+
+---
+
+## v2.1.148 (2026-05-22) — 호환성 점검
+
+> Issue: #1218 — Claude Code v2.1.148 compatibility documentation
+
+### Bash 도구 exit code 127 regression 수정 (긴급)
+
+v2.1.147에서 도입된 regression으로, 일부 사용자에게서 Bash 도구가 모든 명령에 대해 exit code 127을 반환하던 버그가 수정되었습니다.
+
+**oh-my-customcode 연관**: Bash 도구를 사용하는 gh, git, 빌드/테스트 명령 등 oh-my-customcode 워크플로우 전반에 영향을 줍니다. v2.1.147을 사용 중이라면 v2.1.148로 즉시 업그레이드가 권장됩니다.
+
+### oh-my-customcode 연관 평가
+
+| 변경 | oh-my-customcode 영향 | 조치 |
+|------|----------------------|------|
+| Bash exit code 127 regression fix | 모든 Bash 도구 사용 워크플로우 복구 | 즉시 업그레이드 권장 |
+
+**Action items**:
+- v2.1.147 사용 중이면 v2.1.148로 즉시 업그레이드
+- 본 릴리스에서 코드 변경 없음 (docs-only)
+
+---
+
+## v2.1.149 (2026-05-22) — 호환성 점검
+
+> Issue: #1219 — Claude Code v2.1.149 compatibility documentation
+
+### `/usage` per-category 사용량 분석
+
+`/usage`가 limits 사용량 분석을 카테고리별로 표시합니다: skills, subagents, plugins, per-MCP-server 비용 세분화.
+
+**oh-my-customcode 연관**: R013 ecomode 토큰 추적, R012 statusline, `token-efficiency-audit` 스킬과 연관됩니다. per-MCP 비용 가시성 덕분에 `claude-mem`, `ontology-rag` 등 R011/R019 MCP 서버의 비용을 모니터링할 수 있습니다. 호환, 개선.
+
+### `/diff` 키보드 스크롤 지원
+
+`/diff` 상세 뷰에서 키보드 스크롤이 지원됩니다 (arrows, j/k, PgUp/PgDn, Space, Home/End).
+
+**oh-my-customcode 연관**: 코드 리뷰 워크플로우의 UX 향상. 직접 harness 변경 불필요.
+
+### GFM 체크박스 렌더링
+
+Markdown 출력이 GFM task list 체크박스(`- [ ]`/`- [x]`)를 일반 bullet 대신 체크박스로 렌더링합니다.
+
+**oh-my-customcode 연관**: 에이전트 작업 목록(`- [ ]`/`- [x]`) 출력 가독성이 향상됩니다. 호환, 개선.
+
+### git worktree 샌드박스 write allowlist 수정
+
+git worktree에서 sandbox write allowlist가 main repo root 전체 대신 공유 `.git` 디렉토리만 커버하도록 수정되었습니다 (hooks/, config는 deny).
+
+**oh-my-customcode 연관**: `EnterWorktree` 사용 시 보안이 강화됩니다. R001 안전 규칙과 정합. 호환, 보안 개선.
+
+### Bash `find` macOS 크래시 버그 수정
+
+Bash 도구의 `find` 명령이 macOS system file/vnode table을 소진하여 호스트를 크래시시키던 버그가 수정되었습니다.
+
+**oh-my-customcode 연관**: Bash 도구로 대형 디렉토리를 탐색하는 oh-my-customcode 워크플로우의 호스트 안정성이 향상됩니다. 중요한 수정이므로 업그레이드가 권장됩니다.
+
+### `/ultraplan` 및 remote session 생성 수정
+
+작업 트리에 실제 변경이 없을 때 "Could not capture uncommitted changes"로 실패하던 버그가 수정되었습니다.
+
+**oh-my-customcode 연관**: `/ultraplan` 및 remote session 기반 워크플로우 안정성이 향상됩니다. 호환, 개선.
+
+### 기타 수정
+
+- enterprise `allowAllClaudeAiMcps` managed setting 추가
+- PowerShell 권한 우회 수정 (built-in `cd` 함수): macOS 환경 직접 영향 없음
+
+**oh-my-customcode 연관**: macOS 개발 환경에는 직접 영향 없음.
+
+### oh-my-customcode 연관 평가
+
+| 변경 | oh-my-customcode 영향 | 조치 |
+|------|----------------------|------|
+| `/usage` per-category breakdown | R013 ecomode / R012 statusline / MCP 비용 가시성 | 호환, 개선 |
+| `/diff` 키보드 스크롤 | 코드 리뷰 UX 향상 | 호환, 개선 |
+| GFM 체크박스 렌더링 | 에이전트 작업 목록 가독성 향상 | 호환, 개선 |
+| worktree sandbox write allowlist fix | EnterWorktree 보안 강화 | 호환, 보안 개선 |
+| Bash `find` macOS 크래시 fix | 대형 디렉토리 탐색 호스트 안정성 향상 | 업그레이드 권장 |
+| `/ultraplan` 생성 fix | remote session 워크플로우 안정성 | 호환, 개선 |
+| PowerShell `cd` 권한 fix | macOS 영향 없음 | 호환 |
+
+**Action items**:
+- 본 릴리스에서 코드 변경 없음 (docs-only)
+- 후속 follow-up 후보:
+  1. `/usage` per-MCP-server 비용 데이터를 `token-efficiency-audit` 스킬에 통합 검토
+  2. R012 statusline에 per-category usage 표시 강화 검토
+
+---
+
+## v2.1.150 (2026-05-23) — 호환성 점검
+
+> Issue: #1220 — Claude Code v2.1.150 compatibility documentation
+
+### 내부 인프라 개선
+
+내부 인프라 개선으로, 사용자 대면 변경 사항은 없습니다.
+
+**oh-my-customcode 연관**: 코드 및 문서 변경 불필요. 추적 기록용 docs-only 항목입니다.
+
+### oh-my-customcode 연관 평가
+
+| 변경 | oh-my-customcode 영향 | 조치 |
+|------|----------------------|------|
+| 내부 인프라 개선 | 사용자 대면 변경 없음 | 조치 불필요 |
+
+**Action items**:
+- 코드 및 문서 변경 불필요 (추적 기록용 docs-only)
+
+---
+
 ## References
 
 - #967 — Claude Code v2.1.117 release note
@@ -652,6 +901,11 @@ Agent Teams 멤버 이름에 non-ASCII 문자(한국어 포함)가 포함된 경
 - #1147 — .gitignore nested .md pattern limitation note
 - #1187 — Claude Code v2.1.144 compatibility documentation
 - #1191 — Claude Code v2.1.145 compatibility documentation
+- #1205 — Claude Code v2.1.146 compatibility documentation
+- #1216 — Claude Code v2.1.147 compatibility documentation
+- #1218 — Claude Code v2.1.148 compatibility documentation
+- #1219 — Claude Code v2.1.149 compatibility documentation
+- #1220 — Claude Code v2.1.150 compatibility documentation
 - `.claude/skills/claude-native/` — auto-generation source
 - `.claude/rules/SHOULD-hud-statusline.md` — R012 statusline integration
 - `.claude/rules/MUST-agent-design.md` — R006 agent frontmatter spec

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.150.1",
+  "version": "0.151.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/wiki/rules/r017.md
+++ b/wiki/rules/r017.md
@@ -1,7 +1,7 @@
 ---
 title: "R017: Sync Verification Rules"
 type: rule
-updated: 2026-04-12
+updated: 2026-05-24
 sources:
   - .claude/rules/MUST-sync-verification.md
 related:
@@ -44,6 +44,27 @@ Structural changes can silently break routing tables, orphan skill references, o
 
 **sauron = mgr-sauron agent:** Enforces structural integrity verified by the compilation metaphor (see CLAUDE.md architecture).
 
+## Structural Migration Verification (#1217)
+
+디렉토리 재구조화, 템플릿 평탄화(flat templates), 브랜치 전략 변경 등 **구조 마이그레이션** 시, 경로 참조와 파일 존재성 회귀를 사전 검사해야 한다. 표준 5-round 검증이 콘텐츠 정합성에 집중하는 반면, 구조 마이그레이션은 경로·존재성 회귀를 별도로 점검한다.
+
+| 마이그레이션 유형 | 검사 항목 |
+|------------------|-----------|
+| 디렉토리 재구조화 | 모든 경로 참조(스크립트, 테스트, CI workflow)가 새 경로로 업데이트되었는가 |
+| 템플릿 평탄화 | validate-docs/sync 스크립트가 새 경로를 참조하는가 |
+| 브랜치 전략 변경 | CI trigger 경로, 파일 git tracked 상태가 일관되는가 |
+| 파일 존재성 | 테스트가 read하는 파일이 CI 체크아웃 환경(clean clone)에 존재(git tracked)하는가 |
+
+**Common Violations (#1217 items #2/#3/#7):**
+- flat templates 마이그레이션 후 `validate-docs.ts`가 옛 경로 참조 → G1 CI 실패
+- `CLAUDE.md` untracked → strict allowlist `.gitignore`와 결합되어 CI 체크아웃 환경에서 ENOENT
+- release/develop 듀얼 브랜치 전환 시 `verify-template-sync.sh`가 임시 skip 상태로 머지
+
+**구조 마이그레이션 커밋 전 self-check:**
+1. `grep`으로 옛 경로 참조 잔존을 확인했는가?
+2. 테스트가 읽는 파일의 git tracked 상태를 확인했는가? (`git ls-files` 대조)
+3. 임시 skip된 검증 스크립트/테스트가 남아있지 않은가?
+
 ## Enforcement
 
 Prompt-based self-check + `mgr-sauron:watch` verification flow. No hard-block hook — relies on developer discipline per [[r021]].
@@ -56,4 +77,5 @@ Prompt-based self-check + `mgr-sauron:watch` verification flow. No hard-block ho
 
 ## Sources
 
-- `.claude/rules/MUST-sync-verification.md` — rule definition
+- `.claude/rules/MUST-sync-verification.md` — rule definition (Structural Migration Verification added #1217)
+- Issue #1217 — flat templates path drift + CLAUDE.md ENOENT + skip state merge incidents (2026-05-24)

--- a/wiki/rules/r020.md
+++ b/wiki/rules/r020.md
@@ -1,7 +1,7 @@
 ---
 title: "R020: Completion Verification Rules"
 type: rule
-updated: 2026-05-20
+updated: 2026-05-24
 sources:
   - .claude/rules/MUST-completion-verification.md
 related:
@@ -103,6 +103,34 @@ For complex agent invocations or multi-step workflows, 4-metric evidence from th
 
 Reference issues: #1188 item #8.
 
+## Diagnostic Hypothesis Verification (#1217 item #4)
+
+진단 단계에서 채택한 가설로 워크플로우/인프라/설정을 **영구 변경하기 전**, 실제 증거로 가설을 검증해야 한다. 그럴듯한 가설을 검증 없이 영구 변경에 적용하면 잘못된 추정이 영구 부채로 남는다.
+
+| 상황 | 금지 | 필수 |
+|------|------|------|
+| 에러 원인 추정 | 첫 가설로 워크플로우/설정 영구 수정 | 가설을 좁은 범위에서 검증 후 변경 |
+| CI/publish 실패 | 추정 기반 우회 커밋 머지 | 에러 메시지/로그로 실제 원인 확정 |
+| 권한/토큰 오류 | 플래그/옵션 변경으로 우회 시도 | 권한 범위·토큰 종류 직접 확인 |
+
+**Common Violation (#1217 item #4):** npm publish E403을 `--provenance` attestation 충돌로 오진단 → release workflow에서 `--provenance` 제거 커밋 머지 → 2차 시도 동일 실패 → 실제 원인은 NPM_TOKEN 권한(Automation token 필요). 잘못된 추정으로 릴리즈 워크플로우를 영구 변경.
+
+**영구 변경 전 self-check:**
+1. 가설을 뒷받침하는 직접 증거(로그/에러 코드/문서)가 있는가?
+2. 비파괴적 방법으로 가설을 검증할 수 있는가?
+3. 변경이 되돌리기 쉬운가? (영구 워크플로우 변경 vs 일회성 시도)
+
+하나라도 NO면 검증을 먼저 수행한다. 근본 원인 진단은 `superpowers:systematic-debugging` 참조.
+
+## Test-Skip Is Not Completion (#1217 item #5)
+
+테스트 실패를 `describe.skip`/`xfail`/`it.skip` + coverage threshold 하향으로 회피하는 것은 완료가 아니다. 근본 원인 분석 없이 그린 빌드를 만드는 회피는 기술 부채를 다음 마이너로 이월시킨다.
+
+| 금지 | 필수 |
+|------|------|
+| 실패 테스트 skip + threshold 하향으로 그린 빌드 | 근본 원인 분석 후 수정, 불가 시 명시적 deferral + 이슈 등록 |
+| "다음 버전 TODO" 주석만 남기고 머지 | skip 사유·복구 조건·추적 이슈를 함께 기록 |
+
 ## Enforcement
 
 Prompt-based per [[r021]]. Integrates with [[r003]] `[Done]` format and [[r017]] structural verification.
@@ -114,5 +142,6 @@ Prompt-based per [[r021]]. Integrates with [[r003]] `[Done]` format and [[r017]]
 
 ## Sources
 
-- `.claude/rules/MUST-completion-verification.md` — rule definition (Interrupt Priority Re-Ordering added v0.147.0)
+- `.claude/rules/MUST-completion-verification.md` — rule definition (Interrupt Priority Re-Ordering added v0.147.0; Diagnostic Hypothesis Verification + Test-Skip Is Not Completion added #1217)
 - Issue #869 — subagent pre-existing claims + autonomous mode checklist (2026-04-15)
+- Issue #1217 — npm provenance oops + test-skip misuse incidents (2026-05-24)


### PR DESCRIPTION
## 개요

v0.151.0 릴리즈 — CC v2.1.147~v2.1.150 호환성 문서화 및 #1217 피드백 기반 룰 강화입니다.

## 변경 사항

- **CC v2.1.147–v2.1.150 호환성 문서** (`guides/claude-code/15-version-compatibility.md`): Workflow 도구, /simplify→/code-review, Bash exit 127 fix, /usage breakdown, worktree/find fix 등
- **R020**: Diagnostic Hypothesis Verification + Test-Skip Is Not Completion 섹션 (진단 가설 검증, 테스트 skip 회피 금지)
- **R017**: Structural Migration Verification 섹션 (구조 마이그레이션 경로/존재성 회귀 검사)

## 검증

- mgr-sauron R017 PASS
- bun test 1988 pass / 0 fail
- source↔template 동기화 확인
- wiki(R022) 동기화 완료

## 이슈

Closes #1216
Closes #1217
Closes #1218
Closes #1219
Closes #1220

🤖 Generated with [Claude Code](https://claude.com/claude-code)