### PR TITLE
chore(release): v1.0.2 — daily-scout 제거

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.0.1",
-  "generatedAt": "2026-06-11T04:14:41.669Z",
-  "templateVersion": "1.0.1",
+  "generatorVersion": "1.0.2",
+  "generatedAt": "2026-06-11T13:11:52.836Z",
+  "templateVersion": "1.0.2",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -241,7 +241,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "0.181.0",
+    version: "1.0.2",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {
@@ -25750,7 +25750,10 @@ function compareSemver(a, b) {
   }
   return 0;
 }
-function isVersionPlausible(currentVersion, candidateVersion) {
+function isVersionPlausible(currentVersion, candidateVersion, options = {}) {
+  if (options.live) {
+    return true;
+  }
   const current = normalizeVersion(currentVersion).split(".").map((n) => parseInt(n, 10) || 0);
   const candidate = normalizeVersion(candidateVersion).split(".").map((n) => parseInt(n, 10) || 0);
   const majorDiff = (candidate[0] ?? 0) - (current[0] ?? 0);
@@ -25961,7 +25964,7 @@ function checkSelfUpdate(options) {
   }
   if (!latestVersion) {
     const fetched = fetchLatestVersion(packageName);
-    if (fetched && isVersionPlausible(currentVersion, fetched)) {
+    if (fetched && isVersionPlausible(currentVersion, fetched, { live: true })) {
       latestVersion = fetched;
       writeCache(cachePath, latestVersion, now);
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "0.181.0",
+  version: "1.0.2",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
패치 릴리즈입니다. daily-scout cron 워크플로우·스크립트 제거(#1369)를 출시합니다. agent/skill/rule 변경 없음. 버전 1.0.1 → 1.0.2.

## 변경 사항

- `package.json` 버전 1.0.1 → 1.0.2
- `templates/manifest.json` 버전 1.0.1 → 1.0.2
- `dist/` 재빌드

## 검증

- [ ] CI 통과 확인
- [ ] npm 퍼블리시 확인 (release.yml auto-trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)