### PR TITLE
chore(settings): 일회성 Bash permission 규칙 정리

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,8 +17,6 @@
       "Bash(chmod:*)",
       "Edit(.claude/**)",
       "Edit(templates/.claude/**)",
-      "Bash(mkdir -p .claude/outputs/sessions/2026-04-27)",
-      "Bash(cp /tmp/professor-triage-093618.md .claude/outputs/sessions/2026-04-27/professor-triage-093618.md)",
       "Edit(.claude/outputs/**)"
     ],
     "defaultMode": "bypassPermissions"


### PR DESCRIPTION
## 배경

`.claude/settings.local.json`의 `permissions.allow`에 2026-04-27 세션에서 추가된 일회성 규칙 2줄이 남아 있었습니다.

- `Bash(mkdir -p .claude/outputs/sessions/2026-04-27)`
- `Bash(cp /tmp/professor-triage-093618.md .claude/outputs/sessions/2026-04-27/professor-triage-093618.md)`

## 삭제 근거

1. **상위 와일드카드에 포섭됨** — 같은 allow 배열에 `Bash(mkdir:*)`와 `Bash(cp:*)`가 존재하며, `:*` 접두 매칭이 해당 명령 전체를 커버합니다. 인자를 못 박은 두 규칙은 추가로 부여하는 권한이 없습니다.
2. **경로가 소멸함** — 날짜가 박힌 outputs 디렉토리와 `/tmp` 아티팩트는 재사용되지 않습니다.

## 권한 영향: 없음

`permissions.allow` 길이 19 → 17. 와일드카드 규칙(`Bash(mkdir:*)`, `Bash(cp:*)`)과 `Edit(...)` 3종은 모두 보존했습니다.

## 검증

mgr-sauron R017 PASS — JSON 유효, 비의도 변경 0건, `templates/` 미러 부재로 3중 동기화 불요, 카운트 무영향, `bun test` 2043 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)