### PR TITLE
release: v0.154.0 — proactive R007/R008 드리프트 advisory hook (#1229)

### DIFF
--- a/.claude/hooks/hooks.json
+++ b/.claude/hooks/hooks.json
@@ -212,6 +212,16 @@
         "matcher": "*",
         "hooks": [
           {
+            "type": "command",
+            "command": "bash .claude/hooks/scripts/r007-r008-drift-advisor.sh"
+          }
+        ],
+        "description": "Proactive R007/R008 drift advisory \u2014 checks last assistant turn for identification omission (#1229)"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
             "type": "prompt",
             "command": "bash .claude/hooks/scripts/session-autofix-prompt.sh"
           }

--- a/.claude/hooks/scripts/r007-r008-drift-advisor.sh
+++ b/.claude/hooks/scripts/r007-r008-drift-advisor.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# r007-r008-drift-advisor.sh — UserPromptSubmit hook: PROACTIVE R007/R008 drift advisory (#1229)
+#
+# Inspects the LAST completed assistant turn in the session transcript for R007/R008
+# compliance BEFORE Claude responds. If the previous turn drifted (missing identification
+# header / tool prefix), emits a stderr advisory so the upcoming response self-corrects.
+#
+# This is the PROACTIVE complement to the retroactive session-reflection.sh (Stop hook, #1190).
+# Detection patterns are reused from session-reflection.sh.
+#
+# Advisory-only: ALWAYS exits 0, ALWAYS passes stdin through to stdout, NEVER blocks.
+# Performance: parses ONLY the last assistant turn (not the whole transcript).
+#
+# 환경변수 override (테스트/디버깅용):
+#   OMCUSTOM_R007_ADVISOR=off  — advisory 완전 비활성화 (pass-through)
+#   OMCUSTOM_TRANSCRIPT_BASE   — transcript 디렉토리 경로 override
+
+set -euo pipefail
+
+# ── UserPromptSubmit 프로토콜: stdin을 먼저 읽음 ──
+input=$(cat)
+
+# ── Opt-out 체크 ──
+if [ "${OMCUSTOM_R007_ADVISOR:-}" = "off" ]; then
+  echo "$input"
+  exit 0
+fi
+
+# ── jq 의존성 체크 ──
+if ! command -v jq >/dev/null 2>&1; then
+  echo "$input"
+  exit 0
+fi
+
+# ── session_id 추출 ──
+session_id=$(echo "$input" | jq -r '.session_id // empty' 2>/dev/null)
+if [ -z "$session_id" ]; then
+  echo "$input"
+  exit 0
+fi
+
+# ── 경로 결정 (환경변수 override 지원) ──
+TRANSCRIPT_BASE="${OMCUSTOM_TRANSCRIPT_BASE:-${HOME}/.claude/projects/-Users-sangyi-workspace-projects-oh-my-customcode}"
+TRANSCRIPT_PATH="${TRANSCRIPT_BASE}/${session_id}.jsonl"
+
+if [ ! -f "$TRANSCRIPT_PATH" ]; then
+  echo "$input"
+  exit 0
+fi
+
+# ── 마지막 assistant 메시지 추출 (성능: 전체 transcript 스캔 회피) ──
+# 파일을 역순으로 읽으며 첫 번째 role=="assistant" 라인을 찾는다.
+last_assistant=""
+while IFS= read -r line; do
+  role=$(echo "$line" | jq -r '.role // empty' 2>/dev/null) || continue
+  if [ "$role" = "assistant" ]; then
+    last_assistant="$line"
+    break
+  fi
+done < <(tail -r "$TRANSCRIPT_PATH" 2>/dev/null || tac "$TRANSCRIPT_PATH" 2>/dev/null)
+
+if [ -z "$last_assistant" ]; then
+  echo "$input"
+  exit 0
+fi
+
+# ── content 배열 파싱 ──
+content_raw=$(echo "$last_assistant" | jq -c '.content // []' 2>/dev/null) || content_raw="[]"
+
+r007_violations=0
+r008_violations=0
+
+# ── R007: 첫 번째 text 블록의 첫 줄 체크 ──
+first_text=$(echo "$content_raw" | jq -r '[.[] | select(.type == "text")][0].text // empty' 2>/dev/null) || first_text=""
+if [ -n "$first_text" ]; then
+  first_line=$(printf '%s' "$first_text" | head -1)
+  # R007 패턴: '┌─ Agent:' 또는 '[anything]' 단축 형태
+  if ! printf '%s' "$first_line" | grep -qE '(^┌─ Agent:|^\[.+\])'; then
+    r007_violations=$((r007_violations + 1))
+  fi
+fi
+
+# ── R008: tool_use 블록 직전 text에 prefix 체크 ──
+content_length=$(echo "$content_raw" | jq 'length' 2>/dev/null) || content_length=0
+i=0
+while [ "$i" -lt "$content_length" ]; do
+  block_type=$(echo "$content_raw" | jq -r ".[$i].type // empty" 2>/dev/null) || { i=$((i+1)); continue; }
+
+  if [ "$block_type" = "tool_use" ]; then
+    has_prefix=false
+    if [ "$i" -gt 0 ]; then
+      prev_type=$(echo "$content_raw" | jq -r ".[$(( i - 1 ))].type // empty" 2>/dev/null) || true
+      if [ "$prev_type" = "text" ]; then
+        prev_text=$(echo "$content_raw" | jq -r ".[$(( i - 1 ))].text // empty" 2>/dev/null) || true
+        # R008 패턴: '[agent-name][model] → Tool:' 또는 '→ Target:'
+        if printf '%s' "$prev_text" | grep -qE '\[.+\]\[.+\] ?(→|->|—>) ?(Tool|Target):'; then
+          has_prefix=true
+        fi
+      fi
+    fi
+    if [ "$has_prefix" = "false" ]; then
+      r008_violations=$((r008_violations + 1))
+    fi
+  fi
+
+  i=$((i+1))
+done
+
+# ── advisory 출력 (위반 시에만) ──
+if [ "$r007_violations" -gt 0 ] || [ "$r008_violations" -gt 0 ]; then
+  printf '[R007/R008 Advisory] 직전 응답에서 식별 누락 감지 (R007 헤더=%d, R008 접두사=%d). 이번 응답은 ┌─ Agent: 헤더로 시작하고, 모든 도구 호출에 [agent][model] → Tool: 접두사를 포함하십시오.\n' \
+    "$r007_violations" "$r008_violations" >&2
+fi
+
+# ── 항상 stdin pass-through 후 exit 0 (advisory는 절대 차단 금지) ──
+echo "$input"
+exit 0

