### PR TITLE
chore(release): v1.0.4 — wiki-drift blocking + geeknews-scout 제거

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.0.3",
-  "generatedAt": "2026-06-11T13:42:38.709Z",
-  "templateVersion": "1.0.3",
+  "generatorVersion": "1.0.4",
+  "generatedAt": "2026-06-11T20:47:49.716Z",
+  "templateVersion": "1.0.4",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -241,7 +241,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "1.0.3",
+    version: "1.0.4",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "1.0.3",
+  version: "1.0.4",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 릴리즈 요약

v1.0.4 패치 릴리즈입니다. Stage A PR #1373 (develop 머지 완료)에서 shipping한 변경사항을 포함합니다.

## 포함 변경사항

- **#1330** wiki content-drift Phase B — source-hash 기반 blocking 승격 (advisory → blocking)
- **#1331** geeknews-scout 디렉토리 완전 제거 (deprecation 완료)

## 버전 범프

- `package.json`: 1.0.3 → 1.0.4
- `templates/manifest.json`: 1.0.3 → 1.0.4
- `dist/` 재빌드 (bun run build)
- `verify-version-sync.sh` 통과

## 검증

- 테스트: 2021 pass / 0 fail (커버리지 98.26% / 98.37%)
- Agent/Skill/Rule 카운트 변경 없음 (Agents 49, Skills 117, Rules 23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)