### PR TITLE
feat: v0.167.0 — R018 게이트 투명성 + CC v2.1.162 호환 + eraser deprecation

### DIFF
--- a/.claude/rules/MUST-agent-teams.md
+++ b/.claude/rules/MUST-agent-teams.md
@@ -76,6 +76,16 @@ Quick rule: User explicitly preferred plain subagents this session? → use Agen
 ╚══════════════════════════════════════════════════════════════════╝
 -->
 
+### Gate Transparency
+
+When the gate resolves to **Agent Tool** for a 3+ agent dispatch (e.g. mechanical disjoint-file editing with no review loop), announce the gate result in one line BEFORE spawning — e.g. `R018 게이트: 3개 disjoint-file 도메인, 리뷰 사이클 없음 → Agent Tool 폴백`. Silently selecting Agent Tool on a 3+ agent batch loses the gate-evaluation audit trail and reads as if the R018/R009 Self-Check #4 gate was skipped.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| 3+ 에이전트 병렬 스폰 announce에 게이트 평가 결과 누락 | 스폰 전 한 줄로 게이트 결과 명시 (Agent Tool 폴백 사유 또는 Agent Teams 선택 사유) |
+
+Origin: #1293 (Session 110 retrospective, Low).
+
 ### Spawn Completeness Check
 
 All members must be spawned in a single message. Partial spawning needs correction per R018 and R009.
@@ -330,6 +340,8 @@ Agent Teams member completion MUST be verified by deterministic ground-truth —
 | SendMessage report | Low — member may stall before sending | Use as a signal only |
 
 Cross-reference: R020 ("actual outcome ≠ attempt" — verifying that a command ran is not the same as verifying it succeeded).
+
+> **CC v2.1.162+**: `claude agents --json` now includes a `waitingFor` field showing what a waiting session is blocked on (e.g. a permission prompt). Use it as an additional deterministic ground-truth signal — a member with a non-empty `waitingFor` is blocked on input (needs unblocking), NOT silently stalled (reassign per stall handling below). This distinguishes the two failure modes the verification is meant to separate.
 
 **Stall handling**: When a member shows no task progress within ~2 minutes despite spawn + owner assignment + SendMessage coordination, reassign the work to a standalone Agent (R009) rather than continuing to nudge the stalled member. Stalled Teams members waste tokens on idle polling and delay the overall workflow.
 

--- a/.claude/rules/MUST-parallel-execution.md
+++ b/.claude/rules/MUST-parallel-execution.md
@@ -30,7 +30,7 @@ Before writing/editing multiple files:
 1. Are files independent? → YES: spawn parallel agents
 2. Using Write/Edit sequentially for 2+ files? → parallelize instead
 3. Specialized agent available? → Use it (not general-purpose)
-4. Agent Teams available? → **Check R018 criteria before spawning 2+ agents**
+4. Agent Teams available? → **Check R018 criteria before spawning 2+ agents; for a 3+ agent batch, announce the gate result (Agent Tool fallback reason or Agent Teams choice) — see R018 Self-Check "Gate Transparency"**
 5. Running agent stalled (2x+ duration)? → Spawn independent follow-up tasks immediately
 6. Announced a parallel dispatch in prose? → ALL announced tool calls MUST be in the SAME message as the announcement (announce-execution consistency)
 

