### PR TITLE
release: v0.174.0 — CC v2.1.166 호환 노트 (deny-rule glob, fallbackModel, cross-session relay hardening)

### DIFF
--- a/.claude/rules/MUST-agent-design.md
+++ b/.claude/rules/MUST-agent-design.md
@@ -27,6 +27,16 @@ tools: [Read, Write, ...]  # Allowed tools
 
 Extended context suffix: `[1m]` (e.g., `claude-opus-4-6[1m]`) — enables 1M token context window.
 
+### Fallback Models (CC v2.1.166+)
+
+> **v2.1.166+**: The `fallbackModel` setting configures up to three fallback models tried in order when the primary model is overloaded or unavailable. `--fallback-model` now also applies to interactive sessions. CC additionally retries a turn once on the fallback model when the API rejects an unexpected non-retryable error (auth, rate-limit, request-size, and transport errors still surface immediately).
+
+This is a settings-level resilience mechanism, distinct from the per-agent `model:` frontmatter. It complements the `model-escalation` skill (outcome-based escalation) by handling availability/overload failover at the platform level.
+
+### Thinking Toggle (CC v2.1.166+)
+
+> **v2.1.166+**: `MAX_THINKING_TOKENS=0`, `--thinking disabled`, and the per-model thinking toggle disable thinking on models that think by default via the Claude API (3rd-party providers unchanged). Relevant when an agent's `effort` is low and thinking overhead is undesirable.
+
 ### Optional Frontmatter
 
 Key optional fields: `memory`, `effort`, `skills`, `soul`, `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations`, `domain`, `disableSkillShellExecution`. Supported since CC v2.1.63+. See full optional frontmatter via Read tool.

--- a/.claude/rules/MUST-agent-teams.md
+++ b/.claude/rules/MUST-agent-teams.md
@@ -36,6 +36,18 @@ Available when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or TeamCreate/SendMessag
 
 These are distinct mechanisms. Agent Teams `SendMessage` requires `TeamCreate` and operates within a single Claude Code session. claude-peers-mcp `send_message` operates across separate Claude Code processes via a localhost broker.
 
+### Cross-Session Relay Authority Hardening (CC v2.1.166+)
+
+> **v2.1.166+**: Messages relayed via `SendMessage` from other Claude sessions no longer carry user authority — receivers refuse relayed permission requests, and auto mode blocks them. A relayed message cannot escalate privilege on the receiving session.
+
+| Aspect | Behavior (v2.1.166+) |
+|--------|---------------------|
+| Relayed permission request | Refused by receiver |
+| Auto mode + relayed request | Blocked |
+| User authority across relay | Not propagated |
+
+This hardens cross-session coordination (claude-peers-mcp `send_message`, see Scope table above) against privilege escalation — a relayed message from session A cannot grant session B permissions the user did not authorize on B. Aligns with R001 (credential/privileged-scope guardrails) and R010 (out-of-scope privileged chaining). Intra-session Agent Teams `SendMessage` between peers in the same session is unaffected.
+
 ## Self-Check (Before Agent Tool)
 
 Before using Agent tool for 2+ agent tasks, complete this check:

--- a/.claude/rules/MUST-permissions.md
+++ b/.claude/rules/MUST-permissions.md
@@ -33,6 +33,18 @@ Approve?
 
 On insufficient permission: do not attempt, notify user, suggest alternative.
 
+## Deny Rule Glob Patterns (CC v2.1.166+)
+
+> **v2.1.166+**: Deny rules support glob patterns in the tool-name position — `"*"` in a deny rule denies all tools. Allow rules reject non-MCP globs (only MCP tool-name globs are accepted in the allow position). Unknown tool names in deny rules emit a startup warning.
+
+| Position | Glob support |
+|----------|-------------|
+| Deny rule tool-name | Yes — `"*"` denies all tools |
+| Allow rule tool-name | MCP globs only; non-MCP globs rejected |
+| Unknown tool in deny rule | Startup warning |
+
+Use a `"*"` deny rule in `settings.json` to enforce a deny-by-default posture, then add specific allow rules. Complements the Tier-based policy above — settings.json deny rules are evaluated by the CC platform, independent of the advisory tier table.
+
 ## Agent Tool Permission Mode
 
 When spawning subagents via the Agent tool, always pass `mode: "bypassPermissions"` explicitly. The Agent tool's default mode is `acceptEdits`, which **overrides** the agent frontmatter `permissionMode` field.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.173.0",
+  "version": "0.174.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -27,6 +27,16 @@ tools: [Read, Write, ...]  # Allowed tools
 
 Extended context suffix: `[1m]` (e.g., `claude-opus-4-6[1m]`) — enables 1M token context window.
 
