### PR TITLE
fix(cc-monitor): 이슈 본문 선행 들여쓰기 버그 수정 (textwrap.dedent 제거)

### DIFF
--- a/.github/workflows/cc-release-monitor.yml
+++ b/.github/workflows/cc-release-monitor.yml
@@ -30,7 +30,6 @@ jobs:
           import re
           import subprocess
           import sys
-          import textwrap
           import urllib.error
           import urllib.request
 
@@ -196,43 +195,32 @@ jobs:
                   )
 
               if body_raw:
-                  original_block = textwrap.dedent(f"""\
-
-                      <details>
-                      <summary>🔤 원문 (What's Changed)</summary>
-
-                      {body_truncated}
-
-                      </details>
-                      """)
+                  original_block = (
+                      "\n<details>\n"
+                      "<summary>🔤 원문 (What's Changed)</summary>\n\n"
+                      + body_truncated + "\n\n"
+                      "</details>\n"
+                  )
               else:
                   original_block = ""
 
-              issue_body = textwrap.dedent(f"""\
-                  # Claude Code {version}
-
-                  **Release:** {version}
-                  **Published:** {published_at}
-                  **Link:** {html_url}
-
-                  ## 릴리즈 요약 (한국어)
-
-                  {summary_text}
-                  """) + original_block + textwrap.dedent("""\
-
-                  ---
-
-                  ## 액션 아이템
-
-                  - [ ] oh-my-customcode 영향도 관점에서 릴리즈 노트 검토
-                  - [ ] 새 Claude Code 기능이 에이전트에 영향을 주면 에이전트 정의 갱신
-                  - [ ] 현재 oh-my-customcode 버전과의 호환성 테스트
-                  - [ ] 새 기능이 관련되면 CLAUDE.md 갱신
-
-                  ---
-
-                  _이 이슈는 cc-release-monitor GitHub Actions 워크플로우가 자동 생성했습니다._\
-              """)
+              issue_body = (
+                  f"# Claude Code {version}\n\n"
+                  f"**Release:** {version}\n"
+                  f"**Published:** {published_at}\n"
+                  f"**Link:** {html_url}\n\n"
+                  "## 릴리즈 요약 (한국어)\n\n"
+                  f"{summary_text}\n"
+                  + original_block +
+                  "\n---\n\n"
+                  "## 액션 아이템\n\n"
+                  "- [ ] oh-my-customcode 영향도 관점에서 릴리즈 노트 검토\n"
+                  "- [ ] 새 Claude Code 기능이 에이전트에 영향을 주면 에이전트 정의 갱신\n"
+                  "- [ ] 현재 oh-my-customcode 버전과의 호환성 테스트\n"
+                  "- [ ] 새 기능이 관련되면 CLAUDE.md 갱신\n\n"
+                  "---\n\n"
+                  "_이 이슈는 cc-release-monitor GitHub Actions 워크플로우가 자동 생성했습니다._\n"
+              )
 
               create = subprocess.run(
                   [


### PR DESCRIPTION
## 배경

`workflow_dispatch` 실검증에서 재생성된 이슈 #1450 본문을 확인한 결과, `<details>` 블록과 한국어 요약 등에 12칸 리터럴 들여쓰기가 붙어 렌더링이 깨지는 것을 발견했습니다.

## 원인

`textwrap.dedent(f"""...{멀티라인변수}...""")` 패턴의 함정입니다. 템플릿 리터럴 자체는 10~12칸 들여쓰기가 있지만, 삽입된 멀티라인 변수(`body_truncated`)는 들여쓰기가 0입니다. `dedent`는 전체 문자열에서 **공통 최소 들여쓰기**를 계산하는데, 삽입된 변수의 0-들여쓰기 라인 때문에 공통 최소값이 0이 되어 템플릿 리터럴의 원래 들여쓰기가 벗겨지지 않습니다.

## 수정

`textwrap.dedent`를 제거하고, `original_block`과 `issue_body` 조립을 명시적 문자열 concatenation으로 교체했습니다. 이렇게 하면 들여쓰기 함정 자체가 발생하지 않습니다. 다른 곳에서 `textwrap`을 사용하지 않아 `import textwrap`도 함께 제거했습니다.

## 로컬 검증 결과 (R020 shift-left)

- 조립 로직을 독립 스크립트로 추출해 멀티라인 샘플 값(원문 + 한국어 요약)으로 `issue_body`를 실제 조립 → 출력에 선행 들여쓰기 없음 확인 (`grep -nE '^[ ]+(#|<details>|<summary>|##|-)'` 매치 없음)
- 워크플로우 내 heredoc Python 코드 전체를 추출해 `py_compile`로 문법 검증 통과
- `yaml.safe_load`로 전체 워크플로우 YAML 파싱 통과
- `grep textwrap` 결과 완전 제거 확인

## 변경 범위

`.github/workflows/cc-release-monitor.yml` 1개 파일만 수정. 다른 로직(번역, dedup, MAX_BODY 트렁케이션, summary_text 분기)은 변경 없음.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)