### PR TITLE
fix: cc-release-monitor 복구 — repo 내 GitHub Actions 워크플로우로 외부 Airflow 의존성 제거

### DIFF
--- a/.claude/skills/claude-native/SKILL.md
+++ b/.claude/skills/claude-native/SKILL.md
@@ -42,18 +42,18 @@ Search for existing tracking issues to avoid duplicates:
 ```bash
 gh issue list \
   --state all \
-  --search "[Claude Code v" \
+  --search "Claude Code v" \
   --json number,title \
   --limit 100
 ```
 
-Build a set of already-tracked versions by extracting version strings from issue titles matching the pattern `[Claude Code v{version}]`.
+Build a set of already-tracked versions by extracting version strings from issue titles matching the pattern `Claude Code v(\d+\.\d+\.\d+)` (no brackets).
 
 ### Phase 3: Dedup
 
 For each fetched release version:
 - Parse the version string from `tag_name` (e.g., `v2.1.86`)
-- If a matching issue title already exists → skip (already tracked)
+- If an issue title matching `Claude Code v{version}` already exists → skip (already tracked)
 - If no matching issue → add to "needs issue" list
 
 ### Phase 4: Create Issues (or Dry-Run Report)
@@ -76,7 +76,7 @@ For each version in the "needs issue" list, create a GitHub issue:
 
 ```bash
 gh issue create \
-  --title "[Claude Code v{version}] New release detected" \
+  --title "Claude Code v{version}" \
   --label "automated,claude-code-release" \
   --body "{body}"
 ```
