### PR TITLE
chore(release): v1.0.6 — AWS MCP Server 통합

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.0.5",
-  "generatedAt": "2026-06-11T22:54:47.183Z",
-  "templateVersion": "1.0.5",
+  "generatorVersion": "1.0.6",
+  "generatedAt": "2026-06-13T07:09:01.652Z",
+  "templateVersion": "1.0.6",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",
@@ -360,8 +360,8 @@
       "component": "agents"
     },
     ".claude/agents/infra-aws-expert.md": {
-      "templateHash": "8f03583bb5c5fb8ac3b80af3748f3e4365cbc1c5015882c590424ef1bcb50b01",
-      "size": 1345,
+      "templateHash": "17645637a4ac83bb486c75223e62de91a3c91c14f8cbb0cbe54db1fc781baf48",
+      "size": 5099,
       "component": "agents"
     },
     ".claude/agents/slack-cli-expert.md": {
@@ -970,8 +970,8 @@
       "component": "skills"
     },
     ".claude/skills/aws-best-practices/SKILL.md": {
-      "templateHash": "618f1f6d0dbcb1199b4b916103be548e57ab427113ef06b736aa2cd49ba60bec",
-      "size": 5855,
+      "templateHash": "592f6fd80982044c6b6a242fad121c566b79d7d33428afc99c61cafe9ac1e978",
+      "size": 6471,
       "component": "skills"
     },
     ".claude/skills/dev-review/SKILL.md": {
@@ -1840,8 +1840,8 @@
       "component": "guides"
     },
     "guides/aws/index.yaml": {
-      "templateHash": "769acce5ab245dbce1e8eb852c9bda81b20801a75d0d54ecbb6839c69fe04db6",
-      "size": 596,
+      "templateHash": "e30d65b0560ae27e27c64fc537e8b5435f5413e23a119aa163fc36b6a3e08f50",
+      "size": 2375,
       "component": "guides"
     },
     "guides/alembic/README.md": {

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -241,7 +241,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "1.0.5",
+    version: "1.0.6",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {

--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "1.0.5",
+  version: "1.0.6",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약

v1.0.6 버전 범프 릴리즈입니다. Stage A (feat/aws-mcp-integration → develop, PR #1380)가 머지된 이후 버전 범프만 포함하는 Stage B입니다.

### 변경 내용
- `package.json`: 1.0.5 → 1.0.6
- `templates/manifest.json`: 1.0.5 → 1.0.6
- `bun run build` 산출물 갱신 (`dist/cli/index.js`, `dist/index.js`, `.omcustom.lock.json`)

### 연관 이슈
Closes #1379

## 검증 체크리스트
- [x] develop 최신화 확인 (HEAD = cdd102e0, Stage A 머지 확인)
- [x] release/v1.0.6 브랜치 생성 (auto-tag.yml release/v* 패턴 매칭)
- [x] package.json 1.0.5 → 1.0.6
- [x] templates/manifest.json 1.0.5 → 1.0.6
- [x] bun run build 성공 (198 modules / 22 modules bundled)
- [x] git add -u: tracked 5파일만 staging, untracked 노이즈 제외
- [x] 커밋 메시지: chore(release) conventional
- [x] ARCHITECTURE.md 카운트 무변동 (49 agents / 117 skills / 23 rules / 57 guides)