### PR TITLE
chore(release): v1.0.9 — CC v2.1.178 호환성 노트 (#1391)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## v1.0.9 릴리즈
CC v2.1.178 호환성 노트 (R002/R006/R010)

### 변경 요약
- **R002**: `Tool(param:value)` 권한 구문 (`Agent(model:opus)`)
- **R006**: compaction fallbackModel, nested `.claude/skills` 로딩 + `<dir>:<name>`, MCP disallowedTools, nested `.claude/` closest-wins
- **R010**: auto-mode subagent spawn pre-launch classifier 평가, `claude agents` 401 bearer-token fix

### 검증
- bun test 2021 pass / 0 fail
- template-sync / wiki-sync / version-sync 통과
- Stage A feature PR #1392 머지 완료

Closes #1391