### PR TITLE
chore(release): bump to v1.1.39

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.38",
-  "generatedAt": "2026-07-30T08:05:50.776Z",
-  "templateVersion": "1.1.38",
+  "generatorVersion": "1.1.39",
+  "generatedAt": "2026-07-30T08:58:18.753Z",
+  "templateVersion": "1.1.39",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",
@@ -480,8 +480,8 @@
       "component": "skills"
     },
     ".claude/skills/pipeline/workflows/auto-dev.yaml": {
-      "templateHash": "0b0f7dd7e07c33670994ea06dc8006e57f800948f9d76812a04750d45efe832a",
-      "size": 24209,
+      "templateHash": "326b6db760284b1fe0125856026cb323b99b5533e365d19ce8350c4ba3794704",
+      "size": 26821,
       "component": "skills"
     },
     ".claude/skills/pipeline/SKILL.md": {
@@ -1185,8 +1185,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/r007-r008-drift-advisor.sh": {
-      "templateHash": "368e2f1d7689f075c85cf57a8d7cead6ceab3028d9350a11ac85b772860d9ef5",
-      "size": 4386,
+      "templateHash": "174f5973a498a8ebc003ba50d5ff998117e6f31b2dd82fbe0008636d8edd3420",
+      "size": 5078,
       "component": "hooks"
     },
     ".claude/hooks/scripts/session-autofix-prompt.sh": {
@@ -1280,8 +1280,8 @@
       "component": "hooks"
     },
     ".claude/hooks/hooks.json": {
-      "templateHash": "230ca061b6714737c1bee5ebe308d136fc024c0c0b7b2e8186ae88756698f854",
-      "size": 27875,
+      "templateHash": "7b0b1652c46e358559c724d87a758e0899b98d233fb174e35e38d4e26682c9c3",
+      "size": 28071,
       "component": "hooks"
     },
     ".claude/contexts/ecomode.md": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.38",
+  "version": "1.1.39",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.38",
+  "version": "1.1.39",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요지

v1.1.38 릴리즈에서 드러난 릴리즈 절차 결함과 검증 사각지대 3건을 해소합니다.

### #1542 — release 절차 순서 결함 (구조적)
`auto-dev.yaml`이 버전 범프를 develop에 먼저 push한 뒤 release 브랜치를 만들어 두 ref가 동일 커밋이 되고, `git rev-list --count`가 0이 되어 PR 생성이 GitHub GraphQL로 거부되던 결함입니다. 이번 수정은 **release 브랜치를 범프보다 먼저 생성**하도록 4개 사본(`auto-dev.yaml` 실행본 + templates 3사본)의 순서를 교정했습니다. 기능 커밋의 close 키워드도 `Fixes #N` → `Refs #N`으로 교정했습니다 — develop은 default branch이므로 close 키워드가 있으면 태그·npm 배포 전에 이슈가 조기 close됩니다. **이번 v1.1.39 릴리즈 자체가 교정된 절차의 첫 적용입니다.**

### #1545 — R007/R008 advisory 훅 자율 루프 미발동
`r007-r008-drift-advisor.sh`가 `UserPromptSubmit`에만 배선되어 있었는데, 자율 루프(`/fsd` 등)는 task-notification으로 재진입하며 `UserPromptSubmit`이 발화하지 않아 advisory가 구조적으로 도달하지 못했습니다. `SubagentStop`에도 배선을 추가했습니다.

### #1543 — verify-template-sync.sh guides 검사 확장자 필터
guides 내용 검사가 `*.md` 파일로 한정되어 non-md 파일과 templates 쪽 역방향 orphan(원본에 없는데 templates에만 존재)을 놓치고 있었습니다. 필터를 제거하고 역방향 orphan 검사를 추가했습니다.

### #1544 — source-hash.sh workflows 카테고리 미추적
`source-hash.sh`가 고정 4카테고리(agents/skills/rules/guides)만 해싱해 canonical workflows yaml의 drift를 감지하지 못했습니다. workflows 카테고리를 추가했습니다.

## 검증
- [x] 3종 스크립트(verify-template-sync.sh, verify-wiki-sync.sh, verify-version-sync.sh) EXIT=0
- [x] `bun test` 전체 통과 (커밋 시 pre-commit hook에서 실행)
- [x] R017 mgr-sauron 구조 검증 [PASS]
- [x] release 브랜치가 develop 대비 1커밋 앞섬(diff≠0) 확인

Closes #1542
Closes #1543
Closes #1544
Closes #1545

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>