### PR TITLE
chore(release): v1.1.22 — #1500 CI docs-only path-filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,68 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Detect code vs docs-only changes
+        id: filter
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          fi
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+            echo "::notice::base ref unresolved — running full CI (fail-safe)"
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CHANGED="$(git diff --name-only "$BASE" "$HEAD")"
+          echo "Changed files:"
+          printf '%s\n' "$CHANGED"
+          CODE=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.md) ;;
+              .claude/*) ;;
+              templates/*) ;;
+              guides/*) ;;
+              wiki/*) ;;
+              docs/*) ;;
+              package.json) ;;
+              *) CODE=true; echo "::notice::code-triggering path: $f"; break ;;
+            esac
+          done <<< "$CHANGED"
+          echo "code=$CODE" >> "$GITHUB_OUTPUT"
+          echo "::notice::code=$CODE (true=full CI, false=docs-only fast path)"
+
   lockfile-sync:
     name: Lockfile Sync
+    needs: [changes]
     runs-on: macos-latest
     steps:
+      - name: Docs-only skip notice
+        if: needs.changes.outputs.code != 'true'
+        run: echo "Docs-only change — bun.lock unchanged; lockfile verification skipped."
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: needs.changes.outputs.code == 'true'
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        if: needs.changes.outputs.code == 'true'
         with:
           bun-version: latest
       - name: Verify lockfile consistency
+        if: needs.changes.outputs.code == 'true'
         run: |
           if ! bun install --frozen-lockfile 2>/dev/null; then
             echo "::error::bun.lock is out of sync with package.json files"
@@ -37,18 +90,24 @@ jobs:
 
   lint:
     name: Lint
-    needs: [lockfile-sync]
+    needs: [lockfile-sync, changes]
     runs-on: macos-latest
     steps:
+      - name: Docs-only skip notice
+        if: needs.changes.outputs.code != 'true'
+        run: echo "Docs-only change — Biome lint skipped (no lintable source touched)."
       - name: Checkout
+        if: needs.changes.outputs.code == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Bun
+        if: needs.changes.outputs.code == 'true'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
       - name: Cache Bun dependencies
+        if: needs.changes.outputs.code == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: ~/.bun/install/cache
@@ -57,9 +116,11 @@ jobs:
             bun-${{ runner.os }}-
 
       - name: Install dependencies
+        if: needs.changes.outputs.code == 'true'
         run: bun install --frozen-lockfile
 
       - name: Run Biome lint
+        if: needs.changes.outputs.code == 'true'
         run: bun run lint
 
   validate-docs:
@@ -87,18 +148,24 @@ jobs:
 
   test:
     name: Test
-    needs: [lockfile-sync]
+    needs: [lockfile-sync, changes]
     runs-on: macos-latest
     steps:
+      - name: Docs-only skip notice
+        if: needs.changes.outputs.code != 'true'
+        run: echo "Docs-only change — full test suite + coverage skipped (no code paths touched)."
       - name: Checkout
+        if: needs.changes.outputs.code == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Bun
+        if: needs.changes.outputs.code == 'true'
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
       - name: Cache Bun dependencies
+        if: needs.changes.outputs.code == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
         with:
           path: ~/.bun/install/cache
@@ -107,9 +174,11 @@ jobs:
             bun-${{ runner.os }}-
 
       - name: Install dependencies
+        if: needs.changes.outputs.code == 'true'
         run: bun install --frozen-lockfile
 
       - name: Run tests with coverage and check threshold
+        if: needs.changes.outputs.code == 'true'
         shell: bash
         run: |
           # Run coverage: tee shows output in real-time AND saves to file
@@ -162,15 +231,22 @@ jobs:
 
   rust-test:
     name: Rust Tests
+    needs: [changes]
     runs-on: macos-latest
     steps:
+      - name: Docs-only skip notice
+        if: needs.changes.outputs.code != 'true'
+        run: echo "Docs-only change — Rust tests skipped (no Rust/code paths touched)."
       - name: Checkout
+        if: needs.changes.outputs.code == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Rust
+        if: needs.changes.outputs.code == 'true'
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: Rust Cache
+        if: needs.changes.outputs.code == 'true'
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
         with:
           prefix-key: "rust-test-v2-${{ runner.os }}"
@@ -178,6 +254,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/develop' }}
 
       - name: Run Rust tests
+        if: needs.changes.outputs.code == 'true'
         working-directory: packages/ontology-rag
         run: cargo test --all
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.21",
+  "version": "1.1.22",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.21",
+  "version": "1.1.22",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## v1.1.22 — CI docs-only path-filter (#1500)

`.github/workflows/ci.yml`에 docs-only 변경 감지 + 조건부 skip을 추가합니다. markdown/rule 노트만 바꾸는 docs-only 릴리즈에서 `bun test --coverage`(전체 TS 스위트)와 `cargo test`(Rust 컴파일)를 skip하여 릴리즈 지연을 감축합니다.

### 구현
- 신규 `changes` 잡: 변경 파일이 전부 docs allowlist면 `code=false`, 벗어나면 `code=true` (base 미해결 시 fail-safe `code=true`).
- `test`/`rust-test`/`lint`/`lockfile-sync`: 잡은 항상 실행, 비싼 스텝만 `if: code == 'true'` 게이트.
- `validate-docs`/`version-sync`/`template-sync`: 무변경, 항상 full 실행.

### 안전성
required 잡에 **job-level if 미사용** — 잡은 항상 success를 보고하므로 branch protection 유지 (job-level if로 skip하면 미보고 required check가 PR을 영구 차단하는 함정 회피).

### 검증
이 PR은 ci.yml 변경으로 `code=true` → full CI 자기검증. skip 경로는 다음 docs-only 릴리즈(v1.1.23)에서 첫 실증.