### PR TITLE
chore(release): bump to v1.0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
Release v1.0.13 — version bump only.

## Changes in this release

- fix(pipeline): remove manual git tag from release step — delegate to auto-tag.yml (#1404)

## Milestone
Closes milestone v1.0.13 (issues: #1404)

Fixes #1404

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>