### PR TITLE
release: v0.158.0 — validate-docs를 PR CI 블로킹 잡으로 추가 (#1258)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,29 @@ jobs:
       - name: Run Biome lint
         run: bun run lint
 
+  validate-docs:
+    name: Validate Documentation
+    needs: [lockfile-sync]
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+      - name: Cache Bun dependencies
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Validate documentation
+        run: bun run .github/scripts/validate-docs.ts --programmatic-only
+
   test:
     name: Test
     needs: [lockfile-sync]

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.157.1",
-  "generatedAt": "2026-05-29T13:34:29.800Z",
-  "templateVersion": "0.157.1",
+  "generatorVersion": "0.158.0",
+  "generatedAt": "2026-05-29T17:30:31.513Z",
+  "templateVersion": "0.158.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "dc6ce94ab01e1c6abb76e0a1a33b472a47f21706921e63f61ce2fb43bab9a9cf",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.158.0] - 2026-05-30
+
+### Added
+- `validate-docs` job in CI (ci.yml) — runs validate-docs.ts --programmatic-only as a blocking PR check, catching phantom slash-commands and count drift before merge instead of after tag creation. Fixes the gap that caused v0.157.0 to fail npm publish (#1258).
+
 ## [0.157.1] - 2026-05-29
 
 ### Fixed

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2334,7 +2334,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.157.1",
+    version: "0.158.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.157.1",
+  version: "0.158.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.157.1",
+  "version": "0.158.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.157.1",
+  "version": "0.158.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/tests/unit/core/session-reflection.test.ts
+++ b/tests/unit/core/session-reflection.test.ts
@@ -22,7 +22,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { spawn } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -110,13 +110,18 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  // Give the disowned background worker time to finish writing before deleting tmpRoot.
+  // The worker typically completes within 200ms; 2000ms is a safe upper bound.
+  await new Promise((r) => setTimeout(r, 2000));
   await rm(tmpRoot, { recursive: true, force: true });
 });
 
 /** Write a .jsonl transcript and return the expected log path. */
 async function writeTranscript(sessionId: string, lines: string[]): Promise<string> {
   await writeFile(join(transcriptDir, `${sessionId}.jsonl`), `${lines.join('\n')}\n`);
-  const date = new Date().toISOString().slice(0, 10);
+  // bun:test forces TZ=UTC but the bash worker uses the system local date.
+  // Use execFileSync('date', ['+%Y-%m-%d']) — same logic as the worker — to guarantee the paths match.
+  const date = execFileSync('date', ['+%Y-%m-%d']).toString().trim();
   return join(reflectionsDir, `${date}.md`);
 }
 
@@ -207,7 +212,7 @@ describe('session-reflection.sh — Fixture 1: clean transcript', () => {
     expect(log).toContain('**R007 violations**: 0');
     expect(log).toContain('**R008 violations**: 0');
     expect(log).toContain('Total assistant turns analyzed: 2');
-  });
+  }, 15000);
 });
 
 // ════════════════════════════════════════════════════════════════
@@ -230,7 +235,7 @@ describe('session-reflection.sh — Fixture 2: R007 violation', () => {
     expect(log).toContain('**R007 violations**: 1');
     expect(log).toContain('Total assistant turns analyzed: 2');
     expect(log).toContain('[R007 turn');
-  });
+  }, 15000);
 
   it('treats ┌─ Agent: as valid R007 header', async () => {
     const sid = `r007-full-${Date.now()}`;
@@ -242,7 +247,7 @@ describe('session-reflection.sh — Fixture 2: R007 violation', () => {
 
     const log = await waitForLog(logPath, '**R007 violations**: 0');
     expect(log).toContain('**R007 violations**: 0');
-  });
+  }, 15000);
 
   it('treats [agent-name] shorthand as valid R007 header', async () => {
     const sid = `r007-shorthand-${Date.now()}`;
@@ -254,7 +259,7 @@ describe('session-reflection.sh — Fixture 2: R007 violation', () => {
 
     const log = await waitForLog(logPath, '**R007 violations**: 0');
     expect(log).toContain('**R007 violations**: 0');
-  });
+  }, 15000);
 });
 
 // ════════════════════════════════════════════════════════════════
@@ -290,7 +295,7 @@ describe('session-reflection.sh — Fixture 3: R008 violation', () => {
     expect(log).toContain('**R008 violations**: 1');
     expect(log).toContain('[R008 turn');
     expect(log).toContain('missing prefix');
-  });
+  }, 15000);
 
   it('does NOT flag tool_use when preceded by valid R008 prefix', async () => {
     const sid = `r008-ok-${Date.now()}`;
@@ -306,7 +311,7 @@ describe('session-reflection.sh — Fixture 3: R008 violation', () => {
 
     const log = await waitForLog(logPath, '**R008 violations**: 0');
     expect(log).toContain('**R008 violations**: 0');
-  });
+  }, 15000);
 });
 
 // ════════════════════════════════════════════════════════════════
@@ -321,7 +326,7 @@ describe('session-reflection.sh — Fixture 4: opt-out', () => {
       assistantTurn([{ type: 'text', text: 'No header — would be R007 violation.' }]),
     ]);
 
-    const date = new Date().toISOString().slice(0, 10);
+    const date = execFileSync('date', ['+%Y-%m-%d']).toString().trim();
     const logPath = join(reflectionsDir, `${date}.md`);
 
     await runScript(stopInput(sid), {
@@ -366,5 +371,5 @@ describe('session-reflection.sh — sample cap', () => {
     // Count [R007 turn N] occurrences — must be ≤ 3
     const matches = log.match(/\[R007 turn \d+\]/g) ?? [];
     expect(matches.length).toBeLessThanOrEqual(3);
-  });
+  }, 15000);
 });


### PR DESCRIPTION
## 개요
v0.158.0 릴리즈. `validate-docs`를 PR CI의 블로킹 잡으로 추가하여 phantom 슬래시 커맨드와 count drift를 머지 전에 검출합니다.

## 변경 사항
- `ci.yml`에 `validate-docs` 잡 추가 — `validate-docs.ts --programmatic-only`를 블로킹 PR 체크로 실행 (#1258)
- `session-reflection.test.ts` 안정화 — UTC 강제 `new Date()` 대신 bash worker와 동일한 `date` 명령 사용(TZ 의존 경로 불일치 해소), afterEach drain 대기 추가, per-test 타임아웃 상향
- 버전 bump: 0.157.1 → 0.158.0 (package.json, manifest.json, .omcustom.lock.json, dist)

## 배경
v0.157.0가 태그 생성 후 release.yml의 validate-docs 단계에서 실패해 npm 미발행된 문제(#1258)를, 동일 검증을 PR 단계로 시프트하여 재발 방지합니다.

Closes #1258

🤖 Generated with [Claude Code](https://claude.com/claude-code)