### PR TITLE
chore(release): v1.0.5 — R010 사전 prod 승인 경계

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.0.4",
-  "generatedAt": "2026-06-11T20:47:49.716Z",
-  "templateVersion": "1.0.4",
+  "generatorVersion": "1.0.5",
+  "generatedAt": "2026-06-11T22:54:47.183Z",
+  "templateVersion": "1.0.5",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",
@@ -15,8 +15,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "547c79cdd524e5d2bdc7ea2a1d9b75e7764c0066b321a2083691f5c71c230cbb",
-      "size": 28978,
+      "templateHash": "33fa01695ca88ced0b3f72e10c82a0fc79fafee5c381ce34df4e8b5e6f9f3582",
+      "size": 30552,
       "component": "rules"
     },
     ".claude/rules/MUST-intent-transparency.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -241,7 +241,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "1.0.4",
+    version: "1.0.5",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "1.0.4",
+  version: "1.0.5",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 릴리즈 요약

v1.0.5 패치 릴리즈입니다. R010 사전 위임(Pre-Delegation) 권한 범위 경계 강화 (#1368 #5)를 포함하며, PR #1375로 develop에 머지된 내용을 패키징합니다.

## 변경 내용

- `package.json`, `templates/manifest.json`: 1.0.4 → 1.0.5 버전 범프
- `dist/` 재빌드 (bun run build)
- `.omcustom.lock.json` 재생성

## 체크리스트

- [x] 버전 범프: 1.0.4 → 1.0.5
- [x] `verify-version-sync.sh` 통과
- [x] `bun run build` 성공
- [x] 전체 테스트 스위트 통과 (pre-commit hook)
- [x] Stage A (feature PR #1375) develop HEAD 기준

🤖 Generated with [Claude Code](https://claude.com/claude-code)