### PR TITLE
release: v0.153.0 — R015 파괴적 작업 승인 지속성 + wiki-sync drift 수정 (#1230 #1231)

### DIFF
--- a/.claude/rules/MUST-intent-transparency.md
+++ b/.claude/rules/MUST-intent-transparency.md
@@ -103,6 +103,25 @@ Reference issues: #1188 item #4.
 
 **Why**: 사용자 directive 일관성 — #1208 보고. 같은 세션 내 동일 의도를 반복 차단하면 R015 user directive persistence 위반.
 
+### Destructive Operation Approval Persistence (Generalized)
+
+The Git Push Continuation pattern (first-time strict / follow-up relaxed, scoped to session + category + target) generalizes to ALL repeated destructive operations within the same session. Examples: `supabase db push`, `terraform apply`, `kubectl delete`, bulk file deletes, database migrations.
+
+**Scope**: once the user explicitly approves a destructive operation of category C against target T in a session, follow-up operations of the SAME C + SAME T do NOT require re-confirmation. An advisory warning is still emitted. A different category or different target always requires fresh confirmation.
+
+| Scenario | Behavior |
+|----------|----------|
+| 1st explicit approval (category C, target T) | Proceed; advisory warning emitted |
+| Follow-up same session (same C + same T) | No re-confirmation (directive persistence) |
+| Different category or target | Fresh confirmation required |
+| Platform classifier still prompts | Advise user: add `settings.json` permission rule for the specific command |
+
+**R001 exclusion (MUST)**: R001-listed catastrophic git operations (`git reset --hard`, `git clean -fd`, `git push --force` to shared branches, `git branch -D` with unmerged commits) are EXCLUDED from this persistence rule — they always require explicit per-invocation approval regardless of prior session approvals.
+
+**Boundary / honesty note**: This rule is ADVISORY and governs model behavior only. It CANNOT suppress Claude Code's platform-level auto-mode classifier prompts. For genuine prompt suppression on a repeated destructive command, the user must add a `settings.json` permission allow rule scoped to the specific command (e.g., a specific `supabase db push` invocation). The model SHOULD surface this workaround when the user expresses friction about repeated prompts.
+
+Cross-references: R001 (safety — destructive operation pre-checks still apply), R002 (permission tiers). Reference issues: #1230, #1226 (item 2).
+
 ## Agent Triggers
 
 Defined in `.claude/skills/intent-detection/patterns/agent-triggers.yaml`. Each agent has keywords, file patterns, actions, and base confidence.

--- a/.github/scripts/verify-wiki-sync.sh
+++ b/.github/scripts/verify-wiki-sync.sh
@@ -106,8 +106,9 @@ else
   INDEX_RULES=$( { awk '/^  counts:/,/^[a-z]/' "$INDEX_YAML" || true; } | { grep -E '^ +rules:' || true; } | sed 's/.*rules: *//' | tr -d ' ')
   INDEX_GUIDES=$( { awk '/^  counts:/,/^[a-z]/' "$INDEX_YAML" || true; } | { grep -E '^ +guides:' || true; } | sed 's/.*guides: *//' | tr -d ' ')
 
-  # Actual counts (all .md files in wiki/)
-  ACTUAL_TOTAL=$(find wiki -name '*.md' -type f | wc -l | tr -d ' ')
+  # Actual counts
+  # total_pages counts indexed content pages only (navigation/landing pages at wiki/ root excluded, per #1223)
+  ACTUAL_TOTAL=$(find wiki -mindepth 2 -name '*.md' -type f | wc -l | tr -d ' ')
   ACTUAL_SKILLS=$(find wiki/skills -name '*.md' -type f 2>/dev/null | wc -l | tr -d ' ')
   ACTUAL_AGENTS=$(find wiki/agents -name '*.md' -type f 2>/dev/null | wc -l | tr -d ' ')
   ACTUAL_RULES=$(find wiki/rules -name '*.md' -type f 2>/dev/null | wc -l | tr -d ' ')

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.152.0",
+  "version": "0.153.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-intent-transparency.md
+++ b/templates/.claude/rules/MUST-intent-transparency.md
@@ -103,6 +103,25 @@ Reference issues: #1188 item #4.
 
 **Why**: 사용자 directive 일관성 — #1208 보고. 같은 세션 내 동일 의도를 반복 차단하면 R015 user directive persistence 위반.
 
+### Destructive Operation Approval Persistence (Generalized)
+
+The Git Push Continuation pattern (first-time strict / follow-up relaxed, scoped to session + category + target) generalizes to ALL repeated destructive operations within the same session. Examples: `supabase db push`, `terraform apply`, `kubectl delete`, bulk file deletes, database migrations.
+
+**Scope**: once the user explicitly approves a destructive operation of category C against target T in a session, follow-up operations of the SAME C + SAME T do NOT require re-confirmation. An advisory warning is still emitted. A different category or different target always requires fresh confirmation.
+
+| Scenario | Behavior |
+|----------|----------|
+| 1st explicit approval (category C, target T) | Proceed; advisory warning emitted |
+| Follow-up same session (same C + same T) | No re-confirmation (directive persistence) |
+| Different category or target | Fresh confirmation required |
+| Platform classifier still prompts | Advise user: add `settings.json` permission rule for the specific command |
+
+**R001 exclusion (MUST)**: R001-listed catastrophic git operations (`git reset --hard`, `git clean -fd`, `git push --force` to shared branches, `git branch -D` with unmerged commits) are EXCLUDED from this persistence rule — they always require explicit per-invocation approval regardless of prior session approvals.
+
+**Boundary / honesty note**: This rule is ADVISORY and governs model behavior only. It CANNOT suppress Claude Code's platform-level auto-mode classifier prompts. For genuine prompt suppression on a repeated destructive command, the user must add a `settings.json` permission allow rule scoped to the specific command (e.g., a specific `supabase db push` invocation). The model SHOULD surface this workaround when the user expresses friction about repeated prompts.
+
+Cross-references: R001 (safety — destructive operation pre-checks still apply), R002 (permission tiers). Reference issues: #1230, #1226 (item 2).
+
 ## Agent Triggers
 
 Defined in `.claude/skills/intent-detection/patterns/agent-triggers.yaml`. Each agent has keywords, file patterns, actions, and base confidence.

--- a/templates/.claude/rules/SHOULD-memory-integration.md
+++ b/templates/.claude/rules/SHOULD-memory-integration.md
@@ -351,7 +351,7 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 
 ### Session-End Self-Check (MANDATORY)
 
-(1) sys-memory-keeper updated MEMORY.md? (2) claude-mem save attempted? (3) If `omcustom-feedback` skill is active, prompt user to trigger it? All three required before confirming to user. See full self-check via Read tool.
+(1) sys-memory-keeper updated MEMORY.md? (2) claude-mem save attempted? (3) If `omcustom-feedback` skill is active, model MAY draft a retrospective feedback issue for user approval — or prompt user to trigger it manually. All three required before confirming to user. See full self-check via Read tool.
 
 <!-- DETAIL: Session-End Self-Check (MANDATORY)
 ```
@@ -367,8 +367,10 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 ║     NO  → ToolSearch + save now                                  ║
 ║                                                                   ║
 ║  3. Is omcustom-feedback skill available in this project?        ║
-║     YES → Ask user: "이번 세션 피드백을 omcustom-feedback로     ║
-║          기록하시겠습니까?" — accept skip                        ║
+║     YES → If notable friction/learning observed: MODEL DRAFTS    ║
+║          retrospective issue → presents via Phase 4A preview     ║
+║          gate for user approval. Otherwise: prompt user to       ║
+║          trigger manually. Accept skip either way.               ║
 ║     NO  → Skip                                                    ║
 ║                                                                   ║
 ║  Note: episodic-memory auto-indexes conversations after session  ║
@@ -380,6 +382,33 @@ MCP tools (claude-mem, episodic-memory) are **orchestrator-scoped** and not inhe
 ╚══════════════════════════════════════════════════════════════════╝
 ```
 -->
+
+### Session-End Retrospective Feedback (Model-Drafted)
+
+Since `omcustom-feedback` is now model-invocable (#1227), the model MAY draft a retrospective feedback issue at session end — instead of only prompting the user to compose one manually.
+
+**Workflow**
+
+1. Model detects notable friction, workarounds, or harness gaps observed during the session.
+2. Model drafts a feedback issue (title + body) using the `omcustom-feedback` skill.
+3. Draft is presented through the skill's **Phase 4A preview + confirmation gate**. The user reviews and approves before any GitHub issue is created.
+4. The model NEVER auto-submits. User approval is always required.
+
+**Trigger conditions** (all must be true):
+- Session-end detected
+- Notable friction or learning observed during the session
+- `omcustom-feedback` skill active in this project
+
+**Distinction from manual path**
+
+| Path | Who drafts | Who approves | When |
+|------|-----------|--------------|------|
+| Manual (existing) | User | User | User chooses to file feedback |
+| Model-drafted (new, #1226 item 3) | Model | User (Phase 4A gate) | Session-end with notable friction |
+
+The model-drafted path is an enhancement: it proposes a concrete draft rather than asking the user to compose from scratch. Both paths remain valid; neither replaces the other.
+
+References: #1226 (item 3), #1227.
 
 ### Failure Policy
 
@@ -418,7 +447,7 @@ Phase 1 COEXIST 기간 중 세션 종료 시:
 1. sys-memory-keeper가 MEMORY.md 갱신? → YES: 계속
 2. claude-mem 저장 시도? → YES (기존 항목)
 3. AgentMemory 저장 시도? → YES (COEXIST 추가)
-4. omcustom-feedback 권유? → YES (활성 시) / 스킵 (비활성 시)
+4. omcustom-feedback 처리? → YES (활성 시, notable friction 있으면 model draft → Phase 4A gate; 없으면 사용자 권유) / 스킵 (비활성 시)
 네 단계 모두 완료 후 사용자에게 확인. 둘 중 하나 실패해도 비차단.
 
 ### Phase 2 진입 전 필수 조건

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.152.0",
+  "version": "0.153.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/wiki/rules/r015.md
+++ b/wiki/rules/r015.md
@@ -1,7 +1,7 @@
 ---
 title: "R015: Intent Transparency Rules"
 type: rule
-updated: 2026-05-20
+updated: 2026-05-24
 sources:
   - .claude/rules/MUST-intent-transparency.md
 related:
@@ -94,6 +94,30 @@ At the start of every new task, issue, or autonomous sub-loop, answer these thre
 ✓ CORRECT: Directive persists — carry forward until user explicitly rescinds it
 ```
 
+## Destructive Operation Approval Persistence (Generalized)
+
+The Git Push Continuation pattern is generalized to **all repeated destructive operations** within a session (#1230, #1226 item2).
+
+**Core rule:** Once the user explicitly approves a destructive operation of category C against target T, subsequent ops of the **same C + same T** proceed without re-confirmation. An advisory warning is still emitted. A different category or different target always requires a fresh confirmation.
+
+| Scenario | Behavior |
+|----------|----------|
+| Same category + same target (2nd+ invocation) | Proceed with advisory warning only |
+| Different category OR different target | Fresh confirmation required |
+
+**Applies to:** `supabase db push`, `terraform apply`, `kubectl delete`, bulk file deletes, DB migrations, and similar non-git destructive operations — in addition to the existing git push continuation.
+
+**R001 exclusion (MUST):** The following catastrophic git operations are **permanently excluded** — they always require per-invocation approval regardless of session history:
+
+- `git reset --hard` (especially to remote/old SHA)
+- `git clean -fd` / `git clean -fdx`
+- `git push --force` / `--force-with-lease` to shared branches
+- `git branch -D` with unmerged commits
+
+**Advisory boundary note:** This rule governs model behavior only. It CANNOT suppress CC platform auto-mode classifier prompts. If the user experiences unexpected platform-level re-prompts, the model should surface the workaround: adding an explicit `settings.json` permission allow rule.
+
+Cross-references: [[r001]], [[r002]], #1230.
+
 ## Failed Tool Re-Try Discipline (v0.147.0)
 
 User-specified tools/formats persist across failures. After a tool rejection or failure, retry with the SAME tool — do NOT silently switch to a different mechanism.
@@ -120,3 +144,5 @@ Prompt-based per [[r021]]. Advisory only.
 - `.claude/rules/MUST-intent-transparency.md` — rule definition (Failed Tool Re-Try Discipline added v0.147.0)
 - Issue #869 — user directive persistence in autonomous mode (2026-04-15)
 - Issue #1188 item #4 — AskUserQuestion rejected, re-asked via free text (2026-05-19)
+- Issue #1230 — Destructive Operation Approval Persistence generalized beyond git push (2026-05-24)
+- Issue #1226 item2 — session-level approval persistence design input (2026-05-24)


### PR DESCRIPTION
## v0.153.0

### 변경
- **#1230**: R015 directive persistence를 비-git 파괴적 작업(`supabase db push`, `terraform apply` 등)으로 일반화 — 동일 세션+카테고리+타겟 1차 승인 후 후속 재확인 생략. R001 catastrophic ops(reset --hard/clean -fd/force push/branch -D)는 제외(항상 재확인). ADVISORY — 플랫폼 classifier 억제 불가, settings.json 권한 규칙 workaround 안내.
- **#1231**: verify-wiki-sync.sh index drift 오탐 수정 — `ACTUAL_TOTAL`이 `find -mindepth 2`로 15개 루트 navigation 페이지 제외, index.yaml total_pages=271 정책 일치 (#1223).

### Template/Wiki sync
- R015 + R011 rule template 동기화 (R011은 v0.152.0 catch-up)
- wiki/rules/r015.md

Fixes #1230
Fixes #1231

🤖 Generated with [Claude Code](https://claude.com/claude-code)