### PR TITLE
chore(release): bump to v1.1.41

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.40",
-  "generatedAt": "2026-07-30T09:43:12.984Z",
-  "templateVersion": "1.1.40",
+  "generatorVersion": "1.1.41",
+  "generatedAt": "2026-07-30T10:30:47.149Z",
+  "templateVersion": "1.1.41",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.40",
+  "version": "1.1.41",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.40",
+  "version": "1.1.41",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 개요

이슈 #1550 — CI 실행 분수 최적화. 릴리즈당 CI 3회 실행 중 중복 1회(PR 머지 커밋)를 제거하고, concurrency 미설정 워크플로우 6종에 방어선을 추가했습니다.

## 변경 내용

### 1. PR 머지 커밋 중복 CI 제거 (`ci.yml`)

`changes` job에 `merge_commit` 게이트를 추가했습니다. 두 신호를 AND로 판별합니다.

- 구조적 신호: `git rev-list --parents -n 1` 출력 필드 수가 3 (부모 2개 = 머지 커밋)
- 문자열 신호: 커밋 제목이 `Merge pull request #` 로 시작

둘 다 만족할 때만 skip하며, 그 외 모든 경우는 full CI로 폴백합니다(fail-safe). 문자열 단독 판별은 사용자 작성 커밋을 오판하고, 구조 단독 판별은 로컬 머지 후 push를 놓치므로 두 신호를 결합했습니다.

하드 제약 준수: 기능 커밋은 develop에 직접 push되며 부모가 1개이므로 항상 full CI가 실행됩니다. `push` 트리거는 제거하지 않았습니다.

게이트는 step-level `if` 로만 구현했습니다. job-level `if` 는 job을 skipped 상태로 만들어 required status check를 영구 pending에 빠뜨립니다.

### 2. concurrency 6종 추가

| 워크플로우 | group | cancel-in-progress |
|-----------|-------|--------------------|
| `deploy-test.yml` | `deploy-test-<github.ref>` | true |
| `docs-sync.yml` | `docs-sync-<github.ref>` | true |
| `release.yml` | `release-<github.ref>` | false (npm publish 중단 시 부분 publish 위험) |
| `security-audit.yml` | `security-audit-<github.ref>` | true |
| `triage-dispatch.yml` | `triage-dispatch-<github.event.issue.number>` | true |
| `cc-release-monitor.yml` (+ templates 미러) | `cc-release-monitor` | false |

`triage-dispatch.yml` 은 `github.ref` 를 사용하지 않았습니다. `issues` 이벤트에서 ref는 항상 default branch를 가리키므로, ref로 그룹하면 서로 다른 이슈의 triage가 서로를 취소합니다.

`reusable-daily-report.yml` 은 근거와 함께 제외했습니다. `workflow_call` 재사용 워크플로우에 concurrency를 걸면 모든 호출자가 직렬화되며, push 트리거는 `push-guard` job(3초 no-op)만 실행하고 실제 `report` job은 skipped 처리되므로 비용이 무의미합니다.

### 3. 회귀 테스트 추가

`tests/unit/core/ci-workflow.test.ts` — 13개 테스트. `push` 트리거 제거, job-level `if` 유입, required check job name 변경, 게이트 단일-신호화를 모두 회귀로 검출합니다.

## 이슈 항목 3 조사 결과 (정정)

이슈 본문의 "`reusable-daily-report.yml` paths 필터 재확인 필요(미확정)" 항목은 오작동이 아님으로 확인했습니다. 해당 워크플로우는 의도적인 push-guard 패턴입니다. `push-guard` job(`if: github.event_name == 'push'`)이 no-op echo를 실행하고 실제 `report` job은 `if: github.event_name != 'push'` 조건으로 skipped 처리됩니다. 실측 run duration 13초, job duration 3초입니다.

## 검증

- `bun test`: 2043 pass / 0 fail (기존 2030 + 신규 13)
- `verify-template-sync.sh` / `verify-wiki-sync.sh` / `validate-docs.ts`: 전부 EXIT=0
- YAML 문법: 변경 8개 파일 전부 유효
- `cc-release-monitor.yml` 2 사본 md5 일치
- `verify-version-sync.sh`: EXIT=0 (1.1.41)
- 기능 커밋 CI (run 30534801396): 8 job 전부 success
- 회귀 테스트 음성 통제: job-level `if` 주입 mutation과 job name 변경 mutation을 실제 FAIL로 포착 확인

Closes #1550
