### PR TITLE
chore(release): bump to v1.1.9

### DIFF
--- a/.claude/rules/MUST-sync-verification.md
+++ b/.claude/rules/MUST-sync-verification.md
@@ -110,6 +110,17 @@ Any change to: agents, agent frontmatter, skills, guides, routing patterns, rule
 |--------------|----------|
 | 원격 머지 후 stale 로컬 develop에서 릴리즈 브랜치 분기 | 분기 전 `git pull origin develop`; PR 생성 후 mergeStateStatus 확인 — CONFLICTING이면 `git merge origin/develop`+both-유지 해결 후 재CI |
 
+## Pre-Release Target Version Ground-Truth Gate (Origin: #1457)
+
+새 릴리즈의 target 버전을 선정하거나 구현/구현-위임 프롬프트에 target 버전을 전달하기 전, 반드시 원격 실측으로 다음 버전을 확정한다: `git tag --sort=-v:refname | head -1`(최신 태그) + `npm view <pkg> version`(배포된 최신)의 **max에 patch를 더한 값**을 target으로 삼는다. 세션 메모리의 버전 스냅샷(예: "npm latest 1.1.6")은 **참고용이며 ground-truth가 아니다** — 직전 세션에서 릴리즈가 진행돼 stale일 수 있다. stale 버전으로 위임하면 이미 배포된 버전을 target으로 잡아 milestone-closed STOP에 걸리고 재타겟팅 왕복이 강제된다.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| 세션 메모리 버전 스냅샷으로 target 버전을 추정해 구현/릴리즈 위임 | 위임 전 `git tag`+`npm view` 실측 → max+patch를 target으로 확정 |
+| milestone-closed STOP에 걸린 뒤에야 stale을 인지 | 사전 실측으로 STOP+재위임 왕복을 원천 차단 (가드레일은 fail-safe이지 1차 방어선이 아님) |
+
+Origin: #1457 (Session 128 회고 찐빠 #1) — 오케스트레이터가 stale 메모리(npm 1.1.6→target v1.1.7 추정)로 implement를 위임 → v1.1.7이 이미 배포된 closed milestone임을 에이전트가 STOP으로 감지 → v1.1.8 재위임 왕복 1회. 기존 `feedback_session_memory_git_stale`(브랜치 분기 전 pull)의 릴리즈-버전-선정 각도 확장. Cross-ref: R020 (Diagnostic Hypothesis Verification — 영구 변경/위임 전 전제 실측 확정).
+
 ## Post-Gate Scope-Expansion Re-Run (Origin: #1433 #2)
 
 R017 게이트(mgr-sauron) 통과 선언 후 신규 결함 발견 등으로 스코프가 확장되면(추가 파일 편집), 커밋 전 게이트를 **최종 상태에서 재실행**한다. 게이트 통과 시점 이후의 변경은 형식적으로 미검증이므로, 확장분 미검증 커밋은 R017이 최종 산출물을 커버하지 못하게 만든다.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-sync-verification.md
+++ b/templates/.claude/rules/MUST-sync-verification.md
@@ -110,6 +110,17 @@ Any change to: agents, agent frontmatter, skills, guides, routing patterns, rule
 |--------------|----------|
 | 원격 머지 후 stale 로컬 develop에서 릴리즈 브랜치 분기 | 분기 전 `git pull origin develop`; PR 생성 후 mergeStateStatus 확인 — CONFLICTING이면 `git merge origin/develop`+both-유지 해결 후 재CI |
 
