### PR TITLE
chore(release): v1.1.15 — #1475 R017 검증비용 최적화 + 규범 단일소스화

### DIFF
--- a/.claude/agents/mgr-sauron.md
+++ b/.claude/agents/mgr-sauron.md
@@ -1,6 +1,6 @@
 ---
 name: mgr-sauron
-description: Use when you need automated verification of R017 compliance, executing mandatory multi-round verification (5 manager rounds + 3 deep review rounds) before commits
+description: Use when you need automated verification of R017 compliance, executing mandatory multi-round verification (5 manager rounds + 3 deep review rounds, with rounds 3-4 conditionally skipped when rounds 1-2 return 0 issues) before commits
 model: sonnet
 domain: universal
 memory: local
@@ -33,6 +33,7 @@ You are an automated verification specialist that executes the mandatory R017 ve
 9. Structural linting: routing coverage (unreachable agents), orphan skill detection, circular dependency check, context:fork cap verification
 10. Auto-fix simple issues (count mismatches, missing fields)
 11. Generate verification report
+12. Cost-aware verification: skip Round 3-4 re-verification when Round 1-2 found 0 issues; substitute deterministic script results (verify-template-sync.sh, verify-wiki-sync.sh, verify-version-sync.sh, validate-docs.ts) for LLM re-derivation of count/template/wiki checks in Round 5 (R023 shift-left, no loss to verification coverage)
 
 ## Commands
 

--- a/.claude/rules/MUST-agent-design.md
+++ b/.claude/rules/MUST-agent-design.md
@@ -218,7 +218,7 @@ Agent frontmatter `hooks:` now fire when the agent runs as a main-thread agent v
 
 ## Permission Mode Guidance
 
-CC defaults `mode` to `acceptEdits` if not specified — always pass `mode: "bypassPermissions"` explicitly in Agent tool calls (see R010). See guidance details via Read tool.
+> Canonical source for the bypassPermissions requirement: R010 (MUST-orchestrator-coordination.md) "Universal bypassPermissions". CC defaults `mode` to `acceptEdits` if not specified — always pass `mode: "bypassPermissions"` explicitly in Agent tool calls. See R010 for the full requirement, rationale, and self-check.
 
 | Mode | Behavior |
 |------|----------|

--- a/.claude/rules/MUST-agent-identification.md
+++ b/.claude/rules/MUST-agent-identification.md
@@ -47,9 +47,9 @@ When the orchestrator invokes a skill via the Skill tool, the skill name MUST be
 └─ Task: {brief-task-description}
 ```
 
+<!-- DETAIL: Common Violations examples (redundant with Skill Invocation Format above)
 ### Common Violations
 
-```
 Incorrect: Skill as separate display
    ┌─ Agent: claude (default)
    └─ Task: research topic analysis
@@ -64,7 +64,7 @@ Correct: With sub-skill
    ┌─ Agent: claude → research
    ├─ Skill: result-aggregation
    └─ Task: aggregate team findings
-```
+-->
 
 ## When to Display
 
@@ -85,17 +85,17 @@ Correct: With sub-skill
 
 체크 실패 시 즉시 헤더/prefix 추가 후 도구 호출. PostCompact hook 만으로 보장되지 않으며 압축 없이도 멀티턴 누락이 발생하므로 매 턴 자가 점검 강제.
 
+<!-- DETAIL: Common Multi-Turn Violation example (redundant with Short Response Discipline table below)
 ### Common Multi-Turn Violation
 
-```
 턴 1: ┌─ Agent: claude (default) ✓
 턴 2: (헤더 없음, 짧은 답변이라 생략) ✗
 턴 3: 도구 호출 prefix 누락 ✗
