### PR TITLE
v0.168.0 — #1298 scout/research WebFetch 출처 태깅 + #1300 homework opt-in

### DIFF
--- a/.claude/skills/homework/SKILL.md
+++ b/.claude/skills/homework/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: homework
-description: On session cleanup ("세션 정리") or /homework invocation, analyze the current and linked previous sessions, extract mistakes (찐빠), and report them via omcustom-feedback with a confirmation gate. Use when wrapping up a session or auditing recent work for harness gaps.
+description: On explicit /homework invocation, analyze the current and linked previous sessions, extract mistakes (찐빠), and report them via omcustom-feedback with a confirmation gate. Auto-activation on session cleanup/session-end signals is OPT-IN (default OFF) — requires an explicit project/user directive. Use when explicitly auditing recent work for harness gaps.
 scope: harness
 user-invocable: true
 argument-hint: "[--dry-run] [--days <n>] [--severity <critical|high|medium|low>]"
@@ -25,13 +25,15 @@ This skill is the dedicated entry point for R011's "Session-End Retrospective Fe
 
 ## Trigger Detection
 
-Activate when the user says any of:
-- "세션 정리" / "숙제" / "회고"
-- "homework" / "session cleanup" / "wrap up"
-- Explicit `/homework` invocation
-- Session-end signals: "끝", "종료", "마무리", "done", "end session"
+**Default: OFF for auto-activation.** This skill does NOT auto-run on session cleanup or session-end signals unless explicitly enabled. The default is `false` — silence is a non-trigger.
 
-When activated as a session-end signal, this skill runs BEFORE sys-memory-keeper's MEMORY.md update (R011 session-end self-check order: homework → memory save).
+Activate ONLY when:
+- **Explicit `/homework` invocation** (always runs)
+- **Explicit opt-in**: the user/project has explicitly directed homework to run on session cleanup — e.g., a CLAUDE.md directive such as "run homework on every session cleanup", or a settings flag. A one-off explicit request ("회고 돌려줘", "homework 실행") also counts.
+
+If no explicit opt-in exists, treat session-cleanup / session-end phrases ("세션 정리", "숙제", "회고", "끝", "종료", "마무리", "done", "wrap up", "session cleanup", "end session") as **NON-triggers** — do NOT auto-run. You MAY briefly remind the user that `/homework` is available, then proceed with normal session-end handling.
+
+When auto-activation IS explicitly enabled and fires as a session-end signal, this skill runs BEFORE sys-memory-keeper's MEMORY.md update (R011 session-end self-check order: homework → memory save).
 
 ## Workflow
 

--- a/.claude/skills/research/SKILL.md
+++ b/.claude/skills/research/SKILL.md
@@ -117,6 +117,8 @@ fi
 
 **Action**: `[Pre-flight] WARN: Context usage at {pct}%. 10-team research typically adds 30-40% context. Consider /compact before proceeding, or results may be truncated.`
 
