### PR TITLE
chore(release): v1.1.20 — #1492 세션 회고 찐빠 4건 처리

### DIFF
--- a/.claude/rules/MAY-optimization.md
+++ b/.claude/rules/MAY-optimization.md
@@ -24,6 +24,8 @@
 
 > **`ls | tail` 시계열 오판 (#1417)**: `ls`는 파일명을 알파벳/사전순으로 정렬하므로 `ls <dir> | tail`로 "가장 최근 파일"을 판단하면 오판한다(파일명 순서 ≠ mtime 순서). 시계열 최신 판단은 `ls -t`, `find <dir> -newermt <ts>`, 또는 stat/timestamp 기반 정렬을 명시한다. `tail`만으로 "최신" 단정 금지. Origin: #1417 (외부 통화녹음 진단 세션 — `ls TPhoneCallRecords | tail -6`이 알파벳순이라 최신을 6/18로 오판 → `find -newermt`로 6/19~20 파일 발견해 정정).
 
+> **파이프 뒤 `$?`는 마지막 명령의 exit code (#1492)**: `script.sh | tail -N; echo $?`처럼 검증 스크립트를 파이프에 연결한 뒤 `$?`로 읽으면 파이프라인 **마지막 명령**(`tail`)의 종료코드를 얻는다 — 스크립트 자체가 실패(exit 1)해도 `tail`이 성공(exit 0)하면 `$?=0`으로 "통과"를 오판한다. 검증 스크립트는 파이프 없이 단독 실행하거나 `${PIPESTATUS[0]}`으로 원본 exit code를 읽는다. **주의**: `${PIPESTATUS[0]}` 자체는 R023 Workflow JS 템플릿 리터럴 이스케이프 이슈(#1438, `${...}`를 JS가 평가해 ReferenceError)와 별개 문제 — 본 항목은 셸에서 파이프 뒤 exit code를 읽는 각도다. Origin: #1492 (Session 132 회고 찐빠 #3). Cross-ref: R020 ("command executed" ≠ "succeeded").
+
 > **v2.1.206+**: `/doctor`에 checked-in CLAUDE.md에서 코드베이스로부터 파생 가능한 내용을 잘라내도록 제안하는 체크가 추가되었습니다 — R005 "Context Optimization via HTML Comments"의 컨텍스트 절감 원칙과 정합(모델 불필요 메타데이터 축소).
 
 > **v2.1.208+**: Fixed several tool-reliability bugs: env vars like `CLAUDE_CODE_MAX_OUTPUT_TOKENS` silently used only the mantissa of scientific-notation values (`1e6` became `1`); Edit now succeeds on a file modified after being read, as long as the target text still matches uniquely; Read no longer misreports empty files as "shorter than offset"; Grep no longer silently returns "No files found" for invalid regex, no longer under-reports paginated count-mode totals; and Glob no longer crashes on a null byte in pattern/path/cwd.

--- a/.claude/rules/MUST-completion-verification.md
+++ b/.claude/rules/MUST-completion-verification.md
@@ -73,17 +73,19 @@ Never accept "pre-existing" without direct base-branch evidence. A false "pre-ex
 
 ### Verification-Delegation Non-Termination (검증 위임 판정 종료 보장)
 
-구조 검증(mgr-sauron R017)·판정·품질 게이트를 서브에이전트에 위임할 때, 위임 프롬프트에 **"최종 PASS/FAIL 판정 없이 turn을 종료하지 말라"**를 명시해야 한다. 이를 누락하면 검증 에이전트가 판정 직전(예: source-hash 대조 중)에서 turn을 종료해, 오케스트레이터가 판정 없는 불완전 보고를 받는다.
+구조 검증(mgr-sauron R017)·판정·품질 게이트를 서브에이전트에 위임할 때, 위임 프롬프트에 **"최종 PASS/FAIL 판정 없이 turn을 종료하지 말라"**를 명시한다 — 단 이 clause는 **보조 수단**일 뿐 1차 방어선이 아니다. clause를 명시해도 mid-step 종료가 5회 재발했다(v1.1.13/14/17/18/19, 아래 Origin 참조). **1차 방어선은 오케스트레이터의 직접 ground-truth 실측**이다.
 
-mid-step 종료가 발생하면 판정을 그대로 신뢰하지 말고(R020 Core Rule) SendMessage로 해당 에이전트를 resume하여 최종 판정을 받는다.
+mid-step 종료는 예상 가능한 정상 실패 모드로 취급한다 — 발생 시 즉시 ground-truth를 실측해 실제 진행 상태를 확인한다. **증상만으로 결과를 넘겨짚지 않는다**: 같은 "...중" 한 줄 종료라도 실측 결과는 다를 수 있다(예: "merging now" 후 종료 → 실측 시 PR 이미 MERGED, resume 불필요 / "CI 실행 중" 후 종료 → 실측 시 PR OPEN 미머지, resume 필요). 미완이면 SendMessage로 resume하되, 오케스트레이터가 실측한 값(예: "CI 전부 통과, mergeStateStatus=CLEAN")을 resume 메시지에 동봉해 에이전트가 재폴링 후 재종료하는 루프를 끊는다.
 
 | Anti-pattern | Required |
 |--------------|----------|
-| 검증/판정 위임 프롬프트에 종료 조건 미명시 → 판정 없이 mid-step 종료 | 위임 프롬프트에 "판정 없이 turn 종료 금지" 명시 + mid-step 종료 시 SendMessage resume |
+| 위임 프롬프트 clause 명시만으로 판정을 신뢰 | clause는 보조 수단; 오케스트레이터가 항상 직접 ground-truth 실측 |
+| mid-step 종료 증상(예: "merging now")으로 결과를 넘겨짚음 | 매번 `gh pr view`/`gh run list` 등으로 실측 후 완료/미완료 판정 |
+| resume 시 빈 재촉만 전달 | 실측값을 resume 메시지에 동봉해 재폴링 루프 차단 |
 
-Origin: #1443 (Session 126 회고 찐빠 #1) — v1.1.3 R017 검증에서 mgr-sauron이 source-hash 대조 중 판정 없이 종료 → resume 후 PASS. v1.1.4에서 "판정 반드시 출력" 명시로 1회 완료(대조 실증).
+Origin: #1443 (Session 126 회고 찐빠 #1) — v1.1.3 R017 검증에서 mgr-sauron이 source-hash 대조 중 판정 없이 종료 → resume 후 PASS. v1.1.4에서 "판정 반드시 출력" 명시로 1회 완료(대조 실증). **5회 재발 확인(#1492, Session 132)**: v1.1.13/14/17(clause 명시에도 재발) → v1.1.18(완료조건 6항목+종료금지 명시에도 "merging now" 한 줄 남기고 종료, 실측 결과 이미 완료) → v1.1.19(위임 프롬프트에 "4회 무시됨"까지 명시했으나 "CI 실행 중" 한 줄 남기고 종료, 실측 결과 미완료). Session 132에서 2회 모두 오케스트레이터 직접 실측으로 복구 — clause 강화가 아니라 실측 습관화가 유일하게 실증된 방어선.
 
-Cross-reference: R018 (Member Completion Verification), `feedback_release_delegation_phasing` (release delegation phasing을 verification 위임에도 확장).
+Cross-reference: R018 (Member Completion Verification), `feedback_release_delegation_phasing`, `feedback_orchestrator_direct_verify` (release delegation phasing을 verification 위임에도 확장).
 
 > **v2.1.199+**: subagent가 API 오류(usage limit reached 등)를 성공 결과로 오보하던 문제가 수정되어 이제 오류가 parent agent에 정확히 보고됩니다. 플랫폼 수정으로 false-success 자가보고 빈도는 줄지만, "actual outcome ≠ attempt" ground-truth 검증 원칙(R020 Core Rule)은 여전히 유지된다 — subagent 보고를 그대로 신뢰하지 말고 `git status`/`grep`/validation script로 재확인한다.
 

--- a/.claude/rules/MUST-sync-verification.md
+++ b/.claude/rules/MUST-sync-verification.md
@@ -102,6 +102,18 @@ Any change to: agents, agent frontmatter, skills, guides, routing patterns, rule
 2. 테스트가 읽는 파일의 git tracked 상태를 확인했는가? (`git ls-files` 대조)
 3. 임시 skip된 검증 스크립트/테스트가 남아있지 않은가?
 
+### Restore-From-Deletion Regression Check (Origin: #1492)
+
+삭제된 파일/워크플로우/자산을 복원(restore)할 때, 삭제 이전에 그 파일에 적용된 **머지된 수정이 유실되지 않는지** 확인한다. 복원은 "되살리기"가 아니라 **최신 상태로의 재구성**이어야 한다.
+
+| 확인 항목 | 명령 |
+|-----------|------|
+| 삭제 이전 수정 이력 | `git log --oneline -- <path>` (삭제 커밋 이전 커밋들 확인) |
+| 복원 소스 시점 | 복원 대상이 **삭제 직전 커밋**인지 확인 — 더 오래된 버전/외부 사본이면 회귀 |
+| 관련 PR 반영 여부 | 과거 수정 PR의 핵심 변경을 `grep`으로 재확인 |
+
+Origin: #1492 (Session 132) — cc-release-monitor 워크플로우 삭제(#1454, 세션127) 후 복원(세션129)이 삭제 직전 이전 버전을 되살려 머지된 수정(#1451, `textwrap.dedent` 제거)이 소실. 약 8일간 결함 상태로 이슈 자동생성(#1489/#1490에 8칸 선행 들여쓰기+절단). Cross-ref: R020 (Read-Before-Characterize), R023 (Sample-Value Assembly — 문법 검증으로는 미노출, 샘플 조립 검증으로만 드러남).
+
 ## Pre-Branch Freshness Gate (Origin: #1433 #1, ≥3회 재발)
 
 세션 중 원격 머지(`gh pr merge` 등)가 발생한 뒤 새 릴리즈/작업 브랜치를 분기하기 전, 반드시 `git checkout develop && git pull origin develop`로 로컬 develop을 최신화한다. stale 로컬 develop에서 분기하면 새 브랜치가 이미 머지된 변경(직전 릴리즈)을 누락해 PR이 CONFLICTING 상태가 되고, merge+충돌해결+재CI 사이클이 강제된다. advisory 메모리(`feedback_session_memory_git_stale`)만으로는 ≥3회 재발을 막지 못해 R017 필수 게이트로 승격한다.

--- a/.github/workflows/cc-release-monitor.yml
+++ b/.github/workflows/cc-release-monitor.yml
@@ -29,7 +29,6 @@ jobs:
           import re
           import subprocess
           import sys
-          import textwrap
 
           GH_TOKEN = os.environ["GH_TOKEN"]
           REPO = os.environ["GITHUB_REPOSITORY"]
@@ -120,39 +119,35 @@ jobs:
                   skipped += 1
                   continue
 
-              # Truncate release body
-              MAX_BODY = 2000
+              # Truncate release body (GitHub issue body hard limit: 65536 chars;
+              # MAX_BODY leaves a safety margin for the fixed template text below)
+              MAX_BODY = 60000
               if not body_raw:
                   release_summary = "_릴리즈 노트가 제공되지 않았습니다._"
               elif len(body_raw) > MAX_BODY:
-                  release_summary = body_raw[:MAX_BODY] + "... (truncated)"
+                  release_summary = (
+                      body_raw[:MAX_BODY]
+                      + "\n\n... (truncated — 전문은 위 Link 참조)"
+                  )
               else:
                   release_summary = body_raw
 
-              issue_body = textwrap.dedent(f"""\
-                  # Claude Code {version}
-
-                  **Release:** {version}
-                  **Published:** {published_at}
-                  **Link:** {html_url}
-
-                  ## 릴리즈 요약
-
-                  {release_summary}
-
-                  ---
-
-                  ## 액션 아이템
-
-                  - [ ] oh-my-customcode 영향도 관점에서 릴리즈 노트 검토
-                  - [ ] 새 Claude Code 기능이 에이전트에 영향을 주면 에이전트 정의 갱신
-                  - [ ] 현재 oh-my-customcode 버전과의 호환성 테스트
-                  - [ ] 새 기능이 관련되면 CLAUDE.md 갱신
-
-                  ---
-
-                  _이 이슈는 cc-release-monitor GitHub Actions 워크플로우가 자동 생성했습니다._\
-              """)
+              issue_body = (
+                  f"# Claude Code {version}\n\n"
+                  f"**Release:** {version}\n"
+                  f"**Published:** {published_at}\n"
+                  f"**Link:** {html_url}\n\n"
+                  "## 릴리즈 요약\n\n"
+                  f"{release_summary}\n\n"
+                  "---\n\n"
+                  "## 액션 아이템\n\n"
+                  "- [ ] oh-my-customcode 영향도 관점에서 릴리즈 노트 검토\n"
+                  "- [ ] 새 Claude Code 기능이 에이전트에 영향을 주면 에이전트 정의 갱신\n"
+                  "- [ ] 현재 oh-my-customcode 버전과의 호환성 테스트\n"
+                  "- [ ] 새 기능이 관련되면 CLAUDE.md 갱신\n\n"
+                  "---\n\n"
+                  "_이 이슈는 cc-release-monitor GitHub Actions 워크플로우가 자동 생성했습니다._\n"
+              )
 
               create = subprocess.run(
                   [

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.19",
-  "generatedAt": "2026-07-14T10:09:56.683Z",
-  "templateVersion": "1.1.19",
+  "generatorVersion": "1.1.20",
+  "generatedAt": "2026-07-14T10:37:14.925Z",
+  "templateVersion": "1.1.20",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",
@@ -60,8 +60,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-sync-verification.md": {
-      "templateHash": "50edf8f25fd8a67dcdc10b81f7be33a5a61911be3e7af5ca30cb9a03c7777c12",
-      "size": 11033,
+      "templateHash": "09a1c8d87732965ff9602cd46d7975ba0c5debe1953f658370d787d98607126a",
+      "size": 12199,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-teams.md": {
@@ -70,8 +70,8 @@
       "component": "rules"
     },
     ".claude/rules/MAY-optimization.md": {
-      "templateHash": "d79b455932477b453bdcfa702e325fd6b24d775ab08105cda026463205624b1c",
-      "size": 6177,
+      "templateHash": "0a63a54479d20f2d36399d04cabc20db4bf69c6e208cc9f97e74407fd7e3d2b8",
+      "size": 7003,
       "component": "rules"
     },
     ".claude/rules/MUST-continuous-improvement.md": {
@@ -120,8 +120,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-completion-verification.md": {
-      "templateHash": "4c2d96ed6b6448ad100f65e5177b9ced33907793159773984c205c05155ece7d",
-      "size": 28227,
+      "templateHash": "dffae9f80a019a490c04180a547bda219bd790511561466629a18fafdbf43d19",
+      "size": 29570,
       "component": "rules"
     },
     ".claude/agents/be-springboot-expert.md": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MAY-optimization.md
+++ b/templates/.claude/rules/MAY-optimization.md
@@ -24,6 +24,8 @@
 
 > **`ls | tail` 시계열 오판 (#1417)**: `ls`는 파일명을 알파벳/사전순으로 정렬하므로 `ls <dir> | tail`로 "가장 최근 파일"을 판단하면 오판한다(파일명 순서 ≠ mtime 순서). 시계열 최신 판단은 `ls -t`, `find <dir> -newermt <ts>`, 또는 stat/timestamp 기반 정렬을 명시한다. `tail`만으로 "최신" 단정 금지. Origin: #1417 (외부 통화녹음 진단 세션 — `ls TPhoneCallRecords | tail -6`이 알파벳순이라 최신을 6/18로 오판 → `find -newermt`로 6/19~20 파일 발견해 정정).
 
+> **파이프 뒤 `$?`는 마지막 명령의 exit code (#1492)**: `script.sh | tail -N; echo $?`처럼 검증 스크립트를 파이프에 연결한 뒤 `$?`로 읽으면 파이프라인 **마지막 명령**(`tail`)의 종료코드를 얻는다 — 스크립트 자체가 실패(exit 1)해도 `tail`이 성공(exit 0)하면 `$?=0`으로 "통과"를 오판한다. 검증 스크립트는 파이프 없이 단독 실행하거나 `${PIPESTATUS[0]}`으로 원본 exit code를 읽는다. **주의**: `${PIPESTATUS[0]}` 자체는 R023 Workflow JS 템플릿 리터럴 이스케이프 이슈(#1438, `${...}`를 JS가 평가해 ReferenceError)와 별개 문제 — 본 항목은 셸에서 파이프 뒤 exit code를 읽는 각도다. Origin: #1492 (Session 132 회고 찐빠 #3). Cross-ref: R020 ("command executed" ≠ "succeeded").
+
 > **v2.1.206+**: `/doctor`에 checked-in CLAUDE.md에서 코드베이스로부터 파생 가능한 내용을 잘라내도록 제안하는 체크가 추가되었습니다 — R005 "Context Optimization via HTML Comments"의 컨텍스트 절감 원칙과 정합(모델 불필요 메타데이터 축소).
 
 > **v2.1.208+**: Fixed several tool-reliability bugs: env vars like `CLAUDE_CODE_MAX_OUTPUT_TOKENS` silently used only the mantissa of scientific-notation values (`1e6` became `1`); Edit now succeeds on a file modified after being read, as long as the target text still matches uniquely; Read no longer misreports empty files as "shorter than offset"; Grep no longer silently returns "No files found" for invalid regex, no longer under-reports paginated count-mode totals; and Glob no longer crashes on a null byte in pattern/path/cwd.

--- a/templates/.claude/rules/MUST-completion-verification.md
+++ b/templates/.claude/rules/MUST-completion-verification.md
@@ -73,17 +73,19 @@ Never accept "pre-existing" without direct base-branch evidence. A false "pre-ex
 
 ### Verification-Delegation Non-Termination (검증 위임 판정 종료 보장)
 
-구조 검증(mgr-sauron R017)·판정·품질 게이트를 서브에이전트에 위임할 때, 위임 프롬프트에 **"최종 PASS/FAIL 판정 없이 turn을 종료하지 말라"**를 명시해야 한다. 이를 누락하면 검증 에이전트가 판정 직전(예: source-hash 대조 중)에서 turn을 종료해, 오케스트레이터가 판정 없는 불완전 보고를 받는다.
+구조 검증(mgr-sauron R017)·판정·품질 게이트를 서브에이전트에 위임할 때, 위임 프롬프트에 **"최종 PASS/FAIL 판정 없이 turn을 종료하지 말라"**를 명시한다 — 단 이 clause는 **보조 수단**일 뿐 1차 방어선이 아니다. clause를 명시해도 mid-step 종료가 5회 재발했다(v1.1.13/14/17/18/19, 아래 Origin 참조). **1차 방어선은 오케스트레이터의 직접 ground-truth 실측**이다.
 
-mid-step 종료가 발생하면 판정을 그대로 신뢰하지 말고(R020 Core Rule) SendMessage로 해당 에이전트를 resume하여 최종 판정을 받는다.
+mid-step 종료는 예상 가능한 정상 실패 모드로 취급한다 — 발생 시 즉시 ground-truth를 실측해 실제 진행 상태를 확인한다. **증상만으로 결과를 넘겨짚지 않는다**: 같은 "...중" 한 줄 종료라도 실측 결과는 다를 수 있다(예: "merging now" 후 종료 → 실측 시 PR 이미 MERGED, resume 불필요 / "CI 실행 중" 후 종료 → 실측 시 PR OPEN 미머지, resume 필요). 미완이면 SendMessage로 resume하되, 오케스트레이터가 실측한 값(예: "CI 전부 통과, mergeStateStatus=CLEAN")을 resume 메시지에 동봉해 에이전트가 재폴링 후 재종료하는 루프를 끊는다.
 
 | Anti-pattern | Required |
 |--------------|----------|
-| 검증/판정 위임 프롬프트에 종료 조건 미명시 → 판정 없이 mid-step 종료 | 위임 프롬프트에 "판정 없이 turn 종료 금지" 명시 + mid-step 종료 시 SendMessage resume |
+| 위임 프롬프트 clause 명시만으로 판정을 신뢰 | clause는 보조 수단; 오케스트레이터가 항상 직접 ground-truth 실측 |
+| mid-step 종료 증상(예: "merging now")으로 결과를 넘겨짚음 | 매번 `gh pr view`/`gh run list` 등으로 실측 후 완료/미완료 판정 |
+| resume 시 빈 재촉만 전달 | 실측값을 resume 메시지에 동봉해 재폴링 루프 차단 |
 
-Origin: #1443 (Session 126 회고 찐빠 #1) — v1.1.3 R017 검증에서 mgr-sauron이 source-hash 대조 중 판정 없이 종료 → resume 후 PASS. v1.1.4에서 "판정 반드시 출력" 명시로 1회 완료(대조 실증).
+Origin: #1443 (Session 126 회고 찐빠 #1) — v1.1.3 R017 검증에서 mgr-sauron이 source-hash 대조 중 판정 없이 종료 → resume 후 PASS. v1.1.4에서 "판정 반드시 출력" 명시로 1회 완료(대조 실증). **5회 재발 확인(#1492, Session 132)**: v1.1.13/14/17(clause 명시에도 재발) → v1.1.18(완료조건 6항목+종료금지 명시에도 "merging now" 한 줄 남기고 종료, 실측 결과 이미 완료) → v1.1.19(위임 프롬프트에 "4회 무시됨"까지 명시했으나 "CI 실행 중" 한 줄 남기고 종료, 실측 결과 미완료). Session 132에서 2회 모두 오케스트레이터 직접 실측으로 복구 — clause 강화가 아니라 실측 습관화가 유일하게 실증된 방어선.
 
-Cross-reference: R018 (Member Completion Verification), `feedback_release_delegation_phasing` (release delegation phasing을 verification 위임에도 확장).
+Cross-reference: R018 (Member Completion Verification), `feedback_release_delegation_phasing`, `feedback_orchestrator_direct_verify` (release delegation phasing을 verification 위임에도 확장).
 
 > **v2.1.199+**: subagent가 API 오류(usage limit reached 등)를 성공 결과로 오보하던 문제가 수정되어 이제 오류가 parent agent에 정확히 보고됩니다. 플랫폼 수정으로 false-success 자가보고 빈도는 줄지만, "actual outcome ≠ attempt" ground-truth 검증 원칙(R020 Core Rule)은 여전히 유지된다 — subagent 보고를 그대로 신뢰하지 말고 `git status`/`grep`/validation script로 재확인한다.
 

--- a/templates/.claude/rules/MUST-sync-verification.md
+++ b/templates/.claude/rules/MUST-sync-verification.md
@@ -102,6 +102,18 @@ Any change to: agents, agent frontmatter, skills, guides, routing patterns, rule
 2. 테스트가 읽는 파일의 git tracked 상태를 확인했는가? (`git ls-files` 대조)
 3. 임시 skip된 검증 스크립트/테스트가 남아있지 않은가?
 
+### Restore-From-Deletion Regression Check (Origin: #1492)
+
+삭제된 파일/워크플로우/자산을 복원(restore)할 때, 삭제 이전에 그 파일에 적용된 **머지된 수정이 유실되지 않는지** 확인한다. 복원은 "되살리기"가 아니라 **최신 상태로의 재구성**이어야 한다.
+
+| 확인 항목 | 명령 |
+|-----------|------|
+| 삭제 이전 수정 이력 | `git log --oneline -- <path>` (삭제 커밋 이전 커밋들 확인) |
+| 복원 소스 시점 | 복원 대상이 **삭제 직전 커밋**인지 확인 — 더 오래된 버전/외부 사본이면 회귀 |
+| 관련 PR 반영 여부 | 과거 수정 PR의 핵심 변경을 `grep`으로 재확인 |
+
+Origin: #1492 (Session 132) — cc-release-monitor 워크플로우 삭제(#1454, 세션127) 후 복원(세션129)이 삭제 직전 이전 버전을 되살려 머지된 수정(#1451, `textwrap.dedent` 제거)이 소실. 약 8일간 결함 상태로 이슈 자동생성(#1489/#1490에 8칸 선행 들여쓰기+절단). Cross-ref: R020 (Read-Before-Characterize), R023 (Sample-Value Assembly — 문법 검증으로는 미노출, 샘플 조립 검증으로만 드러남).
+
 ## Pre-Branch Freshness Gate (Origin: #1433 #1, ≥3회 재발)
 
 세션 중 원격 머지(`gh pr merge` 등)가 발생한 뒤 새 릴리즈/작업 브랜치를 분기하기 전, 반드시 `git checkout develop && git pull origin develop`로 로컬 develop을 최신화한다. stale 로컬 develop에서 분기하면 새 브랜치가 이미 머지된 변경(직전 릴리즈)을 누락해 PR이 CONFLICTING 상태가 되고, merge+충돌해결+재CI 사이클이 강제된다. advisory 메모리(`feedback_session_memory_git_stale`)만으로는 ≥3회 재발을 막지 못해 R017 필수 게이트로 승격한다.

--- a/templates/.github/workflows/cc-release-monitor.yml
+++ b/templates/.github/workflows/cc-release-monitor.yml
@@ -29,7 +29,6 @@ jobs:
           import re
           import subprocess
           import sys
-          import textwrap
 
           GH_TOKEN = os.environ["GH_TOKEN"]
           REPO = os.environ["GITHUB_REPOSITORY"]
@@ -120,39 +119,35 @@ jobs:
                   skipped += 1
                   continue
 
-              # Truncate release body
-              MAX_BODY = 2000
+              # Truncate release body (GitHub issue body hard limit: 65536 chars;
+              # MAX_BODY leaves a safety margin for the fixed template text below)
+              MAX_BODY = 60000
               if not body_raw:
                   release_summary = "_릴리즈 노트가 제공되지 않았습니다._"
               elif len(body_raw) > MAX_BODY:
-                  release_summary = body_raw[:MAX_BODY] + "... (truncated)"
+                  release_summary = (
+                      body_raw[:MAX_BODY]
+                      + "\n\n... (truncated — 전문은 위 Link 참조)"
+                  )
               else:
                   release_summary = body_raw
 
-              issue_body = textwrap.dedent(f"""\
-                  # Claude Code {version}
-
-                  **Release:** {version}
-                  **Published:** {published_at}
-                  **Link:** {html_url}
-
-                  ## 릴리즈 요약
-
-                  {release_summary}
-
-                  ---
-
-                  ## 액션 아이템
-
-                  - [ ] oh-my-customcode 영향도 관점에서 릴리즈 노트 검토
-                  - [ ] 새 Claude Code 기능이 에이전트에 영향을 주면 에이전트 정의 갱신
-                  - [ ] 현재 oh-my-customcode 버전과의 호환성 테스트
-                  - [ ] 새 기능이 관련되면 CLAUDE.md 갱신
-
-                  ---
-
-                  _이 이슈는 cc-release-monitor GitHub Actions 워크플로우가 자동 생성했습니다._\
-              """)
+              issue_body = (
+                  f"# Claude Code {version}\n\n"
+                  f"**Release:** {version}\n"
+                  f"**Published:** {published_at}\n"
+                  f"**Link:** {html_url}\n\n"
+                  "## 릴리즈 요약\n\n"
+                  f"{release_summary}\n\n"
+                  "---\n\n"
+                  "## 액션 아이템\n\n"
+                  "- [ ] oh-my-customcode 영향도 관점에서 릴리즈 노트 검토\n"
+                  "- [ ] 새 Claude Code 기능이 에이전트에 영향을 주면 에이전트 정의 갱신\n"
+                  "- [ ] 현재 oh-my-customcode 버전과의 호환성 테스트\n"
+                  "- [ ] 새 기능이 관련되면 CLAUDE.md 갱신\n\n"
+                  "---\n\n"
+                  "_이 이슈는 cc-release-monitor GitHub Actions 워크플로우가 자동 생성했습니다._\n"
+              )
 
               create = subprocess.run(
                   [

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.19",
+  "version": "1.1.20",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약

Session 132 세션 회고(#1492)에서 발견된 찐빠 4건 + 신규 회귀 방어 규칙 1건을 처리합니다. 코드 로직 변경 없음 — 규칙 문서 + 워크플로우 스크립트 수정.

- **찐빠 #1**: `cc-release-monitor.yml` 이슈 본문 결함 2건
  - `MAX_BODY` 2000 → 60000 (GitHub 65536자 한계 대비 안전 마진, 절단 시 원문 Link 안내). CC v2.1.208처럼 40+ 항목이 담긴 릴리즈에서 본문 절반 이상이 잘려 규범 항목이 누락되던 문제.
  - `textwrap.dedent` 선행 들여쓰기 회귀 재수정 — PR #1451(2026-07-06 머지)에서 고친 내용이, 워크플로우 삭제(#1454) 후 Session 129에서 GitHub Actions로 복원되며 유실되어 8일간 재발.
- **찐빠 #3**: R005(MAY-optimization)에 파이프 뒤 `$?` 오독 방지 가이드 추가 — `script | tail` 이후 `$?`는 `tail`의 종료 코드임을 명시.
- **찐빠 #4**: R020(MUST-completion-verification) Verification-Delegation Non-Termination 재구조화 — clause 명시만으로는 v1.1.13/14/17/18/19 5회 재발로 소진되어, 1차 방어선을 오케스트레이터의 직접 ground-truth 실측으로 전환하고 clause는 보조 수단으로 격하. "증상 ≠ 결과" 원칙 추가(v1.1.18 실제 완료 vs v1.1.19 미완료 사례 대조).
- **신규**: R017(MUST-sync-verification)에 Restore-From-Deletion Regression Check 추가 — 삭제 후 복원 시 그 사이 머지된 수정이 유실되는 회귀를 방지 (찐빠 #1 조사 중 발견한 패턴).

찐빠 #2(wiki drift 원인 추정)는 이번 커밋 범위가 아니며, #1483 이슈 본문/제목을 실측 68건으로 갱신하여 별도 처리했습니다.

## R017 게이트 충족 (lite 압축 티어, mgr-sauron 스폰 정당하게 생략)

구조 표면 무변경(frontmatter 불변, diff hunk 전부 본문 26행 이후)이므로 다음 결정론적 검증으로 게이트를 충족했습니다:

- R023 샘플 값 조립 검증 5종 전항목 PASS (0-indent 멀티라인 삽입 시 선행공백 0행 / 실제 규모 2528자 절단 없음 / 60001자 초과 시 절단문구+Link 정상 동작, 총 60444자 < 65536 / 빈 본문 placeholder 정상 / 구 결함 회귀 방지 확인)
- `bun test`: 2021 pass / 0 fail (baseline 대비 회귀 없음)
- 원본/templates 미러 4쌍 `diff -q` identical
- `bash .github/scripts/verify-template-sync.sh`: exit 0
- YAML 문법 OK
- wiki content-drift 68건은 pre-existing(#1483 추적 중, CI 미차단) — 본 릴리즈 스코프 아님

## 버전

- `package.json` / `templates/manifest.json`: 1.1.19 → 1.1.20 (patch — R017 Pre-Release Target Version Gate 실측: tag=v1.1.19, npm=1.1.19 → target v1.1.20)
- `bash scripts/verify-version-sync.sh` → `[OK] Version sync verified: 1.1.20`
- `.omcustom.lock.json` 최종 1회 재생성 (393 files) — 변경된 3개 rule 파일 해시 갱신

## 테스트 계획

- [x] `verify-version-sync.sh` PASS
- [x] `bun test` 2021/2021 PASS
- [x] `verify-template-sync.sh` exit 0
- [ ] CI 그린 확인 후 머지
- [ ] `auto-tag.yml` 자동 태깅/이슈 클로즈 확인

Fixes #1492

🤖 Generated with [Claude Code](https://claude.com/claude-code)