### PR TITLE
chore(release): v0.179.0 — omcustom:fsd Full Self Driving 스킬

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.178.0",
-  "generatedAt": "2026-06-09T11:01:41.128Z",
-  "templateVersion": "0.178.0",
+  "generatorVersion": "0.179.0",
+  "generatedAt": "2026-06-09T23:37:49.984Z",
+  "templateVersion": "0.179.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "e5f4b31759741b09d2c3c9d27861ec0441d24d8772bbfd8dbf2d774d661b2e10",
@@ -752,6 +752,11 @@
     ".claude/skills/wiki/SKILL.md": {
       "templateHash": "a309c221216891b82c7a6f873e2a78f51f7e86caa1d9b05233901408385e5136",
       "size": 14611,
+      "component": "skills"
+    },
+    ".claude/skills/fsd/SKILL.md": {
+      "templateHash": "56cfd6e36baab020a4a3fe6c06a91035d85d74fb7dcc3398b475185df001829e",
+      "size": 6874,
       "component": "skills"
     },
     ".claude/skills/dev-lead-routing/SKILL.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.179.0] - 2026-06-10
+
+### Added
+- `omcustom:fsd` (Full Self Driving) skill — thin-alias orchestrator codifying the autonomous release loop as a first-class command. `/omcustom:fsd` expands to `/goal "모든 이슈가 처리될 때까지" /loop "/pipeline auto-dev -> /homework"`, repeating `/pipeline auto-dev` → `/homework` until all auto-dev-eligible issues are exhausted. Optional release cap via `/omcustom:fsd <N>`. Delegates loop/release/retrospective logic to existing `goal`/`pipeline`/`homework`/`omcustom-loop` skills (R006). Skill count 116 → 117.
+
 ## [0.170.0] - 2026-06-06
 
 ### Added

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -241,7 +241,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.173.0",
+    version: "0.179.0",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {
@@ -289,7 +289,7 @@ var init_package = __esm(() => {
       yaml: "^2.8.2"
     },
     devDependencies: {
-      "@anthropic-ai/sdk": "^0.100.1",
+      "@anthropic-ai/sdk": "^0.102.0",
       "@biomejs/biome": "^2.3.12",
       "@types/bun": "^1.3.6",
       "@types/js-yaml": "^4.0.9",

--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.173.0",
+  version: "0.179.0",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {
@@ -2079,7 +2079,7 @@ var package_default = {
     yaml: "^2.8.2"
   },
   devDependencies: {
-    "@anthropic-ai/sdk": "^0.100.1",
+    "@anthropic-ai/sdk": "^0.102.0",
     "@biomejs/biome": "^2.3.12",
     "@types/bun": "^1.3.6",
     "@types/js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.178.0",
+  "version": "0.179.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.178.0",
+  "version": "0.179.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약

- **omcustom:fsd Full Self Driving 스킬 추가** (PR #1337에서 병합됨)
  - 스킬 카운트: 116 → 117
- **버전 범프**: 0.178.0 → 0.179.0
  - `package.json`, `templates/manifest.json` 갱신
- **CHANGELOG [0.179.0]** 추가
- **dist/ 재빌드**: `bun run build`로 재생성
- `.omcustom.lock.json` 동기화 (390 files)

## 체크리스트

- [x] fsd 스킬 병합 확인 (PR #1337)
- [x] 버전 번프 (`package.json` + `templates/manifest.json`)
- [x] `bun run build` 성공 (2013 tests pass, 98%+ coverage)
- [x] pre-commit 검사 모두 통과
- [x] CHANGELOG 항목 포함

## 자동화

머지 시 `auto-tag.yml`이 `v0.179.0` 태그를 생성하고, `release.yml`이 npm publish를 자동 실행합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)