### PR TITLE
chore(release): v1.1.28 — CHANGELOG 폐지 + R007 상태줄 브래킷 명확화

### DIFF
--- a/.claude/rules/MUST-agent-identification.md
+++ b/.claude/rules/MUST-agent-identification.md
@@ -120,6 +120,16 @@ Reference issue: #1096.
 
 <!-- Reference issues: #1188 item #2, #1198 item #2, #1409. -->
 
+#### Status-Line Bracket ≠ Agent Identification Header
+
+`[FSD Iteration N]`, `[Progress]`, `[Done]`, `[Start]` 같은 R003 상태줄 브래킷은 R007 에이전트 식별 헤더를 **충족하지 않는다**. R007 헤더는 반드시 에이전트명(`┌─ Agent: {name}` 풀 헤더 또는 `[{agent-name}]` 단축 헤더)을 포함해야 한다. 장기 자율 루프(`/fsd` 등)의 기술적 몰입 중 상태줄 브래킷이 에이전트-id 브래킷을 대체하는 드리프트가 반복 관찰된다.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| `[FSD Iteration 3/5 — ...]` 상태줄로 응답 시작 (에이전트명 부재) | 먼저 `┌─ Agent: claude → fsd` 또는 `[claude]` R007 헤더를 출력한 뒤 상태줄; 또는 브래킷에 에이전트명 결합(`[claude][opus] [FSD Iteration 3/5]`) |
+
+Origin: #1507 (장기 자율 릴리즈 루프 몰입 중 상태줄 브래킷이 에이전트-id 브래킷 대체 — R007 External-Project/Debugging Session Vigilance의 자율-루프 각도 확장).
+
 ### External-Project / Debugging Session Vigilance
 
 R007 헤더 누락은 외부 프로젝트 디버깅, SSH 진단, 배포 작업 등 기술적 몰입 세션에서 가장 자주 발생한다. 이 규칙은 프로젝트 종류와 무관하게 모든 상황에 적용된다.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,8 +217,7 @@ jobs:
           NOTES=$(awk "/^## \[${VERSION}\]/{flag=1; next} /^## \[/{flag=0} flag" CHANGELOG.md)
 
           if [ -z "$NOTES" ]; then
-            echo "::warning::No changelog entry found for version ${VERSION}."
-            echo "::warning::Will use auto-generated release notes. Consider adding a '## [${VERSION}]' section to CHANGELOG.md."
+            echo "::notice::CHANGELOG.md is deprecated (v1.1.14+); using auto-generated release notes as the single source of truth (expected, per #1503)."
             echo "notes=" >> $GITHUB_OUTPUT
             echo "has_changelog=false" >> $GITHUB_OUTPUT
           else

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.27",
-  "generatedAt": "2026-07-19T08:25:28.490Z",
-  "templateVersion": "1.1.27",
+  "generatorVersion": "1.1.28",
+  "generatedAt": "2026-07-19T10:37:31.051Z",
+  "templateVersion": "1.1.28",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",
@@ -55,8 +55,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
-      "templateHash": "5340051f2249721b52742a36e00373f01d57180812d65d3de787b1527fd6fca0",
-      "size": 5538,
+      "templateHash": "5cf631bb4159755766b31c6f4cabc8b5e692e27d3968d751a4216496305bd0b5",
+      "size": 6570,
       "component": "rules"
     },
     ".claude/rules/MUST-sync-verification.md": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Deprecated — v1.1.14+]
+
+> **이 CHANGELOG는 v1.1.14부터 폐지되었습니다.**
+> v1.1.14 이후 릴리즈 노트는 [GitHub Releases](https://github.com/baekenough/oh-my-customcode/releases)의 auto-generated notes를 **단일 출처(single source of truth)** 로 합니다. `release.yml`이 릴리즈 태그의 커밋·PR 이력에서 자동 생성합니다.
+> 아래 `## [1.1.13]` 이하 엔트리는 이력 보존용으로 유지합니다 — **새 엔트리를 추가하지 마십시오**.
 
 ## [1.1.13] - 2026-07-14
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.27",
+  "version": "1.1.28",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-agent-identification.md
+++ b/templates/.claude/rules/MUST-agent-identification.md
@@ -120,6 +120,16 @@ Reference issue: #1096.
 
 <!-- Reference issues: #1188 item #2, #1198 item #2, #1409. -->
 
+#### Status-Line Bracket ≠ Agent Identification Header
+
+`[FSD Iteration N]`, `[Progress]`, `[Done]`, `[Start]` 같은 R003 상태줄 브래킷은 R007 에이전트 식별 헤더를 **충족하지 않는다**. R007 헤더는 반드시 에이전트명(`┌─ Agent: {name}` 풀 헤더 또는 `[{agent-name}]` 단축 헤더)을 포함해야 한다. 장기 자율 루프(`/fsd` 등)의 기술적 몰입 중 상태줄 브래킷이 에이전트-id 브래킷을 대체하는 드리프트가 반복 관찰된다.
+
+| Anti-pattern | Required |
+|--------------|----------|
+| `[FSD Iteration 3/5 — ...]` 상태줄로 응답 시작 (에이전트명 부재) | 먼저 `┌─ Agent: claude → fsd` 또는 `[claude]` R007 헤더를 출력한 뒤 상태줄; 또는 브래킷에 에이전트명 결합(`[claude][opus] [FSD Iteration 3/5]`) |
+
+Origin: #1507 (장기 자율 릴리즈 루프 몰입 중 상태줄 브래킷이 에이전트-id 브래킷 대체 — R007 External-Project/Debugging Session Vigilance의 자율-루프 각도 확장).
+
 ### External-Project / Debugging Session Vigilance
 
 R007 헤더 누락은 외부 프로젝트 디버깅, SSH 진단, 배포 작업 등 기술적 몰입 세션에서 가장 자주 발생한다. 이 규칙은 프로젝트 종류와 무관하게 모든 상황에 적용된다.

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.27",
+  "version": "1.1.28",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약

- **CHANGELOG.md 폐지**(#1503 finding #4): 더 이상 수동 유지하지 않으며, GitHub Releases를 릴리즈 노트의 단일 출처(source of truth)로 삼습니다. `release.yml`의 CHANGELOG 누락 체크를 hard warning에서 informational notice로 강등했습니다.
- **R007 상태줄 브래킷 조항 신설**(#1507 finding #1): 상태줄(HUD statusline)의 브래킷 세그먼트가 필수 에이전트 식별 헤더(`┌─ Agent:` / `[agent-name]`)를 대체할 수 없음을 명시해, 상태줄 브래킷을 에이전트 식별로 오인하던 드리프트를 차단합니다.
- 규칙 변경은 `templates/.claude/rules/`에도 동일 반영(source-templates parity 유지).
- `package.json` / `templates/manifest.json` → 1.1.28 bump.

## 이슈 처리

Closes #1507

#1503은 finding #4만 본 PR로 해소하며, finding #3 등 잔여 항목이 있어 tracker 이슈 자체는 **종료하지 않습니다**(계속 open 유지).

## 테스트 계획

- [x] pre-commit 훅(type-check, lint, test) 통과 확인
- [x] source ↔ templates 규칙 동기화 확인
- [ ] CI(required checks) 통과 확인 후 머지