+## Pre-Release Target Version Ground-Truth Gate (Origin: #1457)
+
+새 릴리즈의 target 버전을 선정하거나 구현/구현-위임 프롬프트에 target 버전을 전달하기 전, 반드시 원격 실측으로 다음 버전을 확정한다: `git tag --sort=-v:refname | head -1`(최신 태그) + `npm view <pkg> version`(배포된 최신)의 **max에 patch를 더한 값**을 target으로 삼는다. 세션 메모리의 버전 스냅샷(예: "npm latest 1.1.6")은 **참고용이며 ground-truth가 아니다** — 직전 세션에서 릴리즈가 진행돼 stale일 수 있다. stale 버전으로 위임하면 이미 배포된 버전을 target으로 잡아 milestone-closed STOP에 걸리고 재타겟팅 왕복이 강제된다.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| 세션 메모리 버전 스냅샷으로 target 버전을 추정해 구현/릴리즈 위임 | 위임 전 `git tag`+`npm view` 실측 → max+patch를 target으로 확정 |
+| milestone-closed STOP에 걸린 뒤에야 stale을 인지 | 사전 실측으로 STOP+재위임 왕복을 원천 차단 (가드레일은 fail-safe이지 1차 방어선이 아님) |
+
+Origin: #1457 (Session 128 회고 찐빠 #1) — 오케스트레이터가 stale 메모리(npm 1.1.6→target v1.1.7 추정)로 implement를 위임 → v1.1.7이 이미 배포된 closed milestone임을 에이전트가 STOP으로 감지 → v1.1.8 재위임 왕복 1회. 기존 `feedback_session_memory_git_stale`(브랜치 분기 전 pull)의 릴리즈-버전-선정 각도 확장. Cross-ref: R020 (Diagnostic Hypothesis Verification — 영구 변경/위임 전 전제 실측 확정).
+
 ## Post-Gate Scope-Expansion Re-Run (Origin: #1433 #2)
 
 R017 게이트(mgr-sauron) 통과 선언 후 신규 결함 발견 등으로 스코프가 확장되면(추가 파일 편집), 커밋 전 게이트를 **최종 상태에서 재실행**한다. 게이트 통과 시점 이후의 변경은 형식적으로 미검증이므로, 확장분 미검증 커밋은 R017이 최종 산출물을 커버하지 못하게 만든다.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lastUpdated": "2026-07-01T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/wiki/.source-hashes.json
+++ b/wiki/.source-hashes.json
@@ -61,7 +61,7 @@
   ".claude/rules/MUST-parallel-execution.md": "f14a5659885f8080c6055f5a4947df5c6742b4f55288e1a1086ab998f26b6e5e",
   ".claude/rules/MUST-permissions.md": "6cd4dbf5bd8afabb0cb5884ddcd454056a18c45af687399e070f99d15c826e6b",
   ".claude/rules/MUST-safety.md": "b01d76c733fd840fd5e6479236c48e30beb7183e50d4a3842d83aa9f0a9dca0e",
-  ".claude/rules/MUST-sync-verification.md": "77e66d332ffa748d5f960d40a8babc2fd6ad2892ef72ef0d6704aee14892d0a5",
+  ".claude/rules/MUST-sync-verification.md": "50edf8f25fd8a67dcdc10b81f7be33a5a61911be3e7af5ca30cb9a03c7777c12",
   ".claude/rules/MUST-tool-identification.md": "4da6a3e23285deebc88c7f78fbe11755b8987aaccb7c58e77650d9607fc9d03b",
   ".claude/rules/SHOULD-ecomode.md": "91604776396a5b1beb27666704998f8fc6ec8a639ef2e4c47d8cfc57f5bb628b",
   ".claude/rules/SHOULD-error-handling.md": "9d200be09d91765b725a1a5de221b71c3c2b7dd40cffba2ab2c2e33aec08bb61",

--- a/wiki/rules/r017.md
+++ b/wiki/rules/r017.md
@@ -1,7 +1,7 @@
 ---
 title: "R017: Sync Verification Rules"
 type: rule
-updated: 2026-07-01
+updated: 2026-07-06
 sources:
   - .claude/rules/MUST-sync-verification.md
 related:
@@ -77,6 +77,17 @@ Structural changes can silently break routing tables, orphan skill references, o
 
 R017 게이트(mgr-sauron) 통과 선언 후 신규 결함 발견 등으로 스코프가 확장되면(추가 파일 편집), 커밋 전 게이트를 **최종 상태에서 재실행**한다. 게이트 통과 시점 이후의 변경은 형식적으로 미검증이므로, 확장분 미검증 커밋은 R017이 최종 산출물을 커버하지 못하게 만든다.
 
