### PR TITLE
chore(release): bump to v1.1.38

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.37",
-  "generatedAt": "2026-07-29T07:53:05.260Z",
-  "templateVersion": "1.1.37",
+  "generatorVersion": "1.1.38",
+  "generatedAt": "2026-07-30T08:05:50.776Z",
+  "templateVersion": "1.1.38",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",
@@ -70,8 +70,8 @@
       "component": "rules"
     },
     ".claude/rules/MAY-optimization.md": {
-      "templateHash": "ba5b0d193b507eeee6e9371674a7a2b58c55746c69be59d7d272541add84c413",
-      "size": 9051,
+      "templateHash": "b852d6ea86f88cf94b0902cf945e0748daa740219aa22a0a7ad775ab5c3d40b1",
+      "size": 9901,
       "component": "rules"
     },
     ".claude/rules/MUST-continuous-improvement.md": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.37",
+  "version": "1.1.38",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.37",
+  "version": "1.1.38",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요지

이번 릴리즈는 "검증이 도는데 검증 대상이 실제 사용처와 어긋남" 계열 결함 3건과 R005 규칙 갭 1건을 해소합니다.

### #1536 — template-validation.test.ts가 미러만 검사
`tests/unit/core/template-validation.test.ts`가 `templates/.claude/agents` 미러만 검사하고 있어, CC가 실제로 스폰하는 실행본 `.claude/agents/`의 `model` 필드 오류(예: sonnet5/opus5 무효 alias 인시던트, #1524)는 이 테스트를 통과할 수 있었습니다. PR CI에는 실행본 내용 게이트가 없었습니다 — `ci.yml`은 개수만 비교하고, `verify-template-sync.sh`는 `release.yml:117`에서만 실행됩니다. 실행본 `.claude/agents/`에 대해 동일한 frontmatter/model/name 검사를 추가했습니다.

### #1537 — verify-template-sync.sh가 guides를 디렉토리 개수만 비교
`guides/` 동기화 검증이 최상위 토픽 디렉토리 개수만 비교해, 디렉토리 개수는 같지만 내용이 드리프트된 경우를 놓쳤습니다. 재귀 내용 drift 검사를 추가하고, 드리프트가 발견된 4개 가이드 미러 파일을 원본 기준으로 동일 커밋에서 정렬했습니다(순서로 인한 재발 위험 회피).

### #1539 — 쌍 비교만으로는 2×2 그룹 drift 미탐지
기존 검증이 사본 쌍(pair) 단위 비교였기 때문에, 사본이 2개 그룹으로 나뉘어 각 그룹 내부는 일치하지만 그룹 간 drift가 있는 2×2 케이스를 탐지하지 못했습니다. N-way 워크플로우 사본 일치 검사를 추가했습니다.

### #1540 — R005 규칙 갭 (zsh $pipestatus vs bash ${PIPESTATUS[0]})
R005에 zsh `$pipestatus[1]`과 bash `${PIPESTATUS[0]}`의 차이를 명기하고, 파이프 없는 단독 실행을 1차 지침으로 승격했습니다. 이 저장소 셸(zsh)에서 bash 문법을 그대로 쓰면 오류 없이 빈 값을 반환해 조용한 오탐(검증 통과로 오판)을 유발할 수 있습니다.

## 검증

- `verify-template-sync.sh` / `verify-wiki-sync` / `validate-docs`: 전부 EXIT=0
- `bun test`: 2025 pass / 0 fail
- R017 mgr-sauron: `[PASS]`
- guides 재귀 drift 검사 및 N-way 사본 일치 검사: mutation test로 실효성 실증(고의로 drift를 주입해 검사가 실제로 잡아내는지 확인)

## 참고

기능 변경은 `037684b7`로 develop에 선반영되어 있습니다. 본 PR은 버전 범프 커밋(`9d5b2cff`) + 이슈 close 트리거 역할입니다.

## 관련 이슈

Closes #1536
Closes #1537
Closes #1539
Closes #1540
