### PR TITLE
chore(release): bump to v1.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## v1.0.12

### 규칙 강화 (Rule Hardening)
- **R007/R008**: 외부 프로젝트 디버깅·SSH·배포 작업 세션 식별 헤더/prefix 누락 방지 — "External-Project / Debugging Session Vigilance" 섹션 추가 (#1401)
- **R005**: 샌드박스 환경 CLI 도구 부재 노트(WebFetch 우선, `command -v` 확인) + shell 출력 파싱 Python 우선 패턴 노트 추가 (#1401)
- wiki r005/r007/r008 갱신, template 동기화, source-hash 재생성

Milestone: v1.0.12
Previous: v1.0.11 → v1.0.12 (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)