### PR TITLE
chore(release): v1.1.35 — 회고 #1531 R017 build 배선 반영

### DIFF
--- a/.claude/rules/MUST-sync-verification.md
+++ b/.claude/rules/MUST-sync-verification.md
@@ -77,16 +77,21 @@ Wiki verification is also enforced by CI (`.github/workflows/wiki-sync.yml`).
 ```
 -->
 
-### Release Commit Staging Hygiene (빌드 산출물 오염 방지)
+### Release Commit Staging Hygiene (빌드 산출물 오염/누락 방지)
 
-릴리즈 커밋(및 `bun run build`를 수행한 모든 커밋) 직전, `git diff --cached --name-only`로 **스테이징 목록을 실측**하여 `dist/` 등 빌드 산출물이 포함되지 않았는지 확인한다. gitignored 경로라도 `git add -f` 또는 광범위 `git add` 조합으로 스테이징될 수 있으므로, .gitignore 존재가 방어를 보장하지 않는다. 발견 시 `git reset dist/`로 제외한 뒤 커밋한다. 이는 v1.1.12의 `dist/` untrack 조치에 대한 **회귀 방지 게이트**다.
+릴리즈 커밋(및 `bun run build`를 수행한 모든 커밋) 직전, 스테이징 검증은 **양방향**이다 — (a) gitignored 빌드 산출물(`dist/` 등)이 **혼입**되지 않았는가, (b) 빌드가 갱신한 **tracked** 산출물(`.omcustom.lock.json` 등)이 **누락**되지 않았는가. 두 방향은 서로 다른 경로(gitignored vs tracked)를 대상으로 하므로, 한쪽만 확인하면 반대 방향 결함이 통과한다 — .gitignore 존재/부재 확인만으로는 부족하다.
+
+**(a) 혼입 방지**: `git diff --cached --name-only`로 **스테이징 목록을 실측**하여 `dist/` 등 빌드 산출물이 포함되지 않았는지 확인한다. gitignored 경로라도 `git add -f` 또는 광범위 `git add` 조합으로 스테이징될 수 있다. 발견 시 `git reset dist/`로 제외한 뒤 커밋한다. 이는 v1.1.12의 `dist/` untrack 조치에 대한 **회귀 방지 게이트**다.
+
+**(b) 누락 방지**: `bun run build` 실행 후 `git status --short`에 **tracked 변경(`^ M`)이 남아 있으면 스테이징 누락**이다. 커밋 직전 tracked 변경이 0인지 확인한다.
 
 | Anti-pattern | Required |
 |--------------|----------|
 | 빌드 후 광범위 `git add`로 커밋 → gitignored `dist/` force-add 위험 | 커밋 직전 `git diff --cached --name-only` 실측으로 빌드 산출물 부재 확인 |
 | .gitignore에 있으니 안전하다고 가정 | force-add 경로는 .gitignore를 우회하므로 실측 필요 |
+| `dist/` 미포함만 확인하고 커밋 → 빌드가 갱신한 tracked 산출물 누락 | `git status --short`로 tracked 변경 잔존 0 확인 |
 
-Origin: #1512 (v1.1.28 커밋 staging에 dist/ 2파일 포함, 커밋 전 실측으로 정정; v1.1.12 dist/ untrack 회귀 방지). Cross-ref: R020 (완료 검증 — "실행됨 ≠ 성공").
+Origin: #1512 (v1.1.28 커밋 staging에 dist/ 2파일 포함, 커밋 전 실측으로 정정; v1.1.12 dist/ untrack 회귀 방지); #1531 (`.omcustom.lock.json`이 v1.1.29 이후 4개 릴리즈 연속 누락 — 혼입 방지 단방향 조항의 반대편 공백). Cross-ref: R020 (완료 검증 — "실행됨 ≠ 성공").
 
 ### Count Sync — Exhaustive Grep, Not File Enumeration
 

--- a/.claude/skills/pipeline/workflows/auto-dev.yaml
+++ b/.claude/skills/pipeline/workflows/auto-dev.yaml
@@ -307,9 +307,13 @@ steps:
            #   Edit ONLY the .version field — do NOT overwrite templates/manifest.json wholesale (e.g. a source-hash path→hash map).
            #   Recover a corrupted manifest: git show HEAD:templates/manifest.json | jq '.version="<NEW>"' > templates/manifest.json (#1423/#1154).
            b. templates/manifest.json: jq '.version = "<NEW>"' templates/manifest.json > templates/manifest.json.tmp && mv templates/manifest.json.tmp templates/manifest.json
-           c. mgr-gitnerd commit: "chore(release): bump to v<NEW>"
-           d. mgr-gitnerd push develop
-           e. mandatory verification (with existence guard for partial-update safety):
+           c. bun run build — run standalone (NO pipe), read exit code directly ($? after a pipe is the last command's, R005/#1492).
+              This regenerates .omcustom.lock.json (generatorVersion/templateVersion) to <NEW> via scripts/sync-source-lockfile.ts.
+           d. git status --short — enumerate ALL tracked drift (`^ M`) the build produced; stage EVERY one (esp. .omcustom.lock.json) before commit.
+              (#1531 — .omcustom.lock.json missed staging across 4 consecutive releases after v1.1.29; root cause was no build step between version bump and commit.)
+           e. mgr-gitnerd commit: "chore(release): bump to v<NEW>" — MUST include the drift from step d
+           f. mgr-gitnerd push develop
+           g. mandatory verification (with existence guard for partial-update safety):
               [ -f scripts/verify-version-sync.sh ] && bash scripts/verify-version-sync.sh || echo "::warning::verify-version-sync.sh not found, version sync verification skipped"
               (verify-version-sync.sh 가 exit 1 시 release 단계 halt)
 
@@ -325,12 +329,15 @@ steps:
       3. Adapt release mechanism to project (determines how steps 3-5 execute):
          - npm project with auto-tag.yml (this repo — release/v* PR pattern):
            a. mgr-gitnerd creates release/v{NEW} branch from develop with the version-bump commit
-           b. mgr-gitnerd creates PR: gh pr create --base develop --head release/v{NEW} --title "chore(release): bump to v{NEW}"
+           b. mgr-gitnerd creates PR: gh pr create --base develop --head release/v{NEW} --title "chore(release): bump to v{NEW}" --body "<MUST include 'Closes #N' for EVERY issue this release resolves>"
+              ⚠ auto-tag.yml closes issues by grep'ing Closes/Fixes/Resolves keywords in the PR BODY — NOT by milestone membership. If the keywords are missing, no issues close and the workflow still reports success (#1531).
+              Before creating the PR (whether via inline --body or --body-file), confirm the body text actually contains a Closes line per issue.
            c. mgr-gitnerd merges PR (admin merge required due to branch protection)
            d. DO NOT manually git tag or gh release create.
-              auto-tag.yml fires on release/v* PR merge → creates tag → closes linked issues → closes milestone → deletes release branch.
+              auto-tag.yml fires on release/v* PR merge → creates tag → closes issues linked via PR-body Closes/Fixes/Resolves keywords → closes milestone → deletes release branch.
               release.yml fires on the tag → npm publish + GitHub Release creation.
            Milestone close and issue close are handled downstream by auto-tag.yml — do NOT close them manually.
+           After merge, verify each targeted issue is actually CLOSED (gh issue view); close manually if still open. Workflow conclusion=success is not evidence of close (#1531 — v1.1.34 Closes-keyword omission left 5 issues open, manual close required).
          - Non-npm / no auto-tag.yml:
            mgr-gitnerd: git tag v{NEW} && git push origin v{NEW}
            mgr-gitnerd: gh release create v{NEW} (with release notes)

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -69,6 +69,9 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           ISSUES=$(echo "$PR_BODY" | grep -oEi '(Closes|Fixes|Resolves)([[:space:],]+#[0-9]+)+' | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -u)
+          if [ -z "$ISSUES" ]; then
+            echo "::warning::PR body contains no Closes/Fixes/Resolves keyword — no issues were closed. If this release should close issues, add 'Closes #N' lines to the PR body and close them manually."
+          fi
           for ISSUE in $ISSUES; do
             echo "Closing issue #$ISSUE"
             gh issue close "$ISSUE" \

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.34",
-  "generatedAt": "2026-07-29T00:27:08.774Z",
-  "templateVersion": "1.1.34",
+  "generatorVersion": "1.1.35",
+  "generatedAt": "2026-07-29T01:43:06.278Z",
+  "templateVersion": "1.1.35",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",
@@ -60,8 +60,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-sync-verification.md": {
-      "templateHash": "9cc2b52b2cdea53d55ab72ce2e279ca64229a2c87d68a3c08b3e19b255561504",
-      "size": 15192,
+      "templateHash": "9880dfe27012d68f90c0e76cce85f894366fce761484bcd4d2b01fb3d44e50b9",
+      "size": 16088,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-teams.md": {
@@ -480,8 +480,8 @@
       "component": "skills"
     },
     ".claude/skills/pipeline/workflows/auto-dev.yaml": {
-      "templateHash": "507b1576e17f4afeae337d2559bee7507d3c73842c7e08d97617cbd4bc096125",
-      "size": 22835,
+      "templateHash": "c91ee737aa4d6250511ea72f60b799421b3ae8544c187d4b185a7cfbfc352bc2",
+      "size": 23584,
       "component": "skills"
     },
     ".claude/skills/pipeline/SKILL.md": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.34",
+  "version": "1.1.35",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/rules/MUST-sync-verification.md
+++ b/templates/.claude/rules/MUST-sync-verification.md
@@ -77,16 +77,21 @@ Wiki verification is also enforced by CI (`.github/workflows/wiki-sync.yml`).
 ```
 -->
 