+## Pre-Release Target Version Ground-Truth Gate (#1457)
+
+새 릴리즈의 target 버전을 선정하거나 구현/구현-위임 프롬프트에 target 버전을 전달하기 전, 반드시 원격 실측으로 다음 버전을 확정한다: `git tag --sort=-v:refname | head -1`(최신 태그) + `npm view <pkg> version`(배포된 최신)의 **max에 patch를 더한 값**을 target으로 삼는다. 세션 메모리의 버전 스냅샷은 참고용이며 ground-truth가 아니다 — 직전 세션에서 릴리즈가 진행돼 stale일 수 있다. stale 버전으로 위임하면 이미 배포된 버전을 target으로 잡아 milestone-closed STOP에 걸리고 재타겟팅 왕복이 강제된다.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| 세션 메모리 버전 스냅샷으로 target 버전을 추정해 구현/릴리즈 위임 | 위임 전 `git tag`+`npm view` 실측 → max+patch를 target으로 확정 |
+| milestone-closed STOP에 걸린 뒤에야 stale을 인지 | 사전 실측으로 STOP+재위임 왕복을 원천 차단 (가드레일은 fail-safe이지 1차 방어선이 아님) |
+
+Origin: #1457 (Session 128 회고 찐빠 #1) — stale 메모리(npm 1.1.6→v1.1.7 추정)로 implement 위임 → v1.1.7 이미 배포된 closed milestone STOP → v1.1.8 재위임 왕복. `feedback_session_memory_git_stale`의 릴리즈-버전-선정 각도 확장.
+
 ## Enforcement
 
 Prompt-based self-check + `mgr-sauron:watch` verification flow. No hard-block hook — relies on developer discipline per [[r021]].
@@ -89,6 +100,7 @@ Prompt-based self-check + `mgr-sauron:watch` verification flow. No hard-block ho
 
 ## Sources
 
-- `.claude/rules/MUST-sync-verification.md` — rule definition (Structural Migration Verification added #1217; Pre-Branch Freshness Gate + Post-Gate Scope-Expansion Re-Run added #1433)
+- `.claude/rules/MUST-sync-verification.md` — rule definition (Structural Migration Verification added #1217; Pre-Branch Freshness Gate + Post-Gate Scope-Expansion Re-Run added #1433; Pre-Release Target Version Ground-Truth Gate added #1457)
 - Issue #1217 — flat templates path drift + CLAUDE.md ENOENT + skip state merge incidents (2026-05-24)
 - Issue #1433 — harness 개선 #1/#2: stale develop 분기 (≥3회 재발) + gate 통과 후 스코프 확장 미재검증 (2026-07-01)
+- Issue #1457 — release target 버전 선정 전 원격 실측 누락 → stale 메모리 기반 재타겟팅 왕복 (2026-07-06)


### PR DESCRIPTION
## v1.1.9 — R017 Pre-Release Target Version Ground-Truth Gate

Fixes #1457

### 변경 사항
- **R017** (sync verification): `Pre-Release Target Version Ground-Truth Gate` 신규 게이트 — 릴리즈 target 버전을 선정/위임하기 전 `git tag --sort=-v:refname | head -1` + `npm view <pkg> version`의 max+patch를 실측으로 확정. 세션 메모리 버전 스냅샷은 ground-truth 아님. (#1457)

### 배경
본 세션(Iteration 1)에서 stale 메모리(npm 1.1.6)로 v1.1.7을 target으로 잡아 milestone-closed STOP+재위임 왕복이 발생 → 이를 규칙으로 승격. Iteration 2(본 릴리즈)는 이 게이트를 dogfooding하여 v1.1.9를 실측 선정, 왕복 없이 진행.

### 검증
- verify-version-sync exit 0
- validate-docs --programmatic-only PASS (agents 49 / skills 118 / rules 23 / guides 57)
- bun test 2021 pass / 0 fail (pre-commit hook)
- 커밋 SHA: b0972cc1

🤖 Generated with [Claude Code](https://claude.com/claude-code)