### PR TITLE
chore(release): bump to v1.1.42

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.41",
-  "generatedAt": "2026-07-30T10:30:47.149Z",
-  "templateVersion": "1.1.41",
+  "generatorVersion": "1.1.42",
+  "generatedAt": "2026-07-30T11:10:59.020Z",
+  "templateVersion": "1.1.42",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.41",
+  "version": "1.1.42",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.41",
+  "version": "1.1.42",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 개요

이슈 #1552 — `verify-template-sync.sh` 의 검사 스코프를 `templates/.github` 까지 확장하고, 그 결과 검출된 실제 미러 drift를 수정했습니다.

## 결함

`templates/.github/` 하위 파일이 원본 `.github/` 과 drift되어도 CI가 검출하지 못했습니다. 검사 스크립트는 `.claude/` ↔ `templates/.claude/`, `guides/` ↔ `templates/guides/`, repo-root `workflows/` ↔ `templates/workflows/`, pipeline-skill workflows 미러만 보고 있었습니다.

실측된 drift — `templates/.github/workflows/wiki-sync.yml` line 36 의 `actions/checkout` 이 v6, 원본은 v7.0.1 이었습니다. dependabot이 `.github/workflows/` 의 action 버전만 bump하고 미러는 갱신하지 않으며, 검사 스코프 밖이라 무기한 잔존했습니다. `templates/` 는 `omcustom init` 이 배포하는 템플릿이므로 다운스트림 프로젝트가 구버전 action을 받는 경로였습니다.

## 진단 — 필요한 함수는 이미 존재했습니다

`check_workflow_mirror()` 는 이미 있었고, `[ -f "$m" ] || continue` 로 미러에 없는 파일을 skip하여 부분 미러를 올바르게 처리하고 있었습니다. 결함은 두 곳이었습니다.

1. `.github/workflows` ↔ `templates/.github/workflows` 쌍이 호출되지 않았습니다
2. glob이 `*.yaml` 뿐이라 `.github/` 계열의 `.yml` 파일을 매칭하지 못했습니다

확장자 분포 실측:

| 디렉토리 | yml | yaml |
|---|---|---|
| `.github/workflows` | 10 | 0 |
| `templates/.github/workflows` | 2 | 0 |
| `workflows` | 0 | 2 |
| `templates/workflows` | 0 | 1 |
| `.claude/skills/pipeline/workflows` | 0 | 1 |

두 확장자 세계가 완전히 분리되어 있어, 확장자 하드코딩을 풀지 않고 호출만 추가하면 0개를 순회하고 조용히 EXIT=0 으로 통과했을 것입니다.

## 변경 내용

1. `check_workflow_mirror` 가 `*.yaml` 과 `*.yml` 양쪽을 순회합니다. 비매칭 glob 리터럴이 파일명으로 취급되지 않도록 기존 `[ -e "$wf" ] || continue` 방어를 유지했습니다(`set -u` 아래에서 nullglob 의존 없이 동작).
2. `check_workflow_mirror ".github/workflows" "templates/.github/workflows"` 호출을 추가했습니다. 미러는 10개 중 2개만 갖는 부분 미러이므로, 미러에 없는 파일은 에러가 아닙니다.
3. `check_github_scripts_mirror()` 신규 함수로 `.github/scripts` ↔ `templates/.github/scripts` 부분 미러를 검사합니다. `check_content_dir` 을 재사용하지 않은 이유는 그 함수가 `.claude/<sub>` 경로 규약을 가정하고 미러 부재를 에러로 취급하기 때문입니다.
4. `templates/.github/workflows/wiki-sync.yml` 의 `actions/checkout` SHA를 원본과 일치시켰습니다.

검사 추가와 drift 수정을 같은 커밋에 넣었습니다 — 검사만 추가하면 즉시 EXIT=1 이 되어 CI가 막힙니다.

## 음성 통제(negative control) 3/3 실증

검사가 실제로 drift를 잡는지 확인했습니다. 통과만 확인하고 방어선으로 단정하지 않았습니다.

| mutation | 대상 | 결과 |
|---|---|---|
| A | `templates/.github/workflows/wiki-sync.yml` | EXIT=1, `Workflow drift: wiki-sync.yml (.github/workflows vs templates/.github/workflows)` |
| B | `templates/.github/workflows/cc-release-monitor.yml` | EXIT=1, 동일 형식 에러 |
| C | `templates/.github/scripts/verify-fork-list.sh` | EXIT=1, `Content drift in .github/scripts: verify-fork-list.sh` |

에러 메시지에 `.github/workflows` 쌍이 명시된 것이 확장자 수정과 호출 추가가 둘 다 필요했음을 실증합니다. 3건 모두 복구 후 EXIT=0 재확인했습니다.

음성 통제 과정에서 부수 함정 1건도 드러났습니다 — mutation 복구 시 Edit으로 마지막 줄을 제거하면 트레일링 개행이 함께 삭제되어 `\ No newline at end of file` diff가 잔존합니다. 개행만 복원해 해소했습니다.

## 검증

- `bash -n .github/scripts/verify-template-sync.sh`: EXIT=0
- `bash .github/scripts/verify-template-sync.sh`: EXIT=0
- `bash .github/scripts/verify-wiki-sync.sh`: EXIT=0
- `bun .github/scripts/validate-docs.ts --programmatic-only`: EXIT=0
- `bun test`: 2043 pass / 0 fail
- `verify-version-sync.sh`: EXIT=0 (1.1.42)
- 미러 3파일 md5 원본 일치

Closes #1552
