### PR TITLE
chore(release): bump to v1.0.10 — CC v2.1.179/181/183 호환성 노트

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## v1.0.10 — CC v2.1.179/181/183 호환성 노트

Stage B (version bump only). 콘텐츠 변경은 #1397에서 머지됨.

### 룰 호환성 노트 (5종)
- **R001**: v2.1.183 auto-mode 플랫폼 레벨 파괴적 git/IaC 차단 (reset --hard/checkout/clean -fd/stash drop/commit --amend, terraform·pulumi·cdk destroy)
- **R002**: v2.1.183 MCP auth-stub headless/SDK 미노출 + v2.1.181 sandbox.allowAppleEvents
- **R006**: v2.1.183 deprecated-model 경고(agent frontmatter) + thinking.disabled.display 400 fix
- **R010**: v2.1.181 prompt caching custom ANTHROPIC_BASE_URL fix + v2.1.179 remote background tasks fix
- **R018**: v2.1.183 tmux teammate panes fix + WebSearch-in-subagents fix

### 검증
- docs-only 압축 (scope=3, 모두 claude-code-release)
- deterministic self-check: template-sync / wiki Phase B / counts 49·117·23·57 / bun test 2021 pass 0 fail

Closes #1394 #1395 #1396