### PR TITLE
fix(hooks): pre-commit 커버리지 게이트 FORCE_COLOR ANSI 오탐 수정 (v1.1.5)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -64,7 +64,8 @@ fi
 
 # Run tests with coverage
 echo "Running tests with coverage..."
-COVERAGE_OUTPUT=$(bun test --coverage 2>&1)
+# FORCE_COLOR 환경에서 ANSI 이스케이프가 coverage 숫자 파싱을 오염시키는 것 방지 (#1437)
+COVERAGE_OUTPUT=$(env -u FORCE_COLOR NO_COLOR=1 bun test --coverage 2>&1)
 TEST_EXIT_CODE=$?
 echo "$COVERAGE_OUTPUT"
 
@@ -82,8 +83,10 @@ fi
 COVERAGE_LINE=$(echo "$COVERAGE_OUTPUT" | grep -E "All files.*\|")
 
 if [ -n "$COVERAGE_LINE" ]; then
-    FUNC_COV=$(echo "$COVERAGE_LINE" | awk -F'|' '{print $2}' | tr -d ' ')
-    LINE_COV=$(echo "$COVERAGE_LINE" | awk -F'|' '{print $3}' | tr -d ' ')
+    # ANSI 이스케이프 잔존 대비 이중 방어 strip (#1437) — printf ESC로 BSD/GNU sed 양쪽 호환
+    ESC=$(printf '\033')
+    FUNC_COV=$(echo "$COVERAGE_LINE" | awk -F'|' '{print $2}' | sed "s/${ESC}\[[0-9;]*m//g" | tr -d ' ')
+    LINE_COV=$(echo "$COVERAGE_LINE" | awk -F'|' '{print $3}' | sed "s/${ESC}\[[0-9;]*m//g" | tr -d ' ')
 
     echo "Function coverage: $FUNC_COV%"
     echo "Line coverage: $LINE_COV%"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lastUpdated": "2026-07-01T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약

- **근본 원인**: `FORCE_COLOR` 환경변수가 설정된 상태에서 `bun test --coverage` 실행 시 출력에 ANSI 컬러 이스케이프 시퀀스가 포함되고, pre-commit hook의 커버리지 게이트 awk 파싱이 이를 숫자로 오독해 실제 커버리지(98%+)를 통과했음에도 항상 실패로 오탐 처리되던 문제를 수정합니다.
- **수정 내용**:
  - coverage 실행 시 `env -u FORCE_COLOR NO_COLOR=1`로 컬러 출력 자체를 억제 (근본 수정)
  - 파싱 단계에도 ANSI escape strip 이중 방어 추가 (BSD/GNU sed 호환)
  - `.husky/pre-commit`에 동일 적용 (`.git/hooks/pre-commit`은 git 미추적 로컬 실행본이라 이번 커밋 대상 아님)
- version bump: 1.1.4 → 1.1.5 (package.json, templates/manifest.json)

Fixes #1437

## Test plan

- [x] `bun test --coverage` (FORCE_COLOR=3 환경) — 게이트 정상 통과 확인 (98.26%/98.37%)
- [x] `--programmatic-only` validate-docs / template-sync / version-sync EXIT=0
- [ ] CI green 확인 후 별도로 머지 (본 PR은 머지하지 않음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)