### PR TITLE
release: v0.154.1 — 템플릿 content-drift 가드 + stale 복사본 15건 reconcile (#1234)

### DIFF
--- a/.github/scripts/verify-template-sync.sh
+++ b/.github/scripts/verify-template-sync.sh
@@ -167,6 +167,42 @@ if [ "$doc_skills" != "0" ] && [ "$actual_skills" != "$doc_skills" ]; then
   errors=$((errors + 1))
 fi
 
+# ── Content Drift Check (#1234) ──────────────────────────────────────────────
+# Count parity alone misses content drift: a rule/agent/hook edited in .claude/
+# without syncing templates/.claude/ passes the count check but ships stale.
+content_drift=0
+
+check_content_dir() {
+  # $1 = subpath under .claude/ and templates/.claude/ ; $2 = find glob
+  local sub="$1" glob="$2"
+  local src_dir=".claude/$sub" tpl_dir="templates/.claude/$sub"
+  [ -d "$src_dir" ] || return 0
+  while IFS= read -r f; do
+    local base="${f#"$src_dir"/}"
+    local tpl="$tpl_dir/$base"
+    if [ ! -f "$tpl" ]; then
+      echo "::error::Template missing for $sub: $base (source exists, template absent)"
+      content_drift=$((content_drift + 1))
+    elif ! diff -q "$f" "$tpl" >/dev/null 2>&1; then
+      echo "::error::Content drift in $sub: $base (source != template)"
+      content_drift=$((content_drift + 1))
+    fi
+  done < <(find "$src_dir" -maxdepth 1 -type f -name "$glob")
+}
+
+echo ""
+echo "=== Content Drift Check (#1234) ==="
+check_content_dir "rules" "*.md"
+check_content_dir "agents" "*.md"
+check_content_dir "hooks/scripts" "*.sh"
+
+if [ "$content_drift" -gt 0 ]; then
+  echo "::error::$content_drift content drift(s) detected between .claude/ and templates/.claude/"
+  echo "Fix: sync the source file(s) to templates/.claude/ (cp source template)"
+  exit 1
+fi
+echo "[OK] Content drift check: rules, agents, hooks/scripts all in sync"
+
 # ── Final result ─────────────────────────────────────────────────────────────
 if [ "$errors" -gt 0 ]; then
   echo ""

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.154.0",
+  "version": "0.154.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/agents/arch-documenter.md
+++ b/templates/.claude/agents/arch-documenter.md
@@ -50,3 +50,20 @@ When invoked for plan/spec authoring tasks:
 Rationale: Single-agent giant prompts cause latency timeouts and waste context (#1085). Decomposition by domain enables parallel execution and review loops.
 
 Reference rules: R009 (parallel execution), R018 (Agent Teams).
+
+## Output Constraints (Large Artifact Reply)
+
+큰 산출물(>50줄 또는 >2000자)을 호출자에게 회신할 때:
+- **파일 절대경로** 와 **행 수** 만 회신
+- 작성된 핵심 섹션 제목을 bullet 3-7개로 요약
+- 파일 본문 자체는 LLM 출력으로 재출력하지 않음 — 호출자가 `Read` 또는 `cat` 으로 직접 확인
+
+이유: 대용량 텍스트 재출력은 토큰 낭비 + 타임아웃 위험 + 컨텍스트 압박. 디스크에 이미 쓴 파일이 진실의 원본이다.
+
+### Exceptions
+
+- 호출자가 명시적으로 본문을 보여달라고 요구한 경우
+- 산출물이 50줄 또는 2000자 이하인 경우
+- 변경 diff 같은 작은 patch 형태인 경우
+
+Reference issue: #1087.

--- a/templates/.claude/agents/fe-design-expert.md
+++ b/templates/.claude/agents/fe-design-expert.md
@@ -8,6 +8,7 @@ effort: medium
 skills:
   - impeccable-design
   - web-design-guidelines
+  - diagram-design
 tools: [Read, Write, Edit, Grep, Glob, Bash]
 maxTurns: 20
 disallowedTools: [Bash]
@@ -112,8 +113,27 @@ Flag these patterns as AI slop:
 - Backend or API code → use appropriate language/framework agent
 - Bundle size analysis → use `tool-npm-expert`
 
+## Claude Design Handoff
+
+When receiving artifacts from Claude Design (Anthropic's conversational design tool):
+
+```
+Receive handoff (tokens JSON + component specs)
+  ↓
+1. Validate token integrity (OKLCH colors, consistent spacing scale, type hierarchy)
+2. Convert tokens → CSS custom properties
+3. Implement component specs → framework components (all variant states)
+4. Verify motion specs have functional purpose + prefers-reduced-motion guard
+5. Run AI Slop Test before declaring implementation done
+```
+
+**Handoff validation checklist** — see `guides/claude-design/index.md` for the full token integrity, component fidelity, motion verification, and slop check criteria.
+
+**Agent boundary**: Claude Design handoff stops at aesthetics and visual implementation. For accessibility compliance (WCAG, semantic HTML), pass to `fe-vercel-agent` or invoke `web-design-guidelines`.
+
 ## Reference Guides
 
+- `guides/claude-design/index.md` — Claude Design artifact handoff workflow and validation checklist
 - `guides/impeccable-design/typography.md` — type scale, font pairing, hierarchy
 - `guides/impeccable-design/color-and-contrast.md` — OKLCH, palette strategy, tinted neutrals
 - `guides/impeccable-design/motion-design.md` — timing rules, easing, purposeful animation

--- a/templates/.claude/agents/mgr-creator.md
+++ b/templates/.claude/agents/mgr-creator.md
@@ -18,17 +18,9 @@ maxTurns: 25
 permissionMode: bypassPermissions
 ---
 
-## Mandatory: .claude/ 경로 처리 (R010 Universal /tmp Script Bypass)
+## .claude/ 경로 처리 (CC v2.1.121+)
 
-ALL tool calls targeting `.claude/` paths MUST go through `/tmp/*.sh` script via Bash. This includes Write, Edit, and write-Bash. Direct `Write(".claude/...")` or `Edit(".claude/...")` triggers user approval prompts that block unattended automation, regardless of `bypassPermissions` mode or allow rules.
-
-Pattern:
-1. Write tool → `/tmp/fix-{topic}-$$.sh` containing heredoc/sed/cp targeting `.claude/`
-2. Bash tool → `bash /tmp/fix-{topic}-$$.sh`
-
-Read tool on `.claude/` paths is exempt (sensitive-path bypass for read-only). For `templates/.claude/` paths, the same pattern applies (also sensitive).
-
-Reference: R010 (.claude/rules/MUST-orchestrator-coordination.md), #1046, #1052, #1062.
+Direct Write/Edit/Bash on `.claude/**` and `templates/.claude/**` is permitted under `mode: "bypassPermissions"` as of CC v2.1.121 (#1101). The legacy `/tmp/*.sh` bypass is deprecated. For CC < v2.1.121, see git history for the legacy pattern.
 
 You are an agent creation specialist following R006 (MUST-agent-design.md) rules.
 

--- a/templates/.claude/agents/mgr-updater.md
+++ b/templates/.claude/agents/mgr-updater.md
@@ -22,17 +22,9 @@ tools:
 permissionMode: bypassPermissions
 ---
 
-## Mandatory: .claude/ 경로 처리 (R010 Universal /tmp Script Bypass)
+## .claude/ 경로 처리 (CC v2.1.121+)
 
-ALL tool calls targeting `.claude/` paths MUST go through `/tmp/*.sh` script via Bash. This includes Write, Edit, and write-Bash. Direct `Write(".claude/...")` or `Edit(".claude/...")` triggers user approval prompts that block unattended automation, regardless of `bypassPermissions` mode or allow rules.
-
-Pattern:
-1. Write tool → `/tmp/fix-{topic}-$$.sh` containing heredoc/sed/cp targeting `.claude/`
-2. Bash tool → `bash /tmp/fix-{topic}-$$.sh`
-
-Read tool on `.claude/` paths is exempt (sensitive-path bypass for read-only). For `templates/.claude/` paths, the same pattern applies (also sensitive).
-
-Reference: R010 (.claude/rules/MUST-orchestrator-coordination.md), #1046, #1052, #1062.
+Direct Write/Edit/Bash on `.claude/**` and `templates/.claude/**` is permitted under `mode: "bypassPermissions"` as of CC v2.1.121 (#1101). The legacy `/tmp/*.sh` bypass is deprecated. For CC < v2.1.121, see git history for the legacy pattern.
 
 You are an external source synchronization specialist keeping external components up-to-date.
 

--- a/templates/.claude/hooks/scripts/feedback-collector.sh
+++ b/templates/.claude/hooks/scripts/feedback-collector.sh
@@ -5,19 +5,19 @@
 set -euo pipefail
 
 # Pass through stdin (Stop hook protocol)
-cat > /dev/null
+input=$(cat)
 
 # Dependencies check
-command -v jq >/dev/null 2>&1 || exit 0
-command -v sqlite3 >/dev/null 2>&1 || exit 0
+command -v jq >/dev/null 2>&1 || { echo "$input"; exit 0; }
+command -v sqlite3 >/dev/null 2>&1 || { echo "$input"; exit 0; }
 
 # PID scoping
 OUTCOMES_FILE="/tmp/.claude-task-outcomes-${PPID}"
-[ -f "$OUTCOMES_FILE" ] || exit 0
+[ -f "$OUTCOMES_FILE" ] || { echo "$input"; exit 0; }
 
 # DB path
 DB_PATH="${HOME}/.config/oh-my-customcode/eval-core.sqlite"
-[ -f "$DB_PATH" ] || exit 0
+[ -f "$DB_PATH" ] || { echo "$input"; exit 0; }
 
 # Log file for error diagnostics
 LOG_FILE="/tmp/.claude-feedback-collector-${PPID}.log"
@@ -65,7 +65,7 @@ for agent_type in "${!FAILURE_COUNTS[@]}"; do
     action_type="augment"
   fi
 
-  failure_rate=$(awk "BEGIN {printf \"%.2f\", $count/$total}")
+  failure_rate=$(awk "BEGIN {printf \"%.2f\", $count/$total}" 2>/dev/null || echo "0.00")
   description="Agent '${agent_type}' failed ${count}/${total} times (${failure_rate} failure rate) in session"
 
   escaped_agent_type=$(_sql_escape "$agent_type")
@@ -86,4 +86,7 @@ if [ "$INSERTED" -gt 0 ]; then
   echo "[feedback-collector] Extracted ${INSERTED} failure pattern(s) from session outcomes" >&2
 fi
 
+# CRITICAL: Always pass through input and exit 0
+# This hook MUST NEVER block session termination
+echo "$input"
 exit 0

--- a/templates/.claude/hooks/scripts/session-reflection.sh
+++ b/templates/.claude/hooks/scripts/session-reflection.sh
@@ -32,6 +32,16 @@ if [ -z "$session_id" ]; then
   exit 0
 fi
 
+# ── Phase 2 (#1196): background_tasks / session_crons 추출 (CC v2.1.145+) ──
+# 신규 필드 미존재 시 빈 배열로 처리 (graceful degrade).
+bg_tasks_json=$(echo "$input" | jq -c '.background_tasks // []' 2>/dev/null || echo '[]')
+session_crons_json=$(echo "$input" | jq -c '.session_crons // []' 2>/dev/null || echo '[]')
+bg_tasks_count=$(echo "$bg_tasks_json" | jq 'length' 2>/dev/null || echo 0)
+session_crons_count=$(echo "$session_crons_json" | jq 'length' 2>/dev/null || echo 0)
+
+# 미완료 백그라운드 태스크: running/pending/in_progress 상태 카운트
+bg_dangling_count=$(echo "$bg_tasks_json" | jq '[.[] | select(.status == "running" or .status == "pending" or .status == "in_progress")] | length' 2>/dev/null || echo 0)
+
 # ── 경로 결정 (환경변수 override 지원) ──
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -62,6 +72,9 @@ TRANSCRIPT_PATH="$1"
 PROJECT_ROOT="$2"
 SESSION_ID="$3"
 SCRIPT_DIR="$4"
+BG_TASKS_JSON="${5:-[]}"
+SESSION_CRONS_JSON="${6:-[]}"
+BG_DANGLING_COUNT="${7:-0}"
 
 # 출력 디렉토리 준비
 OUTPUT_DIR="${PROJECT_ROOT}/.claude/outputs/reflections"
@@ -142,6 +155,30 @@ while IFS= read -r line; do
 
 done < "$TRANSCRIPT_PATH"
 
+# ── Phase 2 (#1196): background_tasks / session_crons 분석 ──
+bg_total=$(echo "$BG_TASKS_JSON" | jq 'length' 2>/dev/null || echo 0)
+cron_total=$(echo "$SESSION_CRONS_JSON" | jq 'length' 2>/dev/null || echo 0)
+bg_dangling_lines=""
+cron_lines=""
+
+if [ "$bg_total" -gt 0 ]; then
+  # dangling 태스크 목록 (최대 5개): id + status + description (60자 truncate)
+  bg_dangling_lines=$(echo "$BG_TASKS_JSON" | jq -r '
+    [.[] | select(.status == "running" or .status == "pending" or .status == "in_progress")]
+    | .[0:5]
+    | map("  - id=\(.id // "?") status=\(.status // "?") desc=\((.description // "") | .[0:60])")
+    | join("\n")
+  ' 2>/dev/null || echo "")
+fi
+
+if [ "$cron_total" -gt 0 ]; then
+  cron_lines=$(echo "$SESSION_CRONS_JSON" | jq -r '
+    .[0:5]
+    | map("  - id=\(.id // "?") schedule=\(.schedule // "?") prompt=\((.prompt // "") | .[0:60])")
+    | join("\n")
+  ' 2>/dev/null || echo "")
+fi
+
 # ── 로그 작성 ──
 {
   echo ""
@@ -150,14 +187,26 @@ done < "$TRANSCRIPT_PATH"
   echo "- **R007 violations**: ${r007_violations}"
   echo "- **R008 violations**: ${r008_violations}"
   echo "- Total assistant turns analyzed: ${total_turns}"
+  echo "- **Background tasks (#1196)**: total=${bg_total}, dangling=${BG_DANGLING_COUNT}"
+  echo "- **Session crons (#1196)**: total=${cron_total}"
   if [ $sample_count -gt 0 ]; then
     echo ""
     echo "### Sample violations (최대 3개)"
     printf '%s\n' "${sample_lines}"
   fi
+  if [ -n "$bg_dangling_lines" ]; then
+    echo ""
+    echo "### Dangling background tasks (최대 5개)"
+    printf '%s\n' "${bg_dangling_lines}"
+  fi
+  if [ -n "$cron_lines" ]; then
+    echo ""
+    echo "### Session crons (최대 5개)"
+    printf '%s\n' "${cron_lines}"
+  fi
 } >> "${LOG_FILE}"
 
-echo "[session-reflection] Analysis complete: R007=${r007_violations} R008=${r008_violations} turns=${total_turns}" >&2
+echo "[session-reflection] Analysis complete: R007=${r007_violations} R008=${r008_violations} turns=${total_turns} bg_dangling=${BG_DANGLING_COUNT} crons=${cron_total}" >&2
 WORKER_EOF
 
 chmod +x "$WORKER_SCRIPT"
@@ -172,6 +221,9 @@ WORKER_ERR_LOG="/tmp/.claude-reflection-err-${PPID}.log"
     "$PROJECT_ROOT" \
     "$session_id" \
     "$SCRIPT_DIR" \
+    "$bg_tasks_json" \
+    "$session_crons_json" \
+    "$bg_dangling_count" \
     2>>"$WORKER_ERR_LOG"
   rm -f "$WORKER_SCRIPT"
 ) &

--- a/templates/.claude/hooks/scripts/skill-extractor-analyzer.sh
+++ b/templates/.claude/hooks/scripts/skill-extractor-analyzer.sh
@@ -4,11 +4,15 @@
 
 set -euo pipefail
 
+# Pass through stdin (Stop hook protocol)
+input=$(cat)
+
 OUTCOMES_FILE="/tmp/.claude-task-outcomes-${PPID}"
 PROPOSALS_FILE="/tmp/.claude-skill-proposals-${PPID}"
 
 # Early exit if no outcomes
 if [ ! -f "$OUTCOMES_FILE" ] || [ ! -s "$OUTCOMES_FILE" ]; then
+  echo "$input"
   exit 0
 fi
 
@@ -36,7 +40,10 @@ if [ "$CANDIDATES" -gt 0 ] 2>/dev/null; then
   echo "[skill-extractor] Run /skill-extractor to review and create" >&2
 
   # Save proposal count for Stop prompt hook to pick up
-  echo "{\"candidates\": $CANDIDATES, \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$PROPOSALS_FILE"
+  echo "{\"candidates\": $CANDIDATES, \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$PROPOSALS_FILE" || true
 fi
 
+# CRITICAL: Always pass through input and exit 0
+# This hook MUST NEVER block session termination
+echo "$input"
 exit 0

--- a/templates/.claude/rules/MAY-optimization.md
+++ b/templates/.claude/rules/MAY-optimization.md
@@ -10,6 +10,21 @@
 | Caching | Same data accessed repeatedly | Cache file contents, reuse search results |
 | Lazy Loading | Large datasets, partial use | Read only needed files, stream results |
 
+### Capability-Aware Tool Scheduling
+
+When dispatching parallel tool calls, consider per-tool capabilities to optimize scheduling:
+
+| Capability | Parallelizable? | Example |
+|-----------|----------------|---------|
+| Read-only, no side effects | Yes | Read, Glob, Grep |
+| Write with independent targets | Yes | Write(file-A) + Write(file-B) |
+| Write with shared target | No | Sequential edits to same file |
+| External with rate limits | Throttle | WebFetch, API calls |
+
+This aligns with R009 (parallel execution) detection criteria and extends it with tool-level scheduling awareness.
+
+Inspired by [ouroboros PR #353](https://github.com/Q00/ouroboros/pull/353) capability graph pattern.
+
 ## Token Optimization
 
 - Include only necessary info, remove duplicates, use summaries

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -79,6 +79,7 @@ disableSkillShellExecution: true  # Disable inline shell execution in skills (v2
 `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations` are supported in Claude Code v2.1.63+. Hook types `PostCompact`, `Elicitation`, `ElicitationResult` require v2.1.76+. `CwdChanged`, `FileChanged` hook events and `managed-settings.d/` drop-in directory require v2.1.83+. Conditional `if` field for hooks requires v2.1.85+. `PermissionDenied` hook event requires v2.1.88+. `refreshInterval` setting for status line auto-refresh interval added in v2.1.97+. Monitor tool and subprocess sandboxing (`CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`, `CLAUDE_CODE_SCRIPT_CAPS`) added in v2.1.98+. Settings resilience (unrecognized hook event names no longer cause settings.json to be ignored) improved in v2.1.101+. PreCompact hook block support (exit 2 / `{"decision":"block"}`) added in v2.1.105+. Skill description listing cap raised from 250 to 1,536 characters in v2.1.105+. Plugin `monitors` manifest key for background monitors added in v2.1.105+. `ENABLE_PROMPT_CACHING_1H` and `FORCE_PROMPT_CACHING_5M` env vars for prompt cache TTL control added in v2.1.108+. Skill tool can now discover and invoke built-in slash commands (`/init`, `/review`, `/security-review`) in v2.1.108+. `/recap` session context feature and `/undo` alias for `/rewind` added in v2.1.108+. `/tui` command and `tui` setting for fullscreen rendering added in v2.1.110+. PushNotification tool for mobile push notifications (Remote Control + config required) added in v2.1.110+. `autoScrollEnabled` config for fullscreen mode added in v2.1.110+. SDK/headless `TRACEPARENT`/`TRACESTATE` distributed trace linking added in v2.1.110+. Bash tool maximum timeout enforcement added in v2.1.110+. Write tool IDE diff feedback (informs model when user edits proposed content) added in v2.1.110+. `--resume`/`--continue` now resurrects unexpired scheduled tasks in v2.1.110+. `/focus` command (separated from Ctrl+O) added in v2.1.110+. `xhigh` effort level for Opus 4.7 (between `high` and `max`; other models fall back to `high`) added in v2.1.111+. `/effort` interactive slider with arrow-key navigation (when called without arguments) added in v2.1.111+. Auto mode no longer requires `--enable-auto-mode` in v2.1.111+. PowerShell tool progressive rollout (`CLAUDE_CODE_USE_POWERSHELL_TOOL` env var) added in v2.1.111+. Read-only bash commands with glob patterns (`ls *.ts`) and `cd <project-dir> &&` prefix no longer trigger permission prompt in v2.1.111+. `/less-permission-prompts` built-in skill for permission allowlist scanning added in v2.1.111+. `/ultrareview` parallel multi-agent cloud code review added in v2.1.111+. `/skills` menu sorting by estimated token count (press `t`) added in v2.1.111+. `OTEL_LOG_RAW_API_BODIES` env var for full API request/response body logging added in v2.1.111+. Plan files named after prompt content (not random words) in v2.1.111+. Plugin error handling improvements (dependency conflict errors, stale version recovery, install recovery) in v2.1.111+.
 `sandbox.network.deniedDomains` setting for domain blocking within `allowedDomains` wildcards added in v2.1.113+. Subagent mid-stream stall detection with auto-fail after 10 minutes added in v2.1.113+. Bash `find -exec`/`-delete` no longer auto-approved under `Bash(find:*)` allow rules in v2.1.113+. Bash deny rules now match exec wrappers (`env`/`sudo`/`watch`/`ionice`/`setsid`) in v2.1.113+. Native binary spawning (per-platform optional dependency) replaces bundled JavaScript in v2.1.113+. `/loop` Esc now cancels pending wakeups in v2.1.113+.
 Agent frontmatter `hooks:` fire when agent runs as main-thread agent via `--agent` flag (previously subagent-only) in v2.1.116+. `/reload-plugins` auto-installs missing plugin dependencies from added marketplaces in v2.1.116+.
+Hook JSON output `terminalSequence` field for desktop notifications, window title changes, and terminal bells without controlling terminal added in v2.1.141+. `claude agents --cwd <path>` flag to scope session list to a directory added in v2.1.141+. Background agents launched via `/bg` now preserve current permission mode (no longer revert to default) in v2.1.141+. `CLAUDE_CODE_PLUGIN_PREFER_HTTPS` env var to clone GitHub plugin sources over HTTPS instead of SSH added in v2.1.141+. `ANTHROPIC_WORKSPACE_ID` env var for workload identity federation workspace scoping added in v2.1.141+.
 -->
 
 ## Hook Event Types
@@ -253,32 +254,19 @@ Current CC behavior: under `bypassPermissions`, all `.claude/**` paths (includin
 2. Use Write/Edit directly for `.claude/**` paths — no `/tmp/*.sh` wrapping needed
 3. For CC < v2.1.121: see git history of this section (pre-v0.126.0) for the legacy bypass pattern
 
-<!-- DETAIL: Sensitive Path Behavior table and Recommended practice
-#### Sensitive Path Behavior
-
-| Path | Tool | Allow rule | Result |
+<!-- DETAIL: Pre-v2.1.121 sensitive path behavior (historical)
+| Path | Tool | Allow rule | Result (CC < v2.1.121) |
 |------|------|-----------|--------|
-| `.claude/**` | Bash (`cp`, `mkdir`, `rm`) | `Bash(*)` allowed | Prompt (sensitive-path overrides) |
-| `.claude/**` | Write, Edit | `Write(.claude/**)` allowed | Prompt (sensitive-path overrides) |
-| `templates/.claude/**` | Write, Edit | `Write(templates/.claude/**)` allowed | Prompt (confirmed CC v2.1.116+; see #960, #961, #981) |
-| `.claude/outputs/**` | Write, Edit | `Write(.claude/outputs/**)` | Prompt (sensitive-path overrides — confirmed #1043) |
-| `.claude/outputs/**` | Bash via `/tmp/*.sh` | — | Allowed (bypass pattern) |
-
-#### Recommended practice
-
-1. **Prefer `Write`/`Edit` over `Bash(cp)`/`Bash(mkdir)`** — `Write`/`Edit` provide better auditability and avoid shell injection risk
-2. **Add allow rules defensively** — `Write(.claude/**)`, `Edit(.claude/**)`, `Write(templates/.claude/**)`, `Edit(templates/.claude/**)` in `.claude/settings.local.json`. Rules may not bypass sensitive-path check but document intent and aid future CC behavior changes
-3. **For `.claude/outputs/**` specifically**: Use `Bash via /tmp/*.sh` bypass — Write/Edit on this path triggers sensitive-path prompt despite being the artifact convention path (confirmed v0.111.1+, #1043, #1046)
+| `.claude/**` | Bash (`cp`, `mkdir`, `rm`) | `Bash(*)` allowed | Prompt (sensitive-path overrode) |
+| `.claude/**` | Write, Edit | `Write(.claude/**)` allowed | Prompt (sensitive-path overrode) |
+| `templates/.claude/**` | Write, Edit | `Write(templates/.claude/**)` allowed | Prompt (#960, #961, #981) |
+| `.claude/outputs/**` | Write, Edit | `Write(.claude/outputs/**)` | Prompt (#1043) |
+| `.claude/outputs/**` | Bash via `/tmp/*.sh` | — | Allowed (legacy bypass) |
 -->
 
-<!--
-3. **Accept interactive prompts as a release-pipeline constraint** — `templates/.claude/` sync during release automation requires human approval; plan release windows accordingly
-4. **This is CC design behavior, not a bug** — sensitive-path check is a defense-in-depth layer. File upstream as a documentation request (not bug report) if behavior is unclear
-
-#### Cross-references
-
-- `feedback_sensitive_path.md` — session memory with Bash + Write scope (#960, #961, #981)
-- `feedback_templates_claude_glob.md` — `.claude/**` glob does not cover `templates/.claude/**`, separate allow rules required
+<!-- DETAIL: Cross-references
+- `feedback_sensitive_path*.md` — historical (pre-v2.1.121) memories, marked with status: historical (#1101)
+- `feedback_templates_claude_glob.md` — `.claude/**` glob does not cover `templates/.claude/**`, separate allow rules required (still applies for non-bypassPermissions modes)
 -->
 
 ### Artifact Channel Protocol

--- a/templates/.claude/rules/MUST-agent-identification.md
+++ b/templates/.claude/rules/MUST-agent-identification.md
@@ -75,3 +75,38 @@ Correct: With sub-skill
 | General conversation | "claude (default)" |
 | Long tasks | Show progress with agent context |
 | Skill invocation | Integrated `claude → {skill-name}` format |
+
+## Multi-Turn Self-Check (MANDATORY)
+
+매 응답 시작 전, 이전 응답이 자동 체크리스트를 통과했는지 의존하지 말고 다시 자가 점검:
+
+1. 이번 응답이 `┌─ Agent: ...` 또는 `[agent-name]` 단축 헤더로 시작하는가?
+2. 이번 응답에서 호출하는 모든 도구에 `[agent-name][model] → Tool: ...` prefix 가 있는가?
+
+체크 실패 시 즉시 헤더/prefix 추가 후 도구 호출. PostCompact hook 만으로 보장되지 않으며 압축 없이도 멀티턴 누락이 발생하므로 매 턴 자가 점검 강제.
+
+### Common Multi-Turn Violation
+
+```
+턴 1: ┌─ Agent: claude (default) ✓
+턴 2: (헤더 없음, 짧은 답변이라 생략) ✗
+턴 3: 도구 호출 prefix 누락 ✗
+```
+
+응답 길이/턴 위치 무관. 짧은 답변에도 헤더는 필수.
+
+Reference issue: #1096.
+
+### Short Response Discipline
+
+응답 길이와 무관하게 R007 헤더 필수. 다음과 같은 짧은 응답에서도 누락 금지:
+
+| 응답 유형 | 헤더 필수? |
+|-----------|------------|
+| 한 줄 진단 ("확인했습니다") | YES |
+| 회고/사과 응답 | YES |
+| 사용자 질문 재확인 | YES |
+| 도구 호출 없는 텍스트 응답 | YES |
+| 1단어 응답 ("네"/"OK") | YES |
+
+Reference issues: #1188 item #2, #1198 item #2.

--- a/templates/.claude/rules/MUST-enforcement-policy.md
+++ b/templates/.claude/rules/MUST-enforcement-policy.md
@@ -14,6 +14,7 @@ oh-my-customcode uses an **advisory-first enforcement model**. Most rules are en
 | Soft Block | Stop hook prompt | R011 session-end saves | Auto-performs then approves |
 | Conversation Block | PostToolUse hook + `continueOnBlock` (CC v2.1.139+), exit 2 | stuck-detector, context-budget-advisor, cost-cap-advisor | Feeds rejection reason into conversation; Claude continues with awareness |
 | Advisory | PostToolUse hooks | R007, R008, R009, R010, R018 | Warns via stderr, never blocks |
+| Advisory (proactive) | UserPromptSubmit hook | R007, R008 (`r007-r008-drift-advisor.sh`, #1229) | Reads last assistant turn; emits stderr advisory before next response if header/prefix absent. Complements retroactive Stop-hook (`session-reflection.sh`, #1190). |
 | Prompt-based | CLAUDE.md + rules/ + PostCompact | All MUST rules | Behavioral guidance in context |
 
 ## Why Advisory-First
@@ -23,15 +24,15 @@ oh-my-customcode uses an **advisory-first enforcement model**. Most rules are en
 3. **Composability**: External skills and internal rules can coexist without deadlocks
 4. **PostCompact reinforcement**: R007/R008/R009/R010/R018 are re-injected after context compaction
 
-## Hard Enforcement Candidates — R010 git-delegation-guard (conditional), R007/R008 UserPromptSubmit/PreToolUse hook (multi-turn gap candidate, #1096). Promoted: rule-deletion-guard.sh (2026-04-08). See details via Read tool.
+## Hard Enforcement Candidates — R010 git-delegation-guard (conditional), R007/R008 UserPromptSubmit advisory **implemented** (#1229, proactive) + retroactive Stop-hook (#1190); hard-block variant still candidate if advisory insufficient (#1096). Promoted: rule-deletion-guard.sh (2026-04-08). See details via Read tool.
 
 <!-- DETAIL: Hard Enforcement Candidates (Future)
 If advisory enforcement proves insufficient for specific rules, these are candidates for promotion to hard-block:
 
-| Rule | Candidate Hook | Condition for Promotion |
-|------|---------------|------------------------|
-| R010 | git-delegation-guard.sh | If orchestrator-direct-write violations exceed 3/session |
-| R007/R008 | (new hook) | If identification omission rate exceeds 20% |
+| Rule | Candidate Hook | Status | Condition for Promotion |
+|------|---------------|--------|------------------------|
+| R010 | git-delegation-guard.sh | Candidate | If orchestrator-direct-write violations exceed 3/session |
+| R007/R008 | `r007-r008-drift-advisor.sh` (UserPromptSubmit, #1229) | **Advisory implemented** — proactive pre-response check; retroactive: `session-reflection.sh` (Stop, #1190). Two-layer drift detection: proactive (#1229) + retroactive (#1190). | Promote to hard-block if advisory proves insufficient (#1096) |
 
 Promotion requires: (1) measured violation rate data, (2) user approval, (3) rollback plan.
 

--- a/templates/.claude/rules/MUST-language-policy.md
+++ b/templates/.claude/rules/MUST-language-policy.md
@@ -7,9 +7,25 @@
 | Context | Language |
 |---------|----------|
 | User communication | Korean |
+| User communication honorific | 합쇼체 (formal polite, "-습니다/-합니다") |
 | Code, file contents, commits | English |
 | Error messages to user | Korean |
 | PR title/body, GitHub issues | Korean (default, overridable in project CLAUDE.md) |
+
+## Honorific Level
+
+Korean user-facing output MUST use 합쇼체 (formal polite ending: -습니다/-합니다/-십시오), NOT 반말 (informal) or 해요체 (semi-formal).
+
+| Anti-pattern (반말/생략) | Required (합쇼체) |
+|--------------------------|-------------------|
+| "확인" / "확인했음" | "확인했습니다" |
+| "재호출" / "재호출함" | "재호출하겠습니다" |
+| "수정" / "수정함" | "수정하겠습니다" |
+| "안 멈췄음" | "멈추지 않았습니다" |
+| "이상함" | "이상합니다" |
+| "OK" / "좋다" | "확인했습니다" / "좋습니다" |
+
+**Why**: Token-saving 모드에서 LLM 이 비격식체로 회귀하는 패턴이 #1202 / #1188 item #1 에서 관찰됨. 격식 수준은 R000 사용자 통신 규약의 핵심 부분.
 
 ## Delegation Model
 

--- a/templates/.claude/rules/MUST-orchestrator-coordination.md
+++ b/templates/.claude/rules/MUST-orchestrator-coordination.md
@@ -268,6 +268,48 @@ Before spawning any agent:
 ```
 
 
+### Background Agent Permission Mode (`/bg` flow)
+
+> **v2.1.141+**: Background agents launched via `/bg` or `←←` now preserve the current session's permission mode instead of reverting to default. Previously, detaching a session could cause `bypassPermissions` to be lost, triggering unexpected permission prompts in unattended flows.
+
+| CC Version | `/bg` permission behavior |
+|------------|--------------------------|
+| < v2.1.141 | Reverts to default — `bypassPermissions` may be lost on detach |
+| >= v2.1.141 | Preserves current permission mode — `/bg` flows no longer need extra workaround |
+
+`mode: "bypassPermissions"` on every Agent tool call is still required (applies to Agent tool, not `/bg` shell command).
+
+## Agent Capability Pre-Check
+
+Before delegating a task to a subagent, MUST verify the target agent's tool capabilities against the task requirements. Failure to pre-check causes round-trip waste (delegation → failure → re-delegation).
+
+### Required Checks
+
+| Task involves | Verify in target agent frontmatter |
+|--------------|-----------------------------------|
+| `gh` / shell commands | `tools:` includes Bash AND `disallowedTools:` excludes Bash |
+| `Read` external files | `tools:` includes Read |
+| `Write` files | `tools:` includes Write (and target path not in `disallowedTools` scope) |
+| MCP server calls | `mcpServers:` includes the required server |
+
+### Known Limitations (Active Cache)
+
+| Agent | Limitation | Workaround |
+|-------|-----------|-----------|
+| `arch-documenter` | `disallowedTools: [Bash]` — cannot run `gh`, shell scripts | Pre-collect data via orchestrator, pass as content; OR use `general-purpose` for the Bash-needing portion |
+| `qa-engineer` | (verify each invocation) | — |
+
+### Common Violation
+
+```
+❌ WRONG: Delegate `gh issue view` to arch-documenter without pre-check
+   → Agent fails ("Bash not allowed") → 2-3min round-trip waste
+
+✓ CORRECT: Pre-check arch-documenter.disallowedTools → collect data first → pass as content
+```
+
+Reference issues: #1202 item #2, `feedback_arch_documenter_bash_precheck.md`.
+
 ## Sensitive Path Handling (Historical: pre-CC v2.1.121)
 
 > **Status**: Deprecated as of CC v2.1.121 (2026-04-28) and further relaxed in v2.1.126 (2026-05-01). Direct Write/Edit/Bash on `.claude/`, `.git/`, `.vscode/` works without prompts under `bypassPermissions` mode in CC v2.1.121+ (issue #1101).

--- a/templates/.claude/rules/MUST-tool-identification.md
+++ b/templates/.claude/rules/MUST-tool-identification.md
@@ -95,3 +95,40 @@ Parallel spawn description parameter:
 Agent(description: "[1] Go code review", subagent_type: "lang-golang-expert", ...)
 Agent(description: "[2] Python code review", subagent_type: "lang-python-expert", ...)
 ```
+
+## Multi-Turn Self-Check (MANDATORY)
+
+매 도구 호출 직전, 이전 호출이 prefix 를 가졌는지에 의존하지 말고 다시 자가 점검:
+
+1. 이 호출 위에 `[agent-name][model] → Tool: <tool-name>` 라인이 있는가?
+2. agent-name 과 model 이 현재 컨텍스트와 일치하는가?
+
+체크 실패 시 즉시 prefix 추가 후 호출.
+
+### Common Multi-Turn Violation
+
+```
+호출 1 (턴 1): [claude][sonnet] → Tool: Read ✓
+호출 2 (턴 1, 같은 턴 추가 호출): (prefix 없음) ✗
+호출 3 (턴 2 첫 호출): (prefix 없음) ✗
+```
+
+같은 턴 내 추가 호출, 새 턴 첫 호출 모두 prefix 필수.
+
+Reference issue: #1096.
+
+### Short Response Discipline
+
+도구 호출 prefix 도 응답 길이와 무관하게 필수. 같은 턴 내 여러 도구를 호출할 때 각 호출 직전에 개별 prefix 표시:
+
+```
+[agent][model] → Tool: Read
+[agent][model] → Target: file1.md
+<Read call>
+
+[agent][model] → Tool: Bash
+[agent][model] → Target: gh issue list
+<Bash call>
+```
+
+Reference issues: #1188 item #3, #1198 item #3.

--- a/templates/.claude/rules/SHOULD-hud-statusline.md
+++ b/templates/.claude/rules/SHOULD-hud-statusline.md
@@ -15,6 +15,8 @@
 
 Format: `─── [Spawn] {subagent_type}:{model} | {description} ───` — implemented in `.claude/hooks/hooks.json` (PreToolUse → Agent/Task matcher). Display for multi-step/parallel/long-running ops only.
 
+> **v2.1.141+**: Hook JSON output can include `terminalSequence` field to emit window title changes or terminal bells without terminal control. Complementary to HUD stderr channel — e.g., update window title on task completion or ring bell after long parallel run. Modifying `.claude/hooks/` requires explicit user approval (R001).
+
 <!-- DETAIL: HUD Events full spec
 ### When to Display: Multi-step tasks, parallel execution, long-running operations. Skip for single brief operations.
 ### Parallel Display:

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.154.0",
+  "version": "0.154.1",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## v0.154.1

### 변경
- **#1234**: `verify-template-sync.sh`가 이제 rules/agents/hook-scripts의 **content drift**(개수뿐 아니라 내용)를 감지 — 각 source vs template `diff -q`, 불일치 시 exit 1. v0.152.0에서 R011 template drift가 릴리즈된 gap을 차단.
- **stale 템플릿 15건 reconcile** (모두 source-canonical): rules 8건, agents 4건(mgr-updater/fe-design-expert/mgr-creator/arch-documenter), hook scripts 3건. 조사 결과 template이 source 편집을 따라가지 못해 누적된 drift (예: arch-documenter #1087, session-reflection #1196).

### 안전성
- source `.claude/` 내용 불변 — `templates/.claude/`만 source에 맞춰 동기화 + CI 가드 추가
- mgr-sauron R017 PASS: source 불변 확인 + 가드 negative test(drift→exit1, sync→exit0) 검증

Fixes #1234

🤖 Generated with [Claude Code](https://claude.com/claude-code)