### PR TITLE
release: v1.0.16 — 라이선스 PolyForm Noncommercial 전환 + GitHub Sponsors 후원

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [baekenough]

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.0.6",
-  "generatedAt": "2026-06-13T07:09:01.652Z",
-  "templateVersion": "1.0.6",
+  "generatorVersion": "1.0.16",
+  "generatedAt": "2026-06-26T03:05:07.489Z",
+  "templateVersion": "1.0.16",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",
@@ -10,13 +10,13 @@
       "component": "rules"
     },
     ".claude/rules/SHOULD-hud-statusline.md": {
-      "templateHash": "becbb63369f745cdb86612ba9a6c6d05a9a29487ac7ea19fd411ad32efabda82",
-      "size": 3867,
+      "templateHash": "e2c1dd9b5640d8293acdfb0d2fb8022812301291a723805320e93c61e94cb6de",
+      "size": 4750,
       "component": "rules"
     },
     ".claude/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "33fa01695ca88ced0b3f72e10c82a0fc79fafee5c381ce34df4e8b5e6f9f3582",
-      "size": 30552,
+      "templateHash": "517ac64d6fe95edf756cb4667b0607dc8785c7ed696d83831ce69f0f5e5e1bef",
+      "size": 33618,
       "component": "rules"
     },
     ".claude/rules/MUST-intent-transparency.md": {
@@ -50,13 +50,13 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
-      "templateHash": "2a097db541f60a0a7f3108c4667f85b69c190e736d5f1bc1f4d9ad8f3856d155",
-      "size": 29280,
+      "templateHash": "b8b1c36c9f0f20238dac8dcb1ed6364fc3712d31d2b9c8171851ca306b831617",
+      "size": 32528,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
-      "templateHash": "24f5d22a536d7fc201a497d3dec3755360552acf6dc02e088ced5bb311b2f0e0",
-      "size": 3432,
+      "templateHash": "3f896d30e70d53204243d82415d29ef9f9230d688d9b4fdae6e0932e06637668",
+      "size": 5082,
       "component": "rules"
     },
     ".claude/rules/MUST-sync-verification.md": {
@@ -65,13 +65,13 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-teams.md": {
-      "templateHash": "3ccf372e1432c6955594932c56731ca1706cdbf75887481599c8078701d1a8ca",
-      "size": 22826,
+      "templateHash": "fc4c17ccb531d604cb5628edd00f124f2c490fc1d9734746c8f2be5cd45e51d5",
+      "size": 23477,
       "component": "rules"
     },
     ".claude/rules/MAY-optimization.md": {
-      "templateHash": "f31af77a3333ea4b668f97d0f233df3241fbe8e8460beceaae109626aa26d180",
-      "size": 2791,
+      "templateHash": "c4ac1dfa3b257ac775ea88484cbf7ac454e12c0df611ee8ea91bca56f8d9fe60",
+      "size": 3772,
       "component": "rules"
     },
     ".claude/rules/MUST-continuous-improvement.md": {
@@ -80,8 +80,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-permissions.md": {
-      "templateHash": "0a21c7f55b2bea42ccfa2ace819ebc46b140ec43369ffbd5807c90ec67cf3b95",
-      "size": 3474,
+      "templateHash": "34ef44c4cbf9c8bc17c86d754001f79abdf95abae7e8b64a49b33a9ea85a42a6",
+      "size": 5668,
       "component": "rules"
     },
     ".claude/rules/SHOULD-ontology-rag-routing.md": {
@@ -90,13 +90,13 @@
       "component": "rules"
     },
     ".claude/rules/MUST-safety.md": {
-      "templateHash": "d1a38e5a6e0d6679163685d96c8bfc5c58dc16fca1dcc6d6dea153644cd16125",
-      "size": 8543,
+      "templateHash": "cd461ca55fe5b1a2310d8e837868f27f5b9988b5f2f4529565f66a116059e876",
+      "size": 9853,
       "component": "rules"
     },
     ".claude/rules/MUST-tool-identification.md": {
-      "templateHash": "aa89ecab0c3a1518e2b1e1ebbdab9bd5b142cace9afe5ac38dc8f9b8992694ff",
-      "size": 6101,
+      "templateHash": "2baaf19bcc8eb68371693d46778c30ca8b31d08483baa271b48737785e57c92b",
+      "size": 7092,
       "component": "rules"
     },
     ".claude/rules/SHOULD-verification-ladder.md": {
@@ -120,8 +120,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-completion-verification.md": {
-      "templateHash": "19e3ebda2f11e74f5cf517f5b451e4f564d5e0ebace73cedc264f07170d71750",
-      "size": 23647,
+      "templateHash": "7ab1dcd605b16d042b8a9a1ecd4afd82392c165d81eff548a7d9b22c39412b94",
+      "size": 25644,
       "component": "rules"
     },
     ".claude/agents/be-springboot-expert.md": {
@@ -485,8 +485,8 @@
       "component": "skills"
     },
     ".claude/skills/pipeline/workflows/auto-dev.yaml": {
-      "templateHash": "8719c1c83c1cbe16b1e0cde1427dd1eee4f18e1acf35675a9bb6368cfd7c8d15",
-      "size": 19724,
+      "templateHash": "6c8f1e6774bb515d3ac38e64fb4822cb5afa1e81738b53c1aaa8e766458b87d6",
+      "size": 21726,
       "component": "skills"
     },
     ".claude/skills/pipeline/SKILL.md": {
@@ -685,8 +685,8 @@
       "component": "skills"
     },
     ".claude/skills/claude-native/SKILL.md": {
-      "templateHash": "531a911a7f7b1330a2c8cfaa266a41c5e58e6a3c63ca7758c0de54c262c4580d",
-      "size": 6091,
+      "templateHash": "fb2e0da707efbda24c3b46cd58f2729b4a816ab9cb303889eaaf90a6bc98bbc8",
+      "size": 6159,
       "component": "skills"
     },
     ".claude/skills/model-escalation/SKILL.md": {
@@ -755,8 +755,8 @@
       "component": "skills"
     },
     ".claude/skills/fsd/SKILL.md": {
-      "templateHash": "56cfd6e36baab020a4a3fe6c06a91035d85d74fb7dcc3398b475185df001829e",
-      "size": 6874,
+      "templateHash": "4968355e6b2ccd1bddb7b27c1e4abee1b3da15d76358a26a457cf2766a809a58",
+      "size": 8962,
       "component": "skills"
     },
     ".claude/skills/dev-lead-routing/SKILL.md": {
@@ -765,8 +765,8 @@
       "component": "skills"
     },
     ".claude/skills/scout/SKILL.md": {
-      "templateHash": "cc4b7d6b9e84cb36cf7ae1585dd85caa8c5cc9af545c546c7a4072776c5192bd",
-      "size": 9835,
+      "templateHash": "d6f9b95a440c175a3fe66604f67b4b8c4365ab45099138b1340509c6cc1fa560",
+      "size": 9812,
       "component": "skills"
     },
     ".claude/skills/status/SKILL.md": {

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,75 @@
-MIT License
+# PolyForm Noncommercial License 1.0.0
 
-Copyright (c) 2026 baekenough
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Required Notice: Copyright (c) 2026 baekenough (https://github.com/baekenough)
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+## Acceptance
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose. However, you may only distribute the software according to Distribution License and make changes or new works based on the software according to Changes and New Works License.
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software. Your license to distribute covers distributing the software with changes and new works permitted by Changes and New Works License.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software. For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else. These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice. Otherwise, all your licenses end immediately.
+
+## No Liability
+
+As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization. **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise. Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > **Your AI Agent Stack. Compiled, Not Configured.**
 
 [![npm version](https://img.shields.io/npm/v/oh-my-customcode.svg)](https://www.npmjs.com/package/oh-my-customcode)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: PolyForm NC 1.0.0](https://img.shields.io/badge/License-PolyForm%20Noncommercial%201.0.0-blue.svg)](https://polyformproject.org/licenses/noncommercial/1.0.0/)
 [![CI](https://github.com/baekenough/oh-my-customcode/actions/workflows/ci.yml/badge.svg)](https://github.com/baekenough/oh-my-customcode/actions/workflows/ci.yml)
 [![Security Audit](https://github.com/baekenough/oh-my-customcode/actions/workflows/security-audit.yml/badge.svg)](https://github.com/baekenough/oh-my-customcode/actions/workflows/security-audit.yml)
 
@@ -309,9 +309,23 @@ Requirements: Node.js >= 18.0.0, Claude Code CLI.
 
 ---
 
+## Support
+
+If oh-my-customcode saves you time or you like where it's heading, consider supporting development:
+
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-GitHub-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/baekenough)
+
+Every contribution keeps the compiler running. ☕
+
+---
+
 ## License
 
-[MIT](LICENSE)
+This project is licensed under the **[PolyForm Noncommercial License 1.0.0](LICENSE)**.
+
+You are free to **use, modify, and distribute** oh-my-customcode for any **noncommercial** purpose — personal projects, research, education, and nonprofit/government use. **Commercial use is not permitted** under this license.
+
+Need a commercial license? Open an issue or reach out to the author.
 
 ---
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -7,7 +7,7 @@
 > **AI 에이전트 스택. 설정이 아닌 컴파일.**
 
 [![npm version](https://img.shields.io/npm/v/oh-my-customcode.svg)](https://www.npmjs.com/package/oh-my-customcode)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: PolyForm NC 1.0.0](https://img.shields.io/badge/License-PolyForm%20Noncommercial%201.0.0-blue.svg)](https://polyformproject.org/licenses/noncommercial/1.0.0/)
 [![CI](https://github.com/baekenough/oh-my-customcode/actions/workflows/ci.yml/badge.svg)](https://github.com/baekenough/oh-my-customcode/actions/workflows/ci.yml)
 [![Security Audit](https://github.com/baekenough/oh-my-customcode/actions/workflows/security-audit.yml/badge.svg)](https://github.com/baekenough/oh-my-customcode/actions/workflows/security-audit.yml)
 
@@ -335,9 +335,23 @@ bun run cli -- --help
 
 ---
 
+## 후원
+
+oh-my-customcode가 시간을 아껴드렸거나 방향이 마음에 드신다면, 개발을 후원해 주세요:
+
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-GitHub-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/baekenough)
+
+여러분의 후원이 컴파일러를 계속 돌아가게 합니다. ☕
+
+---
+
 ## 라이선스
 
-[MIT](LICENSE)
+이 프로젝트는 **[PolyForm Noncommercial License 1.0.0](LICENSE)** 라이선스를 따릅니다.
+
+**비상업적** 목적(개인 프로젝트, 연구, 교육, 비영리/정부 용도)에 한해 자유롭게 **사용·수정·배포**할 수 있습니다. 본 라이선스에서 **상업적 이용은 허용되지 않습니다**.
+
+상업용 라이선스가 필요하시면 이슈를 열거나 작성자에게 문의해 주세요.
 
 ---
 

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -241,7 +241,7 @@ var init_package = __esm(() => {
     workspaces: [
       "packages/*"
     ],
-    version: "1.0.6",
+    version: "1.0.16",
     description: "Batteries-included agent harness for Claude Code",
     type: "module",
     bin: {
@@ -289,13 +289,13 @@ var init_package = __esm(() => {
       yaml: "^2.8.2"
     },
     devDependencies: {
-      "@anthropic-ai/sdk": "^0.102.0",
+      "@anthropic-ai/sdk": "^0.105.0",
       "@biomejs/biome": "^2.3.12",
       "@types/bun": "^1.3.6",
       "@types/js-yaml": "^4.0.9",
       "@types/nodemailer": "^8.0.0",
-      "js-yaml": "^4.1.0",
-      nodemailer: "^8.0.1",
+      "js-yaml": "^5.0.0",
+      nodemailer: "^9.0.1",
       typescript: "^6.0.2",
       vitepress: "^1.6.4"
     },
@@ -308,7 +308,11 @@ var init_package = __esm(() => {
       "cli"
     ],
     author: "baekenough",
-    license: "MIT",
+    funding: {
+      type: "github",
+      url: "https://github.com/sponsors/baekenough"
+    },
+    license: "PolyForm-Noncommercial-1.0.0",
     repository: {
       type: "git",
       url: "git+https://github.com/baekenough/oh-my-customcode.git"

--- a/dist/index.js
+++ b/dist/index.js
@@ -2031,7 +2031,7 @@ var package_default = {
   workspaces: [
     "packages/*"
   ],
-  version: "1.0.6",
+  version: "1.0.16",
   description: "Batteries-included agent harness for Claude Code",
   type: "module",
   bin: {
@@ -2079,13 +2079,13 @@ var package_default = {
     yaml: "^2.8.2"
   },
   devDependencies: {
-    "@anthropic-ai/sdk": "^0.102.0",
+    "@anthropic-ai/sdk": "^0.105.0",
     "@biomejs/biome": "^2.3.12",
     "@types/bun": "^1.3.6",
     "@types/js-yaml": "^4.0.9",
     "@types/nodemailer": "^8.0.0",
-    "js-yaml": "^4.1.0",
-    nodemailer: "^8.0.1",
+    "js-yaml": "^5.0.0",
+    nodemailer: "^9.0.1",
     typescript: "^6.0.2",
     vitepress: "^1.6.4"
   },
@@ -2098,7 +2098,11 @@ var package_default = {
     "cli"
   ],
   author: "baekenough",
-  license: "MIT",
+  funding: {
+    type: "github",
+    url: "https://github.com/sponsors/baekenough"
+  },
+  license: "PolyForm-Noncommercial-1.0.0",
   repository: {
     type: "git",
     url: "git+https://github.com/baekenough/oh-my-customcode.git"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {
@@ -70,7 +70,11 @@
     "cli"
   ],
   "author": "baekenough",
-  "license": "MIT",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/baekenough"
+  },
+  "license": "PolyForm-Noncommercial-1.0.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/baekenough/oh-my-customcode.git"

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lastUpdated": "2026-05-20T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 변경 요약

- **라이선스 전환**: MIT → PolyForm Noncommercial License 1.0.0. 비상업적 사용/수정/배포만 허용, 상업적 이용 금지. (LICENSE 전문 교체, README/README_ko 배지·섹션, package.json license SPDX)
- **후원 추가**: GitHub Sponsors (`github.com/sponsors/baekenough`). FUNDING.yml(Sponsor 버튼), README 배지, package.json funding 필드.
- **version bump**: 1.0.15 → 1.0.16 (package.json + templates/manifest.json 동기화, build 산출물 갱신).

🤖 Generated with [Claude Code](https://claude.com/claude-code)