-```
 
 응답 길이/턴 위치 무관. 짧은 답변에도 헤더는 필수.
 
 Reference issue: #1096.
+-->
 
 ### Short Response Discipline
 
@@ -118,7 +118,7 @@ Reference issue: #1096.
 |--------------|----------|
 | 도구 결과 수신 후 응답 텍스트 없이 turn 종료 ("(no content)") | 최소 1줄 진행 상태 + R007 헤더 출력 후 종료/계속 |
 
-Reference issues: #1188 item #2, #1198 item #2, #1409.
+<!-- Reference issues: #1188 item #2, #1198 item #2, #1409. -->
 
 ### External-Project / Debugging Session Vigilance
 
@@ -132,6 +132,6 @@ R007 헤더 누락은 외부 프로젝트 디버깅, SSH 진단, 배포 작업 �
 
 기술적 몰입 중 헤더 누락이 반복될 경우 즉시 re-anchor: 다음 응답에 `┌─ Agent:` 풀 헤더를 붙이고 이후 계속 유지한다.
 
-외부 프로젝트 진단 세션(예: #1417 통화녹음 수집 진단)에서 세션 전체에 걸쳐 헤더가 반복 누락되는 재발이 관측되었다 — 진단 몰입 중에도 매 응답 헤더를 고정한다.
-
+<!-- DETAIL: Case history — 외부 프로젝트 진단 세션(예: #1417 통화녹음 수집 진단)에서 세션 전체에 걸쳐 헤더가 반복 누락되는 재발이 관측되었다 — 진단 몰입 중에도 매 응답 헤더를 고정한다.
 Reference issues: #1401, #1417.
+-->

--- a/.claude/rules/MUST-orchestrator-coordination.md
+++ b/.claude/rules/MUST-orchestrator-coordination.md
@@ -278,6 +278,8 @@ Cross-reference: the Subagent Scope-Creep STOP Protocol (reactive halt after tri
 
 ## Universal bypassPermissions
 
+> **This section is the canonical single source for the bypassPermissions requirement.** R002 (MUST-permissions.md) and R006 (MUST-agent-design.md) reference this section rather than repeating it.
+
 **ALL Agent tool calls MUST include `mode: "bypassPermissions"`.**
 
 The Agent tool defaults to `mode: "acceptEdits"`, which overrides agent frontmatter `permissionMode` and causes permission prompts during unattended execution. This is a CC platform behavior, not a configuration error.

--- a/.claude/rules/MUST-permissions.md
+++ b/.claude/rules/MUST-permissions.md
@@ -69,12 +69,4 @@ Use a `"*"` deny rule in `settings.json` to enforce a deny-by-default posture, t
 
 ## Agent Tool Permission Mode
 
-When spawning subagents via the Agent tool, always pass `mode: "bypassPermissions"` explicitly. The Agent tool's default mode is `acceptEdits`, which **overrides** the agent frontmatter `permissionMode` field.
-
-| Setting | Effect |
-|---------|--------|
-| Agent frontmatter `permissionMode: bypassPermissions` | Ignored if Agent tool `mode` not set |
-| Agent tool `mode: "bypassPermissions"` | **Required** — actually controls subagent permissions |
-| Agent tool `mode` omitted | Defaults to `acceptEdits` → prompts for Bash, WebFetch |
-
-Skills that spawn agents MUST include `mode: "bypassPermissions"` in their Agent tool call instructions. This applies to all routing skills, pipeline skills, and any skill that delegates work to subagents.
+> Canonical source: R010 (MUST-orchestrator-coordination.md) "Universal bypassPermissions" owns the full requirement, rationale, self-check, and version history. Core rule: always pass `mode: "bypassPermissions"` explicitly on every Agent tool call — the Agent tool's default `mode` (`acceptEdits`) overrides agent frontmatter `permissionMode` and causes prompts during unattended execution. Skills that spawn agents MUST include this in their Agent tool call instructions. See R010 for details.

--- a/.claude/rules/MUST-tool-identification.md
+++ b/.claude/rules/MUST-tool-identification.md
@@ -107,22 +107,20 @@ R008 "every tool call" applies to Tier-3 interaction tools too — NOT only file
 
 Skill invocation is the one exception: it is identified through the R007 integrated identification block (`┌─ Agent: claude → {skill-name}`), not a standalone R008 tool prefix.
 
-Reference issue: #1321 (session 113 retrospective, 찐빠 #2 — AskUserQuestion prefix omitted twice).
+<!-- Reference issue: #1321 (session 113 retrospective, 찐빠 #2 — AskUserQuestion prefix omitted twice). -->
 
+<!-- DETAIL: Consolidated Example (redundant with Parallel Spawn Prefix Rule example above)
 ## Example
 
-```
 [mgr-creator][sonnet] → Write: .claude/agents/new-agent.md
 [secretary][opus] → Spawning:
   [1] lang-golang-expert:sonnet → Go code review
   [2] lang-python-expert:sonnet → Python code review
