### PR TITLE
chore(release): bump to v1.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
Release v1.0.14 — version bump only.

## Changes in this release

- feat(rules): R007 empty-response (0-word turn termination) prohibition (#1409)

## Milestone
Closes milestone v1.0.14 (issues: #1409)

Fixes #1409

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>