-### Release Commit Staging Hygiene (빌드 산출물 오염 방지)
+### Release Commit Staging Hygiene (빌드 산출물 오염/누락 방지)
 
-릴리즈 커밋(및 `bun run build`를 수행한 모든 커밋) 직전, `git diff --cached --name-only`로 **스테이징 목록을 실측**하여 `dist/` 등 빌드 산출물이 포함되지 않았는지 확인한다. gitignored 경로라도 `git add -f` 또는 광범위 `git add` 조합으로 스테이징될 수 있으므로, .gitignore 존재가 방어를 보장하지 않는다. 발견 시 `git reset dist/`로 제외한 뒤 커밋한다. 이는 v1.1.12의 `dist/` untrack 조치에 대한 **회귀 방지 게이트**다.
+릴리즈 커밋(및 `bun run build`를 수행한 모든 커밋) 직전, 스테이징 검증은 **양방향**이다 — (a) gitignored 빌드 산출물(`dist/` 등)이 **혼입**되지 않았는가, (b) 빌드가 갱신한 **tracked** 산출물(`.omcustom.lock.json` 등)이 **누락**되지 않았는가. 두 방향은 서로 다른 경로(gitignored vs tracked)를 대상으로 하므로, 한쪽만 확인하면 반대 방향 결함이 통과한다 — .gitignore 존재/부재 확인만으로는 부족하다.
+
+**(a) 혼입 방지**: `git diff --cached --name-only`로 **스테이징 목록을 실측**하여 `dist/` 등 빌드 산출물이 포함되지 않았는지 확인한다. gitignored 경로라도 `git add -f` 또는 광범위 `git add` 조합으로 스테이징될 수 있다. 발견 시 `git reset dist/`로 제외한 뒤 커밋한다. 이는 v1.1.12의 `dist/` untrack 조치에 대한 **회귀 방지 게이트**다.
+
+**(b) 누락 방지**: `bun run build` 실행 후 `git status --short`에 **tracked 변경(`^ M`)이 남아 있으면 스테이징 누락**이다. 커밋 직전 tracked 변경이 0인지 확인한다.
 
 | Anti-pattern | Required |
 |--------------|----------|
 | 빌드 후 광범위 `git add`로 커밋 → gitignored `dist/` force-add 위험 | 커밋 직전 `git diff --cached --name-only` 실측으로 빌드 산출물 부재 확인 |
 | .gitignore에 있으니 안전하다고 가정 | force-add 경로는 .gitignore를 우회하므로 실측 필요 |
