### PR TITLE
chore(release): v1.0.11 — FSD open-PR 처리 + dependabot 정리

### DIFF
--- a/.claude/skills/fsd/SKILL.md
+++ b/.claude/skills/fsd/SKILL.md
@@ -37,15 +37,37 @@ FSD expands into:
 2. **`/loop` recurrence** — self-paced loop (model decides cadence), each iteration runs:
    1. `/pipeline auto-dev` — full release pipeline for the next eligible issue
    2. `/homework` — retrospective 찐빠 audit gate
+   3. **Open PR processing** — merge or defer all open PRs before checking convergence
 
 ### Loop Convergence
 
-The loop converges naturally when the auto-dev-eligible issue set reaches 0. Issue eligibility follows `/pipeline auto-dev` label selection exactly:
+The loop converges naturally when **both** conditions are met:
+
+1. The auto-dev-eligible issue set reaches 0
+2. All open PRs have been either merged or explicitly deferred
+
+FSD processes **open PRs as part of each iteration**, not only issues. This includes dependabot PRs and any automatically created PRs. Issue eligibility follows `/pipeline auto-dev` label selection exactly:
 
 - **Included**: `verify-ready` (preferred), unlabeled auto-dev candidates
 - **Excluded**: `verify-done`, `needs-review`, `decision-needed` labels
 
 Do NOT invent new label logic here — defer to the `pipeline` skill's auto-dev issue selection.
+
+### PR Processing Rules
+
+When open PRs are found during an iteration:
+
+| PR state | Action |
+|----------|--------|
+| CI passing, auto-mergeable | Merge via mgr-gitnerd (R010) |
+| CI failing with known pattern (e.g., dependabot frozen-lockfile cascade → `bun install` lockfile regeneration) | Fix CI, then merge |
+| CI failing with unknown cause | Diagnose; if fixable within iteration, fix and merge; otherwise defer |
+| Breaking change / design judgment required | Defer and surface to user |
+| Explicitly excluded by user this session | Skip (honor directive persistence, R015) |
+
+All PR merge operations are delegated to **mgr-gitnerd** (R010). After merging, verify ground-truth via `gh pr view` or `git log` before declaring done (R020).
+
+Do NOT merge PRs that require user approval for architectural decisions. Surface them with a short summary and wait.
 
 ### Iteration Flow (per iteration)
 
@@ -53,9 +75,12 @@ Do NOT invent new label logic here — defer to the `pipeline` skill's auto-dev 
 [FSD Iteration N]
 ├── /pipeline auto-dev        → one release (PR create → merge → npm publish → milestone close)
 ├── /homework                 → extract 찐빠, confirm gate (or --dry-run if requested)
