### PR TITLE
release: v0.156.3 — R020 병렬 진단-변경 안티패턴 명문화

### DIFF
--- a/.claude/rules/MUST-completion-verification.md
+++ b/.claude/rules/MUST-completion-verification.md
@@ -171,6 +171,20 @@ npm publish E403을 `--provenance` attestation 충돌로 오진단 → release w
 3. 변경이 되돌리기 쉬운가? (영구 워크플로우 변경 vs 일회성 시도)
 하나라도 NO면 검증을 먼저 수행한다. 근본 원인 진단은 `superpowers:systematic-debugging` 참조.
 
+### Variant: Parallel Read + Permanent-Change Dispatch (#1250)
+
+진단 자료 수집(로그 조사, 파일 Read)과 그 진단에 의존하는 영구 변경(이슈 등록, 수정 에이전트 위임)을 **같은 메시지에서 병렬 실행**하면, Read 결과를 받기 전에 가설이 확정된다. 병렬 배치는 결과를 동시에 받으므로 "Read 후 판단"이 불가능하다.
+
+| 금지 | 필수 |
+|------|------|
+| 파일 Read + 그 내용 기반 이슈/수정 지시를 한 병렬 배치에 묶기 | 진단 Read는 먼저, 결과 수령 후 *다음 턴*에 변경 지시 |
+| 로그 조사와 동시에 "원인은 X" 이슈 생성 | 로그 결과 확인 후 원인 확정 |
+
+#### Common Violation (#1250)
+triage-dispatch.yml 실패 원인을 파일 Read 전에 "triaged 라벨 부재 + omcustom CLI 부재"로 추정 → 같은 메시지에서 이슈 등록 + mgr-gitnerd 수정 지시를 병렬 실행. 직후 도착한 Read 결과가 실제 원인(외부 Airflow issue_triage DAG의 HTTP 530)을 드러냄. 코드 수정 방향은 우연히 맞았으나 이슈/PR/커밋 서술이 틀려 정정 부채 발생. 머지 전 발각되어 이슈/PR 본문 정정으로 회복.
+
+> 진단에 의존하는 쓰기/위임은 진단 결과를 본 다음 턴에 수행한다. R009 병렬 실행은 독립 작업에만 적용 — 진단→변경은 순차 의존이다.
+
 ## Integration
 
 | Rule | Interaction |

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.156.2",
-  "generatedAt": "2026-05-29T08:59:39.443Z",
-  "templateVersion": "0.156.2",
+  "generatorVersion": "0.156.3",
+  "generatedAt": "2026-05-29T09:19:08.094Z",
+  "templateVersion": "0.156.3",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "dc6ce94ab01e1c6abb76e0a1a33b472a47f21706921e63f61ce2fb43bab9a9cf",
@@ -120,8 +120,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-completion-verification.md": {
-      "templateHash": "198560ce7eb6352ce4698aa2573bbf5c4c1489ac667f71cd3ac0d3c9f1ab0594",
-      "size": 9839,
+      "templateHash": "422019dc90febd79f2e7b4c556061d92752be88254c103ba834f2a2b3f4137b9",
+      "size": 11215,
       "component": "rules"
     },
     ".claude/agents/be-springboot-expert.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.156.3] - 2026-05-29
+
+### Changed
+- R020 (`MUST-completion-verification`): added "Variant: Parallel Read + Permanent-Change Dispatch" subsection to the Diagnostic Hypothesis Verification section — prohibits running a diagnostic file Read and a permanent change (issue registration, fix dispatch) that depends on it in the same parallel batch, since results arrive together and the hypothesis gets locked in before the Read is seen (observed in #1250 triage-dispatch misdiagnosis)
+
 ## [0.156.2] - 2026-05-29
 
 ### Fixed

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2334,7 +2334,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.156.0",
+    version: "0.156.3",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.156.0",
+  version: "0.156.3",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.156.2",
+  "version": "0.156.3",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-completion-verification.md
+++ b/templates/.claude/rules/MUST-completion-verification.md
@@ -171,6 +171,20 @@ npm publish E403을 `--provenance` attestation 충돌로 오진단 → release w
 3. 변경이 되돌리기 쉬운가? (영구 워크플로우 변경 vs 일회성 시도)
 하나라도 NO면 검증을 먼저 수행한다. 근본 원인 진단은 `superpowers:systematic-debugging` 참조.
 
+### Variant: Parallel Read + Permanent-Change Dispatch (#1250)
+
+진단 자료 수집(로그 조사, 파일 Read)과 그 진단에 의존하는 영구 변경(이슈 등록, 수정 에이전트 위임)을 **같은 메시지에서 병렬 실행**하면, Read 결과를 받기 전에 가설이 확정된다. 병렬 배치는 결과를 동시에 받으므로 "Read 후 판단"이 불가능하다.
+
+| 금지 | 필수 |
+|------|------|
+| 파일 Read + 그 내용 기반 이슈/수정 지시를 한 병렬 배치에 묶기 | 진단 Read는 먼저, 결과 수령 후 *다음 턴*에 변경 지시 |
+| 로그 조사와 동시에 "원인은 X" 이슈 생성 | 로그 결과 확인 후 원인 확정 |
+
+#### Common Violation (#1250)
+triage-dispatch.yml 실패 원인을 파일 Read 전에 "triaged 라벨 부재 + omcustom CLI 부재"로 추정 → 같은 메시지에서 이슈 등록 + mgr-gitnerd 수정 지시를 병렬 실행. 직후 도착한 Read 결과가 실제 원인(외부 Airflow issue_triage DAG의 HTTP 530)을 드러냄. 코드 수정 방향은 우연히 맞았으나 이슈/PR/커밋 서술이 틀려 정정 부채 발생. 머지 전 발각되어 이슈/PR 본문 정정으로 회복.
+
+> 진단에 의존하는 쓰기/위임은 진단 결과를 본 다음 턴에 수행한다. R009 병렬 실행은 독립 작업에만 적용 — 진단→변경은 순차 의존이다.
+
 ## Integration
 
 | Rule | Interaction |

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.156.2",
+  "version": "0.156.3",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약

R016 연속개선 — 이번 세션 #1250 오진단(파일 Read 전 가설 확정, Read와 수정 지시 병렬 실행)을 룰로 codify.
R020 Diagnostic Hypothesis Verification에 **Variant: Parallel Read + Permanent-Change Dispatch** 섹션 추가.

## 변경 파일

- `.claude/rules/MUST-completion-verification.md` — R020 Variant 섹션 추가
- `templates/.claude/rules/MUST-completion-verification.md` — 동기화
- `CHANGELOG.md`, `package.json`, `templates/manifest.json`, `.omcustom.lock.json` — v0.156.3 bump

## 테스트 결과

- bun test: 2013 pass / 0 fail
- template-sync: exit 0
- version-sync: exit 0
- rule template parity: IDENTICAL