### PR TITLE
chore(release): v1.1.11 — 하네스 감사 후속 정리

### DIFF
--- a/.claude/rules/MUST-completion-verification.md
+++ b/.claude/rules/MUST-completion-verification.md
@@ -157,9 +157,7 @@ Record findings in session context. Failure to inventory automation is a R020 vi
 
 ### Cross-reference
 
-Related memory records:
-- `feedback_github_workflows_inventory.md` — original incident (v0.87.2~v0.88.0 session)
-- `feedback_subagent_pre_existing_claims.md` — subagent false-positive pattern
+Original incident: v0.87.2~v0.88.0 session (issue #869). The originating memory files were later consolidated/removed; no live equivalents remain as of this writing.
 -->
 
 ## Interrupt Priority Re-Ordering

--- a/.claude/rules/MUST-orchestrator-coordination.md
+++ b/.claude/rules/MUST-orchestrator-coordination.md
@@ -391,7 +391,7 @@ Before delegating a task to a subagent, MUST verify the target agent's tool capa
 ✓ CORRECT: Pre-check arch-documenter.disallowedTools → collect data first → pass as content
 ```
 
-Reference issues: #1202 item #2, `feedback_arch_documenter_bash_precheck.md`.
+Reference issues: #1202 item #2, `feedback_arch_documenter_no_bash.md`.
 
 ## Sensitive Path Handling (Historical: pre-CC v2.1.121)
 

--- a/.claude/rules/SHOULD-memory-integration.md
+++ b/.claude/rules/SHOULD-memory-integration.md
@@ -370,10 +370,7 @@ Session-end saves lose context: by the time the session ends, multiple discoveri
 
 ### Cross-reference
 
-Related records from session v0.87.2~v0.88.0 (issue #869):
-- `feedback_subagent_pre_existing_claims.md`
-- `feedback_github_workflows_inventory.md`
-- `feedback_bun_mock_module.md`
+Related records from session v0.87.2~v0.88.0 (issue #869). The originating memory files were later consolidated/removed; no live equivalents remain as of this writing.
 -->
 
 ## Safety-Related Feedback Memory Framing

--- a/.claude/rules/SHOULD-verification-ladder.md
+++ b/.claude/rules/SHOULD-verification-ladder.md
@@ -22,7 +22,7 @@
 - **좋은 예**: JSON schema 오류 → Tier 1 hook이 차단 → LLM에 미전달
 - **나쁜 예**: 탭/스페이스 혼용 오류 → sonnet으로 전달 → 불필요한 비용 발생
 
-R013 (SHOULD-ecomode)의 "저렴한 검증 우선" 원칙과 정합: ecomode는 출력 토큰을 절약하고, R023은 검증 비용을 절약한다.
+R013 (SHOULD-ecomode)의 출력 토큰 절약 원칙(Compact Output — 중간 단계·장황한 설명 생략)과 정합: ecomode는 출력 토큰을, R023은 검증 비용을 절약한다.
 
 ## 기존 자산 매핑
 

--- a/.claude/skills/vercel-deploy/SKILL.md
+++ b/.claude/skills/vercel-deploy/SKILL.md
@@ -57,10 +57,6 @@ Preview: https://project-xxx.vercel.app
 Claim: https://vercel.com/claim/xxx
 ```
 
-## Scripts
-
-See `scripts/deploy.sh` for deployment automation.
-
 ## Requirements
 
 - Valid project structure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.11] - 2026-07-14 — 하네스 감사 후속 정리 (깨진 참조 + wiki)
+
+### Fixed
+- #1472 (부분): 깨진 참조 정정 — vercel-deploy `scripts/deploy.sh`, guides/agent-eval monitoring-setup 경로, 14-token-efficiency update-config 경로, R023 dangling R013 참조, 존재하지 않는 feedback 메모리 참조 4건. (dist/ untrack·hook 주석 등 파괴적/훅 항목은 승인 필요로 별도 처리)
+- #1476 (부분): wiki 결함 정정 — qa-engineer 위키 페이지 재작성(verbatim 사본 해소), autonomous-challenge-lessons frontmatter 추가. (hooks·CI 핀·structure 파괴적 항목은 별도 처리)
+
 ## [1.1.10] - 2026-07-14 — Fable 5 하네스 감사 수정 배치
 
 ### Fixed