-└── Check: any eligible issues remain?
-    ├── YES → next iteration
-    └── NO  → [FSD Done] converged naturally
+├── Open PR processing        → for each open PR: merge (if CI-green + auto-mergeable)
+│                                                  fix-then-merge (known CI failure pattern)
+│                                                  defer+surface (design decision needed)
+└── Check convergence: eligible issues = 0 AND open PRs = 0 (merged or deferred)?
+    ├── YES → [FSD Done] converged naturally
+    └── NO  → next iteration
 ```
 
 ## Safety and Discipline
@@ -64,11 +89,12 @@ Each iteration operates under full project rules — no relaxation because FSD i
 
 | Rule | Applies |
 |------|---------|
-| R001 (safety) | Destructive ops still require explicit approval. Credential guardrails always active. |
+| R001 (safety) | Destructive ops still require explicit approval. Credential guardrails always active. PR merges that risk data loss require explicit approval. |
 | R009 (parallel) | Independent subtasks within each pipeline iteration run in parallel. |
-| R010 (orchestration) | All file modifications delegated to specialist subagents. mgr-gitnerd for git ops. |
+| R010 (orchestration) | All file modifications delegated to specialist subagents. mgr-gitnerd for git ops including PR merges. |
+| R015 (intent persistence) | If user explicitly defers a specific PR this session, honor that deferral — do not retry it. |
 | R017 (sync verification) | mgr-sauron passes required before any commit. |
-| R020 (completion verification) | Each release verified via `npm view`, `gh release view`, closed issues before `[Done]`. |
+| R020 (completion verification) | Each release verified via `npm view`, `gh release view`, closed issues before `[Done]`. PR merges verified via `gh pr view` ground-truth before declaring iteration complete. |
 
 `/homework` runs as a **retrospective gate** between iterations — findings go through `omcustom-feedback`'s Phase 4A confirmation gate. The loop does NOT skip homework on the grounds that it is "automated". If homework requires user confirmation (e.g., to file a feedback issue), the loop pauses and waits.
 
@@ -119,11 +145,13 @@ That session ran 2 iterations (v0.177.0 and v0.178.0) before converging with 0 e
 | `omcustom-loop` | Session auto-continuation via SubagentStop hook — keeps the loop alive during background agent work |
 | `pipeline` | `/pipeline auto-dev` — the core release pipeline per iteration |
 | `homework` | Retrospective 찐빠 audit gate per iteration |
-| R001 (safety) | Destructive ops require approval; credential guardrails |
+| `mgr-gitnerd` | PR merge operations — all open PR merges delegated here (R010) |
+| R001 (safety) | Destructive ops require approval; credential guardrails; risky PR merges require explicit approval |
 | R009 (parallel execution) | Parallel subtasks within each pipeline iteration |
-| R010 (orchestrator coordination) | All file writes delegated; mgr-gitnerd for git |
+| R010 (orchestrator coordination) | All file writes delegated; mgr-gitnerd for git including PR merges |
+| R015 (intent persistence) | User PR deferral decisions honored for the session |
 | R017 (sync verification) | mgr-sauron required before commit/push |
-| R020 (completion verification) | Actual outcome verified before declaring each release done |
+| R020 (completion verification) | Actual outcome verified before declaring each release or PR merge done |
 
 ## Design Notes
 
@@ -132,6 +160,7 @@ This skill is intentionally a **thin alias**. It does NOT duplicate:
 - Loop cadence / auto-continuation (owned by `omcustom-loop` + SubagentStop hook)
 - Release pipeline steps (owned by `pipeline auto-dev`)
 - Retrospective analysis (owned by `homework`)
+- PR merge execution (owned by `mgr-gitnerd`)
 - Completion verification (owned by R020 + `goal`)
 
 If any of those underlying skills evolve, FSD automatically benefits — its only responsibility is declaring the intent and forwarding to the right components.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/fsd/SKILL.md
+++ b/templates/.claude/skills/fsd/SKILL.md
@@ -37,15 +37,37 @@ FSD expands into:
 2. **`/loop` recurrence** — self-paced loop (model decides cadence), each iteration runs:
    1. `/pipeline auto-dev` — full release pipeline for the next eligible issue
    2. `/homework` — retrospective 찐빠 audit gate
+   3. **Open PR processing** — merge or defer all open PRs before checking convergence
 
 ### Loop Convergence
 
-The loop converges naturally when the auto-dev-eligible issue set reaches 0. Issue eligibility follows `/pipeline auto-dev` label selection exactly:
+The loop converges naturally when **both** conditions are met:
+
+1. The auto-dev-eligible issue set reaches 0
+2. All open PRs have been either merged or explicitly deferred
+
+FSD processes **open PRs as part of each iteration**, not only issues. This includes dependabot PRs and any automatically created PRs. Issue eligibility follows `/pipeline auto-dev` label selection exactly:
 
 - **Included**: `verify-ready` (preferred), unlabeled auto-dev candidates
 - **Excluded**: `verify-done`, `needs-review`, `decision-needed` labels
 
 Do NOT invent new label logic here — defer to the `pipeline` skill's auto-dev issue selection.
+
+### PR Processing Rules
+
+When open PRs are found during an iteration:
+
+| PR state | Action |
+|----------|--------|
+| CI passing, auto-mergeable | Merge via mgr-gitnerd (R010) |
+| CI failing with known pattern (e.g., dependabot frozen-lockfile cascade → `bun install` lockfile regeneration) | Fix CI, then merge |
+| CI failing with unknown cause | Diagnose; if fixable within iteration, fix and merge; otherwise defer |
+| Breaking change / design judgment required | Defer and surface to user |
+| Explicitly excluded by user this session | Skip (honor directive persistence, R015) |
+
+All PR merge operations are delegated to **mgr-gitnerd** (R010). After merging, verify ground-truth via `gh pr view` or `git log` before declaring done (R020).
+
+Do NOT merge PRs that require user approval for architectural decisions. Surface them with a short summary and wait.
 
 ### Iteration Flow (per iteration)
 
@@ -53,9 +75,12 @@ Do NOT invent new label logic here — defer to the `pipeline` skill's auto-dev 
 [FSD Iteration N]
 ├── /pipeline auto-dev        → one release (PR create → merge → npm publish → milestone close)
 ├── /homework                 → extract 찐빠, confirm gate (or --dry-run if requested)
-└── Check: any eligible issues remain?
-    ├── YES → next iteration
-    └── NO  → [FSD Done] converged naturally
+├── Open PR processing        → for each open PR: merge (if CI-green + auto-mergeable)
+│                                                  fix-then-merge (known CI failure pattern)
+│                                                  defer+surface (design decision needed)
+└── Check convergence: eligible issues = 0 AND open PRs = 0 (merged or deferred)?
+    ├── YES → [FSD Done] converged naturally
+    └── NO  → next iteration
 ```
 
 ## Safety and Discipline
