### PR TITLE
chore(settings): 무효 Write(...) permission 규칙 제거

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,11 +15,8 @@
       "Bash(cat:*)",
       "Bash(sed:*)",
       "Bash(chmod:*)",
-      "Write(.claude/**)",
       "Edit(.claude/**)",
-      "Write(templates/.claude/**)",
       "Edit(templates/.claude/**)",
-      "Write(.claude/outputs/**)",
       "Edit(.claude/outputs/**)"
     ],
     "defaultMode": "bypassPermissions"

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,13 +15,10 @@
       "Bash(cat:*)",
       "Bash(sed:*)",
       "Bash(chmod:*)",
-      "Write(.claude/**)",
       "Edit(.claude/**)",
-      "Write(templates/.claude/**)",
       "Edit(templates/.claude/**)",
       "Bash(mkdir -p .claude/outputs/sessions/2026-04-27)",
       "Bash(cp /tmp/professor-triage-093618.md .claude/outputs/sessions/2026-04-27/professor-triage-093618.md)",
-      "Write(.claude/outputs/**)",
       "Edit(.claude/outputs/**)"
     ],
     "defaultMode": "bypassPermissions"


### PR DESCRIPTION
## 배경

Claude Code는 파일 권한 규칙을 `Edit(path)` matcher로만 해석하며, 이 matcher가 Write/Edit/NotebookEdit 등 모든 파일 편집 도구를 커버합니다. `Write(path)` 형태는 matcher로 등록되지 않아 무효(no-op)이며, 매 세션 시작 시 경고를 발생시켰습니다.

## 변경

`.claude/settings.json` 및 `.claude/settings.local.json`의 `permissions.allow`에서 아래 3개 항목을 제거했습니다.

- `Write(.claude/**)`
- `Write(templates/.claude/**)`
- `Write(.claude/outputs/**)`

## 권한 영향: 없음

세 경로 모두 대응하는 `Edit(...)` 규칙이 이미 존재하며 그대로 보존했습니다. 따라서 실효 권한 변화는 없습니다.

| 파일 | allow 길이 | `Write(` | `Edit(` |
|------|-----------|---------|--------|
| `.claude/settings.json` | 20 → 17 | 0 | 3 |
| `.claude/settings.local.json` | 22 → 19 | 0 | 3 |

`permissions.allow` 외 구조는 무변경입니다 (`jq -S 'del(.permissions.allow)'` 결과를 `origin/develop` 버전과 대조하여 확인).

## 검증

mgr-sauron R017 검증 PASS — JSON 유효성, 대응 `Edit(...)` 규칙 보존, 비의도 변경 0건, `templates/` 미러 사본 부재로 3중 동기화 불요, 카운트 무영향, `bun test` 2043 pass / 0 fail.

## 참고

R002에 이미 관련 조항(`Write(path)`/`NotebookEdit(path)`/`Glob(path)` 형태는 시작 시 경고를 발생시키므로 `Edit(path)`로 작성)이 문서화되어 있었으나, 실제 설정 파일이 정렬되지 않은 상태였습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)