### PR TITLE
v1.1.25 — R009 announce-execution self-check 강화 (#1503 finding #1)

### DIFF
--- a/.claude/rules/MUST-parallel-execution.md
+++ b/.claude/rules/MUST-parallel-execution.md
@@ -33,6 +33,7 @@ Before writing/editing multiple files:
 4. Agent Teams available? → **Check R018 criteria before spawning 2+ agents; for a 3+ agent batch, announce the gate result (Agent Tool fallback reason or Agent Teams choice) — see R018 Self-Check "Gate Transparency"**
 5. Running agent stalled (2x+ duration)? → Spawn independent follow-up tasks immediately
 6. Announced a parallel dispatch in prose? → ALL announced tool calls MUST be in the SAME message as the announcement (announce-execution consistency)
+   - **Verify-Bash + action-delegate asymmetry**: when the batch is a verification Bash PLUS an action delegate (Agent/Workflow), the action delegate is the call most often dropped — the Bash fires and the delegate silently slips to the next turn. Dispatch BOTH in the SAME message. Recurred v1.1.22 (resume turn) and v1.1.23 (verify-build turn) — ≥2 occurrences, R016 rule-update mandate.
 
 ### Common Violations to Avoid
 
@@ -46,6 +47,9 @@ Before writing/editing multiple files:
 
 ❌ WRONG: Announce "milestone 생성 + 구조 확인 병렬" but only dispatch one tool; the other runs next turn (announce-execution mismatch)
 ✓ CORRECT: When announcing N parallel tools, include ALL N tool calls in the SAME message as the announcement
+
+❌ WRONG: Announce "verify build (Bash) + delegate fix (Agent) 병렬" but dispatch only the Bash; the Agent delegate slips to next turn (verify-bash + action-delegate asymmetry — the expensive action call is the one dropped)
+✓ CORRECT: Dispatch BOTH the verification Bash AND the action delegate (Agent/Workflow) in the SAME message as the announcement
 ```
 
 > **Token threshold heuristic**: When a delegated agent prompt exceeds ~5000 tokens or spans 3+ unrelated domains, decompose by domain and spawn parallel agents. See R018 for Agent Teams criteria when review cycles are needed. Reference: #1085.

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.20",
-  "generatedAt": "2026-07-14T10:37:14.925Z",
-  "templateVersion": "1.1.20",
+  "generatorVersion": "1.1.25",
+  "generatedAt": "2026-07-19T00:37:09.850Z",
+  "templateVersion": "1.1.25",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",
@@ -15,8 +15,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "afbcb2c46041be401183b23612ae224aa080597afb76d9f956a98cc1c267738d",
-      "size": 41600,
+      "templateHash": "6f9b83518938ee50e68c0545e0de601940224ddd306863ff3b60c6d5c8b75409",
+      "size": 42511,
       "component": "rules"
     },
     ".claude/rules/MUST-intent-transparency.md": {
@@ -35,8 +35,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-parallel-execution.md": {
-      "templateHash": "588ab20fb9fb7cb0f4bf31149dfbb252dddaec1aa7d7a4bcb1fbb431d4e5d315",
-      "size": 10969,
+      "templateHash": "b0e3e92b2bb3cece35fe60b0030ad60a824ad628560e37d368d218d0559f2fdd",
+      "size": 11725,
       "component": "rules"
     },
     ".claude/rules/SHOULD-ecomode.md": {
@@ -50,8 +50,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
-      "templateHash": "5f5e019abc76ee839b140e0142d31ea92214b4825a5f8d27e4f272f9b7aecb2c",
-      "size": 38689,
+      "templateHash": "f9041ebae2f1164d3d7554210b87dff5c6a1f312b103e7c1dd45a68bb6bc500f",
+      "size": 40474,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
@@ -70,8 +70,8 @@
       "component": "rules"
     },
     ".claude/rules/MAY-optimization.md": {
-      "templateHash": "0a63a54479d20f2d36399d04cabc20db4bf69c6e208cc9f97e74407fd7e3d2b8",
-      "size": 7003,
+      "templateHash": "e635b4a8e1d0926ec19d5c1a8ac7a5df9e086f723e00c339f6a469a43201294c",
+      "size": 8184,
       "component": "rules"
     },
     ".claude/rules/MUST-continuous-improvement.md": {
@@ -80,8 +80,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-permissions.md": {
-      "templateHash": "99c7425f59267408e33c7cd5b96668fe0a2429e926cf8c37b894ce08ecd1ae1c",
-      "size": 9868,
+      "templateHash": "2d5f72049ef84d1925811ffd7997aabafc9c9f774bff647a40036866e4676bab",
+      "size": 11448,
       "component": "rules"
     },
     ".claude/rules/SHOULD-ontology-rag-routing.md": {
@@ -105,13 +105,13 @@
       "component": "rules"
     },
     ".claude/rules/SHOULD-memory-integration.md": {
-      "templateHash": "7a0670063132e08e7f47f4060ec450d026b6ca50f1319e631574a88e2b7639e0",
-      "size": 21756,
+      "templateHash": "20dfbeef5e1fe32a3d2a3dec366937a022a493c5fed85ab35a4608e3f0854046",
+      "size": 22251,
       "component": "rules"
     },
     ".claude/rules/MUST-enforcement-policy.md": {
-      "templateHash": "534ceb525a5052462752dc1e960816cd1c8f0ad34dc18193a6f3c182f6a38b0c",
-      "size": 4225,
+      "templateHash": "849e4cbd07b2e06c86e42e01f45aa1fcf26139176ffab3964eaf74650835187f",
+      "size": 5655,
       "component": "rules"
     },
     ".claude/rules/index.yaml": {
@@ -120,8 +120,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-completion-verification.md": {
-      "templateHash": "dffae9f80a019a490c04180a547bda219bd790511561466629a18fafdbf43d19",
-      "size": 29570,
+      "templateHash": "df00b9791dde9e158fdd3068fc637eb3326d380268b15ee0af648bd1dea45eed",
+      "size": 31504,
       "component": "rules"
     },
     ".claude/agents/be-springboot-expert.md": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.24",
+  "version": "1.1.25",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-parallel-execution.md
+++ b/templates/.claude/rules/MUST-parallel-execution.md
@@ -33,6 +33,7 @@ Before writing/editing multiple files:
 4. Agent Teams available? → **Check R018 criteria before spawning 2+ agents; for a 3+ agent batch, announce the gate result (Agent Tool fallback reason or Agent Teams choice) — see R018 Self-Check "Gate Transparency"**
 5. Running agent stalled (2x+ duration)? → Spawn independent follow-up tasks immediately
 6. Announced a parallel dispatch in prose? → ALL announced tool calls MUST be in the SAME message as the announcement (announce-execution consistency)
+   - **Verify-Bash + action-delegate asymmetry**: when the batch is a verification Bash PLUS an action delegate (Agent/Workflow), the action delegate is the call most often dropped — the Bash fires and the delegate silently slips to the next turn. Dispatch BOTH in the SAME message. Recurred v1.1.22 (resume turn) and v1.1.23 (verify-build turn) — ≥2 occurrences, R016 rule-update mandate.
 
 ### Common Violations to Avoid
 
@@ -46,6 +47,9 @@ Before writing/editing multiple files:
 
 ❌ WRONG: Announce "milestone 생성 + 구조 확인 병렬" but only dispatch one tool; the other runs next turn (announce-execution mismatch)
 ✓ CORRECT: When announcing N parallel tools, include ALL N tool calls in the SAME message as the announcement
+
+❌ WRONG: Announce "verify build (Bash) + delegate fix (Agent) 병렬" but dispatch only the Bash; the Agent delegate slips to next turn (verify-bash + action-delegate asymmetry — the expensive action call is the one dropped)
+✓ CORRECT: Dispatch BOTH the verification Bash AND the action delegate (Agent/Workflow) in the SAME message as the announcement
 ```
 
 > **Token threshold heuristic**: When a delegated agent prompt exceeds ~5000 tokens or spans 3+ unrelated domains, decompose by domain and spawn parallel agents. See R018 for Agent Teams criteria when review cycles are needed. Reference: #1085.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.24",
+  "version": "1.1.25",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약

R009(병렬 실행 규칙)의 self-check #6에 "verify-Bash + action-delegate 비대칭" 서브클로즈를 추가하고 Common Violations에 신규 ❌/✓ 예시 쌍을 보강했습니다.

**왜**: 값싼 검증용 Bash 호출은 announce와 같은 메시지에서 발화되지만, 그 검증 결과에 의존하는 값비싼 action delegate(Agent/Workflow 스폰)가 다음 턴으로 누락되는 실패 모드가 최근 릴리즈에서 2회 재발했습니다 — v1.1.22 resume 턴, v1.1.23 verify-build 턴. R016(지속적 개선) 워크플로우에 따라 근본 원인(약한 self-check 문구)을 규칙 자체에 반영했습니다.

## 변경 파일

- `.claude/rules/MUST-parallel-execution.md` — R009 self-check #6 서브클로즈 + Common Violations 예시 추가
- `templates/.claude/rules/MUST-parallel-execution.md` — 위와 동일 (templates 미러)
- `package.json` — version bump 1.1.24 → 1.1.25
- `templates/manifest.json` — version bump 1.1.24 → 1.1.25
- `.omcustom.lock.json` — 버전 변경에 따른 lockfile 재생성

## 검증

- root ↔ templates 미러 md5 일치 확인
- `validate-docs` PASS (pre-commit hook, 문서 카운트 검증 통과)
- `bun run build` 계열 pre-commit 파이프라인: 2021 tests pass, 0 fail, coverage 98.26%/98.37% (threshold 98%) — exit 0

## 참고

Refs #1503 (finding #1만 대응; #3/#4는 미해결 잔존 — 트래커는 열린 상태로 유지)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>