@@ -64,11 +89,12 @@ Each iteration operates under full project rules — no relaxation because FSD i
 
 | Rule | Applies |
 |------|---------|
-| R001 (safety) | Destructive ops still require explicit approval. Credential guardrails always active. |
+| R001 (safety) | Destructive ops still require explicit approval. Credential guardrails always active. PR merges that risk data loss require explicit approval. |
 | R009 (parallel) | Independent subtasks within each pipeline iteration run in parallel. |
-| R010 (orchestration) | All file modifications delegated to specialist subagents. mgr-gitnerd for git ops. |
+| R010 (orchestration) | All file modifications delegated to specialist subagents. mgr-gitnerd for git ops including PR merges. |
+| R015 (intent persistence) | If user explicitly defers a specific PR this session, honor that deferral — do not retry it. |
 | R017 (sync verification) | mgr-sauron passes required before any commit. |
-| R020 (completion verification) | Each release verified via `npm view`, `gh release view`, closed issues before `[Done]`. |
+| R020 (completion verification) | Each release verified via `npm view`, `gh release view`, closed issues before `[Done]`. PR merges verified via `gh pr view` ground-truth before declaring iteration complete. |
 
 `/homework` runs as a **retrospective gate** between iterations — findings go through `omcustom-feedback`'s Phase 4A confirmation gate. The loop does NOT skip homework on the grounds that it is "automated". If homework requires user confirmation (e.g., to file a feedback issue), the loop pauses and waits.
 
@@ -119,11 +145,13 @@ That session ran 2 iterations (v0.177.0 and v0.178.0) before converging with 0 e
 | `omcustom-loop` | Session auto-continuation via SubagentStop hook — keeps the loop alive during background agent work |
 | `pipeline` | `/pipeline auto-dev` — the core release pipeline per iteration |
 | `homework` | Retrospective 찐빠 audit gate per iteration |
-| R001 (safety) | Destructive ops require approval; credential guardrails |
+| `mgr-gitnerd` | PR merge operations — all open PR merges delegated here (R010) |
+| R001 (safety) | Destructive ops require approval; credential guardrails; risky PR merges require explicit approval |
 | R009 (parallel execution) | Parallel subtasks within each pipeline iteration |
-| R010 (orchestrator coordination) | All file writes delegated; mgr-gitnerd for git |
+| R010 (orchestrator coordination) | All file writes delegated; mgr-gitnerd for git including PR merges |
+| R015 (intent persistence) | User PR deferral decisions honored for the session |
 | R017 (sync verification) | mgr-sauron required before commit/push |
-| R020 (completion verification) | Actual outcome verified before declaring each release done |
+| R020 (completion verification) | Actual outcome verified before declaring each release or PR merge done |
 
 ## Design Notes
 
@@ -132,6 +160,7 @@ This skill is intentionally a **thin alias**. It does NOT duplicate:
 - Loop cadence / auto-continuation (owned by `omcustom-loop` + SubagentStop hook)
 - Release pipeline steps (owned by `pipeline auto-dev`)
 - Retrospective analysis (owned by `homework`)
+- PR merge execution (owned by `mgr-gitnerd`)
 - Completion verification (owned by R020 + `goal`)
 
 If any of those underlying skills evolve, FSD automatically benefits — its only responsibility is declaring the intent and forwarding to the right components.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/wiki/.source-hashes.json
+++ b/wiki/.source-hashes.json
@@ -102,7 +102,7 @@
   ".claude/skills/fastapi-best-practices/SKILL.md": "8db303cb53c431f008c2aa4d42c57bf40b9107554e298ef38024be99ce7b3ee3",
   ".claude/skills/fix-refs/SKILL.md": "30a277e82fb55dbbe78ec2d4eccbed333db0b9ea7ea2f1d3c1e604ef034556f6",
   ".claude/skills/flutter-best-practices/SKILL.md": "1b9f52ef3d92f0df12d16f4aa845b47062f566a72fad8f846723c5bd21b1c80d",