+> **File-absent branch (#1298)**: `$CONTEXT_FILE`가 존재하지 않으면 입력이 측정 불가하다 — `PASS (context budget unmeasured — file absent)`로 보고하고 WARN을 내지 않는다. 파일을 읽지 않고 WARN 상태를 특성화하지 않는다(R020 Read-Before-Characterize). WARN은 파일이 존재하고 context_pct > 40 일 때만 emit한다.
+
 ### Display Format
 
 ```
@@ -225,6 +227,10 @@ Reference: `feedback_sensitive_path_tmp_bypass.md`, R006 sensitive-path handling
 | Orchestrator only | Main conversation manages all phases (R010) |
 | Ecomode | Auto-activate for team result aggregation (R013) |
 | Intent display | Show research plan before execution (R015) |
+
+## External Quantitative-Fact Source Tagging
+
+research 팀이 WebFetch로 구체적 정량 주장(benchmark 수치, table 값)을 수집하면, synthesis/report는 출처별로 태깅해야 한다: `WebFetch-derived (unverified)` vs `PDF/primary-verified`. WebFetch는 small fast model + URL당 15분 캐시를 사용하므로, N개 팀이 동일 URL을 fetch하는 것은 독립 교차검증이 아니다(팀 간 합의가 공유 캐시 artifact일 수 있음). primary source에서 검증 불가한 cross-cutting fact는 verifier에게 명시적 ground-truth로 제공해야 한다(R023). 영구 이슈/아티팩트에 정확한 수치를 primary-source 검증 또는 명시적 unverified 태그 없이 사실로 기재하지 않는다.
 
 ## Retrieval-Reasoning Separation
 

--- a/.claude/skills/scout/SKILL.md
+++ b/.claude/skills/scout/SKILL.md
@@ -91,6 +91,8 @@ Before execution, show the plan:
    - Approach and principles
 3. If fetch fails — report error, abort
 
+> **External quantitative-fact source tagging** (#1298): WebFetch가 산출한 구체적 정량 주장(benchmark 수치, table 값, metric)은 이슈 본문에 `WebFetch-derived (unverified)`로 태깅한다 — 검증된 사실로 제시하지 않는다. WebFetch는 small fast model + 15분 URL 캐시를 사용하므로, 동일 URL을 여러 번 fetch해도 독립 교차검증이 아니다. load-bearing 수치는 primary PDF/원문으로 1회 검증하거나 명시적으로 unverified로 표기한다. (R020 Read-Before-Characterize, R023 Verifier Ground-Truth for cross-cutting facts)
+
 ### Phase 2: Load Project Philosophy
 
 1. `Read(CLAUDE.md)` — extract architecture philosophy:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.167.0",
+  "version": "0.168.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/homework/SKILL.md
+++ b/templates/.claude/skills/homework/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: homework
-description: On session cleanup ("세션 정리") or /homework invocation, analyze the current and linked previous sessions, extract mistakes (찐빠), and report them via omcustom-feedback with a confirmation gate. Use when wrapping up a session or auditing recent work for harness gaps.
+description: On explicit /homework invocation, analyze the current and linked previous sessions, extract mistakes (찐빠), and report them via omcustom-feedback with a confirmation gate. Auto-activation on session cleanup/session-end signals is OPT-IN (default OFF) — requires an explicit project/user directive. Use when explicitly auditing recent work for harness gaps.
 scope: harness
 user-invocable: true
 argument-hint: "[--dry-run] [--days <n>] [--severity <critical|high|medium|low>]"
@@ -25,13 +25,15 @@ This skill is the dedicated entry point for R011's "Session-End Retrospective Fe
 
 ## Trigger Detection
 
-Activate when the user says any of:
-- "세션 정리" / "숙제" / "회고"
-- "homework" / "session cleanup" / "wrap up"
-- Explicit `/homework` invocation
-- Session-end signals: "끝", "종료", "마무리", "done", "end session"
+**Default: OFF for auto-activation.** This skill does NOT auto-run on session cleanup or session-end signals unless explicitly enabled. The default is `false` — silence is a non-trigger.
 
-When activated as a session-end signal, this skill runs BEFORE sys-memory-keeper's MEMORY.md update (R011 session-end self-check order: homework → memory save).
+Activate ONLY when:
+- **Explicit `/homework` invocation** (always runs)
+- **Explicit opt-in**: the user/project has explicitly directed homework to run on session cleanup — e.g., a CLAUDE.md directive such as "run homework on every session cleanup", or a settings flag. A one-off explicit request ("회고 돌려줘", "homework 실행") also counts.
+
+If no explicit opt-in exists, treat session-cleanup / session-end phrases ("세션 정리", "숙제", "회고", "끝", "종료", "마무리", "done", "wrap up", "session cleanup", "end session") as **NON-triggers** — do NOT auto-run. You MAY briefly remind the user that `/homework` is available, then proceed with normal session-end handling.
+
+When auto-activation IS explicitly enabled and fires as a session-end signal, this skill runs BEFORE sys-memory-keeper's MEMORY.md update (R011 session-end self-check order: homework → memory save).
 
 ## Workflow
 

--- a/templates/.claude/skills/research/SKILL.md
+++ b/templates/.claude/skills/research/SKILL.md
@@ -117,6 +117,8 @@ fi
 
 **Action**: `[Pre-flight] WARN: Context usage at {pct}%. 10-team research typically adds 30-40% context. Consider /compact before proceeding, or results may be truncated.`
 
+> **File-absent branch (#1298)**: `$CONTEXT_FILE`가 존재하지 않으면 입력이 측정 불가하다 — `PASS (context budget unmeasured — file absent)`로 보고하고 WARN을 내지 않는다. 파일을 읽지 않고 WARN 상태를 특성화하지 않는다(R020 Read-Before-Characterize). WARN은 파일이 존재하고 context_pct > 40 일 때만 emit한다.
+
 ### Display Format
 
 ```
@@ -225,6 +227,10 @@ Reference: `feedback_sensitive_path_tmp_bypass.md`, R006 sensitive-path handling
 | Orchestrator only | Main conversation manages all phases (R010) |
 | Ecomode | Auto-activate for team result aggregation (R013) |
 | Intent display | Show research plan before execution (R015) |
+
+## External Quantitative-Fact Source Tagging
+
+research 팀이 WebFetch로 구체적 정량 주장(benchmark 수치, table 값)을 수집하면, synthesis/report는 출처별로 태깅해야 한다: `WebFetch-derived (unverified)` vs `PDF/primary-verified`. WebFetch는 small fast model + URL당 15분 캐시를 사용하므로, N개 팀이 동일 URL을 fetch하는 것은 독립 교차검증이 아니다(팀 간 합의가 공유 캐시 artifact일 수 있음). primary source에서 검증 불가한 cross-cutting fact는 verifier에게 명시적 ground-truth로 제공해야 한다(R023). 영구 이슈/아티팩트에 정확한 수치를 primary-source 검증 또는 명시적 unverified 태그 없이 사실로 기재하지 않는다.
 
 ## Retrieval-Reasoning Separation
 

--- a/templates/.claude/skills/scout/SKILL.md
+++ b/templates/.claude/skills/scout/SKILL.md
@@ -91,6 +91,8 @@ Before execution, show the plan:
    - Approach and principles
 3. If fetch fails — report error, abort
 
+> **External quantitative-fact source tagging** (#1298): WebFetch가 산출한 구체적 정량 주장(benchmark 수치, table 값, metric)은 이슈 본문에 `WebFetch-derived (unverified)`로 태깅한다 — 검증된 사실로 제시하지 않는다. WebFetch는 small fast model + 15분 URL 캐시를 사용하므로, 동일 URL을 여러 번 fetch해도 독립 교차검증이 아니다. load-bearing 수치는 primary PDF/원문으로 1회 검증하거나 명시적으로 unverified로 표기한다. (R020 Read-Before-Characterize, R023 Verifier Ground-Truth for cross-cutting facts)
+
 ### Phase 2: Load Project Philosophy
 
 1. `Read(CLAUDE.md)` — extract architecture philosophy:

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.167.0",
+  "version": "0.168.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 변경 요약

**#1298 세션 회고 — scout/research 하네스 개선 2건**

- **WebFetch 정량 사실 출처 태깅 컨벤션** (`scout/SKILL.md`, `research/SKILL.md`):
  외부 정량 사실(수치, 벤치마크, 통계)을 수집할 때 출처 유형을 명시하는 컨벤션 추가.
  WebFetch 파생 vs PDF 검증 구분; 15분 URL 캐시는 독립적 교차 검증이 아님을 명시.

- **research Guard 4 파일-부재 분기** (`research/SKILL.md`):
  컨텍스트 파일이 없을 때 WARN 대신 PASS (unmeasured)로 보고하도록 분기 수정.
  파일 부재는 측정 불가 상황이지, 가이드라인 위반이 아님.

- **버전 범프**: `package.json` + `templates/manifest.json` 0.167.0 → 0.168.0

Fixes #1298

**#1300 homework 세션 자동 실행 → opt-in (default OFF) 변경**

- **Trigger Detection 명확화** (`homework/SKILL.md`, `templates/.claude/skills/homework/SKILL.md`):
  세션 정리 / session-end 시그널은 기본적으로 homework 자동 실행 트리거가 **아님**.
  명시적 `/homework` 호출 또는 프로젝트/사용자 레벨 opt-in 설정이 있어야 자동 실행됨.
- **frontmatter description** 업데이트: opt-in default OFF 동작 반영.

Fixes #1300

## 검증 현황

- bun test: 2013 pass / 0 fail ✓
- template-sync: PASS ✓
- wiki-sync: PASS ✓
- R017 lite: PASS ✓
- 카운트 변경 없음: skills 116, agents 49

## 노트

CI 완료 후 머지 예정. 자동 태그(auto-tag.yml)로 `v0.168.0` 태그 및 milestone #63 close, npm publish 트리거됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)