### PR TITLE
v1.1.26 — deploy-test.yml Verdaccio 스모크 게이트 완전 활성화 (#1478)

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -39,8 +39,13 @@ jobs:
       - name: Configure npm for Verdaccio
         run: |
           npm config set registry http://localhost:4873/
-          # Create user for publishing (htpasswd disabled by default in verdaccio)
-          npm config set //localhost:4873/:_authToken "test-token"
+          # Verdaccio's default config requires an authenticated user to publish.
+          # Register a throwaway user via the adduser API and use its real token.
+          TOKEN=$(curl -s -X PUT \
+            -H "Content-type: application/json" \
+            -d '{"name":"test","password":"test1234"}' \
+            http://localhost:4873/-/user/org.couchdb.user:test | jq -r '.token')
+          npm config set //localhost:4873/:_authToken "$TOKEN"
 
       - name: Publish to Verdaccio
         run: |

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -3,11 +3,12 @@ name: Deploy Test
 on:
   pull_request:
     branches:
-      - 'release/**'
+      - develop
 
 jobs:
   deploy-test:
     name: Deploy Test with Verdaccio
+    if: startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -43,7 +44,7 @@ jobs:
 
       - name: Publish to Verdaccio
         run: |
-          npm publish --registry http://localhost:4873/
+          npm publish --ignore-scripts --registry http://localhost:4873/
 
       - name: Test global install
         run: |

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.25",
-  "generatedAt": "2026-07-19T00:37:09.850Z",
-  "templateVersion": "1.1.25",
+  "generatorVersion": "1.1.26",
+  "generatedAt": "2026-07-19T00:54:41.277Z",
+  "templateVersion": "1.1.26",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.25",
+  "version": "1.1.26",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.25",
+  "version": "1.1.26",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약

`deploy-test.yml` (Verdaccio 로컬 스모크 배포 게이트)이 병합 이후 한 번도 실제로 실행된 적이 없던 dead gate였음을 발견하고 완전 활성화합니다.

### 무엇을 / 왜

1. **트리거 조건 수정**
   - `on.pull_request.branches: [release/**]` → `[develop]` + job-level `if: startsWith(github.head_ref, 'release/')`
   - `branches:` 필터는 PR의 **base** 브랜치를 필터링합니다. 이 저장소의 릴리즈 PR은 항상 `release/** → develop` 형태(head가 release/**, base가 develop)이므로, 기존 `branches: [release/**]`는 base=release/**인 PR을 요구했으나 그런 PR은 존재하지 않아 워크플로우가 역대 한 번도 트리거되지 않았습니다.
   - 수정 후: base=develop PR 전체에서 워크플로우가 실행되되, job-level `if:`로 head가 `release/**`인 PR(=릴리즈 PR)에서만 실제 스모크 테스트를 수행합니다.

2. **`npm publish` 스텝에 `--ignore-scripts` 추가**
   - production `release.yml`(L141, L183)의 기존 관례를 따름.
   - 로컬 Verdaccio 게시 시 `prepublishOnly`(`bun build && bun test`) 훅이 중복 실행되어 실패하던 문제를 스킵으로 해결.
   - `dist/` 최신성은 워크플로우의 별도 Build 스텝이 이미 보증하므로, publish 시점 재빌드는 불필요/중복.

3. **버전 bump**: 1.1.26

### 변경 파일

- `.github/workflows/deploy-test.yml` — 트리거 + publish 스텝 수정
- `package.json` — 버전 1.1.26
- `templates/manifest.json` — 버전 동기화
- `.omcustom.lock.json` — lockfile 재생성

### 검증

- YAML 문법 유효성 확인 (`--noEmit`/lint 통과)
- `validate-docs` PASS (pre-commit hook에서 문서 카운트 검증 통과)
- `verify-version-sync` — package.json/manifest.json 모두 1.1.26 일치
- 로컬 빌드(`bun run build`) exit 0
- pre-commit hook 전체 통과: 타입체크, lint, 2021개 테스트 전부 pass, 커버리지 Function 98.26%/Line 98.37%(threshold 98%) 충족

### 참고 노트

재활성화된 "Deploy Test" 잡은 **이 PR(release/v1.1.26, head=release/v1.1.26)에서 최초로 실제 실행됩니다.** 이 체크는 develop 브랜치 보호 규칙의 **required check가 아닌 non-required(참고용)** 체크입니다 — 최초 실행이므로 예상치 못한 실패가 발생할 수 있어, 병합 게이트에는 포함하지 않았습니다.

Closes #1478

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>