### PR TITLE
chore(release): v1.0.3 — CC v2.1.172/173 호환성 노트

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.0.2",
-  "generatedAt": "2026-06-11T13:11:52.836Z",
-  "templateVersion": "1.0.2",
+  "generatorVersion": "1.0.3",
+  "generatedAt": "2026-06-11T13:42:38.709Z",
+  "templateVersion": "1.0.3",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",
@@ -10,13 +10,13 @@
       "component": "rules"
     },
     ".claude/rules/SHOULD-hud-statusline.md": {
-      "templateHash": "4ec917c940224471bcaa7a060c9bb948e6156357ad0b716ace4ade9bb48eadff",
-      "size": 3629,
+      "templateHash": "becbb63369f745cdb86612ba9a6c6d05a9a29487ac7ea19fd411ad32efabda82",
+      "size": 3867,
       "component": "rules"
     },
     ".claude/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "1fdc8fff3b6584056ac36abab07c7910192d6b255666c119030303e43404c893",
-      "size": 28236,
+      "templateHash": "547c79cdd524e5d2bdc7ea2a1d9b75e7764c0066b321a2083691f5c71c230cbb",
+      "size": 28978,
       "component": "rules"
     },
     ".claude/rules/MUST-intent-transparency.md": {
@@ -50,8 +50,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
-      "templateHash": "fedf66f88c6ae3085eb1e9a09c7bb309a920534a8c4063ac258e1beb578cc53d",
-      "size": 28476,
+      "templateHash": "2a097db541f60a0a7f3108c4667f85b69c190e736d5f1bc1f4d9ad8f3856d155",
+      "size": 29280,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -241,7 +241,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "1.0.2",
+    version: "1.0.3",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "1.0.2",
+  version: "1.0.3",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 개요

v1.0.3 패치 릴리즈 — CC v2.1.172/173 호환성 노트(R006/R010/R012) 배포.

## 변경 내용

- **버전 범프**: 1.0.2 → 1.0.3 (`package.json`, `templates/manifest.json`)
- **dist 재빌드**: `bun run build`로 새 버전 반영
- **내용 변경 없음**: Stage A(#1371)에서 이미 머지된 compat 노트 배포만

## 참조

- Stage A (feature): #1371 (merged to develop)
- 이슈: #1366, #1367

🤖 Generated with [Claude Code](https://claude.com/claude-code)