--- a/.claude/rules/MUST-enforcement-policy.md
+++ b/.claude/rules/MUST-enforcement-policy.md
@@ -14,6 +14,7 @@ oh-my-customcode uses an **advisory-first enforcement model**. Most rules are en
 | Soft Block | Stop hook prompt | R011 session-end saves | Auto-performs then approves |
 | Conversation Block | PostToolUse hook + `continueOnBlock` (CC v2.1.139+), exit 2 | stuck-detector, context-budget-advisor, cost-cap-advisor | Feeds rejection reason into conversation; Claude continues with awareness |
 | Advisory | PostToolUse hooks | R007, R008, R009, R010, R018 | Warns via stderr, never blocks |
+| Advisory (proactive) | UserPromptSubmit hook | R007, R008 (`r007-r008-drift-advisor.sh`, #1229) | Reads last assistant turn; emits stderr advisory before next response if header/prefix absent. Complements retroactive Stop-hook (`session-reflection.sh`, #1190). |
 | Prompt-based | CLAUDE.md + rules/ + PostCompact | All MUST rules | Behavioral guidance in context |
 
 ## Why Advisory-First
@@ -23,15 +24,15 @@ oh-my-customcode uses an **advisory-first enforcement model**. Most rules are en
 3. **Composability**: External skills and internal rules can coexist without deadlocks
 4. **PostCompact reinforcement**: R007/R008/R009/R010/R018 are re-injected after context compaction
 
-## Hard Enforcement Candidates — R010 git-delegation-guard (conditional), R007/R008 UserPromptSubmit/PreToolUse hook (multi-turn gap candidate, #1096). Promoted: rule-deletion-guard.sh (2026-04-08). See details via Read tool.
+## Hard Enforcement Candidates — R010 git-delegation-guard (conditional), R007/R008 UserPromptSubmit advisory **implemented** (#1229, proactive) + retroactive Stop-hook (#1190); hard-block variant still candidate if advisory insufficient (#1096). Promoted: rule-deletion-guard.sh (2026-04-08). See details via Read tool.
 
 <!-- DETAIL: Hard Enforcement Candidates (Future)
 If advisory enforcement proves insufficient for specific rules, these are candidates for promotion to hard-block:
 
-| Rule | Candidate Hook | Condition for Promotion |
-|------|---------------|------------------------|
-| R010 | git-delegation-guard.sh | If orchestrator-direct-write violations exceed 3/session |
-| R007/R008 | (new hook) | If identification omission rate exceeds 20% |
+| Rule | Candidate Hook | Status | Condition for Promotion |
+|------|---------------|--------|------------------------|
+| R010 | git-delegation-guard.sh | Candidate | If orchestrator-direct-write violations exceed 3/session |
+| R007/R008 | `r007-r008-drift-advisor.sh` (UserPromptSubmit, #1229) | **Advisory implemented** — proactive pre-response check; retroactive: `session-reflection.sh` (Stop, #1190). Two-layer drift detection: proactive (#1229) + retroactive (#1190). | Promote to hard-block if advisory proves insufficient (#1096) |
 
 Promotion requires: (1) measured violation rate data, (2) user approval, (3) rollback plan.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.153.0",
+  "version": "0.154.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/hooks/hooks.json
+++ b/templates/.claude/hooks/hooks.json
@@ -212,6 +212,16 @@
         "matcher": "*",
         "hooks": [
           {
+            "type": "command",
+            "command": "bash .claude/hooks/scripts/r007-r008-drift-advisor.sh"
+          }
+        ],
+        "description": "Proactive R007/R008 drift advisory \u2014 checks last assistant turn for identification omission (#1229)"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
             "type": "prompt",
             "command": "bash .claude/hooks/scripts/session-autofix-prompt.sh"
           }

--- a/templates/.claude/hooks/scripts/r007-r008-drift-advisor.sh
+++ b/templates/.claude/hooks/scripts/r007-r008-drift-advisor.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# r007-r008-drift-advisor.sh — UserPromptSubmit hook: PROACTIVE R007/R008 drift advisory (#1229)
+#
+# Inspects the LAST completed assistant turn in the session transcript for R007/R008
+# compliance BEFORE Claude responds. If the previous turn drifted (missing identification
+# header / tool prefix), emits a stderr advisory so the upcoming response self-corrects.
+#
+# This is the PROACTIVE complement to the retroactive session-reflection.sh (Stop hook, #1190).
+# Detection patterns are reused from session-reflection.sh.
+#
+# Advisory-only: ALWAYS exits 0, ALWAYS passes stdin through to stdout, NEVER blocks.
+# Performance: parses ONLY the last assistant turn (not the whole transcript).
+#
+# 환경변수 override (테스트/디버깅용):
+#   OMCUSTOM_R007_ADVISOR=off  — advisory 완전 비활성화 (pass-through)
+#   OMCUSTOM_TRANSCRIPT_BASE   — transcript 디렉토리 경로 override
+
+set -euo pipefail
+
+# ── UserPromptSubmit 프로토콜: stdin을 먼저 읽음 ──
+input=$(cat)
+
+# ── Opt-out 체크 ──
+if [ "${OMCUSTOM_R007_ADVISOR:-}" = "off" ]; then
+  echo "$input"
+  exit 0
+fi
+
+# ── jq 의존성 체크 ──
+if ! command -v jq >/dev/null 2>&1; then
+  echo "$input"
+  exit 0
+fi
+
+# ── session_id 추출 ──
+session_id=$(echo "$input" | jq -r '.session_id // empty' 2>/dev/null)
+if [ -z "$session_id" ]; then
+  echo "$input"
+  exit 0
+fi
+
+# ── 경로 결정 (환경변수 override 지원) ──
+TRANSCRIPT_BASE="${OMCUSTOM_TRANSCRIPT_BASE:-${HOME}/.claude/projects/-Users-sangyi-workspace-projects-oh-my-customcode}"
+TRANSCRIPT_PATH="${TRANSCRIPT_BASE}/${session_id}.jsonl"
+
+if [ ! -f "$TRANSCRIPT_PATH" ]; then
+  echo "$input"
+  exit 0
+fi
+
+# ── 마지막 assistant 메시지 추출 (성능: 전체 transcript 스캔 회피) ──
+# 파일을 역순으로 읽으며 첫 번째 role=="assistant" 라인을 찾는다.
+last_assistant=""
+while IFS= read -r line; do
+  role=$(echo "$line" | jq -r '.role // empty' 2>/dev/null) || continue
+  if [ "$role" = "assistant" ]; then
+    last_assistant="$line"
+    break
+  fi
+done < <(tail -r "$TRANSCRIPT_PATH" 2>/dev/null || tac "$TRANSCRIPT_PATH" 2>/dev/null)
+
+if [ -z "$last_assistant" ]; then
+  echo "$input"
+  exit 0
+fi
+
+# ── content 배열 파싱 ──
+content_raw=$(echo "$last_assistant" | jq -c '.content // []' 2>/dev/null) || content_raw="[]"
+
+r007_violations=0
+r008_violations=0
+
+# ── R007: 첫 번째 text 블록의 첫 줄 체크 ──
+first_text=$(echo "$content_raw" | jq -r '[.[] | select(.type == "text")][0].text // empty' 2>/dev/null) || first_text=""
+if [ -n "$first_text" ]; then
+  first_line=$(printf '%s' "$first_text" | head -1)
+  # R007 패턴: '┌─ Agent:' 또는 '[anything]' 단축 형태
+  if ! printf '%s' "$first_line" | grep -qE '(^┌─ Agent:|^\[.+\])'; then
+    r007_violations=$((r007_violations + 1))
+  fi
+fi
+
+# ── R008: tool_use 블록 직전 text에 prefix 체크 ──
+content_length=$(echo "$content_raw" | jq 'length' 2>/dev/null) || content_length=0
+i=0
+while [ "$i" -lt "$content_length" ]; do
+  block_type=$(echo "$content_raw" | jq -r ".[$i].type // empty" 2>/dev/null) || { i=$((i+1)); continue; }
+
+  if [ "$block_type" = "tool_use" ]; then
+    has_prefix=false
+    if [ "$i" -gt 0 ]; then
+      prev_type=$(echo "$content_raw" | jq -r ".[$(( i - 1 ))].type // empty" 2>/dev/null) || true
+      if [ "$prev_type" = "text" ]; then
+        prev_text=$(echo "$content_raw" | jq -r ".[$(( i - 1 ))].text // empty" 2>/dev/null) || true
+        # R008 패턴: '[agent-name][model] → Tool:' 또는 '→ Target:'
+        if printf '%s' "$prev_text" | grep -qE '\[.+\]\[.+\] ?(→|->|—>) ?(Tool|Target):'; then
+          has_prefix=true
+        fi
+      fi
+    fi
+    if [ "$has_prefix" = "false" ]; then
+      r008_violations=$((r008_violations + 1))
+    fi
+  fi
+
+  i=$((i+1))
+done
+
+# ── advisory 출력 (위반 시에만) ──
+if [ "$r007_violations" -gt 0 ] || [ "$r008_violations" -gt 0 ]; then
+  printf '[R007/R008 Advisory] 직전 응답에서 식별 누락 감지 (R007 헤더=%d, R008 접두사=%d). 이번 응답은 ┌─ Agent: 헤더로 시작하고, 모든 도구 호출에 [agent][model] → Tool: 접두사를 포함하십시오.\n' \
+    "$r007_violations" "$r008_violations" >&2
+fi
+
+# ── 항상 stdin pass-through 후 exit 0 (advisory는 절대 차단 금지) ──
+echo "$input"
+exit 0

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.153.0",
+  "version": "0.154.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/tests/unit/core/r007-r008-drift-advisor.test.ts
+++ b/tests/unit/core/r007-r008-drift-advisor.test.ts
@@ -1,0 +1,509 @@
+/**
+ * Tests for r007-r008-drift-advisor.sh hook (proactive R007/R008 drift advisory, #1229).
+ *
+ * The script is a UserPromptSubmit hook:
+ * - Reads UserPromptSubmit JSON from stdin (contains `session_id`)
+ * - Reads the session transcript JSONL at `${OMCUSTOM_TRANSCRIPT_BASE}/${session_id}.jsonl`
+ * - Inspects ONLY the LAST assistant turn for R007/R008 compliance
+ * - If the last turn violates → emits a Korean advisory to stderr containing `[R007/R008 Advisory]`
+ * - ALWAYS passes stdin through to stdout and exits 0 (never blocks)
+ *
+ * Test strategy:
+ * - Use OMCUSTOM_TRANSCRIPT_BASE env-override to isolate every test in a temp directory.
+ * - Run the script directly against the templates/ canonical copy.
+ * - Synchronous result (no background worker) — advisory is emitted immediately.
+ *
+ * Fixtures
+ * ─────────
+ * 1. Clean last turn (header + tool prefixes present) → no advisory, exit 0, stdin passed through
+ * 2. R007 violation in last turn (missing agent header) → advisory in stderr, exit 0
+ * 3. R008 violation in last turn (tool_use without preceding prefix) → advisory in stderr, exit 0
+ * 4. Opt-out OMCUSTOM_R007_ADVISOR=off → no advisory even with violating transcript, exit 0
+ * 5. Missing transcript file → no advisory, exit 0, pass through (graceful degrade)
+ * 6. Missing session_id in stdin → no advisory, exit 0, pass through
+ * 7. Only-last-turn semantics: earlier turn violates but last turn is clean → no advisory
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+// ── Canonical script path (tests always target templates/) ──
+const SCRIPTS_DIR = resolve(import.meta.dir, '../../../templates/.claude/hooks/scripts');
+const SCRIPT = join(SCRIPTS_DIR, 'r007-r008-drift-advisor.sh');
+
+// ── Types ──
+
+interface ScriptResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+// ── Helpers ──
+
+/** Run r007-r008-drift-advisor.sh with given stdin and env overrides. */
+function runScript(stdinJson: string, env: Record<string, string> = {}): Promise<ScriptResult> {
+  return new Promise((done) => {
+    const child = spawn('bash', [SCRIPT], {
+      env: { ...process.env, ...env },
+      cwd: tmpdir(),
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c: Buffer) => {
+      stdout += c.toString();
+    });
+    child.stderr.on('data', (c: Buffer) => {
+      stderr += c.toString();
+    });
+    child.on('close', (code) => done({ stdout, stderr, exitCode: code ?? -1 }));
+    child.stdin.write(stdinJson);
+    child.stdin.end();
+  });
+}
+
+/** Build the UserPromptSubmit JSON payload. */
+function promptInput(sessionId: string): string {
+  return JSON.stringify({ session_id: sessionId, prompt: 'Hello' });
+}
+
+/** Build a JSONL line for an assistant turn (mirrors session-reflection.test.ts format). */
+function assistantTurn(content: object[]): string {
+  return JSON.stringify({ role: 'assistant', content });
+}
+
+/** Build a JSONL line for a user turn. */
+function userTurn(text: string): string {
+  return JSON.stringify({ role: 'user', content: [{ type: 'text', text }] });
+}
+
+// ── Per-test isolated environment ──
+
+let tmpRoot: string;
+let transcriptDir: string;
+
+beforeEach(async () => {
+  tmpRoot = join(
+    tmpdir(),
+    `drift-advisor-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  transcriptDir = join(tmpRoot, 'transcripts');
+  await mkdir(transcriptDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+/** Write a .jsonl transcript and return the session id. */
+async function writeTranscript(sessionId: string, lines: string[]): Promise<string> {
+  await writeFile(join(transcriptDir, `${sessionId}.jsonl`), `${lines.join('\n')}\n`);
+  return sessionId;
+}
+
+/** Common env overrides for an isolated test run. */
+function testEnv(): Record<string, string> {
+  return {
+    OMCUSTOM_TRANSCRIPT_BASE: transcriptDir,
+  };
+}
+
+// ════════════════════════════════════════════════════════════════
+// File existence & syntax
+// ════════════════════════════════════════════════════════════════
+
+describe('r007-r008-drift-advisor.sh — file existence', () => {
+  it('exists at templates/.claude/hooks/scripts/r007-r008-drift-advisor.sh', () => {
+    expect(existsSync(SCRIPT)).toBe(true);
+  });
+
+  it('passes bash -n syntax check', async () => {
+    const r = await new Promise<{ exitCode: number; stderr: string }>((res) => {
+      const c = spawn('bash', ['-n', SCRIPT]);
+      let stderr = '';
+      c.stderr.on('data', (d: Buffer) => {
+        stderr += d.toString();
+      });
+      c.on('close', (code) => res({ exitCode: code ?? -1, stderr }));
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).toBe('');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// Fixture 1: clean last turn — no advisory, exit 0, stdin passed through
+// ════════════════════════════════════════════════════════════════
+
+describe('r007-r008-drift-advisor.sh — Fixture 1: clean last turn', () => {
+  it('emits no advisory when last turn has valid R007 header and R008 prefixes', async () => {
+    const sid = `clean-${Date.now()}`;
+    await writeTranscript(sid, [
+      userTurn('Please read a file.'),
+      assistantTurn([
+        { type: 'text', text: '┌─ Agent: lang-typescript-expert (sonnet)\n└─ Task: read file' },
+        {
+          type: 'text',
+          text: '[lang-typescript-expert][sonnet] → Tool: Read\n[lang-typescript-expert][sonnet] → Target: file.ts',
+        },
+        { type: 'tool_use', id: 'tu1', name: 'Read', input: { file_path: 'file.ts' } },
+      ]),
+    ]);
+
+    const input = promptInput(sid);
+    const r = await runScript(input, testEnv());
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).not.toContain('[R007/R008 Advisory]');
+    // stdin must be passed through unchanged
+    expect(r.stdout.trim()).toBe(input);
+  });
+
+  it('emits no advisory when last turn uses shorthand [agent] header with no tool_use', async () => {
+    const sid = `clean-shorthand-${Date.now()}`;
+    await writeTranscript(sid, [
+      assistantTurn([{ type: 'text', text: '[claude] Here is the answer to your question.' }]),
+    ]);
+
+    const r = await runScript(promptInput(sid), testEnv());
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).not.toContain('[R007/R008 Advisory]');
+  });
+
+  it('passes stdin through to stdout unchanged on clean turn', async () => {
+    const sid = `passthrough-${Date.now()}`;
+    await writeTranscript(sid, [
+      assistantTurn([{ type: 'text', text: '┌─ Agent: claude (default)\n└─ Task: answer' }]),
+    ]);
+
+    const input = promptInput(sid);
+    const r = await runScript(input, testEnv());
+
+    expect(r.stdout.trim()).toBe(input);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// Fixture 2: R007 violation in last turn
+// ════════════════════════════════════════════════════════════════
+
+describe('r007-r008-drift-advisor.sh — Fixture 2: R007 violation', () => {
+  it('emits [R007/R008 Advisory] when last turn first text line lacks agent header', async () => {
+    const sid = `r007-${Date.now()}`;
+    await writeTranscript(sid, [
+      assistantTurn([{ type: 'text', text: 'Sure, I can help with that.' }]),
+    ]);
+
+    const r = await runScript(promptInput(sid), testEnv());
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).toContain('[R007/R008 Advisory]');
+  });
+
+  it('exits 0 even on R007 violation (advisory-only, never blocks)', async () => {
+    const sid = `r007-exit0-${Date.now()}`;
+    await writeTranscript(sid, [assistantTurn([{ type: 'text', text: 'No header here at all.' }])]);
+
+    const r = await runScript(promptInput(sid), testEnv());
+
+    expect(r.exitCode).toBe(0);
+  });
+
+  it('still passes stdin through to stdout on R007 violation', async () => {
+    const sid = `r007-stdout-${Date.now()}`;
+    await writeTranscript(sid, [
+      assistantTurn([{ type: 'text', text: 'Missing identification header.' }]),
+    ]);
+
+    const input = promptInput(sid);
+    const r = await runScript(input, testEnv());
+
+    expect(r.stdout.trim()).toBe(input);
+  });
+
+  it('treats ┌─ Agent: prefix as valid R007 header (no advisory)', async () => {
+    const sid = `r007-full-ok-${Date.now()}`;
+    await writeTranscript(sid, [
+      assistantTurn([
+        { type: 'text', text: '┌─ Agent: mgr-creator (sonnet)\n└─ Task: create agent' },
+      ]),
+    ]);
+
+    const r = await runScript(promptInput(sid), testEnv());
+
+    expect(r.stderr).not.toContain('[R007/R008 Advisory]');
+  });
+
+  it('treats [agent-name] shorthand as valid R007 header (no advisory)', async () => {
+    const sid = `r007-shorthand-ok-${Date.now()}`;
+    await writeTranscript(sid, [
+      assistantTurn([{ type: 'text', text: '[mgr-creator] Creating agent structure...' }]),
+    ]);
+
+    const r = await runScript(promptInput(sid), testEnv());
+
+    expect(r.stderr).not.toContain('[R007/R008 Advisory]');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// Fixture 3: R008 violation in last turn
+// ════════════════════════════════════════════════════════════════
+
+describe('r007-r008-drift-advisor.sh — Fixture 3: R008 violation', () => {
+  it('emits [R007/R008 Advisory] when tool_use is not preceded by R008 prefix text', async () => {
+    const sid = `r008-${Date.now()}`;
+    await writeTranscript(sid, [
+      assistantTurn([
+        // valid R007 header
+        { type: 'text', text: '┌─ Agent: claude (default)\n└─ Task: read file' },
+        // tool_use directly after header text — no [agent][model] → Tool: prefix in between
+        { type: 'tool_use', id: 'tu2', name: 'Read', input: { file_path: 'some.md' } },
+      ]),
+    ]);
+
+    const r = await runScript(promptInput(sid), testEnv());
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).toContain('[R007/R008 Advisory]');
+  });
+
+  it('emits advisory when tool_use is preceded by non-R008 text', async () => {
+    const sid = `r008-bad-prefix-${Date.now()}`;
+    await writeTranscript(sid, [
+      assistantTurn([
+        { type: 'text', text: '┌─ Agent: claude (default)\n└─ Task: search' },
+        // text exists but it doesn't match the R008 pattern
+        { type: 'text', text: 'Let me search for that...' },
+        { type: 'tool_use', id: 'tu5', name: 'Grep', input: { pattern: 'test' } },
+      ]),
+    ]);
+
+    const r = await runScript(promptInput(sid), testEnv());
+
+    expect(r.stderr).toContain('[R007/R008 Advisory]');
+  });
+
+  it('does NOT emit advisory when tool_use is preceded by valid R008 prefix', async () => {
+    const sid = `r008-ok-${Date.now()}`;
+    await writeTranscript(sid, [
+      assistantTurn([
+        { type: 'text', text: '┌─ Agent: claude (default)\n└─ Task: write' },
+        {
+          type: 'text',
+          text: '[claude][sonnet] → Tool: Write\n[claude][sonnet] → Target: out.md',
+        },
+        {
+          type: 'tool_use',
+          id: 'tu3',
+          name: 'Write',
+          input: { file_path: 'out.md', content: 'x' },
+        },
+      ]),
+    ]);
+
+    const r = await runScript(promptInput(sid), testEnv());
+
+    expect(r.stderr).not.toContain('[R007/R008 Advisory]');
+  });
+
+  it('accepts → arrow variant in R008 prefix', async () => {
+    const sid = `r008-arrow-${Date.now()}`;
+    await writeTranscript(sid, [
+      assistantTurn([
+        { type: 'text', text: '[claude] Task start' },
+        { type: 'text', text: '[claude][sonnet] -> Tool: Read' },
+        { type: 'tool_use', id: 'tu6', name: 'Read', input: { file_path: 'x.md' } },
+      ]),
+    ]);
+
+    const r = await runScript(promptInput(sid), testEnv());
+
+    expect(r.stderr).not.toContain('[R007/R008 Advisory]');
+  });
+
+  it('passes stdin through to stdout on R008 violation', async () => {
+    const sid = `r008-stdout-${Date.now()}`;
+    await writeTranscript(sid, [
+      assistantTurn([
+        { type: 'text', text: '┌─ Agent: claude (default)\n└─ Task: read' },
+        { type: 'tool_use', id: 'tu4', name: 'Read', input: { file_path: 'file.md' } },
+      ]),
+    ]);
+
+    const input = promptInput(sid);
+    const r = await runScript(input, testEnv());
+
+    expect(r.stdout.trim()).toBe(input);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// Fixture 4: opt-out
+// ════════════════════════════════════════════════════════════════
+
+describe('r007-r008-drift-advisor.sh — Fixture 4: opt-out', () => {
+  it('emits no advisory when OMCUSTOM_R007_ADVISOR=off, even with R007 violation', async () => {
+    const sid = `opt-out-${Date.now()}`;
+    await writeTranscript(sid, [
+      assistantTurn([{ type: 'text', text: 'No header — would be R007 violation.' }]),
+    ]);
+
+    const r = await runScript(promptInput(sid), {
+      ...testEnv(),
+      OMCUSTOM_R007_ADVISOR: 'off',
+    });
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).not.toContain('[R007/R008 Advisory]');
+  });
+
+  it('passes stdin through unchanged when opt-out active', async () => {
+    const sid = `opt-out-pass-${Date.now()}`;
+    await writeTranscript(sid, [
+      assistantTurn([{ type: 'text', text: 'Violation turn without header.' }]),
+    ]);
+
+    const input = promptInput(sid);
+    const r = await runScript(input, {
+      ...testEnv(),
+      OMCUSTOM_R007_ADVISOR: 'off',
+    });
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe(input);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// Fixture 5: missing transcript file (graceful degrade)
+// ════════════════════════════════════════════════════════════════
+
+describe('r007-r008-drift-advisor.sh — Fixture 5: missing transcript', () => {
+  it('exits 0 with no advisory when transcript file does not exist', async () => {
+    const input = promptInput('nonexistent-session-xyz');
+    const r = await runScript(input, testEnv());
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).not.toContain('[R007/R008 Advisory]');
+  });
+
+  it('passes stdin through unchanged when transcript is missing', async () => {
+    const input = promptInput('no-transcript-session');
+    const r = await runScript(input, testEnv());
+
+    expect(r.stdout.trim()).toBe(input);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// Fixture 6: missing session_id in stdin
+// ════════════════════════════════════════════════════════════════
+
+describe('r007-r008-drift-advisor.sh — Fixture 6: missing session_id', () => {
+  it('exits 0 with no advisory when session_id is absent from input JSON', async () => {
+    const input = JSON.stringify({ prompt: 'Hello' });
+    const r = await runScript(input, testEnv());
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).not.toContain('[R007/R008 Advisory]');
+  });
+
+  it('passes stdin through unchanged when session_id is missing', async () => {
+    const input = JSON.stringify({ prompt: 'No session id here' });
+    const r = await runScript(input, testEnv());
+
+    expect(r.stdout.trim()).toBe(input);
+  });
+
+  it('exits 0 when jq is absent (PATH stripped)', async () => {
+    const input = promptInput('no-jq-session');
+    const r = await runScript(input, { PATH: '/usr/bin:/bin' });
+
+    expect(r.exitCode).toBe(0);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
+// Fixture 7: only-last-turn semantics
+// The hook inspects ONLY the last assistant turn.
+// An earlier turn that violates R007/R008 must NOT trigger an advisory
+// if the last (most recent) turn is compliant.
+// This distinguishes r007-r008-drift-advisor.sh from session-reflection.sh
+// which scans ALL turns.
+// ════════════════════════════════════════════════════════════════
+
+describe('r007-r008-drift-advisor.sh — Fixture 7: only-last-turn semantics', () => {
+  it('does NOT emit advisory when only an earlier turn violates R007 but the last is clean', async () => {
+    const sid = `last-turn-${Date.now()}`;
+    await writeTranscript(sid, [
+      userTurn('First question'),
+      // OLDER turn — R007 violation (no header)
+      assistantTurn([{ type: 'text', text: 'This response has no identification header.' }]),
+      userTurn('Second question'),
+      // LAST turn — fully compliant R007 + R008
+      assistantTurn([
+        { type: 'text', text: '┌─ Agent: claude (default)\n└─ Task: answer second question' },
+      ]),
+    ]);
+
+    const r = await runScript(promptInput(sid), testEnv());
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).not.toContain('[R007/R008 Advisory]');
+  });
+
+  it('does NOT emit advisory when earlier turns violate R008 but the last is clean', async () => {
+    const sid = `last-turn-r008-${Date.now()}`;
+    await writeTranscript(sid, [
+      userTurn('Read a file'),
+      // OLDER turn — R008 violation (tool_use without R008 prefix)
+      assistantTurn([
+        { type: 'text', text: '┌─ Agent: claude (default)\n└─ Task: read' },
+        { type: 'tool_use', id: 'tu-old', name: 'Read', input: { file_path: 'old.md' } },
+      ]),
+      userTurn('Now write a file'),
+      // LAST turn — compliant: R007 header + R008 prefix before tool_use
+      assistantTurn([
+        { type: 'text', text: '┌─ Agent: claude (default)\n└─ Task: write file' },
+        {
+          type: 'text',
+          text: '[claude][sonnet] → Tool: Write\n[claude][sonnet] → Target: new.md',
+        },
+        {
+          type: 'tool_use',
+          id: 'tu-new',
+          name: 'Write',
+          input: { file_path: 'new.md', content: 'ok' },
+        },
+      ]),
+    ]);
+
+    const r = await runScript(promptInput(sid), testEnv());
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).not.toContain('[R007/R008 Advisory]');
+  });
+
+  it('emits advisory when the LAST turn violates even though all prior turns are clean', async () => {
+    const sid = `last-turn-bad-${Date.now()}`;
+    await writeTranscript(sid, [
+      userTurn('First'),
+      // OLDER turn — compliant
+      assistantTurn([{ type: 'text', text: '┌─ Agent: claude (default)\n└─ Task: answer first' }]),
+      userTurn('Second'),
+      // LAST turn — R007 violation
+      assistantTurn([{ type: 'text', text: 'Forgot the header this time.' }]),
+    ]);
+
+    const r = await runScript(promptInput(sid), testEnv());
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).toContain('[R007/R008 Advisory]');
+  });
+});

--- a/wiki/rules/r021.md
+++ b/wiki/rules/r021.md
@@ -1,7 +1,7 @@
 ---
 title: "R021: Enforcement Policy"
 type: rule
-updated: 2026-04-12
+updated: 2026-05-24
 sources:
   - .claude/rules/MUST-enforcement-policy.md
 related:
@@ -32,6 +32,7 @@ Hard-blocking hooks are reserved for critical safety boundaries. The majority of
 |------|-----------|-------|----------|
 | Hard Block | PreToolUse hook, exit 2 | stage-blocker, dev-server tmux, rule-deletion-guard | Prevents tool execution |
 | Soft Block | Stop hook prompt | [[r011]] session-end saves | Auto-performs then approves |
+| Advisory (proactive) | UserPromptSubmit hook | [[r007]], [[r008]] — `r007-r008-drift-advisor.sh` (#1229) | Reads last assistant turn, emits stderr advisory before next response if identification header/prefix absent |
 | Advisory | PostToolUse hooks | [[r007]], [[r008]], [[r009]], [[r010]], [[r018]] | Warns via stderr, never blocks |
 | Prompt-based | CLAUDE.md + rules/ + PostCompact | All MUST rules | Behavioral guidance in context |
 
@@ -43,10 +44,14 @@ Hard-blocking hooks are reserved for critical safety boundaries. The majority of
 
 **Hard-block promotion conditions:**
 
-| Rule | Condition for Promotion |
-|------|------------------------|
-| [[r010]] | Orchestrator-direct-write violations > 3/session |
-| [[r007]]/[[r008]] | Identification omission rate > 20% |
+| Rule | Status |
+|------|--------|
+| [[r010]] | Candidate — orchestrator-direct-write violations > 3/session |
+| [[r007]]/[[r008]] | Advisory implemented (#1229 proactive UserPromptSubmit + #1190 retroactive Stop-hook); hard-block variant still candidate if advisory insufficient (#1096) |
+
+**Two-layer R007/R008 drift detection (as of #1229):**
+- **Proactive** (#1229): `r007-r008-drift-advisor.sh` UserPromptSubmit hook — fires before each response, catches missing headers early
+- **Retroactive** (#1190): `session-reflection.sh` Stop hook — analyzes full transcript at session end
 
 **Promoted to hard block:**
 - `rule-deletion-guard.sh` (2026-04-08) — prevents accidental bulk deletion of rule files


### PR DESCRIPTION
## v0.154.0

### 변경
- **#1229**: 신규 UserPromptSubmit hook `r007-r008-drift-advisor.sh` — 직전 assistant 턴을 transcript에서 검사해 R007 헤더/R008 접두사 누락 시 다음 응답 *전에* stderr advisory 발행. retroactive `session-reflection.sh`(#1190)의 proactive 보완. **Advisory-only: 항상 exit 0, 프롬프트 제출 절대 차단 안 함**. `OMCUSTOM_R007_ADVISOR=off` opt-out.
- **R021**: "Advisory (proactive)" enforcement tier 신설; #1096 hard-block 후보가 advisory로 구현됨. 두-계층 드리프트 감지(proactive #1229 + retroactive #1190).

### 검증
- 25 unit tests (advisory-only 안전성: 6개 exit 모두 0, stdin pass-through, jq/graceful degrade)
- mgr-sauron R017 PASS (hook 차단 불가 검증)

### Template/Wiki sync
- script + hooks.json (source/template 동일), wiki/rules/r021.md

Fixes #1229

🤖 Generated with [Claude Code](https://claude.com/claude-code)