### PR TITLE
chore(rules): R010 사전 prod 승인 경계 강화 (#1368)

### DIFF
--- a/.claude/rules/MUST-orchestrator-coordination.md
+++ b/.claude/rules/MUST-orchestrator-coordination.md
@@ -262,6 +262,18 @@ Broad single-task scopes (e.g. "migrate + backfill") MUST be pre-decomposed by d
 
 A subagent MUST NOT chain from an approved action into unrequested privileged operations. Example: approved "delete tunnel X" → unrequested "create new public tunnel Y" is a scope violation. Each privileged action requires its own authorization trace back to the user request.
 
+### Pre-Delegation Privileged-Scope Boundary (proactive)
+
+> Origin: #1368 #5 — an infra subagent was delegated a prod-touching task with NO explicit approval boundary in the delegation prompt; it freely ran prod DB queries, file deletes, and SMS reads, tripping the safety classifier 3+ times. The orchestrator never stated the approved scope or forbidden actions up front.
+
+The Subagent Scope-Creep STOP Protocol (above) is REACTIVE — it halts an agent after it trips the classifier. This rule is its PROACTIVE complement: prevent the trips by stating the boundary before the subagent runs. When delegating ANY task that touches prod / privileged resources (prod DB, infra deletion, credential stores, external messaging/SMS, shared-namespace secrets), the orchestrator MUST state — explicitly IN the delegation prompt — the approved actions, the forbidden actions, and the authorization scope. A subagent given a prod-touching task without a stated boundary will improvise into adjacent privileged operations.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| Delegate a prod/privileged-touching task with no scope or forbidden-line in the prompt | State in the prompt: the approved action(s), explicit forbidden actions (e.g. "do NOT delete files, do NOT query prod DB, do NOT read SMS/messages"), and the authorization scope tied back to the user request |
+
+Cross-reference: the Subagent Scope-Creep STOP Protocol (reactive halt after trips) and R001 (credential/privileged-scope guardrails, re-confirm scope before irreversible shared-infra actions).
+
 ## Universal bypassPermissions
 
 **ALL Agent tool calls MUST include `mode: "bypassPermissions"`.**

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.0.3",
-  "generatedAt": "2026-06-11T13:42:38.709Z",
-  "templateVersion": "1.0.3",
+  "generatorVersion": "1.0.4",
+  "generatedAt": "2026-06-11T20:47:49.716Z",
+  "templateVersion": "1.0.4",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -241,7 +241,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "1.0.3",
+    version: "1.0.4",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "1.0.3",
+  version: "1.0.4",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-orchestrator-coordination.md
+++ b/templates/.claude/rules/MUST-orchestrator-coordination.md
@@ -262,6 +262,18 @@ Broad single-task scopes (e.g. "migrate + backfill") MUST be pre-decomposed by d
 
 A subagent MUST NOT chain from an approved action into unrequested privileged operations. Example: approved "delete tunnel X" → unrequested "create new public tunnel Y" is a scope violation. Each privileged action requires its own authorization trace back to the user request.
 
+### Pre-Delegation Privileged-Scope Boundary (proactive)
+
+> Origin: #1368 #5 — an infra subagent was delegated a prod-touching task with NO explicit approval boundary in the delegation prompt; it freely ran prod DB queries, file deletes, and SMS reads, tripping the safety classifier 3+ times. The orchestrator never stated the approved scope or forbidden actions up front.
+
+The Subagent Scope-Creep STOP Protocol (above) is REACTIVE — it halts an agent after it trips the classifier. This rule is its PROACTIVE complement: prevent the trips by stating the boundary before the subagent runs. When delegating ANY task that touches prod / privileged resources (prod DB, infra deletion, credential stores, external messaging/SMS, shared-namespace secrets), the orchestrator MUST state — explicitly IN the delegation prompt — the approved actions, the forbidden actions, and the authorization scope. A subagent given a prod-touching task without a stated boundary will improvise into adjacent privileged operations.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| Delegate a prod/privileged-touching task with no scope or forbidden-line in the prompt | State in the prompt: the approved action(s), explicit forbidden actions (e.g. "do NOT delete files, do NOT query prod DB, do NOT read SMS/messages"), and the authorization scope tied back to the user request |
+
+Cross-reference: the Subagent Scope-Creep STOP Protocol (reactive halt after trips) and R001 (credential/privileged-scope guardrails, re-confirm scope before irreversible shared-infra actions).
+
 ## Universal bypassPermissions
 
 **ALL Agent tool calls MUST include `mode: "bypassPermissions"`.**

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/wiki/.source-hashes.json
+++ b/wiki/.source-hashes.json
@@ -57,7 +57,7 @@
   ".claude/rules/MUST-enforcement-policy.md": "9753983ea33868b0b3686fb381327e0896efeab96f2277a1195f97baf60d82e5",
   ".claude/rules/MUST-intent-transparency.md": "dad6c542165c7d5bba6403651690aee1b3190cf732a9e115287e03eb22a31f95",
   ".claude/rules/MUST-language-policy.md": "afb21d6e1b068a45e356191edf452c50b1018403dd4168664ffc8daee1316def",
-  ".claude/rules/MUST-orchestrator-coordination.md": "547c79cdd524e5d2bdc7ea2a1d9b75e7764c0066b321a2083691f5c71c230cbb",
+  ".claude/rules/MUST-orchestrator-coordination.md": "33fa01695ca88ced0b3f72e10c82a0fc79fafee5c381ce34df4e8b5e6f9f3582",
   ".claude/rules/MUST-parallel-execution.md": "767ccd36055d8b01ca7b67b0f0972fff777dcf0bc40e37e5e25b8ab35a109296",
   ".claude/rules/MUST-permissions.md": "0a21c7f55b2bea42ccfa2ace819ebc46b140ec43369ffbd5807c90ec67cf3b95",
   ".claude/rules/MUST-safety.md": "d1a38e5a6e0d6679163685d96c8bfc5c58dc16fca1dcc6d6dea153644cd16125",

--- a/wiki/rules/r010.md
+++ b/wiki/rules/r010.md
@@ -1,7 +1,7 @@
 ---
 title: "R010: Orchestrator Coordination Rules"
 type: rule
-updated: 2026-06-11
+updated: 2026-06-12
 sources:
   - .claude/rules/MUST-orchestrator-coordination.md
 related:
@@ -77,6 +77,20 @@ The legacy `/tmp/*.sh` script bypass pattern applied to CC < v2.1.121 only. For 
 
 **Background-agent project-settings isolation (v2.1.172+):** Fixed background agents potentially reading another directory's project settings (`.mcp.json` approvals, trust) when dispatched onto a pre-warmed worker. A `/bg`-dispatched agent now correctly reads its own project's settings. Strengthens background-agent isolation for unattended `/bg` flows.
 
+## Pre-Delegation Privileged-Scope Boundary (proactive)
+
+> Origin: #1368 #5 — an infra subagent was delegated a prod-touching task with NO explicit approval boundary in the delegation prompt; it freely ran prod DB queries, file deletes, and SMS reads, tripping the safety classifier 3+ times.
+
+The **Subagent Scope-Creep STOP Protocol is REACTIVE** — it halts an agent after classifier trips. This is its PROACTIVE complement: prevent the trips by stating the boundary before the subagent runs.
+
+When delegating ANY task that touches prod or privileged resources (prod DB, infra deletion, credential stores, external messaging/SMS, shared-namespace secrets), the orchestrator MUST state — **explicitly in the delegation prompt** — the approved actions, forbidden actions, and authorization scope.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| Delegate a prod/privileged-touching task with no scope or forbidden-line in the prompt | State in the prompt: approved action(s), explicit forbidden actions (e.g. "do NOT delete files, do NOT query prod DB, do NOT read SMS/messages"), and authorization scope |
+
+Cross-reference: Subagent Scope-Creep STOP Protocol (reactive halt after trips), [[r001]] (credential/privileged-scope guardrails).
+
 ## Enforcement
 
 Advisory PostToolUse hook (`git-delegation-guard.sh`) + PostCompact re-injection per [[r021]]. Candidate for hard-block if direct-write violations exceed 3/session.
@@ -89,4 +103,4 @@ Advisory PostToolUse hook (`git-delegation-guard.sh`) + PostCompact re-injection
 
 ## Sources
 
-- `.claude/rules/MUST-orchestrator-coordination.md` — rule definition (Agent Capability Pre-Check added v0.147.0; v2.1.172 sub-agent nesting note + background-agent project-settings isolation fix note added 2026-06-11)
+- `.claude/rules/MUST-orchestrator-coordination.md` — rule definition (Agent Capability Pre-Check added v0.147.0; v2.1.172 sub-agent nesting note + background-agent project-settings isolation fix note added 2026-06-11; Pre-Delegation Privileged-Scope Boundary proactive subsection added 2026-06-12)


### PR DESCRIPTION
## 개요

R010에 **Pre-Delegation Privileged-Scope Boundary (proactive)** 조항을 추가합니다.

## 변경 내용

- **R010 강화** (`.claude/rules/MUST-orchestrator-coordination.md`): prod/특권 작업을 서브에이전트에 위임할 때, 오케스트레이터가 위임 프롬프트에 다음을 명시해야 합니다:
  - 사용자가 승인한 행동 경계 (allowed scope)
  - 명시적 금지 행동 (forbidden actions)
  - 기존 "Subagent Scope-Creep STOP Protocol"(사후 반응)의 **사전 예방 보완재**로 동작
- **templates mirror 동기화** (`templates/.claude/rules/MUST-orchestrator-coordination.md`)
- **wiki 페이지 업데이트** (`wiki/rules/r010.md`)
- **source-hashes 재생성** (`wiki/.source-hashes.json`)

## 배경

Issue #1368 finding #5: 오케스트레이터가 prod 작업을 위임할 때 승인 경계를 프롬프트에 전달하지 않아 서브에이전트가 범위를 임의로 해석할 수 있는 gap 식별. 기존 Stop Protocol은 위반 발생 후 대응하는 구조였으나, 이번 조항은 위임 시점에 경계를 명시하는 사전 예방 레이어를 추가합니다.

## 테스트

- pre-commit hooks 통과 (타입체크, lint, 전체 테스트 스위트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)