### PR TITLE
chore(release): v1.0.1 — self-update cross-major 수정 (#1358)

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.0.0",
-  "generatedAt": "2026-06-11T01:19:03.091Z",
-  "templateVersion": "1.0.0",
+  "generatorVersion": "1.0.1",
+  "generatedAt": "2026-06-11T04:14:41.669Z",
+  "templateVersion": "1.0.1",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-06-11
+
+### Fixed
+- self-update: cross-major self-updates (0.x → 1.x, 1.x → 2.x) were blocked because `isVersionPlausible`'s cache-corruption guards (major-bump and large-minor-jump rejection) were also applied to the live npm-fetch path. A live fetch is authoritative confirmation, so the live path now bypasses those guards while the cache path stays strict. Downgrades remain gated by the independent `compareSemver` check (updates only when current < latest). Closes #1358.
+
 ## [1.0.0] - 2026-06-11
 
 ### 🎉 First stable release

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 릴리즈 요약

- **버전**: 1.0.0 → 1.0.1 (patch)
- **정책**: 패치-우선 릴리즈 정책 첫 적용
- **변경**: self-update live fetch가 cross-major 업데이트를 허용하도록 수정 (캐시-손상 가드 우회)

## 변경 파일

- `package.json` — 버전 1.0.1
- `templates/manifest.json` — 버전 1.0.1
- `.omcustom.lock.json` — 동기화
- `CHANGELOG.md` — [1.0.1] 항목 추가

Fixes #1358

🤖 Generated with [Claude Code](https://claude.com/claude-code)