### PR TITLE
release: v0.171.0 — 룰 강화 + TIDE measure-before-adopt

### DIFF
--- a/.claude/rules/MAY-optimization.md
+++ b/.claude/rules/MAY-optimization.md
@@ -10,6 +10,8 @@
 | Caching | Same data accessed repeatedly | Cache file contents, reuse search results |
 | Lazy Loading | Large datasets, partial use | Read only needed files, stream results |
 
+> **Tool-availability assumption (#1307 찐빠 #3)**: On first exploration, do NOT assume a tool (e.g., `Glob`) is available without confirming. Prefer `Bash` (`find`/`grep`) for initial search when the available-tool set is unconfirmed, to avoid "No such tool available" round-trips.
+
 ### Capability-Aware Tool Scheduling
 
 When dispatching parallel tool calls, consider per-tool capabilities to optimize scheduling:

--- a/.claude/rules/MUST-safety.md
+++ b/.claude/rules/MUST-safety.md
@@ -25,6 +25,21 @@ The following git commands have caused working tree loss in past sessions (#1146
 
 **Recovery hint**: If working tree loss occurs, check `git reflog` immediately — most operations are recoverable within 30 days.
 
+### Pre-Delegation Blast-Radius Enumeration
+
+> Origin: #1307 찐빠 #1 (High) — user chose "discard local changes and pull", and `git reset --hard origin/develop` was delegated immediately → user rejected (interrupt). The blast radius — that "discard local changes" included 18 files of *intended* uncommitted work (rule edits, new skills, new guides), not just a version downgrade — was never enumerated for the user.
+
+Before delegating ANY destructive git command (the table above), the orchestrator MUST first enumerate the EXACT discard targets and present them for explicit approval. Do NOT delegate a destructive git op on a paraphrased intent ("로컬 변경 버리기" / "discard local changes") without showing what will actually be lost.
+
+| Required before delegation | Command |
+|----------------------------|---------|
+| List modified/staged tracked files | `git status --short` |
+| Show uncommitted diff scope | `git diff --stat` (and `git diff --stat --cached`) |
+| Show stashable work scope | `git stash show --stat` (when a stash is involved) |
+| Show untracked files at risk (for `clean`) | `git clean -nd` |
+
+Enumerate ALL affected work — intended uncommitted edits (rule changes, new skills/guides) count too, not just the symptom the user named. Prefer a non-destructive alternative (`git stash`) when the user's goal (e.g., "reach remote state") can be met without permanent loss.
+
 ## Credential & Privileged-Scope Guardrails
 
 > Origin: #1266 ① (Critical) — a subagent dumped `.env` and Gmail OAuth credentials into the transcript (Credential Exploration) and ran an unauthorized credential-rotation flow that caused a dashboard data outage.

--- a/.claude/rules/SHOULD-memory-integration.md
+++ b/.claude/rules/SHOULD-memory-integration.md
@@ -364,6 +364,19 @@ Related records from session v0.87.2~v0.88.0 (issue #869):
 - `feedback_bun_mock_module.md`
 -->
 
+## Safety-Related Feedback Memory Framing
+
+> Origin: #1307 찐빠 #2 (Medium) — a sys-memory-keeper delegation prompt framed a learning as "오탐으로 판단하고 진행한다" (conclude it's a false positive and proceed), tripping the memory-poisoning safety classifier and requiring a rewrite.
+
+Safety-related feedback memories MUST be written in **verification-obligation form**, NOT **conclusion form**. Conclusion-form framing ("ignore the warning and proceed", "오탐이므로 무시") risks future sessions ignoring genuine threat warnings (memory-poisoning).
+
+| Anti-pattern (conclusion form) | Required (verification-obligation form) |
+|--------------------------------|------------------------------------------|
+| "이 경고는 오탐이므로 무시하고 진행" | "이 패턴은 X 검증을 트리거; 검증 통과 시에만 진행, 실패 시 STOP" |
+| "warning is false positive, proceed" | "warning triggers a duty to verify Y; proceed only if verified, else STOP" |
+
+Write safety learnings as triggers (what to check) + STOP conditions (when to halt), never as standing permission to dismiss a class of warnings.
+
 ## Session-End Auto-Save
 
 ### Trigger

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.167.0",
-  "generatedAt": "2026-06-04T12:06:22.117Z",
-  "templateVersion": "0.167.0",
+  "generatorVersion": "0.171.0",
+  "generatedAt": "2026-06-06T05:42:49.232Z",
+  "templateVersion": "0.171.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "e5f4b31759741b09d2c3c9d27861ec0441d24d8772bbfd8dbf2d774d661b2e10",
@@ -50,8 +50,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
-      "templateHash": "ad619343009067aaca8c04dacadcdf39f77cea31c085216b04f649a48e5a7662",
-      "size": 25490,
+      "templateHash": "d51213ba0a9e143637c0316631023a6aa02bf7267aa1af424c6889972ddf6310",
+      "size": 25774,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
@@ -70,8 +70,8 @@
       "component": "rules"
     },
     ".claude/rules/MAY-optimization.md": {
-      "templateHash": "804c6ad466976f24f489c679f046e5fc67a8aaae72106343ce9c9bc18edab1cb",
-      "size": 2301,
+      "templateHash": "221532739c80cf81d8ead6b653e4dc1c678331064c4beb116c2a25e3ae59b810",
+      "size": 2587,
       "component": "rules"
     },
     ".claude/rules/MUST-continuous-improvement.md": {
@@ -90,8 +90,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-safety.md": {
-      "templateHash": "97d354f08c72368b522e1e5bfcd98aa14f6aca799d410e18b039b409ddbe926b",
-      "size": 3153,
+      "templateHash": "d9af935c87dbe74a68da6eea60385c877c8c78a824d9054809b4ff0a53d91931",
+      "size": 4566,
       "component": "rules"
     },
     ".claude/rules/MUST-tool-identification.md": {
@@ -105,13 +105,13 @@
       "component": "rules"
     },
     ".claude/rules/SHOULD-memory-integration.md": {
-      "templateHash": "70b984fbef72dfc22d614a428a3ca45a20f8c446dc4e9b771c991622aca7fd28",
-      "size": 19627,
+      "templateHash": "81246b77b73cbec186b7010d6fbd6de9b6d50b5ef8c0b0c1f1985c54f703f5f9",
+      "size": 20767,
       "component": "rules"
     },
     ".claude/rules/MUST-enforcement-policy.md": {
-      "templateHash": "35d7ee3d9d9710de28949323ad672c8877f0da82e236f8b79b43bf11d9e56696",
-      "size": 3418,
+      "templateHash": "9753983ea33868b0b3686fb381327e0896efeab96f2277a1195f97baf60d82e5",
+      "size": 3895,
       "component": "rules"
     },
     ".claude/rules/index.yaml": {
@@ -390,8 +390,8 @@
       "component": "skills"
     },
     ".claude/skills/research/SKILL.md": {
-      "templateHash": "ccfbce752f34c1eaa76972179f8e65f143576251b07866207965bbfb6277b4e4",
-      "size": 17094,
+      "templateHash": "5245b677a7fc5691e8ed9719b02d34a673f9b3ef6015fcf29203994beba7d99b",
+      "size": 18206,
       "component": "skills"
     },
     ".claude/skills/hada-scout/SKILL.md": {
@@ -485,8 +485,8 @@
       "component": "skills"
     },
     ".claude/skills/pipeline/workflows/auto-dev.yaml": {
-      "templateHash": "c6e2486c6f8a0944f826f792eb169d8ac1b4d1cfd584811d428bf71cd997f30d",
-      "size": 16893,
+      "templateHash": "8147466c3d41f2a9d9afa8b1fc2e880f1ea2ee58068a1cde56e02d8096f65e28",
+      "size": 17192,
       "component": "skills"
     },
     ".claude/skills/pipeline/SKILL.md": {
@@ -495,8 +495,8 @@
       "component": "skills"
     },
     ".claude/skills/pipeline/labels.md": {
-      "templateHash": "7224f1613cce291407fe4948fc3a1d97ace275686885da453eef3ecd5c1fc1a9",
-      "size": 2323,
+      "templateHash": "0132c0cb172f6912528c59808ea62c8f031a87d9db1bf65b1981d4c77c2ac8ec",
+      "size": 2850,
       "component": "skills"
     },
     ".claude/skills/dev-refactor/SKILL.md": {
@@ -760,8 +760,8 @@
       "component": "skills"
     },
     ".claude/skills/scout/SKILL.md": {
-      "templateHash": "5006f1dec6755cbe949d9f72372a398e0d419e5dca63744438e653f08de607bd",
-      "size": 9242,
+      "templateHash": "cc4b7d6b9e84cb36cf7ae1585dd85caa8c5cc9af545c546c7a4072776c5192bd",
+      "size": 9835,
       "component": "skills"
     },
     ".claude/skills/status/SKILL.md": {
@@ -865,8 +865,8 @@
       "component": "skills"
     },
     ".claude/skills/homework/SKILL.md": {
-      "templateHash": "67b1f6fee65056e5157e397ec4a7336bb56dfb8b10b4c329a7a68d04184f00fe",
-      "size": 10801,
+      "templateHash": "d6ca8d692d8f6aca5b760ca0f0902ae7bbe96d5debe10758196913030cf65762",
+      "size": 11584,
       "component": "skills"
     },
     ".claude/skills/typescript-best-practices/SKILL.md": {
@@ -1285,7 +1285,7 @@
       "component": "hooks"
     },
     ".claude/hooks/hooks.json": {
-      "templateHash": "174e0a6e5fa90ad4183bf5bf842812f348c1d9c6d6105e16ba4f2bdd114a35d7",
+      "templateHash": "f9d50cbfdb3e02376422f39c7983fc6ac62362e97ed09dd6d303e39a6dc71690",
       "size": 28270,
       "component": "hooks"
     },

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -241,7 +241,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.167.0",
+    version: "0.171.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.167.0",
+  version: "0.171.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.170.0",
+  "version": "0.171.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MAY-optimization.md
+++ b/templates/.claude/rules/MAY-optimization.md
@@ -10,6 +10,8 @@
 | Caching | Same data accessed repeatedly | Cache file contents, reuse search results |
 | Lazy Loading | Large datasets, partial use | Read only needed files, stream results |
 
+> **Tool-availability assumption (#1307 찐빠 #3)**: On first exploration, do NOT assume a tool (e.g., `Glob`) is available without confirming. Prefer `Bash` (`find`/`grep`) for initial search when the available-tool set is unconfirmed, to avoid "No such tool available" round-trips.
+
 ### Capability-Aware Tool Scheduling
 
 When dispatching parallel tool calls, consider per-tool capabilities to optimize scheduling:

--- a/templates/.claude/rules/MUST-safety.md
+++ b/templates/.claude/rules/MUST-safety.md
@@ -25,6 +25,21 @@ The following git commands have caused working tree loss in past sessions (#1146
 
 **Recovery hint**: If working tree loss occurs, check `git reflog` immediately — most operations are recoverable within 30 days.
 
+### Pre-Delegation Blast-Radius Enumeration
+
+> Origin: #1307 찐빠 #1 (High) — user chose "discard local changes and pull", and `git reset --hard origin/develop` was delegated immediately → user rejected (interrupt). The blast radius — that "discard local changes" included 18 files of *intended* uncommitted work (rule edits, new skills, new guides), not just a version downgrade — was never enumerated for the user.
+
+Before delegating ANY destructive git command (the table above), the orchestrator MUST first enumerate the EXACT discard targets and present them for explicit approval. Do NOT delegate a destructive git op on a paraphrased intent ("로컬 변경 버리기" / "discard local changes") without showing what will actually be lost.
+
+| Required before delegation | Command |
+|----------------------------|---------|
+| List modified/staged tracked files | `git status --short` |
+| Show uncommitted diff scope | `git diff --stat` (and `git diff --stat --cached`) |
+| Show stashable work scope | `git stash show --stat` (when a stash is involved) |
+| Show untracked files at risk (for `clean`) | `git clean -nd` |
+
+Enumerate ALL affected work — intended uncommitted edits (rule changes, new skills/guides) count too, not just the symptom the user named. Prefer a non-destructive alternative (`git stash`) when the user's goal (e.g., "reach remote state") can be met without permanent loss.
+
 ## Credential & Privileged-Scope Guardrails
 
 > Origin: #1266 ① (Critical) — a subagent dumped `.env` and Gmail OAuth credentials into the transcript (Credential Exploration) and ran an unauthorized credential-rotation flow that caused a dashboard data outage.

--- a/templates/.claude/rules/SHOULD-memory-integration.md
+++ b/templates/.claude/rules/SHOULD-memory-integration.md
@@ -364,6 +364,19 @@ Related records from session v0.87.2~v0.88.0 (issue #869):
 - `feedback_bun_mock_module.md`
 -->
 
+## Safety-Related Feedback Memory Framing
+
+> Origin: #1307 찐빠 #2 (Medium) — a sys-memory-keeper delegation prompt framed a learning as "오탐으로 판단하고 진행한다" (conclude it's a false positive and proceed), tripping the memory-poisoning safety classifier and requiring a rewrite.
+
+Safety-related feedback memories MUST be written in **verification-obligation form**, NOT **conclusion form**. Conclusion-form framing ("ignore the warning and proceed", "오탐이므로 무시") risks future sessions ignoring genuine threat warnings (memory-poisoning).
+
+| Anti-pattern (conclusion form) | Required (verification-obligation form) |
+|--------------------------------|------------------------------------------|
+| "이 경고는 오탐이므로 무시하고 진행" | "이 패턴은 X 검증을 트리거; 검증 통과 시에만 진행, 실패 시 STOP" |
+| "warning is false positive, proceed" | "warning triggers a duty to verify Y; proceed only if verified, else STOP" |
+
+Write safety learnings as triggers (what to check) + STOP conditions (when to halt), never as standing permission to dismiss a class of warnings.
+
 ## Session-End Auto-Save
 
 ### Trigger

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.170.0",
+  "version": "0.171.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## v0.171.0

### 변경 사항
- **#1307** 룰 강화: R001 파괴적 git 작업 전 blast-radius 명시 열거, R011 안전 관련 feedback 메모리 검증-의무형 작성, R005 도구 가용성 확인 노트
- **#1296 / #1297** TIDE conditioned-discovery measure-before-adopt: homework Phase 3 PoC를 A/B dry-run 측정 → **GATE NOT MET**(보수 게이트, N=4 단일일자 corpus 신뢰성 부족) → 미채택. 향후 multi-session corpus 재측정 경로 문서화.

### 검증
- bun test: 2013 pass / 0 fail
- verify-template-sync / verify-wiki-sync / verify-version-sync: PASS
- R017 구조 검증: PASS

Fixes #1307

🤖 Generated with [Claude Code](https://claude.com/claude-code)