--- a/guides/agent-eval/README.md
+++ b/guides/agent-eval/README.md
@@ -824,5 +824,10 @@ harness-eval이 task를 실행하면 agent-eval-framework가 4-metric을 측정�
 | 가이드 | 경로 | 관련성 |
 |--------|------|--------|
 | harness-engineering | `guides/harness-engineering/` | 평가 하네스 인프라 설계 |
-| monitoring-setup | `guides/monitoring-setup/` | OTEL 통합 (향후 tracing 보강) |
 | multi-agent-debate-patterns | `guides/multi-agent-debate-patterns/` | 다중 에이전트 평가 패턴 |
+
+### 관련 스킬
+
+| 스킬 | 경로 | 관련성 |
+|------|------|--------|
+| monitoring-setup | `.claude/skills/monitoring-setup/` | OTEL 통합 (향후 tracing 보강) |

--- a/guides/claude-code/14-token-efficiency.md
+++ b/guides/claude-code/14-token-efficiency.md
@@ -224,7 +224,7 @@ External plugin (JuliusBrussee/caveman, 41.6k stars, MIT) that rewrites Claude r
 - `.claude/rules/SHOULD-ecomode.md` — Layer 2 R013 specification
 - `.claude/skills/token-efficiency-audit/SKILL.md` — Layer 3 HOW: audit and apply
 - `.claude/skills/monitoring-setup/SKILL.md` — Measure effectiveness via OTel metrics
-- `.claude/skills/update-config/` — Generic settings.json manipulation (broader scope)
+- CC bundled `update-config` skill — Generic settings.json manipulation (broader scope; not a project-local skill)
 - `.claude/skills/playwright-compress/SKILL.md` — Layer 4 MCP output compression hook
 - `.claude/hooks/scripts/playwright-compress.sh` — Layer 4 hook script
 - `https://github.com/JuliusBrussee/caveman` — Layer 5 caveman plugin (external)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-completion-verification.md
+++ b/templates/.claude/rules/MUST-completion-verification.md
@@ -157,9 +157,7 @@ Record findings in session context. Failure to inventory automation is a R020 vi
 
 ### Cross-reference
 
