### PR TITLE
chore(release): bump to v1.1.40

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.39",
-  "generatedAt": "2026-07-30T08:58:18.753Z",
-  "templateVersion": "1.1.39",
+  "generatorVersion": "1.1.40",
+  "generatedAt": "2026-07-30T09:43:12.984Z",
+  "templateVersion": "1.1.40",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",
@@ -110,8 +110,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-enforcement-policy.md": {
-      "templateHash": "e4ac4faceb0c97f6558c2ceada5c9a51bf0c4bb9ad8b49171f2482f189c9c563",
-      "size": 5664,
+      "templateHash": "fd059b5cdf9a67e19824204270082b7562631e19a9e40a25e8804e26f04f6ba9",
+      "size": 7212,
       "component": "rules"
     },
     ".claude/rules/index.yaml": {
@@ -1185,8 +1185,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/r007-r008-drift-advisor.sh": {
-      "templateHash": "174f5973a498a8ebc003ba50d5ff998117e6f31b2dd82fbe0008636d8edd3420",
-      "size": 5078,
+      "templateHash": "e4c390f4b9900501e771e548f7180969f6a907e03fb259bc0982685ae89b7e64",
+      "size": 7198,
       "component": "hooks"
     },
     ".claude/hooks/scripts/session-autofix-prompt.sh": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.39",
+  "version": "1.1.40",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.39",
+  "version": "1.1.40",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요지

v1.1.39가 남긴 R007/R008 advisory 전달 경로 결함을 해소하고 R021 규칙·wiki 서술을 동기화합니다.

## #1547 — advisory 전달 경로 수정

advisory가 stderr로만 출력돼 모델 컨텍스트에 도달하지 않던 문제를 해소했습니다. `hookSpecificOutput.additionalContext`(CC v2.1.163+)로 전환해 `UserPromptSubmit`/`SubagentStop` 양쪽에서 모델 컨텍스트에 실제로 주입되도록 했습니다. `decision`/`continue`/`stopReason` 필드는 발행하지 않아 advisory 성격(비차단)을 유지합니다. #1229의 stdin pass-through 계약은 폐기했습니다 — 같은 이벤트 배열의 훅들은 각자 원본 stdin을 독립적으로 받으므로 payload를 echo하는 것이 무기능이었고, `UserPromptSubmit`에서는 exit-0 stdout이 실제 주입되므로 매 프롬프트마다 raw 훅 payload가 노이즈로 컨텍스트에 들어가는 부작용이 있었습니다.

## #1548 — R021 규칙·wiki 서술 동기화

r007-r008-drift-advisor가 SubagentStop에도 배선된 상태를 R021 규칙·wiki 서술에 반영해, 배선 2곳(hooks.json 이벤트 배열)과 전달 경로(stdout additionalContext) 서술을 실제 구현과 일치시켰습니다.

## 검증

- `bun test`: **2030 pass / 0 fail / 0 skip** (커버리지 25→30 케이스 증가, blocking 필드 부재를 확인하는 가드 포함)
- 3종 스크립트(`tsc --noEmit`, `biome check`, `verify-version-sync.sh`) 전부 EXIT=0
- R017 mgr-sauron `[PASS]`
- 훅 실행 검증으로 stdout 최상위 키가 `hookSpecificOutput` 단일임을 실증

Closes #1547
Closes #1548