-```
 
 Parallel spawn description parameter:
-```
 Agent(description: "[1] Go code review", subagent_type: "lang-golang-expert", ...)
 Agent(description: "[2] Python code review", subagent_type: "lang-python-expert", ...)
-```
+-->
 
 ## Multi-Turn Self-Check (MANDATORY)
 
@@ -134,17 +132,17 @@ Agent(description: "[2] Python code review", subagent_type: "lang-python-expert"
 
 체크 실패 시 즉시 prefix/필수 파라미터를 보완한 후 호출.
 
+<!-- DETAIL: Common Multi-Turn Violation example (redundant with Self-Check steps above)
 ### Common Multi-Turn Violation
 
-```
 호출 1 (턴 1): [claude][sonnet] → Tool: Read ✓
 호출 2 (턴 1, 같은 턴 추가 호출): (prefix 없음) ✗
 호출 3 (턴 2 첫 호출): (prefix 없음) ✗
-```
 
 같은 턴 내 추가 호출, 새 턴 첫 호출 모두 prefix 필수.
 
 Reference issue: #1096.
+-->
 
 ### Short Response Discipline
 
@@ -160,7 +158,7 @@ Reference issue: #1096.
 <Bash call>
 ```
 
-Reference issues: #1188 item #3, #1198 item #3.
+<!-- Reference issues: #1188 item #3, #1198 item #3. -->
 
 ### External-Project / Debugging Session Vigilance
 
@@ -172,6 +170,6 @@ R007 헤더와 마찬가지로, R008 prefix 누락도 외부 프로젝트 디버
 | 외부 프로젝트 디버깅 | **동일하게 필수** |
 | SSH / 배포 / 인프라 작업 | **동일하게 필수** |
 