-  ".claude/skills/fsd/SKILL.md": "56cfd6e36baab020a4a3fe6c06a91035d85d74fb7dcc3398b475185df001829e",
+  ".claude/skills/fsd/SKILL.md": "4968355e6b2ccd1bddb7b27c1e4abee1b3da15d76358a26a457cf2766a809a58",
   ".claude/skills/go-backend-best-practices/SKILL.md": "4dfdbe5407ee855630ab6dc4bf4cbf3e38e90f08e52ca72ae81164121a87b517",
   ".claude/skills/go-best-practices/SKILL.md": "fb712d8cd70d7dbfe82a6581f42a2ecf7786920425f5fb4b52cca4feb335c5f3",
   ".claude/skills/goal/SKILL.md": "f13ed958a26f112aad154c801de3d4932047e02556e654ec65501a5174434acd",

--- a/wiki/skills/fsd.md
+++ b/wiki/skills/fsd.md
@@ -2,7 +2,7 @@
 title: FSD (Full Self Driving)
 type: skill
 scope: harness
-updated: 2026-06-10
+updated: 2026-06-21
 sources:
   - .claude/skills/fsd/SKILL.md
 related:
@@ -10,26 +10,28 @@ related:
   - [[pipeline]]
   - [[homework]]
   - [[omcustom-loop]]
+  - [[mgr-gitnerd]]
   - [[R001]]
   - [[R009]]
   - [[R010]]
+  - [[R015]]
   - [[R017]]
   - [[R020]]
 ---
 
 # FSD (Full Self Driving)
 
-Autonomous release loop — processes all auto-dev-eligible GitHub issues until none remain, by repeatedly running `/pipeline auto-dev` then `/homework`.
+Autonomous release loop — processes all auto-dev-eligible GitHub issues **and open PRs** until both are exhausted, by repeatedly running `/pipeline auto-dev`, `/homework`, and open PR processing.
 
 ## Overview
 
 Thin alias / orchestrator skill. FSD expands into:
 
 ```
-/goal "모든 이슈가 처리될 때까지" /loop "/pipeline auto-dev -> /homework"
+/goal "모든 이슈와 PR이 처리될 때까지" /loop "/pipeline auto-dev -> /homework -> open PR processing"
 ```
 
-It does not implement loop logic, issue-polling, release steps, or verification itself — it delegates entirely to [[goal]], [[pipeline]], and [[homework]]. The loop converges naturally when the auto-dev-eligible issue set reaches zero.
+It does not implement loop logic, issue-polling, release steps, or verification itself — it delegates entirely to [[goal]], [[pipeline]], [[homework]], and [[mgr-gitnerd]]. The loop converges naturally when the auto-dev-eligible issue set reaches zero **and** all open PRs are merged or deferred.
 
 Extracted from the manual pattern used in Session 114 (2026-06-09), which ran 2 iterations (v0.177.0 and v0.178.0) before converging.
 
@@ -45,7 +47,7 @@ Extracted from the manual pattern used in Session 114 (2026-06-09), which ran 2 
 ## Usage
 
 ```bash
-/omcustom:fsd        # Run until all auto-dev-eligible issues are exhausted
+/omcustom:fsd        # Run until all eligible issues and open PRs are exhausted
 /omcustom:fsd 3      # Optional: cap at N releases (default: unlimited)
 ```
 
@@ -55,14 +57,37 @@ Each FSD iteration:
 
 ```
 [FSD Iteration N]
-├── /pipeline auto-dev   → one release (PR → merge → npm publish → milestone close)
-├── /homework            → retrospective 찐빠 audit gate (pauses for user confirmation if needed)
-└── Check: any eligible issues remain?
-    ├── YES → next iteration
-    └── NO  → [FSD Done] converged naturally
+├── /pipeline auto-dev     → one release (PR → merge → npm publish → milestone close)
+├── /homework              → retrospective 찐빠 audit gate (pauses for user confirmation if needed)
+├── Open PR processing     → handle all open PRs (dependabot included)
+└── Check: eligible issues = 0 AND open PRs = 0?
+    ├── YES → [FSD Done] converged naturally
+    └── NO  → next iteration
 ```
 
 Issue eligibility follows `/pipeline auto-dev` label selection exactly — **included**: `verify-ready`, unlabeled candidates; **excluded**: `verify-done`, `needs-review`, `decision-needed`.
