### PR TITLE
chore(release): v1.1.19 — #1485 fork cap staleness + #1476 release.yml 핀 정책

### DIFF
--- a/.claude/skills/sauron-watch/SKILL.md
+++ b/.claude/skills/sauron-watch/SKILL.md
@@ -109,10 +109,10 @@ Build dependency graph:
 Count skills with context: fork in frontmatter:
   grep "context: fork" .claude/skills/*/SKILL.md
 
-  If count > 10:
-    ERROR: "Context fork cap exceeded: {count}/10"
+  If count > 12:
+    ERROR: "Context fork cap exceeded: {count}/12"
   If count >= 8:
-    WARN: "Context fork usage high: {count}/10 — only {10-count} slots remaining"
+    WARN: "Context fork usage high: {count}/12 — only {12-count} slots remaining"
 ```
 
 All structural lints are **advisory** (WARN level) except circular dependencies and fork cap exceeded (ERROR level — should block commit).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           bun-version: latest
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -52,7 +52,7 @@ jobs:
         run: bun run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: build-output
           path: |
@@ -74,7 +74,7 @@ jobs:
           bun-version: latest
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
@@ -104,7 +104,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: build-output
 

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.18",
-  "generatedAt": "2026-07-14T09:48:24.845Z",
-  "templateVersion": "1.1.18",
+  "generatorVersion": "1.1.19",
+  "generatedAt": "2026-07-14T10:09:56.683Z",
+  "templateVersion": "1.1.19",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",
@@ -930,7 +930,7 @@
       "component": "skills"
     },
     ".claude/skills/sauron-watch/SKILL.md": {
-      "templateHash": "df0a63f9638340d933ffa5f68cf6a6c411649824f05b0b69650f62df40848107",
+      "templateHash": "dd0dc57416454565b0c2248378d1db3de8227ca63963e755e89c2cf9005782cf",
       "size": 8821,
       "component": "skills"
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/skills/sauron-watch/SKILL.md
+++ b/templates/.claude/skills/sauron-watch/SKILL.md
@@ -109,10 +109,10 @@ Build dependency graph:
 Count skills with context: fork in frontmatter:
   grep "context: fork" .claude/skills/*/SKILL.md
 
-  If count > 10:
-    ERROR: "Context fork cap exceeded: {count}/10"
+  If count > 12:
+    ERROR: "Context fork cap exceeded: {count}/12"
   If count >= 8:
-    WARN: "Context fork usage high: {count}/10 — only {10-count} slots remaining"
+    WARN: "Context fork usage high: {count}/12 — only {12-count} slots remaining"
 ```
 
 All structural lints are **advisory** (WARN level) except circular dependencies and fork cap exceeded (ERROR level — should block commit).

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.18",
+  "version": "1.1.19",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약

- **#1485**: `sauron-watch` Lint 4의 Context Fork Cap 하드코딩값(10)이 R006 canonical cap(12)과 불일치하여 11~12번째 context fork 추가 시 오탐(false ERROR/WARN)이 발생하던 문제를 정정. `.claude/skills/sauron-watch/SKILL.md` 및 `templates/` 미러의 cap 참조 3곳을 10 → 12로 수정.
- **#1476 (잔여)**: `.github/workflows/release.yml`의 mutable 태그핀 4건(`actions/cache@v6` ×2, `actions/upload-artifact@v7`, `actions/download-artifact@v8`)을 실측 commit SHA 핀으로 전환. NPM_TOKEN을 다루는 release.yml이 `ci.yml`보다 핀 정책이 느슨하던 역전을 해소(SHA핀 9건 → 13건).

`#1476`의 나머지 항목(PPID 스코핑, 훅 chmod, `verify-version-sync` 이중사본 정합, docs-sync 주석, dead/orphan 스크립트, lock stale 등)은 v1.1.17 및 이전 릴리즈에서 이미 해소되었음을 실측 확인했습니다(중복 작업 없음).

## R017 게이트 충족 경로 (lite 압축 티어)

이번 변경은 구조 표면(frontmatter) 무변경 — SKILL.md 본문 lint 로직 hunk만 변경 — 이므로 mgr-sauron 스폰 없이 다음 결정론적 경로로 게이트를 충족했습니다:

| 검증 | 결과 |
|------|------|
| `bun test` | 2021 pass / 0 fail (baseline 대비 회귀 없음) |
| `bash .github/scripts/verify-template-sync.sh` | PASS (agents=49 skills=118 rules=23 guides=57) |
| sauron-watch 원본/templates 미러 동기화 | 확인 완료 |
| release.yml mutable pins 잔존 | 0건 (SHA pins 13건, YAML 문법 OK) |
| `.omcustom.lock.json` 재생성 | 전체 편집 완료 후 최종 1회 수행 (조기 재생성 방지) |
| wiki content-drift 68건 | 전량 pre-existing(#1483 별도 추적), 본 PR 스코프 아님 |

## 주의사항

이번 릴리즈는 `release.yml` 자체를 수정합니다. 이 PR이 머지되어 태그가 생성되면 **수정된 release.yml이 실행**됩니다 — SHA핀 오류 시 npm publish가 실패할 수 있으므로 CI 결과를 특히 주의 깊게 확인해야 합니다.

## 관련 이슈

Fixes #1485
Fixes #1476

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>