### PR TITLE
v0.169.0 — #1301 auto-dev mid-run scope verify-build 재진입 + lite tier improvement 라벨

### DIFF
--- a/.claude/skills/pipeline/labels.md
+++ b/.claude/skills/pipeline/labels.md
@@ -41,6 +41,13 @@ An issue is eligible for `docs-only` compression mode if its labels include at l
 If ALL scoped issues are compression-eligible AND scope size ≤ 3, the pipeline MAY use
 `compression_mode=docs-only` (skip professor-triage / release-plan / deep-plan / deep-verify skill spawns).
 
+An issue is eligible for `lite` (Tier 2) compression mode if its labels include at least one of:
+`documentation`, `automated`, `claude-code-release`, `feedback`, `professor`, `enhancement`, `improvement`
+
+If ALL scoped issues carry at least one lite-eligible label AND scope size ≤ 7 AND no issue carries
+`breaking-change` or `decision-needed`, the pipeline MAY use `compression_mode=lite`
+(integrated analysis replaces heavy skill spawns for triage/plan/deep-plan/deep-verify; implement and verify-build execute normally).
+
 ## Lifecycle Labels (set by `implement` step)
 
 | Transition | Action |

--- a/.claude/skills/pipeline/workflows/auto-dev.yaml
+++ b/.claude/skills/pipeline/workflows/auto-dev.yaml
@@ -137,7 +137,7 @@ steps:
       Evaluate ONLY if docs-only NOT met. Conditions (ALL must hold):
       1. scope size ≤ 7
       2. ALL scoped issues are low-risk: for EVERY issue,
-         labels ∩ {documentation, automated, claude-code-release, feedback, professor, enhancement} ≠ ∅
+         labels ∩ {documentation, automated, claude-code-release, feedback, professor, enhancement, improvement} ≠ ∅
       3. NO scoped issue carries a breaking-change or decision-needed label
       4. No code logic change is expected — work is docs/rule/skill/config/script-centric
          (verify against each issue body; if any issue implies application code logic change, FAIL the lite check)
@@ -201,6 +201,7 @@ steps:
       - Issues whose prerequisites failed in-run MUST be skipped (log reason)
       - No direct orchestrator writes (R010)
       - All Agent tool calls MUST pass mode: "bypassPermissions" to prevent permission prompts during unattended execution
