### PR TITLE
Release v1.0.7 — CC v2.1.174~177 호환성 노트

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## v1.0.7 — CC v2.1.174~177 호환성 노트

auto-dev 파이프라인 lite tier 릴리즈. 4개 CC 릴리즈의 oh-my-customcode 영향 항목을 룰에 반영.

### 반영 내용
- **R006** (#1377 v2.1.175): `enforceAvailableModels` managed setting — availableModels allowlist가 Default model까지 제약
- **R008** (#1378 v2.1.174): Workflow `agent()` 서브에이전트 per-agent attribution header 수정 반영
- **R010** (#1378 v2.1.174): background 세션의 `ANTHROPIC_*` provider env isolation
- **R012** (#1378/#1383 v2.1.174/176): `/usage` attribution view + `footerLinksRegexes` footer 배지
- #1382 (v2.1.177): 릴리즈 노트 없음 — 추적/close만

### 검증
- verify-template-sync EXIT 0
- verify-wiki-sync content-drift 0 (wiki/rules r006/r008/r010/r012 + source-hashes 재생성)
- bun test 2005 pass / 0 fail
- lint/typecheck 통과

Closes #1377, Closes #1378, Closes #1382, Closes #1383

🤖 Generated with [Claude Code](https://claude.com/claude-code)