### PR TITLE
release: v0.172.0 — compression-mode-eval converged-artifact substitution

### DIFF
--- a/.claude/skills/pipeline/workflows/auto-dev.yaml
+++ b/.claude/skills/pipeline/workflows/auto-dev.yaml
@@ -160,6 +160,19 @@ steps:
         - All pipeline steps execute normally with full skill spawns
         - Log: "[compression-mode] standard mode (scope={n}, mixed/high-risk labels, large scope, or code logic change)"
 
+      ## Cross-tier — Pre-Existing Converged Artifact Substitution
+
+      Independent of the tier selected above, an INDIVIDUAL planning/verification step (triage / plan / deep-plan / deep-verify) MAY be satisfied by a pre-existing converged artifact instead of a fresh skill spawn — even in standard mode — when ALL of the following hold for that step:
+      1. A scoped issue carries (in its body or a linked artifact) a CONVERGED research/plan output equivalent to the step's skill — e.g. a `/research` multi-team analysis that explicitly converged, a `/deep-plan` artifact, or a prior `professor-triage`/`release-plan` output.
+      2. The artifact covers the scoped issues' domain (not stale or unrelated).
+      3. The substitution is for a PLANNING/VERIFICATION step ONLY — never for implement, verify-build, release, or ci-check.
+
+      If substituted, emit a MANDATORY justification log naming the artifact:
+        "[compression-mode] step '{step}' satisfied by converged artifact {ref} (substitution); skill spawn skipped"
+      If the artifact's convergence or domain coverage cannot be concretely asserted, do NOT substitute — spawn the skill.
+
+      This authorizes, under an audit log, a substitution that would otherwise be a standard-mode contract deviation. Origin: #1309 (a converged `/research` artifact was used in place of triage/plan/deep-plan under standard mode without an authorizing rule).
+
       ## Output
 
       compression_mode ∈ {docs-only, lite, standard} as pipeline state for downstream steps.

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.171.0",
-  "generatedAt": "2026-06-06T05:42:49.232Z",
-  "templateVersion": "0.171.0",
+  "generatorVersion": "0.172.0",
+  "generatedAt": "2026-06-06T06:07:28.994Z",
+  "templateVersion": "0.172.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "e5f4b31759741b09d2c3c9d27861ec0441d24d8772bbfd8dbf2d774d661b2e10",
@@ -485,8 +485,8 @@
       "component": "skills"
     },
     ".claude/skills/pipeline/workflows/auto-dev.yaml": {
-      "templateHash": "8147466c3d41f2a9d9afa8b1fc2e880f1ea2ee58068a1cde56e02d8096f65e28",
-      "size": 17192,
+      "templateHash": "e094eefef4be991a8e9c8da17223065f81652755f615fde793d745e8dcbea972",
+      "size": 18622,
       "component": "skills"
     },
     ".claude/skills/pipeline/SKILL.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -241,7 +241,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.171.0",
+    version: "0.172.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.171.0",
+  version: "0.172.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.171.0",
+  "version": "0.172.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/pipeline/workflows/auto-dev.yaml
+++ b/templates/.claude/skills/pipeline/workflows/auto-dev.yaml
@@ -160,6 +160,19 @@ steps:
         - All pipeline steps execute normally with full skill spawns
         - Log: "[compression-mode] standard mode (scope={n}, mixed/high-risk labels, large scope, or code logic change)"
 
+      ## Cross-tier — Pre-Existing Converged Artifact Substitution
+
+      Independent of the tier selected above, an INDIVIDUAL planning/verification step (triage / plan / deep-plan / deep-verify) MAY be satisfied by a pre-existing converged artifact instead of a fresh skill spawn — even in standard mode — when ALL of the following hold for that step:
+      1. A scoped issue carries (in its body or a linked artifact) a CONVERGED research/plan output equivalent to the step's skill — e.g. a `/research` multi-team analysis that explicitly converged, a `/deep-plan` artifact, or a prior `professor-triage`/`release-plan` output.
+      2. The artifact covers the scoped issues' domain (not stale or unrelated).
+      3. The substitution is for a PLANNING/VERIFICATION step ONLY — never for implement, verify-build, release, or ci-check.
+
+      If substituted, emit a MANDATORY justification log naming the artifact:
+        "[compression-mode] step '{step}' satisfied by converged artifact {ref} (substitution); skill spawn skipped"
+      If the artifact's convergence or domain coverage cannot be concretely asserted, do NOT substitute — spawn the skill.
+
+      This authorizes, under an audit log, a substitution that would otherwise be a standard-mode contract deviation. Origin: #1309 (a converged `/research` artifact was used in place of triage/plan/deep-plan under standard mode without an authorizing rule).
+
       ## Output
 
       compression_mode ∈ {docs-only, lite, standard} as pipeline state for downstream steps.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.171.0",