+      - Mid-run scope additions (a new issue added via user interrupt AFTER implement began) MUST re-enter the verify-build gate before release — do NOT let a late-added scope item ride to release on a prior verify-build pass. Critical for code changes; benign for docs-only (#1301).
 
 
       ## Sensitive Path Handling (CC v2.1.121+)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.168.0",
+  "version": "0.169.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/pipeline/labels.md
+++ b/templates/.claude/skills/pipeline/labels.md
@@ -41,6 +41,13 @@ An issue is eligible for `docs-only` compression mode if its labels include at l
 If ALL scoped issues are compression-eligible AND scope size ≤ 3, the pipeline MAY use
 `compression_mode=docs-only` (skip professor-triage / release-plan / deep-plan / deep-verify skill spawns).
 
+An issue is eligible for `lite` (Tier 2) compression mode if its labels include at least one of:
+`documentation`, `automated`, `claude-code-release`, `feedback`, `professor`, `enhancement`, `improvement`
+
+If ALL scoped issues carry at least one lite-eligible label AND scope size ≤ 7 AND no issue carries
+`breaking-change` or `decision-needed`, the pipeline MAY use `compression_mode=lite`
+(integrated analysis replaces heavy skill spawns for triage/plan/deep-plan/deep-verify; implement and verify-build execute normally).
+
 ## Lifecycle Labels (set by `implement` step)
 
 | Transition | Action |

--- a/templates/.claude/skills/pipeline/workflows/auto-dev.yaml
+++ b/templates/.claude/skills/pipeline/workflows/auto-dev.yaml
@@ -137,7 +137,7 @@ steps:
       Evaluate ONLY if docs-only NOT met. Conditions (ALL must hold):
       1. scope size ≤ 7
       2. ALL scoped issues are low-risk: for EVERY issue,
-         labels ∩ {documentation, automated, claude-code-release, feedback, professor, enhancement} ≠ ∅
+         labels ∩ {documentation, automated, claude-code-release, feedback, professor, enhancement, improvement} ≠ ∅
       3. NO scoped issue carries a breaking-change or decision-needed label
       4. No code logic change is expected — work is docs/rule/skill/config/script-centric
          (verify against each issue body; if any issue implies application code logic change, FAIL the lite check)
@@ -201,6 +201,7 @@ steps:
       - Issues whose prerequisites failed in-run MUST be skipped (log reason)
       - No direct orchestrator writes (R010)
       - All Agent tool calls MUST pass mode: "bypassPermissions" to prevent permission prompts during unattended execution
+      - Mid-run scope additions (a new issue added via user interrupt AFTER implement began) MUST re-enter the verify-build gate before release — do NOT let a late-added scope item ride to release on a prior verify-build pass. Critical for code changes; benign for docs-only (#1301).
 
 
       ## Sensitive Path Handling (CC v2.1.121+)

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.168.0",
+  "version": "0.169.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/templates/workflows/auto-dev.yaml
+++ b/templates/workflows/auto-dev.yaml
@@ -137,7 +137,7 @@ steps:
       Evaluate ONLY if docs-only NOT met. Conditions (ALL must hold):
       1. scope size ≤ 7
       2. ALL scoped issues are low-risk: for EVERY issue,
-         labels ∩ {documentation, automated, claude-code-release, feedback, professor, enhancement} ≠ ∅
+         labels ∩ {documentation, automated, claude-code-release, feedback, professor, enhancement, improvement} ≠ ∅
       3. NO scoped issue carries a breaking-change or decision-needed label
       4. No code logic change is expected — work is docs/rule/skill/config/script-centric
          (verify against each issue body; if any issue implies application code logic change, FAIL the lite check)
@@ -201,6 +201,7 @@ steps:
       - Issues whose prerequisites failed in-run MUST be skipped (log reason)
       - No direct orchestrator writes (R010)
       - All Agent tool calls MUST pass mode: "bypassPermissions" to prevent permission prompts during unattended execution
+      - Mid-run scope additions (a new issue added via user interrupt AFTER implement began) MUST re-enter the verify-build gate before release — do NOT let a late-added scope item ride to release on a prior verify-build pass. Critical for code changes; benign for docs-only (#1301).
 
 
       ## Sensitive Path Handling (CC v2.1.121+)

--- a/workflows/auto-dev.yaml
+++ b/workflows/auto-dev.yaml
@@ -137,7 +137,7 @@ steps:
       Evaluate ONLY if docs-only NOT met. Conditions (ALL must hold):
       1. scope size ≤ 7
       2. ALL scoped issues are low-risk: for EVERY issue,
-         labels ∩ {documentation, automated, claude-code-release, feedback, professor, enhancement} ≠ ∅
+         labels ∩ {documentation, automated, claude-code-release, feedback, professor, enhancement, improvement} ≠ ∅
       3. NO scoped issue carries a breaking-change or decision-needed label
       4. No code logic change is expected — work is docs/rule/skill/config/script-centric
          (verify against each issue body; if any issue implies application code logic change, FAIL the lite check)
@@ -201,6 +201,7 @@ steps:
       - Issues whose prerequisites failed in-run MUST be skipped (log reason)
       - No direct orchestrator writes (R010)
       - All Agent tool calls MUST pass mode: "bypassPermissions" to prevent permission prompts during unattended execution
+      - Mid-run scope additions (a new issue added via user interrupt AFTER implement began) MUST re-enter the verify-build gate before release — do NOT let a late-added scope item ride to release on a prior verify-build pass. Critical for code changes; benign for docs-only (#1301).
 
 
       ## Sensitive Path Handling (CC v2.1.121+)


### PR DESCRIPTION
## 변경 요약

### 1. auto-dev mid-run scope verify-build 재진입 (#1301)
- `/pipeline auto-dev` 실행 중 scope에 이슈가 추가될 경우, 릴리즈 전 verify-build 게이트를 반드시 재진입하도록 강제
- 4개 yaml 사본 모두 동일하게 적용 (md5 일치 확인 완료)

### 2. compression lite tier `improvement` 라벨 추가
- lite tier(Tier 2, scope ≤ 7) 저위험 라벨 셋에 `improvement` 추가
- `labels.md`: lite (Tier 2) 압축 라벨 셋 명문화
- 적용 파일: auto-dev.yaml 4곳 + labels.md 2곳

## 카운트 (변경 없음)
- Skills: 116, Agents: 49

## 로컬 검증 완료
- bun test: 2013 pass / 0 fail
- verify-template-sync: PASS (4-copy md5 identical)
- R017 lite 검증: PASS

Fixes #1301
Milestone: v0.169.0 (#64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)