+| `dist/` 미포함만 확인하고 커밋 → 빌드가 갱신한 tracked 산출물 누락 | `git status --short`로 tracked 변경 잔존 0 확인 |
 
-Origin: #1512 (v1.1.28 커밋 staging에 dist/ 2파일 포함, 커밋 전 실측으로 정정; v1.1.12 dist/ untrack 회귀 방지). Cross-ref: R020 (완료 검증 — "실행됨 ≠ 성공").
+Origin: #1512 (v1.1.28 커밋 staging에 dist/ 2파일 포함, 커밋 전 실측으로 정정; v1.1.12 dist/ untrack 회귀 방지); #1531 (`.omcustom.lock.json`이 v1.1.29 이후 4개 릴리즈 연속 누락 — 혼입 방지 단방향 조항의 반대편 공백). Cross-ref: R020 (완료 검증 — "실행됨 ≠ 성공").
 
 ### Count Sync — Exhaustive Grep, Not File Enumeration
 

--- a/templates/.claude/skills/pipeline/workflows/auto-dev.yaml
+++ b/templates/.claude/skills/pipeline/workflows/auto-dev.yaml
@@ -307,9 +307,13 @@ steps:
            #   Edit ONLY the .version field — do NOT overwrite templates/manifest.json wholesale (e.g. a source-hash path→hash map).
            #   Recover a corrupted manifest: git show HEAD:templates/manifest.json | jq '.version="<NEW>"' > templates/manifest.json (#1423/#1154).
            b. templates/manifest.json: jq '.version = "<NEW>"' templates/manifest.json > templates/manifest.json.tmp && mv templates/manifest.json.tmp templates/manifest.json