+  "version": "0.172.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/templates/workflows/auto-dev.yaml
+++ b/templates/workflows/auto-dev.yaml
@@ -160,6 +160,19 @@ steps:
         - All pipeline steps execute normally with full skill spawns
         - Log: "[compression-mode] standard mode (scope={n}, mixed/high-risk labels, large scope, or code logic change)"
 
+      ## Cross-tier — Pre-Existing Converged Artifact Substitution
+
+      Independent of the tier selected above, an INDIVIDUAL planning/verification step (triage / plan / deep-plan / deep-verify) MAY be satisfied by a pre-existing converged artifact instead of a fresh skill spawn — even in standard mode — when ALL of the following hold for that step:
+      1. A scoped issue carries (in its body or a linked artifact) a CONVERGED research/plan output equivalent to the step's skill — e.g. a `/research` multi-team analysis that explicitly converged, a `/deep-plan` artifact, or a prior `professor-triage`/`release-plan` output.
+      2. The artifact covers the scoped issues' domain (not stale or unrelated).
+      3. The substitution is for a PLANNING/VERIFICATION step ONLY — never for implement, verify-build, release, or ci-check.
+
+      If substituted, emit a MANDATORY justification log naming the artifact:
+        "[compression-mode] step '{step}' satisfied by converged artifact {ref} (substitution); skill spawn skipped"
+      If the artifact's convergence or domain coverage cannot be concretely asserted, do NOT substitute — spawn the skill.
+
+      This authorizes, under an audit log, a substitution that would otherwise be a standard-mode contract deviation. Origin: #1309 (a converged `/research` artifact was used in place of triage/plan/deep-plan under standard mode without an authorizing rule).
+
       ## Output
 
       compression_mode ∈ {docs-only, lite, standard} as pipeline state for downstream steps.

--- a/workflows/auto-dev.yaml
+++ b/workflows/auto-dev.yaml
@@ -160,6 +160,19 @@ steps:
         - All pipeline steps execute normally with full skill spawns
         - Log: "[compression-mode] standard mode (scope={n}, mixed/high-risk labels, large scope, or code logic change)"
 
+      ## Cross-tier — Pre-Existing Converged Artifact Substitution
+
+      Independent of the tier selected above, an INDIVIDUAL planning/verification step (triage / plan / deep-plan / deep-verify) MAY be satisfied by a pre-existing converged artifact instead of a fresh skill spawn — even in standard mode — when ALL of the following hold for that step:
+      1. A scoped issue carries (in its body or a linked artifact) a CONVERGED research/plan output equivalent to the step's skill — e.g. a `/research` multi-team analysis that explicitly converged, a `/deep-plan` artifact, or a prior `professor-triage`/`release-plan` output.
+      2. The artifact covers the scoped issues' domain (not stale or unrelated).
+      3. The substitution is for a PLANNING/VERIFICATION step ONLY — never for implement, verify-build, release, or ci-check.
+
+      If substituted, emit a MANDATORY justification log naming the artifact:
+        "[compression-mode] step '{step}' satisfied by converged artifact {ref} (substitution); skill spawn skipped"
+      If the artifact's convergence or domain coverage cannot be concretely asserted, do NOT substitute — spawn the skill.
+
+      This authorizes, under an audit log, a substitution that would otherwise be a standard-mode contract deviation. Origin: #1309 (a converged `/research` artifact was used in place of triage/plan/deep-plan under standard mode without an authorizing rule).
+
       ## Output
 
       compression_mode ∈ {docs-only, lite, standard} as pipeline state for downstream steps.


### PR DESCRIPTION
## v0.172.0

### 변경 사항
- **#1309** auto-dev `compression-mode-eval`에 "Pre-Existing Converged Artifact Substitution" cross-tier 규칙 추가: scope 이슈가 수렴된 research/plan 아티팩트를 보유하면 해당 planning/verification 단계를 그 아티팩트로 대체 가능(standard 모드 포함), MANDATORY 정당화 로그 의무. auto-dev.yaml 4개 사본 동일 유지.

### 검증
- bun test: 2013 pass / 0 fail
- verify-template-sync / verify-wiki-sync / verify-version-sync: PASS
- auto-dev.yaml 4-copy md5 identical, YAML 유효

Fixes #1309

🤖 Generated with [Claude Code](https://claude.com/claude-code)