### PR TITLE
release: v0.152.0 — omcustom-feedback 모델 호출 가능 전환 + 세션 회고 피드백 통합 (#1226 #1227)

### DIFF
--- a/.claude/rules/SHOULD-memory-integration.md
+++ b/.claude/rules/SHOULD-memory-integration.md
@@ -351,7 +351,7 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 
 ### Session-End Self-Check (MANDATORY)
 
-(1) sys-memory-keeper updated MEMORY.md? (2) claude-mem save attempted? (3) If `omcustom-feedback` skill is active, prompt user to trigger it? All three required before confirming to user. See full self-check via Read tool.
+(1) sys-memory-keeper updated MEMORY.md? (2) claude-mem save attempted? (3) If `omcustom-feedback` skill is active, model MAY draft a retrospective feedback issue for user approval — or prompt user to trigger it manually. All three required before confirming to user. See full self-check via Read tool.
 
 <!-- DETAIL: Session-End Self-Check (MANDATORY)
 ```
@@ -367,8 +367,10 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 ║     NO  → ToolSearch + save now                                  ║
 ║                                                                   ║
 ║  3. Is omcustom-feedback skill available in this project?        ║
-║     YES → Ask user: "이번 세션 피드백을 omcustom-feedback로     ║
-║          기록하시겠습니까?" — accept skip                        ║
+║     YES → If notable friction/learning observed: MODEL DRAFTS    ║
+║          retrospective issue → presents via Phase 4A preview     ║
+║          gate for user approval. Otherwise: prompt user to       ║
+║          trigger manually. Accept skip either way.               ║
 ║     NO  → Skip                                                    ║
 ║                                                                   ║
 ║  Note: episodic-memory auto-indexes conversations after session  ║
@@ -380,6 +382,33 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 ╚══════════════════════════════════════════════════════════════════╝
 ```
 -->
+
+### Session-End Retrospective Feedback (Model-Drafted)
+
+Since `omcustom-feedback` is now model-invocable (#1227), the model MAY draft a retrospective feedback issue at session end — instead of only prompting the user to compose one manually.
+
+**Workflow**
+
+1. Model detects notable friction, workarounds, or harness gaps observed during the session.
+2. Model drafts a feedback issue (title + body) using the `omcustom-feedback` skill.
+3. Draft is presented through the skill's **Phase 4A preview + confirmation gate**. The user reviews and approves before any GitHub issue is created.
+4. The model NEVER auto-submits. User approval is always required.
+
+**Trigger conditions** (all must be true):
+- Session-end detected
+- Notable friction or learning observed during the session
+- `omcustom-feedback` skill active in this project
+
+**Distinction from manual path**
+
+| Path | Who drafts | Who approves | When |
+|------|-----------|--------------|------|
+| Manual (existing) | User | User | User chooses to file feedback |
+| Model-drafted (new, #1226 item 3) | Model | User (Phase 4A gate) | Session-end with notable friction |
+
+The model-drafted path is an enhancement: it proposes a concrete draft rather than asking the user to compose from scratch. Both paths remain valid; neither replaces the other.
+
+References: #1226 (item 3), #1227.
 
 ### Failure Policy
 
@@ -418,7 +447,7 @@ Phase 1 COEXIST 기간 중 세션 종료 시:
 1. sys-memory-keeper가 MEMORY.md 갱신? → YES: 계속
 2. claude-mem 저장 시도? → YES (기존 항목)
 3. AgentMemory 저장 시도? → YES (COEXIST 추가)
-4. omcustom-feedback 권유? → YES (활성 시) / 스킵 (비활성 시)
+4. omcustom-feedback 처리? → YES (활성 시, notable friction 있으면 model draft → Phase 4A gate; 없으면 사용자 권유) / 스킵 (비활성 시)
 네 단계 모두 완료 후 사용자에게 확인. 둘 중 하나 실패해도 비차단.
 
 ### Phase 2 진입 전 필수 조건

--- a/.claude/skills/omcustom-feedback/SKILL.md
+++ b/.claude/skills/omcustom-feedback/SKILL.md
@@ -3,7 +3,6 @@ name: omcustom-feedback
 description: Submit feedback about oh-my-customcode (supports anonymous submission)
 scope: harness
 user-invocable: true
-disable-model-invocation: true
 argument-hint: "[description or leave empty for interactive] [--anonymous]"
 ---
 
@@ -201,5 +200,6 @@ Submit manually when connectivity is available:
 - Route A creates a visible GitHub issue attributed to the user's gh account
 - When `--anonymous` is used, the title is prefixed with `[Anonymous Feedback]` and the `anonymous` label is added
 - Fallback ensures no feedback is silently lost even in offline environments
-- `disable-model-invocation: true` ensures this skill only runs when explicitly invoked by the user
+- This skill is invocable by BOTH the user (`/omcustom-feedback`) and the model (Skill tool). Model invocation enables session-end retrospective feedback drafting (#1226 item 3, #1227).
+- The Phase 4A "Preview + confirmation" gate (steps 2-3) is the safety boundary: the model can DRAFT a feedback issue but CANNOT create a public GitHub issue without explicit user confirmation. This mitigates the abuse concern of model-invocation.
 - Target repo is hardcoded to `baekenough/oh-my-customcode` — feedback is always about omcustom itself

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.151.1",
+  "version": "0.152.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/omcustom-feedback/SKILL.md
+++ b/templates/.claude/skills/omcustom-feedback/SKILL.md
@@ -3,7 +3,6 @@ name: omcustom-feedback
 description: Submit feedback about oh-my-customcode (supports anonymous submission)
 scope: harness
 user-invocable: true
-disable-model-invocation: true
 argument-hint: "[description or leave empty for interactive] [--anonymous]"
 ---
 
@@ -201,5 +200,6 @@ Submit manually when connectivity is available:
 - Route A creates a visible GitHub issue attributed to the user's gh account
 - When `--anonymous` is used, the title is prefixed with `[Anonymous Feedback]` and the `anonymous` label is added
 - Fallback ensures no feedback is silently lost even in offline environments
-- `disable-model-invocation: true` ensures this skill only runs when explicitly invoked by the user
+- This skill is invocable by BOTH the user (`/omcustom-feedback`) and the model (Skill tool). Model invocation enables session-end retrospective feedback drafting (#1226 item 3, #1227).
+- The Phase 4A "Preview + confirmation" gate (steps 2-3) is the safety boundary: the model can DRAFT a feedback issue but CANNOT create a public GitHub issue without explicit user confirmation. This mitigates the abuse concern of model-invocation.
 - Target repo is hardcoded to `baekenough/oh-my-customcode` — feedback is always about omcustom itself

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.151.1",
+  "version": "0.152.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/wiki/rules/r011.md
+++ b/wiki/rules/r011.md
@@ -1,7 +1,7 @@
 ---
 title: "R011: Memory Integration Rules"
 type: rule
-updated: 2026-05-18
+updated: 2026-05-24
 sources:
   - .claude/rules/SHOULD-memory-integration.md
 related:
@@ -70,6 +70,23 @@ Save memory IMMEDIATELY upon surprising discovery — do not defer to session en
 **Why Immediate (not session-end):** Session-end saves lose context: by the time the session ends, multiple discoveries have compounded and nuance is lost. Immediate saves preserve the exact trigger context that makes the memory actionable.
 
 **Anti-pattern**: "I'll batch all learnings at session end" — by then you'll have forgotten WHY each one mattered, and further violations may have occurred using the un-saved pattern.
+
+## Session-End Retrospective Feedback (Model-Drafted)
+
+Since `omcustom-feedback` is model-invocable (#1227), at session end the model MAY draft a retrospective feedback issue summarizing notable session friction or learnings — instead of only prompting the user to file it manually.
+
+**Trigger conditions**: session-end detected AND notable friction/learning observed AND `omcustom-feedback` skill active.
+
+**Key constraint**: The model NEVER auto-submits. Every draft passes through the skill's Phase 4A preview + confirmation gate before any GitHub issue is created. The user approves before publication.
+
+| Path | Who Drafts | Who Approves |
+|------|-----------|-------------|
+| Manual (existing) | User | User (self-review) |
+| Model-drafted (new) | Model | User via Phase 4A gate |
+
+This complements — does not replace — the existing self-check item "prompt user to trigger omcustom-feedback". The Session-End Self-Check wording was updated to reflect that the model MAY draft instead of only prompting.
+
+See [[omcustom-feedback]] for Phase 4A gate details.
 
 ## Dual-Backend Advisory (Phase 1 COEXIST)
 

--- a/wiki/skills/omcustom-feedback.md
+++ b/wiki/skills/omcustom-feedback.md
@@ -1,7 +1,7 @@
 ---
 title: Omcustom Feedback
 type: skill
-updated: 2026-04-12
+updated: 2026-05-24
 sources:
   - .claude/skills/omcustom-feedback/SKILL.md
 related:
@@ -11,17 +11,21 @@ related:
 
 # Omcustom Feedback
 
-Submit user feedback as a GitHub Issue for tracking and improvement.
+Submit feedback as a GitHub Issue for tracking and improvement — invocable by both user and model.
 
 ## Overview
 
-Collects user feedback (bug reports, feature requests, improvement suggestions) and creates a formatted GitHub Issue with appropriate labels. Guides the user through providing structured feedback: title, description, reproduction steps (for bugs), and expected behavior. Delegates issue creation to `mgr-gitnerd` via `gh issue create`. Supports the R016 continuous improvement workflow.
+Collects feedback (bug reports, feature requests, improvement suggestions) and creates a formatted GitHub Issue with appropriate labels. Guides through providing structured feedback: title, description, reproduction steps (for bugs), and expected behavior. Delegates issue creation to `mgr-gitnerd` via `gh issue create`. Supports the [[R016]] continuous improvement workflow.
+
+As of #1226/#1227, `disable-model-invocation: true` was removed. The skill is now invocable by **both the user** (`/omcustom-feedback`) **and the model** (via the Skill tool). The primary new use case is **session-end retrospective feedback drafting**: the model can analyze the session and draft a feedback issue proposal automatically. The Phase 4A "Preview + confirmation" gate is the abuse-mitigation safety boundary — the model can draft but cannot create a public GitHub issue without explicit user confirmation.
 
 ## Key Details
 
 - **Scope**: harness
-- **User-invocable**: yes
-- **Command**: `/omcustom-feedback`
+- **User-invocable**: yes (`/omcustom-feedback`)
+- **Model-invocable**: yes (via Skill tool — since #1226/#1227, 2026-05-24)
+- **Safety boundary**: Phase 4A Preview + confirmation gate (model cannot publish without user approval)
+- **Primary model use case**: session-end retrospective feedback drafting
 - **Effort**: not specified
 
 ## Relationships


### PR DESCRIPTION
## v0.152.0

### 변경
- **#1227**: `omcustom-feedback` 스킬 model-invocable 전환 — `disable-model-invocation: true` 제거. 사용자(`/omcustom-feedback`) + 모델(Skill tool) 양쪽 호출 가능. Phase 4A preview+confirmation 게이트가 abuse-mitigation 안전 경계.
- **#1226 item3**: R011에 "Session-End Retrospective Feedback (Model-Drafted)" 추가 — 세션 종료 시 모델이 회고 피드백 초안 작성 → Phase 4A 게이트 사용자 승인 후 제출.

### Deferred (follow-up 예정)
- **#1226 item1**: proactive R007/R008 advisory hook — `.claude/hooks/` 변경 R001 승인 필요, 별도 사이클.
- **#1226 item2**: prod DB push 반복 승인 — Investigated, R020상 영구 변경 보류 (CC 플랫폼 classifier + R015 일반화 후보).

### Docs
- wiki/skills/omcustom-feedback.md, wiki/rules/r011.md 동기화

Fixes #1227

🤖 Generated with [Claude Code](https://claude.com/claude-code)