### PR TITLE
chore(release): v0.182.0 — CC v2.1.170 Fable 5 + carve-out 사전점검 (#1352, #1353)

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.181.0",
-  "generatedAt": "2026-06-10T12:03:14.631Z",
-  "templateVersion": "0.181.0",
+  "generatorVersion": "0.182.0",
+  "generatedAt": "2026-06-10T12:08:25.283Z",
+  "templateVersion": "0.182.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.182.0] - 2026-06-10
+
+### Added
+- R006 (agent design): Claude Fable 5 model alias — `fable` → `claude-fable-5`, a Mythos-class model positioned as a tier above Opus, GA on the Claude API with access added in CC v2.1.170. Reserve for the most complex reasoning; `sonnet` stays the default and `opus` for architecture (R005 cost/latency awareness). Closes #1352.
+- R023 (verification ladder): "Safety-Signal Rule Authoring — Carve-Out Pre-Check (shift-left)" — when authoring interrupt/cancel/halt/emergency-stop rules, pre-check the R001 destructive-op carve-out at Tier 1 (authoring time) instead of relying on the Tier 3 adversarial review. Encodes the #1341 lesson surfaced in the #1353 retrospective. Closes #1353.
+
+### Changed
+- CC v2.1.170 compatibility: the VS Code integrated-terminal transcript-saving fix (also `--resume` visibility) is noted in R006 — relevant to transcript-dependent skills (homework, episodic-memory).
+- Wiki pages r006/r023 synced; `wiki/.source-hashes.json` regenerated (0 content drift).
+
 ## [0.181.0] - 2026-06-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.181.0",
+  "version": "0.182.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.181.0",
+  "version": "0.182.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약

- **버전**: 0.181.0 → 0.182.0
- **번들 이슈**: #1352 (CC v2.1.170 Fable 5 모델 별칭 추가), #1353 (R023 safety-signal carve-out 사전점검 체크리스트)

## 변경 내역

- `R006`: CC v2.1.170 Fable 5 (`opus47`) 모델 별칭 추가
- `R023`: infra-diagnostic/safety-signal 검증 carve-out 사전점검 체크리스트 추가
- `package.json` + `templates/manifest.json`: 0.181.0 → 0.182.0
- `CHANGELOG.md`: [0.182.0] 엔트리 추가
- `dist/` 재빌드, `.omcustom.lock.json` 동기화

## 이슈 연결

Fixes #1352
Fixes #1353

## Milestone

v0.182.0 (milestone #76)

## 테스트 계획

- [ ] CI (validate-docs, lint, type-check, test) 통과 확인
- [ ] release.yml npm publish 확인
- [ ] `npm view oh-my-customcode version` → 0.182.0 실측
- [ ] GitHub Release v0.182.0 생성 확인
- [ ] #1352, #1353 auto-close 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)