### PR TITLE
release: v0.176.0 — R008 required-parameter completeness check (#1324 proposal 1)

### DIFF
--- a/.claude/rules/MUST-completion-verification.md
+++ b/.claude/rules/MUST-completion-verification.md
@@ -96,6 +96,10 @@ Never accept "pre-existing" without direct base-branch evidence. A false "pre-ex
 | "UI changes done" / "CSS updated" | type-check passes but browser render not verified; visual output unknown | Start dev server, open browser, confirm visual output; capture screenshot or describe what was seen |
 -->
 
+### Tool-Call Payload Completeness
+
+도구 호출의 required 파라미터는 invoke 전에 확인한다(완료 선언 후가 아니라 호출 시점의 전제조건). announce(prefix)만 출력하고 payload 의 required 필드를 누락하는 패턴은 R008 "Required-Parameter Completeness Check"가 canonical owner다. Reference: #1324.
+
 ## Completion Contract Format — [Contract] + [Done] with criterion/evidence pairs. See template via Read tool.
 
 <!-- DETAIL: Completion Contract Format

--- a/.claude/rules/MUST-tool-identification.md
+++ b/.claude/rules/MUST-tool-identification.md
@@ -31,6 +31,17 @@ Incorrect parallel: tool_call(url1), tool_call(url2), tool_call(cmd) — no iden
 Correct parallel: list ALL [agent][model] → Tool/Fetching/Running lines FIRST, then all tool_calls
 -->
 
+### Required-Parameter Completeness Check
+
+R008 prefix(announce)와 실제 도구 호출은 분리된 단계다. prefix 를 출력한 뒤 호출 payload 에서 도구 스키마상 required 파라미터를 누락하면 호출이 실패하거나 빈 동작이 된다. 호출 직전, prefix 존재뿐 아니라 required 파라미터가 모두 채워졌는지 확인한다.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| `[agent][model] → Tool: AskUserQuestion` prefix 만 출력하고 `questions` 파라미터 없이/빈 배열로 호출 | prefix + `questions` 배열(최소 1개) 모두 채워 호출 |
+| announce 후 payload 의 required 필드 누락 (announce-payload separation gap) | announce 와 동일 메시지에서 required 필드 완비 호출 |
+
+Cross-reference: R020 (action-completeness precondition — invoke 전에 required 파라미터 확인). Reference issue: #1324 (찐빠: AskUserQuestion `questions`-missing recurrence).
+
 ## Models
 
 | Model | Use |
@@ -117,8 +128,9 @@ Agent(description: "[2] Python code review", subagent_type: "lang-python-expert"
 
 1. 이 호출 위에 `[agent-name][model] → Tool: <tool-name>` 라인이 있는가?
 2. agent-name 과 model 이 현재 컨텍스트와 일치하는가?
+3. 이 호출에 도구 스키마상 required 파라미터가 모두 채워져 있는가? (예: AskUserQuestion 는 `questions` 배열이 비어 있지 않아야 함) prefix(announce)만 출력하고 실제 호출 payload 의 required 필드를 누락하면 안 된다.
 
-체크 실패 시 즉시 prefix 추가 후 호출.
+체크 실패 시 즉시 prefix/필수 파라미터를 보완한 후 호출.
 
 ### Common Multi-Turn Violation
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.175.0",
+  "version": "0.176.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-completion-verification.md
+++ b/templates/.claude/rules/MUST-completion-verification.md
@@ -96,6 +96,10 @@ Never accept "pre-existing" without direct base-branch evidence. A false "pre-ex
 | "UI changes done" / "CSS updated" | type-check passes but browser render not verified; visual output unknown | Start dev server, open browser, confirm visual output; capture screenshot or describe what was seen |
 -->
 
+### Tool-Call Payload Completeness
+
+도구 호출의 required 파라미터는 invoke 전에 확인한다(완료 선언 후가 아니라 호출 시점의 전제조건). announce(prefix)만 출력하고 payload 의 required 필드를 누락하는 패턴은 R008 "Required-Parameter Completeness Check"가 canonical owner다. Reference: #1324.
+
 ## Completion Contract Format — [Contract] + [Done] with criterion/evidence pairs. See template via Read tool.
 
 <!-- DETAIL: Completion Contract Format

--- a/templates/.claude/rules/MUST-tool-identification.md
+++ b/templates/.claude/rules/MUST-tool-identification.md
@@ -31,6 +31,17 @@ Incorrect parallel: tool_call(url1), tool_call(url2), tool_call(cmd) — no iden
 Correct parallel: list ALL [agent][model] → Tool/Fetching/Running lines FIRST, then all tool_calls
 -->
 
+### Required-Parameter Completeness Check
+
+R008 prefix(announce)와 실제 도구 호출은 분리된 단계다. prefix 를 출력한 뒤 호출 payload 에서 도구 스키마상 required 파라미터를 누락하면 호출이 실패하거나 빈 동작이 된다. 호출 직전, prefix 존재뿐 아니라 required 파라미터가 모두 채워졌는지 확인한다.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| `[agent][model] → Tool: AskUserQuestion` prefix 만 출력하고 `questions` 파라미터 없이/빈 배열로 호출 | prefix + `questions` 배열(최소 1개) 모두 채워 호출 |
+| announce 후 payload 의 required 필드 누락 (announce-payload separation gap) | announce 와 동일 메시지에서 required 필드 완비 호출 |
+
+Cross-reference: R020 (action-completeness precondition — invoke 전에 required 파라미터 확인). Reference issue: #1324 (찐빠: AskUserQuestion `questions`-missing recurrence).
+
 ## Models
 
 | Model | Use |
@@ -117,8 +128,9 @@ Agent(description: "[2] Python code review", subagent_type: "lang-python-expert"
 
 1. 이 호출 위에 `[agent-name][model] → Tool: <tool-name>` 라인이 있는가?
 2. agent-name 과 model 이 현재 컨텍스트와 일치하는가?
+3. 이 호출에 도구 스키마상 required 파라미터가 모두 채워져 있는가? (예: AskUserQuestion 는 `questions` 배열이 비어 있지 않아야 함) prefix(announce)만 출력하고 실제 호출 payload 의 required 필드를 누락하면 안 된다.
 
-체크 실패 시 즉시 prefix 추가 후 호출.
+체크 실패 시 즉시 prefix/필수 파라미터를 보완한 후 호출.
 
 ### Common Multi-Turn Violation
 

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.175.0",
+  "version": "0.176.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 개요

세션 113 회고 이슈 #1324 proposal 1을 반영한 릴리즈입니다.

`AskUserQuestion` 호출 시 `questions` 파라미터 누락 재발 방지를 위해 R008 Multi-Turn Self-Check에 **Required-Parameter Completeness Check** 서브섹션을 추가하였습니다. Announce prefix 출력과 실제 tool 호출은 별개 단계이므로, prefix 작성 시점이 아닌 **tool 호출 직전** 필수 파라미터 존재 여부를 검증하도록 규칙을 강화하였습니다.

Proposal 2 (content-based wiki staleness 감지 + manifest-hash 추천)는 #1325로 분리하였습니다.

## 변경 사항

### R008 (`MUST-tool-identification.md`)
- `Required-Parameter Completeness Check` 서브섹션 신설
  - Announce prefix 작성 ≠ 파라미터 완성; 호출 직전 필수 파라미터 검증 의무 명시
  - `AskUserQuestion.questions` 누락 사례를 canonical 예시로 추가
- `Multi-Turn Self-Check` 3번 항목 추가: "이번 호출의 필수 파라미터가 모두 채워져 있는가?"

### R020 (`MUST-completion-verification.md`)
- `Tool-Call Payload Completeness` thin cross-ref 추가
  - "tool call이 실행되었는가" ≠ "필수 파라미터가 모두 포함되었는가" 구분 명시
  - R008 Required-Parameter Completeness Check로 참조 연결

### 버전
- `package.json`, `templates/manifest.json`: `0.176.0` bump

## Proposal 2 분리 메모
- #1325: content-based wiki staleness 감지 (rule-only 시점 defer-wiki 강화) + manifest-hash 추천
- 이번 릴리즈 범위 외 — rule surface 변경 없음, 독립 처리 권장

## 검증
- template-sync: `.claude/rules` ↔ `templates/.claude/rules` 3쌍 동기화 확인
- wiki-sync: 룰 .md 내용 변경 (no-structural-surface) — lite deep-verify R017-skip 적용
- lint/typecheck: biome + tsc --noEmit clean
- bun test: 2013 pass / 0 fail
- lite deep-verify R017-skip: frontmatter 무변경, mgr-sauron 스폰 생략 (v0.173.0+ 기준 충족)

Fixes #1324

🤖 Generated with [Claude Code](https://claude.com/claude-code)