+### Fallback Models (CC v2.1.166+)
+
+> **v2.1.166+**: The `fallbackModel` setting configures up to three fallback models tried in order when the primary model is overloaded or unavailable. `--fallback-model` now also applies to interactive sessions. CC additionally retries a turn once on the fallback model when the API rejects an unexpected non-retryable error (auth, rate-limit, request-size, and transport errors still surface immediately).
+
+This is a settings-level resilience mechanism, distinct from the per-agent `model:` frontmatter. It complements the `model-escalation` skill (outcome-based escalation) by handling availability/overload failover at the platform level.
+
+### Thinking Toggle (CC v2.1.166+)
+
+> **v2.1.166+**: `MAX_THINKING_TOKENS=0`, `--thinking disabled`, and the per-model thinking toggle disable thinking on models that think by default via the Claude API (3rd-party providers unchanged). Relevant when an agent's `effort` is low and thinking overhead is undesirable.
+
 ### Optional Frontmatter
 
 Key optional fields: `memory`, `effort`, `skills`, `soul`, `isolation`, `background`, `maxTurns`, `maxTokens`, `mcpServers`, `hooks`, `permissionMode`, `disallowedTools`, `limitations`, `domain`, `disableSkillShellExecution`. Supported since CC v2.1.63+. See full optional frontmatter via Read tool.

--- a/templates/.claude/rules/MUST-agent-teams.md
+++ b/templates/.claude/rules/MUST-agent-teams.md
@@ -36,6 +36,18 @@ Available when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` or TeamCreate/SendMessag
 
 These are distinct mechanisms. Agent Teams `SendMessage` requires `TeamCreate` and operates within a single Claude Code session. claude-peers-mcp `send_message` operates across separate Claude Code processes via a localhost broker.
 
+### Cross-Session Relay Authority Hardening (CC v2.1.166+)
+
+> **v2.1.166+**: Messages relayed via `SendMessage` from other Claude sessions no longer carry user authority — receivers refuse relayed permission requests, and auto mode blocks them. A relayed message cannot escalate privilege on the receiving session.
+
+| Aspect | Behavior (v2.1.166+) |
+|--------|---------------------|
+| Relayed permission request | Refused by receiver |
+| Auto mode + relayed request | Blocked |
+| User authority across relay | Not propagated |
+
+This hardens cross-session coordination (claude-peers-mcp `send_message`, see Scope table above) against privilege escalation — a relayed message from session A cannot grant session B permissions the user did not authorize on B. Aligns with R001 (credential/privileged-scope guardrails) and R010 (out-of-scope privileged chaining). Intra-session Agent Teams `SendMessage` between peers in the same session is unaffected.
+
 ## Self-Check (Before Agent Tool)
 
 Before using Agent tool for 2+ agent tasks, complete this check:

--- a/templates/.claude/rules/MUST-permissions.md
+++ b/templates/.claude/rules/MUST-permissions.md
@@ -33,6 +33,18 @@ Approve?
 
 On insufficient permission: do not attempt, notify user, suggest alternative.
 
+## Deny Rule Glob Patterns (CC v2.1.166+)
+
+> **v2.1.166+**: Deny rules support glob patterns in the tool-name position — `"*"` in a deny rule denies all tools. Allow rules reject non-MCP globs (only MCP tool-name globs are accepted in the allow position). Unknown tool names in deny rules emit a startup warning.
+
+| Position | Glob support |
+|----------|-------------|
+| Deny rule tool-name | Yes — `"*"` denies all tools |
+| Allow rule tool-name | MCP globs only; non-MCP globs rejected |
+| Unknown tool in deny rule | Startup warning |
+
+Use a `"*"` deny rule in `settings.json` to enforce a deny-by-default posture, then add specific allow rules. Complements the Tier-based policy above — settings.json deny rules are evaluated by the CC platform, independent of the advisory tier table.
+
 ## Agent Tool Permission Mode
 
 When spawning subagents via the Agent tool, always pass `mode: "bypassPermissions"` explicitly. The Agent tool's default mode is `acceptEdits`, which **overrides** the agent frontmatter `permissionMode` field.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.173.0",
+  "version": "0.174.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 개요

Claude Code v2.1.166/v2.1.167/v2.1.168 호환성 검토 릴리즈 (docs-only 압축 tier).

## 변경 사항

CC v2.1.166의 신규 기능을 omcustom 규칙에 호환성 노트로 반영:

| 규칙 | 노트 | CC v2.1.166 기능 |
|------|------|-----------------|
| R002 (MUST-permissions) | Deny Rule Glob Patterns | deny rule tool-name glob (`"*"` denies all), allow rule MCP-only glob |
| R006 (MUST-agent-design) | Fallback Models + Thinking Toggle | `fallbackModel` 설정(최대 3개), `MAX_THINKING_TOKENS=0`/`--thinking disabled` |
| R018 (MUST-agent-teams) | Cross-Session Relay Authority Hardening | 다른 세션 relayed SendMessage는 user authority 미보유 — 권한 요청 거부, auto mode 차단 |

v2.1.167/v2.1.168은 bugfix-only로 규칙 영향 없음 (호환 확인 후 종결).

## 검증

- bun test: 2013 pass / 0 fail (baseline 0, delta 0)
- verify-template-sync.sh: PASS (규칙 3쌍 md5 일치)
- verify-wiki-sync.sh: PASS (missing 0)
- verify-version-sync.sh: PASS (0.174.0)
- compression tier: docs-only (scope=3, 모두 automated/claude-code-release 라벨)
- deep-verify: lite/docs-only R017-skip (구조 표면 없음 — 규칙 마크다운 텍스트만 변경, frontmatter 무변경)

## Closes

- #1313 (CC v2.1.167)
- #1314 (CC v2.1.166)
- #1315 (CC v2.1.168)

🤖 Generated with [Claude Code](https://claude.com/claude-code)