+
+## Open PR Processing Rules
+
+After each `/homework` gate, FSD processes all open PRs before checking convergence:
+
+| PR State | Action |
+|----------|--------|
+| CI passing | Delegate merge to [[mgr-gitnerd]]; verify via `gh pr view` (R020) |
+| Dependabot frozen-lockfile cascade (CI failing) | Run `bun install` to regenerate lockfile → merge after CI passes |
+| Requires design judgment | Defer + surface to user; continue loop |
+| User explicitly skipped | Respect skip per [R015](../rules/r015.md) directive persistence |
+
+PR merge execution is always delegated to [[mgr-gitnerd]] ([R010](../rules/r010.md)). Post-merge ground-truth verification uses `gh pr view` ([R020](../rules/r020.md)).
+
+## Loop Convergence
+
+FSD converges when **both** conditions are met:
+
+1. Auto-dev-eligible issue set = 0 (no `verify-ready` or unlabeled candidates)
+2. Open PR set = 0 (all PRs merged or explicitly deferred)
+
+Checking only issue eligibility and ignoring open PRs is insufficient for convergence.
 
 ## Safety and Discipline
 
@@ -72,9 +97,10 @@ FSD operates under full project rules without relaxation:
 |------|------------|
 | [R001](../rules/r001.md) | Destructive ops require explicit approval; credential guardrails always active |
 | [R009](../rules/r009.md) | Independent subtasks within each iteration run in parallel |
-| [R010](../rules/r010.md) | All file modifications delegated to specialist subagents; mgr-gitnerd for git |
+| [R010](../rules/r010.md) | All file modifications delegated to specialist subagents; mgr-gitnerd for git and PR merges |
+| [R015](../rules/r015.md) | User directive persistence — explicitly skipped PRs are not retried |
 | [R017](../rules/r017.md) | mgr-sauron must pass before any commit/push |
-| [R020](../rules/r020.md) | Each release verified via `npm view` + `gh release view` + closed issues before `[Done]` |
+| [R020](../rules/r020.md) | Each release and PR merge verified via ground-truth checks before `[Done]` |
 
 `/homework` is a mandatory retrospective gate between iterations — it is NOT skipped in automated mode. If homework requires user confirmation (e.g., to file a feedback issue), the loop pauses and waits.
 
@@ -82,17 +108,17 @@ FSD operates under full project rules without relaxation:
 
 | Scenario | Use FSD? |
 |----------|----------|
-| Multiple eligible issues, "let it run" autonomously | YES |
+| Multiple eligible issues and/or open PRs, "let it run" autonomously | YES |
 | Single targeted fix | NO — use `/pipeline auto-dev` directly |
 | Issues require design decisions or stakeholder approval | NO |
-| Only `decision-needed` / `needs-review` issues remain | NO — loop converges immediately |
+| Only `decision-needed` / `needs-review` issues remain and no open PRs | NO — loop converges immediately |
 | Cost-sensitive, large backlog | Inspect eligible set first |
 
 ## Relationships
 
-- **Delegates to**: [[goal]] (objective wrapper + R020 verification), [[pipeline]] (auto-dev release pipeline per iteration), [[homework]] (retrospective gate per iteration)
+- **Delegates to**: [[goal]] (objective wrapper + R020 verification), [[pipeline]] (auto-dev release pipeline per iteration), [[homework]] (retrospective gate per iteration), [[mgr-gitnerd]] (git operations and PR merges)
 - **Session continuity**: [[omcustom-loop]] (SubagentStop hook keeps session alive during background agent work)
-- **Rules**: [R001](../rules/r001.md), [R009](../rules/r009.md), [R010](../rules/r010.md), [R017](../rules/r017.md), [R020](../rules/r020.md)
+- **Rules**: [R001](../rules/r001.md), [R009](../rules/r009.md), [R010](../rules/r010.md), [R015](../rules/r015.md), [R017](../rules/r017.md), [R020](../rules/r020.md)
 
 ## Sources
 


### PR DESCRIPTION
## v1.0.11 — FSD open-PR 처리 확장 (R016)

### 변경
- **FSD 스킬 확장**: FSD 루프가 적격 이슈뿐 아니라 **open PR(dependabot 포함)도 처리**. 수렴 조건 = 이슈 0 AND open PR 0. PR Processing Rules 테이블 + Iteration Flow 갱신 (사용자 지시 "FSD는 PR들도 항상 다 처리").
- wiki/skills/fsd.md 동기화 + source-hash 재생성 (Phase B clean)
- version bump 1.0.10 → 1.0.11

### 함께 처리된 dependabot PR (이번 세션)
- #1389 @anthropic-ai/sdk 0.102.0 → 0.105.0 (frozen-lockfile 해소 후 머지)
- #1390 nodemailer 8.0.11 → 9.0.1 (frozen-lockfile 해소 후 머지)

### 검증
- deterministic self-check: template-sync / wiki Phase B / counts 49·117·23·57 / bun test 2021 pass 0 fail
- FSD 스킬 frontmatter 무변경 → mgr-sauron R017-skip (lite)