### PR TITLE
release: v0.173.0 — lite deep-verify R017-skip rule

### DIFF
--- a/.claude/skills/pipeline/workflows/auto-dev.yaml
+++ b/.claude/skills/pipeline/workflows/auto-dev.yaml
@@ -147,7 +147,12 @@ steps:
         - plan step: MAY replace release-plan skill spawn with orchestrator integrated analysis
         - deep-plan step: MAY replace deep-plan skill spawn with orchestrator integrated analysis
         - deep-verify step: perform via mgr-sauron R017 structural verification + core self-check
-          (instead of full deep-verify skill spawn)
+          (instead of full deep-verify skill spawn). If the change set has NO structural surface
+          (no agent/skill/guide/rule frontmatter changed — e.g. a workflow-yaml-only or docs-only change),
+          the mgr-sauron R017 spawn MAY be skipped and replaced by deterministic self-check
+          (template-sync + md5 multi-copy + counts + bun test), under a MANDATORY justification log:
+          "[compression-mode] lite deep-verify — R017 spawn skipped (no structural surface); deterministic self-check only".
+          (#1311, extends #1309 substitution principle.)
         - implement / verify-build / release / ci-check / post-release-followup: execute normally (no compression)
         - MANDATORY justification log (REQUIRED whenever a skill stage is replaced by integrated analysis):
           "[compression-mode] lite — skill 단계 통합 분석 대체. 정당화: scope={n}, 모든 이슈 저위험(라벨 {labels}), 구현 대상 이슈 본문 명시 {issue_refs}"

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.172.0",
-  "generatedAt": "2026-06-06T06:07:28.994Z",
-  "templateVersion": "0.172.0",
+  "generatorVersion": "0.173.0",
+  "generatedAt": "2026-06-06T06:20:34.016Z",
+  "templateVersion": "0.173.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "e5f4b31759741b09d2c3c9d27861ec0441d24d8772bbfd8dbf2d774d661b2e10",
@@ -485,8 +485,8 @@
       "component": "skills"
     },
     ".claude/skills/pipeline/workflows/auto-dev.yaml": {
-      "templateHash": "e094eefef4be991a8e9c8da17223065f81652755f615fde793d745e8dcbea972",
-      "size": 18622,
+      "templateHash": "382a910df72a5d8e46b30d8496e7c85a67bde913ea7fecec3b9760437f4c22dc",
+      "size": 19153,
       "component": "skills"
     },
     ".claude/skills/pipeline/SKILL.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -241,7 +241,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.172.0",
+    version: "0.173.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.172.0",
+  version: "0.173.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.172.0",
+  "version": "0.173.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/pipeline/workflows/auto-dev.yaml
+++ b/templates/.claude/skills/pipeline/workflows/auto-dev.yaml
@@ -147,7 +147,12 @@ steps:
         - plan step: MAY replace release-plan skill spawn with orchestrator integrated analysis
         - deep-plan step: MAY replace deep-plan skill spawn with orchestrator integrated analysis
         - deep-verify step: perform via mgr-sauron R017 structural verification + core self-check
-          (instead of full deep-verify skill spawn)
+          (instead of full deep-verify skill spawn). If the change set has NO structural surface
+          (no agent/skill/guide/rule frontmatter changed — e.g. a workflow-yaml-only or docs-only change),
+          the mgr-sauron R017 spawn MAY be skipped and replaced by deterministic self-check
+          (template-sync + md5 multi-copy + counts + bun test), under a MANDATORY justification log:
+          "[compression-mode] lite deep-verify — R017 spawn skipped (no structural surface); deterministic self-check only".
+          (#1311, extends #1309 substitution principle.)
         - implement / verify-build / release / ci-check / post-release-followup: execute normally (no compression)
         - MANDATORY justification log (REQUIRED whenever a skill stage is replaced by integrated analysis):
           "[compression-mode] lite — skill 단계 통합 분석 대체. 정당화: scope={n}, 모든 이슈 저위험(라벨 {labels}), 구현 대상 이슈 본문 명시 {issue_refs}"

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.172.0",
+  "version": "0.173.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/templates/workflows/auto-dev.yaml
+++ b/templates/workflows/auto-dev.yaml
@@ -147,7 +147,12 @@ steps:
         - plan step: MAY replace release-plan skill spawn with orchestrator integrated analysis
         - deep-plan step: MAY replace deep-plan skill spawn with orchestrator integrated analysis
         - deep-verify step: perform via mgr-sauron R017 structural verification + core self-check
-          (instead of full deep-verify skill spawn)
+          (instead of full deep-verify skill spawn). If the change set has NO structural surface
+          (no agent/skill/guide/rule frontmatter changed — e.g. a workflow-yaml-only or docs-only change),
+          the mgr-sauron R017 spawn MAY be skipped and replaced by deterministic self-check
+          (template-sync + md5 multi-copy + counts + bun test), under a MANDATORY justification log:
+          "[compression-mode] lite deep-verify — R017 spawn skipped (no structural surface); deterministic self-check only".
+          (#1311, extends #1309 substitution principle.)
         - implement / verify-build / release / ci-check / post-release-followup: execute normally (no compression)
         - MANDATORY justification log (REQUIRED whenever a skill stage is replaced by integrated analysis):
           "[compression-mode] lite — skill 단계 통합 분석 대체. 정당화: scope={n}, 모든 이슈 저위험(라벨 {labels}), 구현 대상 이슈 본문 명시 {issue_refs}"

--- a/workflows/auto-dev.yaml
+++ b/workflows/auto-dev.yaml
@@ -147,7 +147,12 @@ steps:
         - plan step: MAY replace release-plan skill spawn with orchestrator integrated analysis
         - deep-plan step: MAY replace deep-plan skill spawn with orchestrator integrated analysis
         - deep-verify step: perform via mgr-sauron R017 structural verification + core self-check
-          (instead of full deep-verify skill spawn)
+          (instead of full deep-verify skill spawn). If the change set has NO structural surface
+          (no agent/skill/guide/rule frontmatter changed — e.g. a workflow-yaml-only or docs-only change),
+          the mgr-sauron R017 spawn MAY be skipped and replaced by deterministic self-check
+          (template-sync + md5 multi-copy + counts + bun test), under a MANDATORY justification log:
+          "[compression-mode] lite deep-verify — R017 spawn skipped (no structural surface); deterministic self-check only".
+          (#1311, extends #1309 substitution principle.)
         - implement / verify-build / release / ci-check / post-release-followup: execute normally (no compression)
         - MANDATORY justification log (REQUIRED whenever a skill stage is replaced by integrated analysis):
           "[compression-mode] lite — skill 단계 통합 분석 대체. 정당화: scope={n}, 모든 이슈 저위험(라벨 {labels}), 구현 대상 이슈 본문 명시 {issue_refs}"


### PR DESCRIPTION
## v0.173.0

### 변경 사항
- **#1311** auto-dev lite tier deep-verify에 "구조 변경 surface 없는 변경(workflow-yaml/docs-only)은 mgr-sauron R017 spawn 생략 + 결정론 self-check 대체 + MANDATORY 정당화 로그" 규칙 추가 (#1309 substitution 원칙의 deep-verify 확장). auto-dev.yaml 4개 사본 동일 유지.

### 검증
- bun test: 2013 pass / 0 fail
- verify-template-sync / verify-wiki-sync / verify-version-sync: PASS
- auto-dev.yaml 4-copy md5 identical, YAML 유효

Fixes #1311

🤖 Generated with [Claude Code](https://claude.com/claude-code)