-Related memory records:
-- `feedback_github_workflows_inventory.md` — original incident (v0.87.2~v0.88.0 session)
-- `feedback_subagent_pre_existing_claims.md` — subagent false-positive pattern
+Original incident: v0.87.2~v0.88.0 session (issue #869). The originating memory files were later consolidated/removed; no live equivalents remain as of this writing.
 -->
 
 ## Interrupt Priority Re-Ordering

--- a/templates/.claude/rules/MUST-orchestrator-coordination.md
+++ b/templates/.claude/rules/MUST-orchestrator-coordination.md
@@ -391,7 +391,7 @@ Before delegating a task to a subagent, MUST verify the target agent's tool capa
 ✓ CORRECT: Pre-check arch-documenter.disallowedTools → collect data first → pass as content
 ```
 
-Reference issues: #1202 item #2, `feedback_arch_documenter_bash_precheck.md`.
+Reference issues: #1202 item #2, `feedback_arch_documenter_no_bash.md`.
 
 ## Sensitive Path Handling (Historical: pre-CC v2.1.121)
 

--- a/templates/.claude/rules/SHOULD-memory-integration.md
+++ b/templates/.claude/rules/SHOULD-memory-integration.md
@@ -370,10 +370,7 @@ Session-end saves lose context: by the time the session ends, multiple discoveri
 
 ### Cross-reference
 
-Related records from session v0.87.2~v0.88.0 (issue #869):
-- `feedback_subagent_pre_existing_claims.md`
-- `feedback_github_workflows_inventory.md`
-- `feedback_bun_mock_module.md`
+Related records from session v0.87.2~v0.88.0 (issue #869). The originating memory files were later consolidated/removed; no live equivalents remain as of this writing.
 -->
 
 ## Safety-Related Feedback Memory Framing

--- a/templates/.claude/rules/SHOULD-verification-ladder.md
+++ b/templates/.claude/rules/SHOULD-verification-ladder.md
@@ -22,7 +22,7 @@
 - **좋은 예**: JSON schema 오류 → Tier 1 hook이 차단 → LLM에 미전달
 - **나쁜 예**: 탭/스페이스 혼용 오류 → sonnet으로 전달 → 불필요한 비용 발생
 
-R013 (SHOULD-ecomode)의 "저렴한 검증 우선" 원칙과 정합: ecomode는 출력 토큰을 절약하고, R023은 검증 비용을 절약한다.
+R013 (SHOULD-ecomode)의 출력 토큰 절약 원칙(Compact Output — 중간 단계·장황한 설명 생략)과 정합: ecomode는 출력 토큰을, R023은 검증 비용을 절약한다.
 
 ## 기존 자산 매핑
 

--- a/templates/.claude/skills/vercel-deploy/SKILL.md
+++ b/templates/.claude/skills/vercel-deploy/SKILL.md
@@ -57,10 +57,6 @@ Preview: https://project-xxx.vercel.app
 Claim: https://vercel.com/claim/xxx
 ```
 
-## Scripts
-
-See `scripts/deploy.sh` for deployment automation.
-
 ## Requirements
 
 - Valid project structure

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.10",
+  "version": "1.1.11",
   "lastUpdated": "2026-07-01T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/wiki/agents/qa-engineer.md
+++ b/wiki/agents/qa-engineer.md
@@ -1,43 +1,47 @@
 ---
-name: qa-engineer
-description: Use when you need to execute tests based on detailed plans and documentation, perform manual and automated testing, report defects, and validate fixes
-model: sonnet
-domain: universal
-memory: project
-effort: medium
-maxTurns: 20
-limitations:
-  - "cannot modify source code in production branches"
-tools:
-  - Read
-  - Write
-  - Edit
-  - Grep
-  - Glob
-  - Bash
-permissionMode: bypassPermissions
+title: qa-engineer
+type: agent
+updated: 2026-07-14
+sources:
+  - .claude/agents/qa-engineer.md
+related:
+  - [[qa-planner]]
+  - [[qa-writer]]
+  - [[arch-documenter]]
+  - [[autonomous-challenge-lessons]]
+  - [[r020]]
 ---
 
-You are a QA execution specialist that runs tests, identifies defects, and validates software quality.
+# qa-engineer
 
-## Capabilities
+QA execution specialist that runs manual and automated tests, identifies and documents defects, and validates fixes against test plans produced by [[qa-planner]] and [[qa-writer]].
 
-- Manual and automated test execution, regression testing
-- Defect identification, documentation, severity classification, fix verification
-- Test script development and CI/CD integration
-- Acceptance, cross-browser, API, and security testing
+## Overview
+
+`qa-engineer` is the execution arm of the QA triad, downstream of [[qa-planner]] (risk-based prioritization) and [[qa-writer]] (detailed test cases). It runs regression, acceptance, cross-browser, API, and security testing across Jest, Vitest, pytest, go test, JUnit, Playwright, and Cypress, then documents defects with severity classification and verifies fixes. Unlike its upstream QA peers, it holds Bash and can develop test scripts and integrate them into CI/CD, but it cannot modify source code in production branches.
+
+The agent enforces a strict verification discipline before writing any QA report: it must grep/read the target implementation and quote selectors, identifiers, filenames, and commands verbatim, never inventing `data-testid`, DOM selectors, function names, or CLI flags from memory — a task-specific application of [[r020]]'s "actual outcome ≠ attempt" principle. It also has explicit tool-denial and repeated-failure handling: it does not retry an identical denied tool call, and after the same critical launch/runtime error appears twice it stops relaunching and re-checks flag semantics, existing processes, and environment assumptions. This discipline is generalized further in [[autonomous-challenge-lessons]] for long-running autonomous QA sessions.
+
+## Key Details
+
+- **Model**: sonnet
+- **Domain**: universal
+- **Tools**: Read, Write, Edit, Grep, Glob, Bash
+- **Memory**: project
+- **Effort**: medium
+- **Max Turns**: 20
+- **Limitations**: cannot modify source code in production branches
 
 ## Supported Frameworks
 
 Jest, Vitest, pytest, go test, JUnit, Playwright, Cypress
 
-## Verification Discipline
+## Relationships
 
-- Before writing a QA report, grep/read the target code and quote selectors, identifiers, filenames, and commands verbatim from the implementation.
-- Do not invent `data-testid`, DOM selectors, function names, mapping names, or CLI flags from memory.
-- If a browser/MCP/tool call is denied, do not retry the exact same call; switch to an allowed fallback and record the denial.
-- When the same critical launch/runtime error appears twice, stop repeating launches and re-check flag semantics, existing processes, and environment assumptions.
+- **Depends on**: test cases from [[qa-writer]], priorities from [[qa-planner]]
+- **Used by**: `qa-lead-routing` skill (QA execution tasks)
+- **See also**: [[qa-writer]] (upstream test case source), [[qa-planner]] (upstream priorities), [[arch-documenter]] (defect/results archive destination), [[autonomous-challenge-lessons]] (verification discipline generalized for long autonomous runs), [[r020]] (completion verification principle underlying the QA evidence discipline)
 
-## Collaboration
+## Sources
 
-Receives from: qa-writer (test cases), qa-planner (priorities). Outputs to: dev-lead (defects), qa-writer (results).
+- `.claude/agents/qa-engineer.md` — agent definition

--- a/wiki/guides/agent-workflow/autonomous-challenge-lessons.md
+++ b/wiki/guides/agent-workflow/autonomous-challenge-lessons.md
@@ -1,3 +1,18 @@
+---
+title: "Autonomous Challenge Lessons"
+type: guide
+updated: 2026-07-14
+sources:
+  - guides/agent-workflow/05-autonomous-challenge-lessons.md
+related:
+  - [[agent-workflow]]
+  - [[qa-engineer]]
+  - [[qa-planner]]
+  - [[qa-writer]]
+  - [[r020]]
+  - [[r023]]
+---
+
 # Autonomous Challenge Lessons
 
 Lessons from the 2026-05 Minecraft Cobblemon autonomous run post-mortem (#1149). Use these as guardrails for long-running challenge, QA, and tool-heavy sessions.


### PR DESCRIPTION
## 요약
- v1.1.10 → v1.1.11 patch 릴리즈
- #1472 (부분): 깨진 참조 4건 정정 — vercel-deploy `scripts/deploy.sh`, guides/agent-eval monitoring-setup 경로, 14-token-efficiency update-config 경로, R023 dangling R013 참조, 존재하지 않는 feedback 메모리 참조
- #1476 (부분): wiki 결함 정정 — qa-engineer 위키 페이지 재작성(verbatim 사본 해소), autonomous-challenge-lessons frontmatter 추가

Refs #1472 #1476

> 두 이슈 모두 **안전한 항목만 부분 반영**되었습니다. 훅 편집·파괴적 파일 작업 등 승인이 필요한 잔여 항목은 defer되어 이슈에 남아 있으므로 `Closes`가 아닌 `Refs`로 참조합니다 — 이슈는 자동 종료되지 않습니다.

## 검증 요약
- `bash scripts/verify-version-sync.sh` → `[OK] Version sync verified: 1.1.11`
- 14개 소스 변경(rules 4×2 templates 미러 + skill 1×2 + guides 2 + wiki 2) 보존 확인
- 버전 bump: package.json, templates/manifest.json (1.1.10 → 1.1.11)
- CHANGELOG.md v1.1.11 항목 추가
- pre-commit hook 통과 (type-check, lint, test with coverage)

## Test plan
- [ ] CI 전체 그린 확인 (validate-docs, type-check, lint, test)
- [ ] mergeStateStatus 확인 (CONFLICTING 아님)
- [ ] 머지는 사용자 별도 지시 대기 (자동 진행 금지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)