### PR TITLE
chore(release): v1.0.0 — 첫 stable 릴리즈 + 패치-우선 정책

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "0.182.0",
-  "generatedAt": "2026-06-11T00:27:06.128Z",
-  "templateVersion": "0.182.0",
+  "generatorVersion": "1.0.0",
+  "generatedAt": "2026-06-11T01:19:03.091Z",
+  "templateVersion": "1.0.0",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-06-11
+
+### 🎉 First stable release
+
+oh-my-customcode reaches 1.0.0 — a stability milestone after 180+ iterative releases. No breaking changes from 0.182.0; this release declares the agent harness (49 agents, 117 skills, 23 rules) stable and establishes the go-forward versioning policy.
+
+### Changed
+- Versioning policy (pipeline `auto-dev.yaml`, all 4 copies): **patch-preferred** from 1.0.0 onward — rule/doc/skill/config/wiki/workflow changes, bugfixes, and hardening default to **patch**; **minor** is reserved for genuinely new user-facing capabilities (a new skill/agent/command); **major** for breaking changes to user-facing contracts or a deliberate milestone declaration. When in doubt, patch.
+
 ## [0.182.0] - 2026-06-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "0.182.0",
+  "version": "1.0.0",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.182.0",
+  "version": "1.0.0",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/tests/unit/cli/update.test.ts
+++ b/tests/unit/cli/update.test.ts
@@ -16,6 +16,14 @@ describe('update command', () => {
   let consoleErrorSpy: ReturnType<typeof spyOn>;
   let consoleWarnSpy: ReturnType<typeof spyOn>;
 
+  // Saved value for OMCUSTOM_SKIP_SELF_UPDATE so we can restore it in afterEach.
+  // Set to 'true' in beforeEach so that tests which call updateCommand({}) without
+  // skipSelf do not trigger an actual self-update (which depends on ambient
+  // process.env.CI and causes 13-test failures when rtk-installer.test.ts deletes
+  // CI from the environment, letting handleSelfUpdate → executeSelfUpdate run and
+  // call process.exit on a 1.0.0 major-bump version).
+  let savedSkipSelfUpdate: string | undefined;
+
   beforeEach(async () => {
     tempDir = realpathSync(await mkdtemp(join(tmpdir(), 'omcustom-update-test-')));
     originalCwd = process.cwd();
@@ -36,6 +44,13 @@ describe('update command', () => {
     consoleLogSpy = spyOn(console, 'log').mockImplementation(() => {});
     consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
     consoleWarnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+
+    // Ensure self-update is deterministically skipped for tests that call
+    // updateCommand({}) without a skipSelf flag or a self-update.js mock.
+    // Tests that exercise the self-update path manage this env var themselves
+    // via their own beforeEach (which runs after this one and overrides it).
+    savedSkipSelfUpdate = process.env.OMCUSTOM_SKIP_SELF_UPDATE;
+    process.env.OMCUSTOM_SKIP_SELF_UPDATE = 'true';
   });
 
   afterEach(async () => {
@@ -49,6 +64,13 @@ describe('update command', () => {
     consoleLogSpy.mockRestore();
     consoleErrorSpy.mockRestore();
     consoleWarnSpy.mockRestore();
+
+    // Restore OMCUSTOM_SKIP_SELF_UPDATE to whatever it was before this test suite
+    if (savedSkipSelfUpdate !== undefined) {
+      process.env.OMCUSTOM_SKIP_SELF_UPDATE = savedSkipSelfUpdate;
+    } else {
+      delete process.env.OMCUSTOM_SKIP_SELF_UPDATE;
+    }
 
     // Clear all mocks
     mock.restore();
@@ -1959,6 +1981,20 @@ describe('update command', () => {
   });
 
   describe('exitWithChildStatus signal handling (#867)', () => {
+    // This describe block tests the re-exec path (executeSelfUpdate → updated:true →
+    // reexecUpdatedCli → spawnSync). The outer beforeEach sets OMCUSTOM_SKIP_SELF_UPDATE='true'
+    // to isolate unrelated tests, but the re-exec gate (src/cli/update.ts line 136) checks
+    // that same env var. We must clear it here so reexecUpdatedCli is actually called.
+    beforeEach(() => {
+      delete process.env.OMCUSTOM_SKIP_SELF_UPDATE;
+    });
+
+    afterEach(() => {
+      // Outer afterEach restores savedSkipSelfUpdate; nothing extra needed here,
+      // but restore explicitly for clarity and safety.
+      process.env.OMCUSTOM_SKIP_SELF_UPDATE = 'true';
+    });
+
     it('should exit 128+15 (143) when child terminated by SIGTERM (#867)', async () => {
       const spawnSyncMock = mock(() => ({
         status: null,
@@ -2010,10 +2046,15 @@ describe('update command', () => {
 
     beforeEach(() => {
       originalArgv = process.argv;
+      // Clear the skip guard so that handleSelfUpdate proceeds to call
+      // reexecUpdatedCli (which then hits the argv guard under test).
+      delete process.env.OMCUSTOM_SKIP_SELF_UPDATE;
     });
 
     afterEach(() => {
       process.argv = originalArgv;
+      // Outer afterEach restores savedSkipSelfUpdate; pre-restore here for safety.
+      process.env.OMCUSTOM_SKIP_SELF_UPDATE = 'true';
     });
 
     it('should warn and skip re-exec when process.argv[1] is empty (#867)', async () => {


### PR DESCRIPTION
## 요약

- **버전**: 0.182.0 → 1.0.0 (package.json + templates/manifest.json)
- **안정화 마일스톤**: breaking change 없음 — 의도적 major 버전 선언. 0.x 시리즈의 기능적 완성을 나타냄.
- **패치-우선 정책**: 이후 일반 릴리즈는 1.0.x 패치 버전 사용. 새 기능은 1.x.0 minor. Breaking은 2.0.0.

## Test 오염 수정 포함

`update.test.ts`의 self-update 테스트가 ambient `CI` 환경변수에 의존하고 있었음:
- `rtk-installer.test.ts`가 `process.env.CI`를 변조(mutate)하는데, 전체 스위트 실행 시 이 오염이 `update.test.ts`에 전파됨
- 1.0.0 major-version boundary에서 `isVersionPlausible()` 검사가 처음으로 실패 조건을 트리거하면서 13개 테스트가 full-suite 실행에서만 실패
- 수정: `beforeEach`에서 `OMCUSTOM_SKIP_SELF_UPDATE=1` 설정으로 self-update 격리

## Known Follow-up

- **v1.0.1**: `self-update isVersionPlausible` live major-bump guard 구현 (cross-major 버전 비교 강화)

## CI 체크

pre-commit hook: 2013 pass, 0 fail (Function 98.26% / Line 98.37% — 임계값 98% 초과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)