--- a/.claude/skills/pipeline/SKILL.md
+++ b/.claude/skills/pipeline/SKILL.md
@@ -152,7 +152,7 @@ The `auto-dev.yaml` (and other workflow YAML files) exist in **4 locations**. On
 **Key rules:**
 - The runtime source is `.claude/skills/pipeline/workflows/` (skill base dir). Do NOT confuse with repo-root `workflows/`.
 - When modifying any workflow YAML, update **all applicable mirrors** to prevent drift. `verify-template-sync.sh` (#1286) detects drift automatically on CI.
-- Repo-root `workflows/` is a legacy `/omcustom:workflow` remnant — it also contains `eraser.yaml`. Do not delete without checking for other references.
+- Repo-root `workflows/` is a legacy `/omcustom:workflow` remnant. It contains `eraser.yaml`, **deprecated as of v0.167.0 (#1289)** — retained but unmaintained: its ARCHITECTURE.md-sync function moved to the release workflow + validate-docs, and its diagram generation to the `eraser-diagrams` plugin skill. Not reachable via `/pipeline`. Do not delete without checking for other references.
 
 ## Error Handling
 

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.166.0",
-  "generatedAt": "2026-06-04T02:16:26.100Z",
-  "templateVersion": "0.166.0",
+  "generatorVersion": "0.167.0",
+  "generatedAt": "2026-06-04T12:06:22.117Z",
+  "templateVersion": "0.167.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "e5f4b31759741b09d2c3c9d27861ec0441d24d8772bbfd8dbf2d774d661b2e10",
@@ -35,8 +35,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-parallel-execution.md": {
-      "templateHash": "4f77083601911b6e9faae4d704b22551da5affda0e336f36a4238109ceb4d2f9",
-      "size": 8146,
+      "templateHash": "40cef9feeb307f5117c139e0e82b03394aa9cb3e68a118bce32fad4ab87a1b26",
+      "size": 8289,
       "component": "rules"
     },
     ".claude/rules/SHOULD-ecomode.md": {
@@ -65,8 +65,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-teams.md": {
-      "templateHash": "e37b06c148f05a1c32b2d496850ff709d02928d005725f81c5eeef83b5df9048",
-      "size": 18899,
+      "templateHash": "36ecef70f952488ad4f2c3505b68bf3b25326d8c4d48c384d9e6d1f786013ca2",
+      "size": 20077,
       "component": "rules"
     },
     ".claude/rules/MAY-optimization.md": {
@@ -490,8 +490,8 @@
       "component": "skills"
     },
     ".claude/skills/pipeline/SKILL.md": {
-      "templateHash": "0ac9436b8a46016b3e4d29c584d1704bd6b2732a7aeb97268889d056a2a56331",
-      "size": 6660,
+      "templateHash": "1fc48a852dd5f02df9c3ba88108d2aa6b45cf136a12b9dbeddf52f2d324fb8a1",
+      "size": 6899,
       "component": "skills"
     },
     ".claude/skills/pipeline/labels.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.167.0] - 2026-06-04
+
+### Added
+- R018 "Gate Transparency" — 3+ 에이전트를 Agent Tool로 폴백할 때 스폰 전 게이트 평가 결과를 한 줄로 announce하는 의무 + anti-pattern 표. Silent Agent-Tool 선택이 게이트 평가 audit trail을 잃는 문제 해소 (#1293)
+- R009 Self-Check #4에 게이트 announce cross-ref 추가 — R018 Gate Transparency 참조 (#1293)
+- R018 Member Completion Verification에 CC v2.1.162+ `claude agents --json waitingFor` 노트 — blocked(입력 대기) vs silently stalled(reassign) 두 실패 모드를 deterministic ground-truth로 구분 (#1294)
+
+### Deprecated
+- eraser workflow (`workflows/eraser.yaml`) deprecation — 레거시 /omcustom:workflow remnant. 두 기능이 대체됨: ARCHITECTURE.md count/version sync → 릴리즈 워크플로우 + validate-docs, Eraser MCP 다이어그램 생성 → eraser-diagrams 플러그인 스킬. 파일은 retained-but-unmaintained로 유지, pipeline SKILL.md "Workflow File Locations"에 명문화 (#1289)
+
 ## [0.166.0] - 2026-06-04
 
 ### Added

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -241,7 +241,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.166.0",
+    version: "0.167.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.166.0",
+  version: "0.167.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.166.0",
+  "version": "0.167.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-agent-teams.md
+++ b/templates/.claude/rules/MUST-agent-teams.md
@@ -76,6 +76,16 @@ Quick rule: User explicitly preferred plain subagents this session? → use Agen
 ╚══════════════════════════════════════════════════════════════════╝
 -->
 
+### Gate Transparency
+
+When the gate resolves to **Agent Tool** for a 3+ agent dispatch (e.g. mechanical disjoint-file editing with no review loop), announce the gate result in one line BEFORE spawning — e.g. `R018 게이트: 3개 disjoint-file 도메인, 리뷰 사이클 없음 → Agent Tool 폴백`. Silently selecting Agent Tool on a 3+ agent batch loses the gate-evaluation audit trail and reads as if the R018/R009 Self-Check #4 gate was skipped.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| 3+ 에이전트 병렬 스폰 announce에 게이트 평가 결과 누락 | 스폰 전 한 줄로 게이트 결과 명시 (Agent Tool 폴백 사유 또는 Agent Teams 선택 사유) |
+
+Origin: #1293 (Session 110 retrospective, Low).
+
 ### Spawn Completeness Check
 
 All members must be spawned in a single message. Partial spawning needs correction per R018 and R009.
@@ -330,6 +340,8 @@ Agent Teams member completion MUST be verified by deterministic ground-truth —
 | SendMessage report | Low — member may stall before sending | Use as a signal only |
 
 Cross-reference: R020 ("actual outcome ≠ attempt" — verifying that a command ran is not the same as verifying it succeeded).
+
+> **CC v2.1.162+**: `claude agents --json` now includes a `waitingFor` field showing what a waiting session is blocked on (e.g. a permission prompt). Use it as an additional deterministic ground-truth signal — a member with a non-empty `waitingFor` is blocked on input (needs unblocking), NOT silently stalled (reassign per stall handling below). This distinguishes the two failure modes the verification is meant to separate.
 
 **Stall handling**: When a member shows no task progress within ~2 minutes despite spawn + owner assignment + SendMessage coordination, reassign the work to a standalone Agent (R009) rather than continuing to nudge the stalled member. Stalled Teams members waste tokens on idle polling and delay the overall workflow.
 

--- a/templates/.claude/rules/MUST-parallel-execution.md
+++ b/templates/.claude/rules/MUST-parallel-execution.md
@@ -30,7 +30,7 @@ Before writing/editing multiple files:
 1. Are files independent? → YES: spawn parallel agents
 2. Using Write/Edit sequentially for 2+ files? → parallelize instead
 3. Specialized agent available? → Use it (not general-purpose)
-4. Agent Teams available? → **Check R018 criteria before spawning 2+ agents**
+4. Agent Teams available? → **Check R018 criteria before spawning 2+ agents; for a 3+ agent batch, announce the gate result (Agent Tool fallback reason or Agent Teams choice) — see R018 Self-Check "Gate Transparency"**
 5. Running agent stalled (2x+ duration)? → Spawn independent follow-up tasks immediately
 6. Announced a parallel dispatch in prose? → ALL announced tool calls MUST be in the SAME message as the announcement (announce-execution consistency)
 

--- a/templates/.claude/skills/pipeline/SKILL.md
+++ b/templates/.claude/skills/pipeline/SKILL.md
@@ -152,7 +152,7 @@ The `auto-dev.yaml` (and other workflow YAML files) exist in **4 locations**. On
 **Key rules:**
 - The runtime source is `.claude/skills/pipeline/workflows/` (skill base dir). Do NOT confuse with repo-root `workflows/`.
 - When modifying any workflow YAML, update **all applicable mirrors** to prevent drift. `verify-template-sync.sh` (#1286) detects drift automatically on CI.
-- Repo-root `workflows/` is a legacy `/omcustom:workflow` remnant — it also contains `eraser.yaml`. Do not delete without checking for other references.
+- Repo-root `workflows/` is a legacy `/omcustom:workflow` remnant. It contains `eraser.yaml`, **deprecated as of v0.167.0 (#1289)** — retained but unmaintained: its ARCHITECTURE.md-sync function moved to the release workflow + validate-docs, and its diagram generation to the `eraser-diagrams` plugin skill. Not reachable via `/pipeline`. Do not delete without checking for other references.
 
 ## Error Handling
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.166.0",
+  "version": "0.167.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/workflows/eraser.yaml
+++ b/workflows/eraser.yaml
@@ -1,3 +1,9 @@
+# ⚠️ DEPRECATED (v0.167.0, #1289) — legacy /omcustom:workflow, retained but unmaintained.
+# Its two functions are now covered by other assets:
+#   - ARCHITECTURE.md count/version sync → release workflow + validate-docs (runs every release)
+#   - Eraser MCP diagram generation → eraser-diagrams plugin skill (general-purpose)
+# NOT reachable via /pipeline (runtime source: .claude/skills/pipeline/workflows/). Do not extend.
+#
 # /omcustom:workflow eraser — Architecture documentation sync via Eraser MCP
 # Analyzes ARCHITECTURE.md, updates text, generates/replaces diagrams
 


### PR DESCRIPTION
## 개요
Session 110 회고 찐빠(#1293 R018 게이트 announce 투명성) 보정 + CC v2.1.162 호환 + 레거시 eraser workflow deprecation. compression lite tier 적용.

## 변경 사항
### R018 게이트 투명성 (#1293 — Session 110 회고)
- R018 "Gate Transparency" subsection 추가 — 3+ 에이전트를 Agent Tool로 폴백할 때 스폰 전 게이트 평가 결과를 한 줄로 announce하는 의무 (silent Agent-Tool 선택이 게이트 audit trail 손실)
- R009 Self-Check #4에 게이트 announce cross-ref 추가 (R018 Gate Transparency 참조)

### CC v2.1.162 호환 (#1294)
- R018 Member Completion Verification에 `claude agents --json waitingFor` 노트 — blocked(입력 대기) vs silently stalled(reassign) 두 실패 모드를 deterministic ground-truth로 구분

### eraser workflow deprecation (#1289)
- workflows/eraser.yaml deprecation 주석 — 기능이 릴리즈 워크플로우+validate-docs(ARCHITECTURE.md sync) 및 eraser-diagrams 플러그인 스킬(다이어그램)로 대체됨
- pipeline SKILL.md "Workflow File Locations"에 deprecation 명문화 (retained-but-unmaintained)

## 검증
- bun test: 2013 pass / 0 fail (regression 없음)
- verify-template-sync / verify-wiki-sync: PASS
- deep-verify (lite, mgr-sauron R017): PASS — cross-ref/drift/모순 없음

## 릴리즈 정보
- 버전: 0.166.0 → 0.167.0 (minor)
- 카운트 불변: agents=49, skills=116, rules=23, guides=57
- compression mode: lite (scope=3, 저위험)

Closes #1289
Closes #1293
Closes #1294

🤖 Generated with [Claude Code](https://claude.com/claude-code)