-           c. mgr-gitnerd commit: "chore(release): bump to v<NEW>"
-           d. mgr-gitnerd push develop
-           e. mandatory verification (with existence guard for partial-update safety):
+           c. bun run build — run standalone (NO pipe), read exit code directly ($? after a pipe is the last command's, R005/#1492).
+              This regenerates .omcustom.lock.json (generatorVersion/templateVersion) to <NEW> via scripts/sync-source-lockfile.ts.
+           d. git status --short — enumerate ALL tracked drift (`^ M`) the build produced; stage EVERY one (esp. .omcustom.lock.json) before commit.
+              (#1531 — .omcustom.lock.json missed staging across 4 consecutive releases after v1.1.29; root cause was no build step between version bump and commit.)
+           e. mgr-gitnerd commit: "chore(release): bump to v<NEW>" — MUST include the drift from step d
+           f. mgr-gitnerd push develop
+           g. mandatory verification (with existence guard for partial-update safety):
               [ -f scripts/verify-version-sync.sh ] && bash scripts/verify-version-sync.sh || echo "::warning::verify-version-sync.sh not found, version sync verification skipped"
               (verify-version-sync.sh 가 exit 1 시 release 단계 halt)
 
@@ -325,12 +329,15 @@ steps:
       3. Adapt release mechanism to project (determines how steps 3-5 execute):
          - npm project with auto-tag.yml (this repo — release/v* PR pattern):
            a. mgr-gitnerd creates release/v{NEW} branch from develop with the version-bump commit
-           b. mgr-gitnerd creates PR: gh pr create --base develop --head release/v{NEW} --title "chore(release): bump to v{NEW}"
+           b. mgr-gitnerd creates PR: gh pr create --base develop --head release/v{NEW} --title "chore(release): bump to v{NEW}" --body "<MUST include 'Closes #N' for EVERY issue this release resolves>"
+              ⚠ auto-tag.yml closes issues by grep'ing Closes/Fixes/Resolves keywords in the PR BODY — NOT by milestone membership. If the keywords are missing, no issues close and the workflow still reports success (#1531).
+              Before creating the PR (whether via inline --body or --body-file), confirm the body text actually contains a Closes line per issue.
            c. mgr-gitnerd merges PR (admin merge required due to branch protection)
            d. DO NOT manually git tag or gh release create.
-              auto-tag.yml fires on release/v* PR merge → creates tag → closes linked issues → closes milestone → deletes release branch.
+              auto-tag.yml fires on release/v* PR merge → creates tag → closes issues linked via PR-body Closes/Fixes/Resolves keywords → closes milestone → deletes release branch.
               release.yml fires on the tag → npm publish + GitHub Release creation.
            Milestone close and issue close are handled downstream by auto-tag.yml — do NOT close them manually.
+           After merge, verify each targeted issue is actually CLOSED (gh issue view); close manually if still open. Workflow conclusion=success is not evidence of close (#1531 — v1.1.34 Closes-keyword omission left 5 issues open, manual close required).
          - Non-npm / no auto-tag.yml:
            mgr-gitnerd: git tag v{NEW} && git push origin v{NEW}
            mgr-gitnerd: gh release create v{NEW} (with release notes)

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.34",
+  "version": "1.1.35",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/wiki/.source-hashes.json
+++ b/wiki/.source-hashes.json
@@ -61,7 +61,7 @@
   ".claude/rules/MUST-parallel-execution.md": "a1e43ab30e0b80c8a8bd3c587a8c270650628f6243199e2871ccd3aac2daaf25",
   ".claude/rules/MUST-permissions.md": "790c5b5f42f079c79eb67d9d8f5b77d329532399fe3ba9ea8db9f3407e8f67c9",
   ".claude/rules/MUST-safety.md": "895152f884c6c23af56d2476db0a58685f2432b7d6c8b7ffc44f14d80a386b2f",
-  ".claude/rules/MUST-sync-verification.md": "9cc2b52b2cdea53d55ab72ce2e279ca64229a2c87d68a3c08b3e19b255561504",
+  ".claude/rules/MUST-sync-verification.md": "9880dfe27012d68f90c0e76cce85f894366fce761484bcd4d2b01fb3d44e50b9",
   ".claude/rules/MUST-tool-identification.md": "0027061d27d58a5135ba1b8f6ce4bc8ee88db8b7809585471105ba908d62582b",
   ".claude/rules/SHOULD-ecomode.md": "91604776396a5b1beb27666704998f8fc6ec8a639ef2e4c47d8cfc57f5bb628b",
   ".claude/rules/SHOULD-error-handling.md": "9d200be09d91765b725a1a5de221b71c3c2b7dd40cffba2ab2c2e33aec08bb61",

--- a/wiki/agents/mgr-gitnerd.md
+++ b/wiki/agents/mgr-gitnerd.md
@@ -1,9 +1,11 @@
 ---
 title: mgr-gitnerd
 type: agent
-updated: 2026-07-19
+updated: 2026-07-29
 sources:
   - .claude/agents/mgr-gitnerd.md
+  - .claude/skills/pipeline/workflows/auto-dev.yaml
+  - .github/workflows/auto-tag.yml
 related:
   - [[mgr-sauron]]
   - [[tool-npm-expert]]
@@ -75,6 +77,14 @@ If title-matching returns no results, do NOT immediately report the milestone as
 
 Origin: #1287 (v0.164.0 session retrospective — milestone reported absent but confirmed present via direct re-query).
 
+## PR Body Closes-Keyword Requirement (#1531)
+
+`auto-tag.yml` closes issues by grep'ing `Closes|Fixes|Resolves #N` keywords in the merged PR body — NOT by milestone membership. When creating a release PR, `mgr-gitnerd` MUST include a `Closes #N` line for every issue the release resolves; a missing keyword lets the workflow report `success` while closing zero issues.
+
+After merge, `mgr-gitnerd` verifies each targeted issue is actually `CLOSED` via `gh issue view` — workflow conclusion=success is not evidence of close (cf. [[r020]] "actual outcome ≠ attempt"). If an issue is still open, close it manually.
+
+Origin: #1531 (v1.1.34 Closes-keyword omission left 5 issues open despite a green workflow; PR-body requirement + post-merge verification added in response).
+
 ## Relationships
 
 - **Depends on**: mgr-sauron verification (prerequisite for push)
@@ -107,3 +117,4 @@ The local `release` branch (file ref) conflicts with `release/v*` directory ref 
 - Issue #1148 — rustup symlink false-positive CI failure (v0.137.0)
 - Issue #1287 — milestone query false-negative retrospective (v0.164.0, origin of Milestone Query Robustness)
 - Issue #1468 — memory scope migration to `local` (v1.1.13)
+- Issue #1531 — PR-body Closes-keyword omission left 5 issues open despite green workflow (v1.1.34)

--- a/wiki/rules/r017.md
+++ b/wiki/rules/r017.md
@@ -1,7 +1,7 @@
 ---
 title: "R017: Sync Verification Rules"
 type: rule
-updated: 2026-07-20
+updated: 2026-07-29
 sources:
   - .claude/rules/MUST-sync-verification.md
 related:
@@ -101,16 +101,21 @@ Origin: #1492 (Session 132) — cc-release-monitor 워크플로우 삭제(#1454)
 
 Origin: #1457 (Session 128 회고 찐빠 #1) — stale 메모리(npm 1.1.6→v1.1.7 추정)로 implement 위임 → v1.1.7 이미 배포된 closed milestone STOP → v1.1.8 재위임 왕복. `feedback_session_memory_git_stale`의 릴리즈-버전-선정 각도 확장.
 
-## Release Commit Staging Hygiene (빌드 산출물 오염 방지) (#1512)
+## Release Commit Staging Hygiene (빌드 산출물 오염/누락 방지) (#1512, #1531)
 
-릴리즈 커밋(및 `bun run build`를 수행한 모든 커밋) 직전, `git diff --cached --name-only`로 스테이징 목록을 실측하여 `dist/` 등 빌드 산출물이 포함되지 않았는지 확인한다. gitignored 경로라도 `git add -f` 또는 광범위 `git add` 조합으로 스테이징될 수 있으므로, `.gitignore` 존재가 방어를 보장하지 않는다. 발견 시 `git reset dist/`로 제외한 뒤 커밋한다. v1.1.12의 `dist/` untrack 조치에 대한 회귀 방지 게이트다.
+릴리즈 커밋(및 `bun run build`를 수행한 모든 커밋) 직전, 스테이징 검증은 **양방향**이다 — (a) gitignored 빌드 산출물(`dist/` 등)이 **혼입**되지 않았는가, (b) 빌드가 갱신한 **tracked** 산출물(`.omcustom.lock.json` 등)이 **누락**되지 않았는가. 두 방향은 서로 다른 경로(gitignored vs tracked)를 대상으로 하므로, 한쪽만 확인하면 반대 방향 결함이 통과한다 — `.gitignore` 존재/부재 확인만으로는 부족하다.
+
+**(a) 혼입 방지**: `git diff --cached --name-only`로 스테이징 목록을 실측하여 `dist/` 등 빌드 산출물이 포함되지 않았는지 확인한다. gitignored 경로라도 `git add -f` 또는 광범위 `git add` 조합으로 스테이징될 수 있다. 발견 시 `git reset dist/`로 제외한 뒤 커밋한다. v1.1.12의 `dist/` untrack 조치에 대한 회귀 방지 게이트다.
+
+**(b) 누락 방지**: `bun run build` 실행 후 `git status --short`에 tracked 변경(`^ M`)이 남아 있으면 스테이징 누락이다. 커밋 직전 tracked 변경이 0인지 확인한다.
 
 | Anti-pattern | Required |
 |--------------|----------|
 | 빌드 후 광범위 `git add`로 커밋 → gitignored `dist/` force-add 위험 | 커밋 직전 `git diff --cached --name-only` 실측으로 빌드 산출물 부재 확인 |
 | .gitignore에 있으니 안전하다고 가정 | force-add 경로는 .gitignore를 우회하므로 실측 필요 |
+| `dist/` 미포함만 확인하고 커밋 → 빌드가 갱신한 tracked 산출물 누락 | `git status --short`로 tracked 변경 잔존 0 확인 |
 
-Origin: #1512 (v1.1.28 커밋 staging에 dist/ 2파일 포함, 커밋 전 실측으로 정정; v1.1.12 dist/ untrack 회귀 방지). Cross-ref: [[r020]] (완료 검증 — "실행됨 ≠ 성공").
+Origin: #1512 (v1.1.28 커밋 staging에 dist/ 2파일 포함, 커밋 전 실측으로 정정; v1.1.12 dist/ untrack 회귀 방지); #1531 (`.omcustom.lock.json`이 v1.1.29 이후 4개 릴리즈 연속 누락 — 혼입 방지 단방향 조항의 반대편 공백). Cross-ref: [[r020]] (완료 검증 — "실행됨 ≠ 성공").
 
 ## Count Sync — Exhaustive Grep, Not File Enumeration (#1521)
 
@@ -141,10 +146,11 @@ Prompt-based self-check + `mgr-sauron:watch` verification flow. No hard-block ho
 
 ## Sources
 
-- `.claude/rules/MUST-sync-verification.md` — rule definition (Structural Migration Verification added #1217; Pre-Branch Freshness Gate + Post-Gate Scope-Expansion Re-Run added #1433; Pre-Release Target Version Ground-Truth Gate added #1457; Restore-From-Deletion Regression Check added #1492; Release Commit Staging Hygiene added #1512; Count Sync — Exhaustive Grep, Not File Enumeration added #1521)
+- `.claude/rules/MUST-sync-verification.md` — rule definition (Structural Migration Verification added #1217; Pre-Branch Freshness Gate + Post-Gate Scope-Expansion Re-Run added #1433; Pre-Release Target Version Ground-Truth Gate added #1457; Restore-From-Deletion Regression Check added #1492; Release Commit Staging Hygiene added #1512; Count Sync — Exhaustive Grep, Not File Enumeration added #1521; Release Commit Staging Hygiene expanded bidirectionally (오염 → 오염/누락) #1531)
 - Issue #1217 — flat templates path drift + CLAUDE.md ENOENT + skip state merge incidents (2026-05-24)
 - Issue #1433 — harness 개선 #1/#2: stale develop 분기 (≥3회 재발) + gate 통과 후 스코프 확장 미재검증 (2026-07-01)
 - Issue #1457 — release target 버전 선정 전 원격 실측 누락 → stale 메모리 기반 재타겟팅 왕복 (2026-07-06)
 - Issue #1492 — cc-release-monitor 삭제-후-복원이 삭제 직전 버전을 되살려 머지된 수정 소실, ~8일 결함 상태 (2026-07-19)
 - Issue #1512 — v1.1.28 커밋 staging에 dist/ 빌드 산출물 2파일 포함, 커밋 전 실측으로 정정 (2026-07-20)
 - Issue #1521 — v1.1.32 skills 118→114 카운트 동기화가 파일 열거식 위임으로 6곳만 갱신, 전수 grep으로 15곳 확정 (2026-07-20)
+- Issue #1531 — `.omcustom.lock.json`이 v1.1.29 이후 4개 릴리즈 연속 누락, 혼입 방지 단방향 조항의 반대편 공백 발견 (2026-07-29)

--- a/wiki/skills/pipeline.md
+++ b/wiki/skills/pipeline.md
@@ -1,7 +1,7 @@
 ---
 title: Pipeline
 type: skill
-updated: 2026-05-15
+updated: 2026-07-29
 sources:
   - .claude/skills/pipeline/SKILL.md
   - .claude/skills/pipeline/workflows/auto-dev.yaml
@@ -64,6 +64,10 @@ The `auto-dev` workflow runs a full release cycle: `pre-triage → scope-selecti
 
 **Purpose**: Catches unit test regressions that static checks miss. Addresses the v0.133.0 pattern where hook script exit code changes introduced test regressions not detected by lint/typecheck alone.
 
+### release: PR-body Closes-keyword requirement (#1531)
+
+`auto-tag.yml` closes issues by grep'ing `Closes|Fixes|Resolves #N` keywords in the **merged PR body** — NOT by milestone membership. The `release` step's PR-creation instruction now mandates a `Closes #N` line for every issue the release resolves; omitting it lets the workflow report `success` while closing zero issues. After merge, the step verifies each targeted issue is actually `CLOSED` (`gh issue view`) rather than trusting workflow conclusion alone — v1.1.34 omitted the keyword and left 5 issues open despite a green run.
+
 ## Relationships
 
 - **Used by agents**: orchestrator
@@ -73,4 +77,5 @@ The `auto-dev` workflow runs a full release cycle: `pre-triage → scope-selecti
 ## Sources
 
 - `.claude/skills/pipeline/SKILL.md` — skill definition
-- `.claude/skills/pipeline/workflows/auto-dev.yaml` — auto-dev workflow YAML (G1/G2 added v0.137.0)
+- `.claude/skills/pipeline/workflows/auto-dev.yaml` — auto-dev workflow YAML (G1/G2 added v0.137.0; release step PR-body Closes-keyword requirement added v1.1.35 / #1531)
+- Issue #1531 — PR-body Closes-keyword omission left 5 issues open despite green workflow (v1.1.34)


### PR DESCRIPTION
## 변경 내용

1. **R017 Release Commit Staging Hygiene → 양방향 확장** (`.claude/rules/MUST-sync-verification.md` + templates 미러)
   - 제목: "빌드 산출물 오염 방지" → "오염/누락 방지"
   - (a) 혼입 방지(기존 보존) / (b) 누락 방지(신규): `bun run build` 후 `git status --short`에 tracked 변경 잔존 0 확인
   - Anti-pattern 표 3번째 행 추가, Origin에 #1531 추가(#1512 보존)
2. **auto-dev.yaml version-bump 절차에 build 배선** (런타임 쌍 2곳)
   - a/b(버전 편집) → **c. `bun run build`** → **d. `git status --short` drift 열거·스테이징** → e/f/g(commit/push/verify)
   - 이것이 #1531의 진짜 근본 원인 수정입니다: 기존 절차엔 버전 범프 후 build 단계가 아예 없어 `.omcustom.lock.json`이 갱신될 기회조차 없었습니다
3. **auto-dev.yaml 릴리즈 PR `Closes #N` 요건 명시** (런타임 쌍 2곳)
   - auto-tag.yml의 close가 마일스톤이 아니라 **PR 본문 키워드 grep** 기반임을 명시
4. **auto-tag.yml 키워드 부재 경고** (`::warning::`, 동작 불변)
5. **wiki 정합** + 버전 1.1.34 → 1.1.35

repo-root `workflows/auto-dev.yaml` 레거시 쌍은 **의도적 미변경**(md5 `2ebdaca8…` 불변 확인).

## 검증 결과

| 검증 | 결과 |
|------|------|
| `bun run lint` | EXIT=0 (94 files) |
| `verify-template-sync.sh` | EXIT=0 — agents=49 skills=114 rules=23 guides=56 |
| `verify-version-sync.sh` | EXIT=0 — 1.1.35 |
| `validate-docs.ts --programmatic-only` | EXIT=0 |
| `verify-wiki-sync.sh` | EXIT=0 — drift=0 |
| `bun test` | EXIT=0 — 2005 pass / 0 fail |
| `bun run build` | EXIT=0, dist/ 혼입 0, `.omcustom.lock.json` generatorVersion=1.1.35 |
| 런타임 쌍 md5 | `92fd2dbe…` 일치 / 레거시 `2ebdaca8…` 미변경 |
| mgr-sauron R017 | 1차 FAIL(build 배선 공백 지적) → 수정 → 재검증 PASS |

Closes #1531

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>