### PR TITLE
chore(release): v1.1.14 — #1472 하네스 위생 정리

### DIFF
--- a/.claude/hooks/scripts/stuck-detector.sh
+++ b/.claude/hooks/scripts/stuck-detector.sh
@@ -10,7 +10,7 @@ command -v jq >/dev/null 2>&1 || exit 0
 # Purpose: Detect repetitive failure loops and advise recovery
 # Protocol: stdin JSON -> process -> stdout pass-through
 #   - exit 0: advisory (normal cases, < HARD_BLOCK_THRESHOLD repetitions)
-#   - exit 1: hard block (extreme stuck loops, >= HARD_BLOCK_THRESHOLD repetitions)
+#   - exit 2: hard block (extreme stuck loops, >= HARD_BLOCK_THRESHOLD repetitions)
 
 # Hard block threshold: consecutive identical operations before blocking
 HARD_BLOCK_THRESHOLD=${CLAUDE_STUCK_THRESHOLD:-3}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/hooks/scripts/stuck-detector.sh
+++ b/templates/.claude/hooks/scripts/stuck-detector.sh
@@ -10,7 +10,7 @@ command -v jq >/dev/null 2>&1 || exit 0
 # Purpose: Detect repetitive failure loops and advise recovery
 # Protocol: stdin JSON -> process -> stdout pass-through
 #   - exit 0: advisory (normal cases, < HARD_BLOCK_THRESHOLD repetitions)
-#   - exit 1: hard block (extreme stuck loops, >= HARD_BLOCK_THRESHOLD repetitions)
+#   - exit 2: hard block (extreme stuck loops, >= HARD_BLOCK_THRESHOLD repetitions)
 
 # Hard block threshold: consecutive identical operations before blocking
 HARD_BLOCK_THRESHOLD=${CLAUDE_STUCK_THRESHOLD:-3}

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.13",
+  "version": "1.1.14",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",
@@ -99,8 +99,7 @@
           },
           "react-best-practices",
           "typescript-best-practices",
-          "fastapi-best-practices",
-          "nextjs-best-practices"
+          "fastapi-best-practices"
         ],
         "guides": [
           "agent-design",
@@ -108,9 +107,7 @@
           "claude-code",
           "drizzle-orm",
           "docker",
-          "fastapi",
-          "nextjs",
-          "react"
+          "fastapi"
         ]
       }
     },
@@ -165,7 +162,6 @@
           "agent-design",
           "git-safety",
           "claude-code",
-          "skill-authoring",
           "agent-workflow"
         ]
       }


### PR DESCRIPTION
## 요약
Fable 5 하네스 감사(#1472, Low)에서 확정된 위생 결함 2건 정리. R020 사전 실측으로 9개 주장 중 6건(claim 1/2/3/6/7/8)은 이미 해소/false-positive로 확인되어, 실측 확정된 2건만 수정.

## 변경사항
- **manifest profiles dead-ref 4건 제거** (claim 5): web-app 프로필의 `nextjs-best-practices` skill + `nextjs`/`react` guides, harness-dev의 `skill-authoring` guide — 실제 디렉토리 부재 확인 후 제거
- **stuck-detector.sh 주석 drift 정정** (claim 9, 사용자 승인): 헤더 주석 `exit 1: hard block` → `exit 2` (코드 실측 및 R021 정합); 실행본 + templates 미러 동일 적용, 로직 무변경

## 검증
- bun test: 2021 pass / 0 fail (회귀 없음)
- typecheck / lockfile / template-sync: PASS
- deep-verify: lite (no structural surface — deterministic self-check)

Fixes #1472