### PR TITLE
R020 바이너리/렌더 산출물 완결성 게이트 추가 (#1384)

### DIFF
--- a/.claude/rules/MUST-completion-verification.md
+++ b/.claude/rules/MUST-completion-verification.md
@@ -306,6 +306,19 @@ Before closing or marking-done an issue/task that CLAIMS an infrastructure or re
 
 This is the infra/state extension of "actual outcome ≠ attempt". Closing on the command-issued assumption leaves orphaned running resources.
 
+### Binary/Rendered-Artifact Completeness (text-grep ≠ complete)
+
+> Origin: #1384 (second-brain 공개 저장소 redaction 세션 회고 찐빠 #1) — 텍스트 + git 히스토리 force-push 후 "원격 완전 정리됨"이라 선언했으나, 직후 렌더된 다이어그램 PNG 3종에 redaction 대상 식별자가 시각적으로 잔존 + 텍스트 잔여 호스트 토큰 1건 발견 → 추가 force-push 2회 필요. redaction 범위를 grep 가능한 텍스트로만 잡고, 렌더된 이미지/바이너리를 완결 선언 전에 점검하지 않음.
+
+완료/완결성을 주장하는 작업(redaction, 식별자 제거, 콘텐츠 정리, 시크릿 스크럽, 데이터 마이그레이션)에서 텍스트 grep 통과는 완결을 보장하지 않는다. 렌더된 이미지/바이너리 산출물(PNG/PDF/렌더 다이어그램/임베디드 메타데이터/EXIF)에 동일 대상이 시각적·바이너리적으로 잔존할 수 있다. "완전 제거됨/완료" 선언 전, 텍스트뿐 아니라 바이너리/이미지/렌더 산출물 완결성까지 검증해야 한다.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| 텍스트 grep 통과 후 "완전 제거됨/정리됨" 선언 | 렌더 이미지/바이너리/임베디드 메타데이터 시각·내용 스캔까지 통과한 뒤 선언 |
+| redaction 범위를 grep 가능 텍스트로만 한정 → 잔여를 순차 발견하며 force-push 반복 | 사전 전수 점검(대소문자 무시 텍스트 + 부분문자열 변형 + 바이너리/이미지 + 참조/고아 분석) 후 단일 패스 rewrite (R005 효율) |
+
+This is the redaction/binary extension of the UI/Frontend "browser render verified" row in the Task-Type Completion Matrix — text-layer verification alone is insufficient when rendered/binary artifacts carry the same content. Cross-reference: R001 (보안 완결성 — 시크릿/식별자 잔존 차단), R005 (단일 패스 효율 — 사전 전수 점검이 반복 force-push를 방지).
+
 ## Integration
 
 | Rule | Interaction |

--- a/templates/.claude/rules/MUST-completion-verification.md
+++ b/templates/.claude/rules/MUST-completion-verification.md
@@ -306,6 +306,19 @@ Before closing or marking-done an issue/task that CLAIMS an infrastructure or re
 
 This is the infra/state extension of "actual outcome ≠ attempt". Closing on the command-issued assumption leaves orphaned running resources.
 
+### Binary/Rendered-Artifact Completeness (text-grep ≠ complete)
+
+> Origin: #1384 (second-brain 공개 저장소 redaction 세션 회고 찐빠 #1) — 텍스트 + git 히스토리 force-push 후 "원격 완전 정리됨"이라 선언했으나, 직후 렌더된 다이어그램 PNG 3종에 redaction 대상 식별자가 시각적으로 잔존 + 텍스트 잔여 호스트 토큰 1건 발견 → 추가 force-push 2회 필요. redaction 범위를 grep 가능한 텍스트로만 잡고, 렌더된 이미지/바이너리를 완결 선언 전에 점검하지 않음.
+
+완료/완결성을 주장하는 작업(redaction, 식별자 제거, 콘텐츠 정리, 시크릿 스크럽, 데이터 마이그레이션)에서 텍스트 grep 통과는 완결을 보장하지 않는다. 렌더된 이미지/바이너리 산출물(PNG/PDF/렌더 다이어그램/임베디드 메타데이터/EXIF)에 동일 대상이 시각적·바이너리적으로 잔존할 수 있다. "완전 제거됨/완료" 선언 전, 텍스트뿐 아니라 바이너리/이미지/렌더 산출물 완결성까지 검증해야 한다.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| 텍스트 grep 통과 후 "완전 제거됨/정리됨" 선언 | 렌더 이미지/바이너리/임베디드 메타데이터 시각·내용 스캔까지 통과한 뒤 선언 |
+| redaction 범위를 grep 가능 텍스트로만 한정 → 잔여를 순차 발견하며 force-push 반복 | 사전 전수 점검(대소문자 무시 텍스트 + 부분문자열 변형 + 바이너리/이미지 + 참조/고아 분석) 후 단일 패스 rewrite (R005 효율) |
+
+This is the redaction/binary extension of the UI/Frontend "browser render verified" row in the Task-Type Completion Matrix — text-layer verification alone is insufficient when rendered/binary artifacts carry the same content. Cross-reference: R001 (보안 완결성 — 시크릿/식별자 잔존 차단), R005 (단일 패스 효율 — 사전 전수 점검이 반복 force-push를 방지).
+
 ## Integration
 
 | Rule | Interaction |

--- a/wiki/.source-hashes.json
+++ b/wiki/.source-hashes.json
@@ -52,7 +52,7 @@
   ".claude/rules/MUST-agent-design.md": "ccc9dd2723a3b199a75bd0d263c16f90e6d6f64f1c24a99b2fd02691adfecf78",
   ".claude/rules/MUST-agent-identification.md": "24f5d22a536d7fc201a497d3dec3755360552acf6dc02e088ced5bb311b2f0e0",
   ".claude/rules/MUST-agent-teams.md": "3ccf372e1432c6955594932c56731ca1706cdbf75887481599c8078701d1a8ca",
-  ".claude/rules/MUST-completion-verification.md": "19e3ebda2f11e74f5cf517f5b451e4f564d5e0ebace73cedc264f07170d71750",
+  ".claude/rules/MUST-completion-verification.md": "7ab1dcd605b16d042b8a9a1ecd4afd82392c165d81eff548a7d9b22c39412b94",
   ".claude/rules/MUST-continuous-improvement.md": "3651952744257761819232644f2ed9bb7ca92ec31423ab3f53bb90c0cb95773d",
   ".claude/rules/MUST-enforcement-policy.md": "9753983ea33868b0b3686fb381327e0896efeab96f2277a1195f97baf60d82e5",
   ".claude/rules/MUST-intent-transparency.md": "dad6c542165c7d5bba6403651690aee1b3190cf732a9e115287e03eb22a31f95",

--- a/wiki/rules/r020.md
+++ b/wiki/rules/r020.md
@@ -1,7 +1,7 @@
 ---
 title: "R020: Completion Verification Rules"
 type: rule
-updated: 2026-06-10
+updated: 2026-06-14
 sources:
   - .claude/rules/MUST-completion-verification.md
 related:
@@ -219,6 +219,21 @@ This is the infra/state extension of "actual outcome ≠ attempt." Closing on th
 
 **Common Violation (#1335 ①):** Issue #101 (secretary teardown) was closed as "대체 완료·teardown 보류", but the secretary LaunchAgents (onedrive-bridge / calendar-worker / minikube-mount) were still running on the host. The user caught it — they were not torn down.
 
+## Binary/Rendered-Artifact Completeness (text-grep ≠ complete) (#1384)
+
+완료/완결성을 주장하는 작업(redaction, 식별자 제거, 콘텐츠 정리, 시크릿 스크럽, 데이터 마이그레이션)에서 텍스트 grep 통과는 완결을 보장하지 않는다. 렌더된 이미지/바이너리 산출물(PNG/PDF/렌더 다이어그램/임베디드 메타데이터/EXIF)에 동일 대상이 시각적·바이너리적으로 잔존할 수 있다.
+
+"완전 제거됨/완료" 선언 전, 텍스트뿐 아니라 바이너리/이미지/렌더 산출물 완결성까지 검증해야 한다. Task-Type Completion Matrix의 UI/Frontend "browser render verified" 행의 redaction/binary 확장이다.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| 텍스트 grep 통과 후 "완전 제거됨/정리됨" 선언 | 렌더 이미지/바이너리/임베디드 메타데이터 시각·내용 스캔까지 통과한 뒤 선언 |
+| redaction 범위를 grep 가능 텍스트로만 한정 → 잔여를 순차 발견하며 force-push 반복 | 사전 전수 점검(텍스트 + 부분문자열 변형 + 바이너리/이미지 + 참조/고아 분석) 후 단일 패스 rewrite |
+
+**Common Violation (#1384):** 텍스트 + git 히스토리 force-push 후 "원격 완전 정리됨" 선언 → 직후 렌더된 다이어그램 PNG 3종에 redaction 대상 식별자가 시각적으로 잔존 + 텍스트 잔여 토큰 1건 발견 → 추가 force-push 2회 필요. redaction 범위를 grep 가능한 텍스트로만 잡고 렌더 이미지를 완결 선언 전에 점검하지 않은 것이 원인.
+
+Cross-reference: [[r001]] (보안 완결성 — 시크릿/식별자 잔존 차단), [[r005]] (단일 패스 효율 — 사전 전수 점검이 반복 force-push를 방지).
+
 ## Enforcement
 
 Prompt-based per [[r021]]. Integrates with [[r003]] `[Done]` format and [[r017]] structural verification.
@@ -236,3 +251,4 @@ Prompt-based per [[r021]]. Integrates with [[r003]] `[Done]` format and [[r017]]
 - Issue #1327 — Config-Schema-Before-Edit: provider switch omitted base_url (2026-06-09)
 - Issue #1335 — State-Change Claim: secretary LaunchAgents still running after teardown claim (2026-06-10)
 - Issue #1336 — Proxy Signal vs Canonical Ground-Truth: transcription/SMS pipeline over-diagnosis from proxy artifacts (2026-06-10)
+- Issue #1384 — Binary/Rendered-Artifact Completeness: redaction PNG 잔존 → force-push 반복 (2026-06-14)


### PR DESCRIPTION
## 변경 개요

#1384 회고 찐빠 #1(second-brain redaction)을 oh-my-customcode R020에 일반화한 룰 강화입니다.

## 주요 변경

- **R020 완결성 게이트 확장**: 완료 선언 전 텍스트 grep 통과만으로는 불충분. 바이너리/이미지/렌더 산출물(PNG/PDF/다이어그램/임베디드 메타데이터/EXIF 등)의 완결성까지 검증 필요
- **적용 범위**: UI/Frontend "browser render verified" Task-Type matrix 행의 redaction/binary 확장 — 렌더 산출물이 관여하는 모든 태스크에 적용
- **제외**: second-brain 특화 부분(redaction 프리플라이트 스킬, whisper-annotate 파이프라인)은 포함하지 않음. 일반 원칙만 반영
- **wiki/rules/r020.md**: 변경된 R020 룰과 동기화
- **wiki/.source-hashes.json**: source-hashes 재생성
- **templates/.claude mirror**: templates/ 미러 동기화

## 검증

- verify-template-sync EXIT 0
- verify-wiki-sync drift 0
- bun test 2005/0

## 관련 이슈

Fixes #1384

🤖 Generated with [Claude Code](https://claude.com/claude-code)