@@ -105,7 +105,7 @@ Issue body format (matching the pattern established by issue #683):
 
 ---
 
-_This issue was created by the `/omcustom:claude-native` skill._
+_This issue was auto-created by the cc-release-monitor workflow (claude-native skill)._
 ```
 
 **Notes:**
@@ -128,8 +128,8 @@ Versions checked: {N}
 New issues created: {M}
 
 Created:
-  - #1234 [Claude Code v2.1.86] New release detected
-  - #1235 [Claude Code v2.1.87] New release detected
+  - #1234 Claude Code v2.1.86
+  - #1235 Claude Code v2.1.87
 
 Already tracked (skipped):
   - v2.1.85 → #683
@@ -156,6 +156,8 @@ For each release:
 ```
 
 Semver comparison: major → minor → patch (all numeric). Pre-release suffixes (e.g., `-beta`) are included and compared lexicographically after numeric parts.
+
+**Note on non-contiguous patch numbers**: Claude Code skips some patch numbers (e.g., v2.1.151 and v2.1.155 were never released publicly). The skill MUST act only on versions that actually appear in the GitHub releases API response — never assume contiguous numbering or attempt to fill gaps.
 
 ## Error Handling
 

--- a/.github/workflows/cc-release-monitor.yml
+++ b/.github/workflows/cc-release-monitor.yml
@@ -1,0 +1,182 @@
+name: cc-release-monitor
+
+on:
+  schedule:
+    - cron: "17 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+env:
+  MIN_PATCH: "151"
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Claude Code releases and create issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          MIN_PATCH: ${{ env.MIN_PATCH }}
+        run: |
+          python3 << 'PYEOF'
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+          import textwrap
+
+          GH_TOKEN = os.environ["GH_TOKEN"]
+          REPO = os.environ["GITHUB_REPOSITORY"]
+          MIN_PATCH = int(os.environ.get("MIN_PATCH", "151"))
+
+          print(f"=== cc-release-monitor: fetching Claude Code releases ===")
+          print(f"MIN_PATCH={MIN_PATCH}")
+
+          # ── Step 1: fetch all releases from anthropics/claude-code ──────────
+          result = subprocess.run(
+              ["gh", "api", "repos/anthropics/claude-code/releases", "--paginate"],
+              capture_output=True,
+              text=True,
+              env=os.environ,
+          )
+          if result.returncode != 0:
+              print(f"ERROR: gh api failed: {result.stderr.strip()}", file=sys.stderr)
+              sys.exit(1)
+
+          try:
+              releases = json.loads(result.stdout)
+          except json.JSONDecodeError as e:
+              print(f"ERROR: Failed to parse releases JSON: {e}", file=sys.stderr)
+              sys.exit(1)
+
+          # ── Step 2: filter — v2.1.NNN, no nightly, patch >= MIN_PATCH ───────
+          pattern = re.compile(r"^v2\.1\.(\d+)$")
+          candidates = []
+          for r in releases:
+              tag = r.get("tag_name", "")
+              if "nightly" in tag.lower():
+                  continue
+              m = pattern.match(tag)
+              if not m:
+                  continue
+              if int(m.group(1)) < MIN_PATCH:
+                  continue
+              candidates.append({
+                  "tag": tag,
+                  "published_at": r.get("published_at", ""),
+                  "html_url": r.get("html_url", ""),
+                  "body": (r.get("body") or "").strip(),
+              })
+
+          print(f"Found {len(candidates)} candidate release(s) matching filter.")
+
+          if not candidates:
+              print("Nothing to do.")
+              sys.exit(0)
+
+          # ── Step 3: dedup and create ─────────────────────────────────────────
+          created = 0
+          skipped = 0
+
+          for release in candidates:
+              version = release["tag"]          # e.g. "v2.1.151"
+              published_at = release["published_at"]
+              html_url = release["html_url"]
+              body_raw = release["body"]
+
+              issue_title = f"Claude Code {version}"
+
+              # Dedup: exact title match among all issues (open + closed)
+              check = subprocess.run(
+                  [
+                      "gh", "issue", "list",
+                      "--repo", REPO,
+                      "--state", "all",
+                      "--search", issue_title,
+                      "--json", "title",
+                  ],
+                  capture_output=True,
+                  text=True,
+                  env=os.environ,
+              )
+              if check.returncode != 0:
+                  print(
+                      f"WARNING: issue list failed for {version}: {check.stderr.strip()}",
+                      file=sys.stderr,
+                  )
+                  skipped += 1
+                  continue
+
+              existing = json.loads(check.stdout or "[]")
+              if any(i["title"] == issue_title for i in existing):
+                  print(f"SKIP  {version} — issue already exists")
+                  skipped += 1
+                  continue
+
+              # Truncate release body
+              MAX_BODY = 2000
+              if not body_raw:
+                  release_summary = "_No release notes provided._"
+              elif len(body_raw) > MAX_BODY:
+                  release_summary = body_raw[:MAX_BODY] + "... (truncated)"
+              else:
+                  release_summary = body_raw
+
+              issue_body = textwrap.dedent(f"""\
+                  # Claude Code {version}
+
+                  **Release:** {version}
+                  **Published:** {published_at}
+                  **Link:** {html_url}
+
+                  ## Release Summary
+
+                  {release_summary}
+
+                  ---
+
+                  ## Action Items
+
+                  - [ ] Review release notes for impact on oh-my-customcode
+                  - [ ] Update agent definitions if new Claude Code features affect agents
+                  - [ ] Test compatibility with current oh-my-customcode version
+                  - [ ] Update CLAUDE.md if new capabilities are relevant
+
+                  ---
+
+                  _This issue was auto-created by the cc-release-monitor GitHub Actions workflow._\
+              """)
+
+              create = subprocess.run(
+                  [
+                      "gh", "issue", "create",
+                      "--repo", REPO,
+                      "--title", issue_title,
+                      "--body", issue_body,
+                      "--label", "automated,claude-code-release",
+                  ],
+                  capture_output=True,
+                  text=True,
+                  env=os.environ,
+              )
+              if create.returncode != 0:
+                  print(
+                      f"ERROR  {version} — create failed: {create.stderr.strip()}",
+                      file=sys.stderr,
+                  )
+                  skipped += 1
+                  continue
+
+              issue_url = create.stdout.strip()
+              print(f"CREATE {version} — {issue_url}")
+              created += 1
+
+          print()
+          print(f"=== Summary: {created} created, {skipped} skipped ===")
+          PYEOF

--- a/templates/.claude/skills/claude-native/SKILL.md
+++ b/templates/.claude/skills/claude-native/SKILL.md
@@ -42,18 +42,18 @@ Search for existing tracking issues to avoid duplicates:
 ```bash
 gh issue list \
   --state all \
-  --search "[Claude Code v" \
+  --search "Claude Code v" \
   --json number,title \
   --limit 100
 ```
 
-Build a set of already-tracked versions by extracting version strings from issue titles matching the pattern `[Claude Code v{version}]`.
+Build a set of already-tracked versions by extracting version strings from issue titles matching the pattern `Claude Code v(\d+\.\d+\.\d+)` (no brackets).
 
 ### Phase 3: Dedup
 
 For each fetched release version:
 - Parse the version string from `tag_name` (e.g., `v2.1.86`)
-- If a matching issue title already exists → skip (already tracked)
+- If an issue title matching `Claude Code v{version}` already exists → skip (already tracked)
 - If no matching issue → add to "needs issue" list
 
 ### Phase 4: Create Issues (or Dry-Run Report)
@@ -76,7 +76,7 @@ For each version in the "needs issue" list, create a GitHub issue:
 
 ```bash
 gh issue create \
-  --title "[Claude Code v{version}] New release detected" \
+  --title "Claude Code v{version}" \
   --label "automated,claude-code-release" \
   --body "{body}"
 ```
@@ -105,7 +105,7 @@ Issue body format (matching the pattern established by issue #683):
 
 ---
 
-_This issue was created by the `/omcustom:claude-native` skill._
+_This issue was auto-created by the cc-release-monitor workflow (claude-native skill)._
 ```
 
 **Notes:**
@@ -128,8 +128,8 @@ Versions checked: {N}
 New issues created: {M}
 
 Created:
-  - #1234 [Claude Code v2.1.86] New release detected
-  - #1235 [Claude Code v2.1.87] New release detected
+  - #1234 Claude Code v2.1.86
+  - #1235 Claude Code v2.1.87
 
 Already tracked (skipped):
   - v2.1.85 → #683
@@ -156,6 +156,8 @@ For each release:
 ```
 
 Semver comparison: major → minor → patch (all numeric). Pre-release suffixes (e.g., `-beta`) are included and compared lexicographically after numeric parts.
+
+**Note on non-contiguous patch numbers**: Claude Code skips some patch numbers (e.g., v2.1.151 and v2.1.155 were never released publicly). The skill MUST act only on versions that actually appear in the GitHub releases API response — never assume contiguous numbering or attempt to fill gaps.
 
 ## Error Handling
 

--- a/templates/.github/workflows/cc-release-monitor.yml
+++ b/templates/.github/workflows/cc-release-monitor.yml
@@ -1,0 +1,182 @@
+name: cc-release-monitor
+
+on:
+  schedule:
+    - cron: "17 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+env:
+  MIN_PATCH: "151"
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Claude Code releases and create issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          MIN_PATCH: ${{ env.MIN_PATCH }}
+        run: |
+          python3 << 'PYEOF'
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+          import textwrap
+
+          GH_TOKEN = os.environ["GH_TOKEN"]
+          REPO = os.environ["GITHUB_REPOSITORY"]
+          MIN_PATCH = int(os.environ.get("MIN_PATCH", "151"))
+
+          print(f"=== cc-release-monitor: fetching Claude Code releases ===")
+          print(f"MIN_PATCH={MIN_PATCH}")
+
+          # ── Step 1: fetch all releases from anthropics/claude-code ──────────
+          result = subprocess.run(
+              ["gh", "api", "repos/anthropics/claude-code/releases", "--paginate"],
+              capture_output=True,
+              text=True,
+              env=os.environ,
+          )
+          if result.returncode != 0:
+              print(f"ERROR: gh api failed: {result.stderr.strip()}", file=sys.stderr)
+              sys.exit(1)
+
+          try:
+              releases = json.loads(result.stdout)
+          except json.JSONDecodeError as e:
+              print(f"ERROR: Failed to parse releases JSON: {e}", file=sys.stderr)
+              sys.exit(1)
+
+          # ── Step 2: filter — v2.1.NNN, no nightly, patch >= MIN_PATCH ───────
+          pattern = re.compile(r"^v2\.1\.(\d+)$")
+          candidates = []
+          for r in releases:
+              tag = r.get("tag_name", "")
+              if "nightly" in tag.lower():
+                  continue
+              m = pattern.match(tag)
+              if not m:
+                  continue
+              if int(m.group(1)) < MIN_PATCH:
+                  continue
+              candidates.append({
+                  "tag": tag,
+                  "published_at": r.get("published_at", ""),
+                  "html_url": r.get("html_url", ""),
+                  "body": (r.get("body") or "").strip(),
+              })
+
+          print(f"Found {len(candidates)} candidate release(s) matching filter.")
+
+          if not candidates:
+              print("Nothing to do.")
+              sys.exit(0)
+
+          # ── Step 3: dedup and create ─────────────────────────────────────────
+          created = 0
+          skipped = 0
+
+          for release in candidates:
+              version = release["tag"]          # e.g. "v2.1.151"
+              published_at = release["published_at"]
+              html_url = release["html_url"]
+              body_raw = release["body"]
+
+              issue_title = f"Claude Code {version}"
+
+              # Dedup: exact title match among all issues (open + closed)
+              check = subprocess.run(
+                  [
+                      "gh", "issue", "list",
+                      "--repo", REPO,
+                      "--state", "all",
+                      "--search", issue_title,
+                      "--json", "title",
+                  ],
+                  capture_output=True,
+                  text=True,
+                  env=os.environ,
+              )
+              if check.returncode != 0:
+                  print(
+                      f"WARNING: issue list failed for {version}: {check.stderr.strip()}",
+                      file=sys.stderr,
+                  )
+                  skipped += 1
+                  continue
+
+              existing = json.loads(check.stdout or "[]")
+              if any(i["title"] == issue_title for i in existing):
+                  print(f"SKIP  {version} — issue already exists")
+                  skipped += 1
+                  continue
+
+              # Truncate release body
+              MAX_BODY = 2000
+              if not body_raw:
+                  release_summary = "_No release notes provided._"
+              elif len(body_raw) > MAX_BODY:
+                  release_summary = body_raw[:MAX_BODY] + "... (truncated)"
+              else:
+                  release_summary = body_raw
+
+              issue_body = textwrap.dedent(f"""\
+                  # Claude Code {version}
+
+                  **Release:** {version}
+                  **Published:** {published_at}
+                  **Link:** {html_url}
+
+                  ## Release Summary
+
+                  {release_summary}
+
+                  ---
+
+                  ## Action Items
+
+                  - [ ] Review release notes for impact on oh-my-customcode
+                  - [ ] Update agent definitions if new Claude Code features affect agents
+                  - [ ] Test compatibility with current oh-my-customcode version
+                  - [ ] Update CLAUDE.md if new capabilities are relevant
+
+                  ---
+
+                  _This issue was auto-created by the cc-release-monitor GitHub Actions workflow._\
+              """)
+
+              create = subprocess.run(
+                  [
+                      "gh", "issue", "create",
+                      "--repo", REPO,
+                      "--title", issue_title,
+                      "--body", issue_body,
+                      "--label", "automated,claude-code-release",
+                  ],
+                  capture_output=True,
+                  text=True,
+                  env=os.environ,
+              )
+              if create.returncode != 0:
+                  print(
+                      f"ERROR  {version} — create failed: {create.stderr.strip()}",
+                      file=sys.stderr,
+                  )
+                  skipped += 1
+                  continue
+
+              issue_url = create.stdout.strip()
+              print(f"CREATE {version} — {issue_url}")
+              created += 1
+
+          print()
+          print(f"=== Summary: {created} created, {skipped} skipped ===")
+          PYEOF


### PR DESCRIPTION
## 근본 원인

외부 Airflow `cc-release-monitor` DAG가 2026-05-23(#1220, v2.1.150) 이후 Claude Code 릴리즈 추적 이슈를 자동 생성하지 않았습니다. 원인은 외부 DAG의 중단으로, v2.1.152~v2.1.156에 해당하는 4개 이슈가 누락되었습니다.

## 해결책

- **백필 4건**: 누락된 릴리즈 추적 이슈를 수동으로 생성했습니다.
  - #1242 — Claude Code v2.1.152
  - #1243 — Claude Code v2.1.153
  - #1244 — Claude Code v2.1.154
  - #1245 — Claude Code v2.1.156
- **repo 내 GitHub Actions cron 워크플로우 추가** (`.github/workflows/cc-release-monitor.yml`): 외부 Airflow 의존성을 제거하고 매일 자동 실행 + `workflow_dispatch` 수동 트리거를 지원합니다. 정확한 타이틀(`Claude Code v{version}`)로 dedup하여 중복 이슈 생성을 방지합니다.
- **`claude-native` SKILL.md 버그 수정**: 타이틀 컨벤션과 dedup 검색 패턴 불일치로 중복 이슈가 생성될 수 있던 버그를 수정했습니다. 풋터 및 비연속 버전 처리 노트도 보완했습니다.
- **`templates/` 미러 동기화**: 위 두 파일의 `templates/` 사본을 함께 업데이트했습니다.

## 변경 파일

| 파일 | 변경 유형 |
|------|---------|
| `.github/workflows/cc-release-monitor.yml` | 신규 추가 |
| `templates/.github/workflows/cc-release-monitor.yml` | 신규 추가 (미러) |
| `.claude/skills/claude-native/SKILL.md` | 수정 (dedup 버그 수정) |
| `templates/.claude/skills/claude-native/SKILL.md` | 수정 (미러 동기화) |

## 테스트 플랜

- [ ] PR 머지 후 Actions 탭에서 `cc-release-monitor` 워크플로우 확인
- [ ] `workflow_dispatch`로 수동 트리거 실행하여 중복 이슈 미생성 확인 (기존 이슈가 있는 버전으로 테스트)
- [ ] 신규 Claude Code 버전 릴리즈 시 다음 날 자동으로 이슈가 생성되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)