### PR TITLE
feat: 패치-우선 버저닝 정책 코드화 (v1.0.0 준비)

### DIFF
--- a/.claude/skills/pipeline/workflows/auto-dev.yaml
+++ b/.claude/skills/pipeline/workflows/auto-dev.yaml
@@ -306,9 +306,12 @@ steps:
               [ -f scripts/verify-version-sync.sh ] && bash scripts/verify-version-sync.sh || echo "::warning::verify-version-sync.sh not found, version sync verification skipped"
               (verify-version-sync.sh 가 exit 1 시 release 단계 halt)
 
-         Version decision (semver):
+         Version decision (semver) — PATCH-PREFERRED policy (post-1.0.0):
          - No existing tags → v0.1.0
-         - Previous tag exists → patch (bugfix) / minor (features) / major (breaking)
+         - Previous tag exists → DEFAULT to patch. When in doubt, patch — do NOT reflexively bump minor for rule/doc/skill edits.
+           - patch (DEFAULT): rule/doc/skill/config/wiki/workflow changes, bugfixes, hardening, CC-compat notes — the vast majority of this project's changes
+           - minor: ONLY a genuinely NEW user-facing capability (a new skill/agent/command adding user-visible surface), not a refinement of an existing one
+           - major: breaking changes to user-facing contracts (CLI flags, public skill/command names, public API), or a deliberate milestone declaration (e.g., v1.0.0)
          - Previous tag is ahead of source version (e.g., tag v0.136.1, package.json 0.136.0): use next available skip-version (0.136.2)
 
       2. Release notes via omcustom-release-notes skill

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,7 +1,7 @@
 {
   "lockfileVersion": 1,
   "generatorVersion": "0.182.0",
-  "generatedAt": "2026-06-10T12:08:25.283Z",
+  "generatedAt": "2026-06-11T00:27:06.128Z",
   "templateVersion": "0.182.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
@@ -485,8 +485,8 @@
       "component": "skills"
     },
     ".claude/skills/pipeline/workflows/auto-dev.yaml": {
-      "templateHash": "382a910df72a5d8e46b30d8496e7c85a67bde913ea7fecec3b9760437f4c22dc",
-      "size": 19153,
+      "templateHash": "8719c1c83c1cbe16b1e0cde1427dd1eee4f18e1acf35675a9bb6368cfd7c8d15",
+      "size": 19724,
       "component": "skills"
     },
     ".claude/skills/pipeline/SKILL.md": {

--- a/templates/.claude/skills/pipeline/workflows/auto-dev.yaml
+++ b/templates/.claude/skills/pipeline/workflows/auto-dev.yaml
@@ -306,9 +306,12 @@ steps:
               [ -f scripts/verify-version-sync.sh ] && bash scripts/verify-version-sync.sh || echo "::warning::verify-version-sync.sh not found, version sync verification skipped"
               (verify-version-sync.sh 가 exit 1 시 release 단계 halt)
 
-         Version decision (semver):
+         Version decision (semver) — PATCH-PREFERRED policy (post-1.0.0):
          - No existing tags → v0.1.0
-         - Previous tag exists → patch (bugfix) / minor (features) / major (breaking)
+         - Previous tag exists → DEFAULT to patch. When in doubt, patch — do NOT reflexively bump minor for rule/doc/skill edits.
+           - patch (DEFAULT): rule/doc/skill/config/wiki/workflow changes, bugfixes, hardening, CC-compat notes — the vast majority of this project's changes
+           - minor: ONLY a genuinely NEW user-facing capability (a new skill/agent/command adding user-visible surface), not a refinement of an existing one
+           - major: breaking changes to user-facing contracts (CLI flags, public skill/command names, public API), or a deliberate milestone declaration (e.g., v1.0.0)
          - Previous tag is ahead of source version (e.g., tag v0.136.1, package.json 0.136.0): use next available skip-version (0.136.2)
 
       2. Release notes via omcustom-release-notes skill

--- a/templates/workflows/auto-dev.yaml
+++ b/templates/workflows/auto-dev.yaml
@@ -306,9 +306,12 @@ steps:
               [ -f scripts/verify-version-sync.sh ] && bash scripts/verify-version-sync.sh || echo "::warning::verify-version-sync.sh not found, version sync verification skipped"
               (verify-version-sync.sh 가 exit 1 시 release 단계 halt)
 
-         Version decision (semver):
+         Version decision (semver) — PATCH-PREFERRED policy (post-1.0.0):
          - No existing tags → v0.1.0
-         - Previous tag exists → patch (bugfix) / minor (features) / major (breaking)
+         - Previous tag exists → DEFAULT to patch. When in doubt, patch — do NOT reflexively bump minor for rule/doc/skill edits.
+           - patch (DEFAULT): rule/doc/skill/config/wiki/workflow changes, bugfixes, hardening, CC-compat notes — the vast majority of this project's changes
+           - minor: ONLY a genuinely NEW user-facing capability (a new skill/agent/command adding user-visible surface), not a refinement of an existing one
+           - major: breaking changes to user-facing contracts (CLI flags, public skill/command names, public API), or a deliberate milestone declaration (e.g., v1.0.0)
          - Previous tag is ahead of source version (e.g., tag v0.136.1, package.json 0.136.0): use next available skip-version (0.136.2)
 
       2. Release notes via omcustom-release-notes skill

--- a/workflows/auto-dev.yaml
+++ b/workflows/auto-dev.yaml
@@ -306,9 +306,12 @@ steps:
               [ -f scripts/verify-version-sync.sh ] && bash scripts/verify-version-sync.sh || echo "::warning::verify-version-sync.sh not found, version sync verification skipped"
               (verify-version-sync.sh 가 exit 1 시 release 단계 halt)
 
-         Version decision (semver):
+         Version decision (semver) — PATCH-PREFERRED policy (post-1.0.0):
          - No existing tags → v0.1.0
-         - Previous tag exists → patch (bugfix) / minor (features) / major (breaking)
+         - Previous tag exists → DEFAULT to patch. When in doubt, patch — do NOT reflexively bump minor for rule/doc/skill edits.
+           - patch (DEFAULT): rule/doc/skill/config/wiki/workflow changes, bugfixes, hardening, CC-compat notes — the vast majority of this project's changes
+           - minor: ONLY a genuinely NEW user-facing capability (a new skill/agent/command adding user-visible surface), not a refinement of an existing one
+           - major: breaking changes to user-facing contracts (CLI flags, public skill/command names, public API), or a deliberate milestone declaration (e.g., v1.0.0)
          - Previous tag is ahead of source version (e.g., tag v0.136.1, package.json 0.136.0): use next available skip-version (0.136.2)
 
       2. Release notes via omcustom-release-notes skill


### PR DESCRIPTION
## 요약

- `auto-dev.yaml` 4개 사본(`.claude/skills/pipeline/workflows/`, `templates/.claude/skills/pipeline/workflows/`, `workflows/`, `templates/workflows/`)의 `version-decision` 섹션을 **패치-우선 정책**으로 코드화
- 변경 유형별 버전 결정 기준:
  - **PATCH** (기본값): 규칙/문서/스킬/config/wiki/workflow 변경, 버그픽스, 하드닝 — "의심스러우면 patch"
  - **MINOR**: 신규 사용자-가시 기능에만 한정 (새 스킬/에이전트/커맨드)
  - **MAJOR**: 브레이킹 체인지 또는 명시적 마일스톤 선언 (예: v1.0.0)
- v0.156~v0.182 기간 동안 거의 모든 릴리즈가 minor였던 반사적 관행을 대체
- 4개 사본 byte-identical 유지 + `.omcustom.lock.json` sync-source-lockfile 갱신
- v1.0.0 마일스톤 준비를 위한 정책 기반 정립 (Stage A feature PR)

## 테스트 계획

- [ ] pre-commit CI (type-check + lint + test + coverage) 통과 확인
- [ ] 4개 auto-dev.yaml 사본 내용 일치 확인 (byte-identical)
- [ ] `.omcustom.lock.json` sync 완료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)