-외부 프로젝트 진단 세션(#1417)에서 Bash/Edit/Read/Agent 모든 호출에 `[agent][model] → Tool:` prefix가 세션 전체 누락된 재발이 관측되었다 — 도구 호출 직전 prefix 부착을 워크플로에 내재화한다.
-
+<!-- DETAIL: Case history — 외부 프로젝트 진단 세션(#1417)에서 Bash/Edit/Read/Agent 모든 호출에 `[agent][model] → Tool:` prefix가 세션 전체 누락된 재발이 관측되었다 — 도구 호출 직전 prefix 부착을 워크플로에 내재화한다.
 Reference issues: #1401, #1417.
+-->

--- a/.claude/skills/sauron-watch/SKILL.md
+++ b/.claude/skills/sauron-watch/SKILL.md
@@ -26,6 +26,9 @@ Ensure complete synchronization of agents, skills, documentation, and project st
 ```
 
 #### Round 3-4: Re-verify + Update
+
+**Conditional skip (R023 shift-left, no loss)**: If Round 1-2 returned **0 issues** (both `mgr-supplier:audit` and `mgr-updater:docs` clean), SKIP Round 3-4 entirely — there is nothing to re-verify. If Round 1-2 found ANY issue (including auto-fixed ones), Round 3-4 MUST run in full to confirm the fix.
+
 ```
 □ mgr-supplier:audit - Re-verify after fixes
 □ mgr-updater:docs - Re-run and apply any detected changes
@@ -33,17 +36,22 @@ Ensure complete synchronization of agents, skills, documentation, and project st
 ```
 
 #### Round 5: Final Count Verification
+
+**Deterministic-script substitution (R023 shift-left, no loss)**: The items below marked `[script]` are already covered by existing deterministic scripts (`verify-template-sync.sh`, `verify-wiki-sync.sh`, `verify-version-sync.sh`, `validate-docs.ts`, pre-commit count-coverage hook). For those items, RUN the script and consume its PASS/FAIL result instead of re-deriving the same check via an LLM re-spawn. Items without `[script]` have no deterministic equivalent (semantic/philosophy checks) and MUST still be verified directly.
+
 ```
-□ Agent count matches: CLAUDE.md vs actual .md files
-□ Skill count matches: CLAUDE.md vs actual SKILL.md files
+□ [script] Agent count matches: CLAUDE.md vs actual .md files (pre-commit coverage / validate-docs.ts)
+□ [script] Skill count matches: CLAUDE.md vs actual SKILL.md files (pre-commit coverage / validate-docs.ts)
 □ Memory field distribution correct
-□ Hook/context/guide/rule counts match
+□ [script] Hook/context/guide/rule counts match (validate-docs.ts / verify-version-sync.sh)
 □ All frontmatter valid
 □ All skill refs exist
 □ All memory scopes valid (project|user|local)
 □ Routing patterns updated
-□ R006 Context Fork Criteria list matches actual SKILL.md frontmatter
+□ [script] R006 Context Fork Criteria list matches actual SKILL.md frontmatter
   (run `bash .github/scripts/verify-fork-list.sh`)
+□ [script] templates/ mirror byte-identical to source (verify-template-sync.sh)
+□ [script] wiki pages current vs source (verify-wiki-sync.sh)
 ```
 
 ### Phase 2: Deep Review (3 rounds)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.14",
+  "version": "1.1.15",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/agents/mgr-sauron.md
+++ b/templates/.claude/agents/mgr-sauron.md
@@ -1,6 +1,6 @@
 ---
 name: mgr-sauron
-description: Use when you need automated verification of R017 compliance, executing mandatory multi-round verification (5 manager rounds + 3 deep review rounds) before commits
+description: Use when you need automated verification of R017 compliance, executing mandatory multi-round verification (5 manager rounds + 3 deep review rounds, with rounds 3-4 conditionally skipped when rounds 1-2 return 0 issues) before commits
 model: sonnet
 domain: universal
 memory: local
@@ -33,6 +33,7 @@ You are an automated verification specialist that executes the mandatory R017 ve
 9. Structural linting: routing coverage (unreachable agents), orphan skill detection, circular dependency check, context:fork cap verification
 10. Auto-fix simple issues (count mismatches, missing fields)
 11. Generate verification report
+12. Cost-aware verification: skip Round 3-4 re-verification when Round 1-2 found 0 issues; substitute deterministic script results (verify-template-sync.sh, verify-wiki-sync.sh, verify-version-sync.sh, validate-docs.ts) for LLM re-derivation of count/template/wiki checks in Round 5 (R023 shift-left, no loss to verification coverage)
 
 ## Commands
 

--- a/templates/.claude/rules/MUST-agent-design.md
+++ b/templates/.claude/rules/MUST-agent-design.md
@@ -218,7 +218,7 @@ Agent frontmatter `hooks:` now fire when the agent runs as a main-thread agent v
 
 ## Permission Mode Guidance
 
-CC defaults `mode` to `acceptEdits` if not specified — always pass `mode: "bypassPermissions"` explicitly in Agent tool calls (see R010). See guidance details via Read tool.
+> Canonical source for the bypassPermissions requirement: R010 (MUST-orchestrator-coordination.md) "Universal bypassPermissions". CC defaults `mode` to `acceptEdits` if not specified — always pass `mode: "bypassPermissions"` explicitly in Agent tool calls. See R010 for the full requirement, rationale, and self-check.
 
 | Mode | Behavior |
 |------|----------|

--- a/templates/.claude/rules/MUST-agent-identification.md
+++ b/templates/.claude/rules/MUST-agent-identification.md
@@ -47,9 +47,9 @@ When the orchestrator invokes a skill via the Skill tool, the skill name MUST be
 └─ Task: {brief-task-description}
 ```
 
+<!-- DETAIL: Common Violations examples (redundant with Skill Invocation Format above)
 ### Common Violations
 
-```
 Incorrect: Skill as separate display
    ┌─ Agent: claude (default)
    └─ Task: research topic analysis
@@ -64,7 +64,7 @@ Correct: With sub-skill
    ┌─ Agent: claude → research
    ├─ Skill: result-aggregation
    └─ Task: aggregate team findings
-```
+-->
 
 ## When to Display
 
@@ -85,17 +85,17 @@ Correct: With sub-skill
 
 체크 실패 시 즉시 헤더/prefix 추가 후 도구 호출. PostCompact hook 만으로 보장되지 않으며 압축 없이도 멀티턴 누락이 발생하므로 매 턴 자가 점검 강제.
 
+<!-- DETAIL: Common Multi-Turn Violation example (redundant with Short Response Discipline table below)
 ### Common Multi-Turn Violation
 
-```
 턴 1: ┌─ Agent: claude (default) ✓
 턴 2: (헤더 없음, 짧은 답변이라 생략) ✗
 턴 3: 도구 호출 prefix 누락 ✗
-```
 
 응답 길이/턴 위치 무관. 짧은 답변에도 헤더는 필수.
 
 Reference issue: #1096.
+-->
 
 ### Short Response Discipline
 
@@ -118,7 +118,7 @@ Reference issue: #1096.
 |--------------|----------|
 | 도구 결과 수신 후 응답 텍스트 없이 turn 종료 ("(no content)") | 최소 1줄 진행 상태 + R007 헤더 출력 후 종료/계속 |
 
-Reference issues: #1188 item #2, #1198 item #2, #1409.
+<!-- Reference issues: #1188 item #2, #1198 item #2, #1409. -->
 
 ### External-Project / Debugging Session Vigilance
 
@@ -132,6 +132,6 @@ R007 헤더 누락은 외부 프로젝트 디버깅, SSH 진단, 배포 작업 �
 
 기술적 몰입 중 헤더 누락이 반복될 경우 즉시 re-anchor: 다음 응답에 `┌─ Agent:` 풀 헤더를 붙이고 이후 계속 유지한다.
 
-외부 프로젝트 진단 세션(예: #1417 통화녹음 수집 진단)에서 세션 전체에 걸쳐 헤더가 반복 누락되는 재발이 관측되었다 — 진단 몰입 중에도 매 응답 헤더를 고정한다.
-
+<!-- DETAIL: Case history — 외부 프로젝트 진단 세션(예: #1417 통화녹음 수집 진단)에서 세션 전체에 걸쳐 헤더가 반복 누락되는 재발이 관측되었다 — 진단 몰입 중에도 매 응답 헤더를 고정한다.
 Reference issues: #1401, #1417.
+-->

--- a/templates/.claude/rules/MUST-orchestrator-coordination.md
+++ b/templates/.claude/rules/MUST-orchestrator-coordination.md
@@ -278,6 +278,8 @@ Cross-reference: the Subagent Scope-Creep STOP Protocol (reactive halt after tri
 
 ## Universal bypassPermissions
 
+> **This section is the canonical single source for the bypassPermissions requirement.** R002 (MUST-permissions.md) and R006 (MUST-agent-design.md) reference this section rather than repeating it.
+
 **ALL Agent tool calls MUST include `mode: "bypassPermissions"`.**
 
 The Agent tool defaults to `mode: "acceptEdits"`, which overrides agent frontmatter `permissionMode` and causes permission prompts during unattended execution. This is a CC platform behavior, not a configuration error.

--- a/templates/.claude/rules/MUST-permissions.md
+++ b/templates/.claude/rules/MUST-permissions.md
@@ -69,12 +69,4 @@ Use a `"*"` deny rule in `settings.json` to enforce a deny-by-default posture, t
 
 ## Agent Tool Permission Mode
 
-When spawning subagents via the Agent tool, always pass `mode: "bypassPermissions"` explicitly. The Agent tool's default mode is `acceptEdits`, which **overrides** the agent frontmatter `permissionMode` field.
-
-| Setting | Effect |
-|---------|--------|
-| Agent frontmatter `permissionMode: bypassPermissions` | Ignored if Agent tool `mode` not set |
-| Agent tool `mode: "bypassPermissions"` | **Required** — actually controls subagent permissions |
-| Agent tool `mode` omitted | Defaults to `acceptEdits` → prompts for Bash, WebFetch |
-
-Skills that spawn agents MUST include `mode: "bypassPermissions"` in their Agent tool call instructions. This applies to all routing skills, pipeline skills, and any skill that delegates work to subagents.
+> Canonical source: R010 (MUST-orchestrator-coordination.md) "Universal bypassPermissions" owns the full requirement, rationale, self-check, and version history. Core rule: always pass `mode: "bypassPermissions"` explicitly on every Agent tool call — the Agent tool's default `mode` (`acceptEdits`) overrides agent frontmatter `permissionMode` and causes prompts during unattended execution. Skills that spawn agents MUST include this in their Agent tool call instructions. See R010 for details.

--- a/templates/.claude/rules/MUST-tool-identification.md
+++ b/templates/.claude/rules/MUST-tool-identification.md
@@ -107,22 +107,20 @@ R008 "every tool call" applies to Tier-3 interaction tools too — NOT only file
 
 Skill invocation is the one exception: it is identified through the R007 integrated identification block (`┌─ Agent: claude → {skill-name}`), not a standalone R008 tool prefix.
 
-Reference issue: #1321 (session 113 retrospective, 찐빠 #2 — AskUserQuestion prefix omitted twice).
+<!-- Reference issue: #1321 (session 113 retrospective, 찐빠 #2 — AskUserQuestion prefix omitted twice). -->
 
+<!-- DETAIL: Consolidated Example (redundant with Parallel Spawn Prefix Rule example above)
 ## Example
 
-```
 [mgr-creator][sonnet] → Write: .claude/agents/new-agent.md
 [secretary][opus] → Spawning:
   [1] lang-golang-expert:sonnet → Go code review
   [2] lang-python-expert:sonnet → Python code review
-```
 
 Parallel spawn description parameter:
-```
 Agent(description: "[1] Go code review", subagent_type: "lang-golang-expert", ...)
 Agent(description: "[2] Python code review", subagent_type: "lang-python-expert", ...)
-```
+-->
 
 ## Multi-Turn Self-Check (MANDATORY)
 
@@ -134,17 +132,17 @@ Agent(description: "[2] Python code review", subagent_type: "lang-python-expert"
 
 체크 실패 시 즉시 prefix/필수 파라미터를 보완한 후 호출.
 
+<!-- DETAIL: Common Multi-Turn Violation example (redundant with Self-Check steps above)
 ### Common Multi-Turn Violation
 
-```
 호출 1 (턴 1): [claude][sonnet] → Tool: Read ✓
 호출 2 (턴 1, 같은 턴 추가 호출): (prefix 없음) ✗
 호출 3 (턴 2 첫 호출): (prefix 없음) ✗
-```
 
 같은 턴 내 추가 호출, 새 턴 첫 호출 모두 prefix 필수.
 
 Reference issue: #1096.
+-->
 
 ### Short Response Discipline
 
@@ -160,7 +158,7 @@ Reference issue: #1096.
 <Bash call>
 ```
 
-Reference issues: #1188 item #3, #1198 item #3.
+<!-- Reference issues: #1188 item #3, #1198 item #3. -->
 
 ### External-Project / Debugging Session Vigilance
 
@@ -172,6 +170,6 @@ R007 헤더와 마찬가지로, R008 prefix 누락도 외부 프로젝트 디버
 | 외부 프로젝트 디버깅 | **동일하게 필수** |
 | SSH / 배포 / 인프라 작업 | **동일하게 필수** |
 
-외부 프로젝트 진단 세션(#1417)에서 Bash/Edit/Read/Agent 모든 호출에 `[agent][model] → Tool:` prefix가 세션 전체 누락된 재발이 관측되었다 — 도구 호출 직전 prefix 부착을 워크플로에 내재화한다.
-
+<!-- DETAIL: Case history — 외부 프로젝트 진단 세션(#1417)에서 Bash/Edit/Read/Agent 모든 호출에 `[agent][model] → Tool:` prefix가 세션 전체 누락된 재발이 관측되었다 — 도구 호출 직전 prefix 부착을 워크플로에 내재화한다.
 Reference issues: #1401, #1417.
+-->

--- a/templates/.claude/skills/sauron-watch/SKILL.md
+++ b/templates/.claude/skills/sauron-watch/SKILL.md
@@ -26,6 +26,9 @@ Ensure complete synchronization of agents, skills, documentation, and project st
 ```
 
 #### Round 3-4: Re-verify + Update
+
+**Conditional skip (R023 shift-left, no loss)**: If Round 1-2 returned **0 issues** (both `mgr-supplier:audit` and `mgr-updater:docs` clean), SKIP Round 3-4 entirely — there is nothing to re-verify. If Round 1-2 found ANY issue (including auto-fixed ones), Round 3-4 MUST run in full to confirm the fix.
+
 ```
 □ mgr-supplier:audit - Re-verify after fixes
 □ mgr-updater:docs - Re-run and apply any detected changes
@@ -33,17 +36,22 @@ Ensure complete synchronization of agents, skills, documentation, and project st
 ```
 
 #### Round 5: Final Count Verification
+
+**Deterministic-script substitution (R023 shift-left, no loss)**: The items below marked `[script]` are already covered by existing deterministic scripts (`verify-template-sync.sh`, `verify-wiki-sync.sh`, `verify-version-sync.sh`, `validate-docs.ts`, pre-commit count-coverage hook). For those items, RUN the script and consume its PASS/FAIL result instead of re-deriving the same check via an LLM re-spawn. Items without `[script]` have no deterministic equivalent (semantic/philosophy checks) and MUST still be verified directly.
+
 ```
-□ Agent count matches: CLAUDE.md vs actual .md files
-□ Skill count matches: CLAUDE.md vs actual SKILL.md files
+□ [script] Agent count matches: CLAUDE.md vs actual .md files (pre-commit coverage / validate-docs.ts)
+□ [script] Skill count matches: CLAUDE.md vs actual SKILL.md files (pre-commit coverage / validate-docs.ts)
 □ Memory field distribution correct
-□ Hook/context/guide/rule counts match
+□ [script] Hook/context/guide/rule counts match (validate-docs.ts / verify-version-sync.sh)
 □ All frontmatter valid
 □ All skill refs exist
 □ All memory scopes valid (project|user|local)
 □ Routing patterns updated
-□ R006 Context Fork Criteria list matches actual SKILL.md frontmatter
+□ [script] R006 Context Fork Criteria list matches actual SKILL.md frontmatter
   (run `bash .github/scripts/verify-fork-list.sh`)
+□ [script] templates/ mirror byte-identical to source (verify-template-sync.sh)
+□ [script] wiki pages current vs source (verify-wiki-sync.sh)
 ```
 
 ### Phase 2: Deep Review (3 rounds)

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.14",
+  "version": "1.1.15",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약
Fable5 하네스 전략(#1475)의 무손실 검증비용/컨텍스트 감축 3건.

## 변경사항
- **R017 rounds 조건부화**: sauron-watch rounds 3-4를 "1-2가 0 issues일 때만 스킵", Round 5 카운트/템플릿/wiki 검증을 결정론 스크립트 결과 소비(`[script]`)로 대체 — 0-issue 경로 고정비 제거, semantic 검증은 유지
- **bypassPermissions 단일소스화**: R010을 canonical owner로, R002/R006 중복 서술을 R010 포인터로 치환(무손실). SKILL.md 36 인라인 반복은 의도적 방어로 존치
- **R007/R008 본문 압축**: 중복 예시·reference 블록만 HTML-comment화, actionable 지시/Core Rule/anti-pattern 표/self-check 스텝은 전량 visible 유지

## 검증
- mgr-sauron R017: PASS (actionable 은닉 0, dedup 무손실, orphan 0, 조건부화 정합)
- bun test 2021/0, typecheck/template-sync/version-sync PASS

Fixes #1475