### PR TITLE
release: v0.162.1 — fix auto-tag.yml multi-issue close (#1273)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -68,7 +68,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
-          ISSUES=$(echo "$PR_BODY" | grep -oEi '(Closes|Fixes|Resolves)(\s+#[0-9]+)+' | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -u)
+          ISSUES=$(echo "$PR_BODY" | grep -oEi '(Closes|Fixes|Resolves)([[:space:],]+#[0-9]+)+' | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -u)
           for ISSUE in $ISSUES; do
             echo "Closing issue #$ISSUE"
             gh issue close "$ISSUE" \

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.162.0",
-  "generatedAt": "2026-06-01T00:58:06.772Z",
-  "templateVersion": "0.162.0",
+  "generatorVersion": "0.162.1",
+  "generatedAt": "2026-06-01T02:19:06.874Z",
+  "templateVersion": "0.162.1",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "e5f4b31759741b09d2c3c9d27861ec0441d24d8772bbfd8dbf2d774d661b2e10",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.162.1] - 2026-06-01
+
+### Fixed
+- `auto-tag.yml`: comma-separated multi-issue auto-close. The issue-extraction regex `(Closes|Fixes|Resolves)(\s+#[0-9]+)+` only captured the first `#N` in a `Closes #A, #B, #C` list (the comma breaks the `\s+` repetition), so multi-issue release PRs auto-closed only the first issue (e.g., v0.162.0 closed #1268 but left #1269/#1271 open). Separator widened to `[[:space:],]+`. Closes #1273.
+
 ## [0.162.0] - 2026-06-01
 
 ### Changed

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -2334,7 +2334,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.162.0",
+    version: "0.162.1",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.162.0",
+  version: "0.162.1",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.162.0",
+  "version": "0.162.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.162.0",
+  "version": "0.162.1",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## v0.162.1 — auto-tag.yml 멀티이슈 close 수정

`/pipeline auto-dev` 후속(#1273). v0.162.0 머지 시 #1268만 자동 close되고 #1269/#1271이 누락된 근본 원인 수정.

### 수정
- auto-tag.yml 이슈 추출 정규식 `(\s+#[0-9]+)+` → `([[:space:],]+#[0-9]+)+` — `Closes #A, #B, #C` 콤마 구분 멀티이슈를 전부 캡처. 기존 정규식은 콤마에서 반복이 끊겨 첫 이슈만 추출.
- 로컬 검증: `Closes #1268, #1269, #1271` → 1268/1269/1271 전부 추출 확인.

Closes #1273

🤖 Generated with [Claude Code](https://claude.com/claude-code)