### PR TITLE
Release v1.0.8 — R020 바이너리/렌더 산출물 완결성 게이트

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## v1.0.8 — R020 바이너리/렌더 산출물 완결성 게이트

auto-dev 파이프라인 릴리즈. #1384(second-brain redaction 세션 회고)의 찐빠 #1을 oh-my-customcode R020에 일반화.

### 반영 내용
- **R020**: `### Binary/Rendered-Artifact Completeness (text-grep ≠ complete)` 신규 섹션
  - 완료/완결성 주장 작업(redaction, 식별자 제거, 시크릿 스크럽)에서 텍스트 grep 통과 ≠ 완결
  - 렌더 이미지/바이너리(PNG/PDF/다이어그램/임베디드 메타데이터/EXIF) 완결성까지 검증 후 선언
  - UI/Frontend "browser render verified" 행의 redaction/binary 확장
  - second-brain 특화 부분(redaction 프리플라이트 스킬)은 제외 — 일반 원칙만 반영

### 검증
- verify-template-sync EXIT 0
- verify-wiki-sync content-drift 0 (wiki/rules/r020.md + source-hashes 재생성)
- bun test 2005 pass / 0 fail
- lint/typecheck 통과

Closes #1384

🤖 Generated with [Claude Code](https://claude.com/claude-code)