### PR TITLE
chore(release): bump to v1.1.43

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.42",
-  "generatedAt": "2026-07-30T11:10:59.020Z",
-  "templateVersion": "1.1.42",
+  "generatorVersion": "1.1.43",
+  "generatedAt": "2026-08-05T13:01:51.305Z",
+  "templateVersion": "1.1.43",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",
@@ -15,8 +15,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "e76744b4f1b119226a6b5bf17c6f2dfcf42a1fe524395cc5c9b2ab7004badde8",
-      "size": 44698,
+      "templateHash": "d159b99b9d855c0e1c2f98a425b1d3e09b9217daa9e0b7eee22a34961a6376c7",
+      "size": 48075,
       "component": "rules"
     },
     ".claude/rules/MUST-intent-transparency.md": {
@@ -50,13 +50,13 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
-      "templateHash": "ae24567fd513c3c80469d53afd88dfbe1439573adb6a0b55638043aa1ef3fd67",
-      "size": 44101,
+      "templateHash": "763c8b075b7f19a07af4e8ec8286e574101e876e928ed477d0b1d2da58c23d0f",
+      "size": 47237,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
-      "templateHash": "5cf631bb4159755766b31c6f4cabc8b5e692e27d3968d751a4216496305bd0b5",
-      "size": 6570,
+      "templateHash": "a828d087d98612df86e80b3bac1a6a3d616eda5f02e23d5d02a8616723a194dd",
+      "size": 8009,
       "component": "rules"
     },
     ".claude/rules/MUST-sync-verification.md": {
@@ -65,23 +65,23 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-teams.md": {
-      "templateHash": "723487c1005f0abcb9bd1e6477d9f735d8c632d8dcaddd3be5114c10d695e954",
-      "size": 24763,
+      "templateHash": "18111b089bf217784e65e4177becde1357c5c52885c1f5a45a6ad71c5cda2d76",
+      "size": 25870,
       "component": "rules"
     },
     ".claude/rules/MAY-optimization.md": {
-      "templateHash": "b852d6ea86f88cf94b0902cf945e0748daa740219aa22a0a7ad775ab5c3d40b1",
-      "size": 9901,
+      "templateHash": "c44ac858488ae14b854a1aeac32a6434775ffa07ff2551fa51fac10acd0f2e55",
+      "size": 10315,
       "component": "rules"
     },
     ".claude/rules/MUST-continuous-improvement.md": {
-      "templateHash": "c6bf4089ba08ef5b33f0f1237be44490657c2ce7760ba2345b7a0c33d6fe056d",
+      "templateHash": "049969954e9fc00e873f38aabd207eee95e209556490e2a7742e09bc2ca72d87",
       "size": 9232,
       "component": "rules"
     },
     ".claude/rules/MUST-permissions.md": {
-      "templateHash": "790c5b5f42f079c79eb67d9d8f5b77d329532399fe3ba9ea8db9f3407e8f67c9",
-      "size": 11457,
+      "templateHash": "0fc05801abf48e9d8f1aaf56d0aa23d984ad1b7b8ef6a0e689673c30007e1d9b",
+      "size": 12745,
       "component": "rules"
     },
     ".claude/rules/SHOULD-ontology-rag-routing.md": {
@@ -90,8 +90,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-safety.md": {
-      "templateHash": "895152f884c6c23af56d2476db0a58685f2432b7d6c8b7ffc44f14d80a386b2f",
-      "size": 11803,
+      "templateHash": "23050f6966479a916dbeb401eb981d2e064146561640315e3dc9fcbde087d469",
+      "size": 12559,
       "component": "rules"
     },
     ".claude/rules/MUST-tool-identification.md": {
@@ -110,8 +110,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-enforcement-policy.md": {
-      "templateHash": "fd059b5cdf9a67e19824204270082b7562631e19a9e40a25e8804e26f04f6ba9",
-      "size": 7212,
+      "templateHash": "b1a795296063640ed3bcaea06e4e5734c6ae94c29ebfce08d4094ebd223612c7",
+      "size": 8351,
       "component": "rules"
     },
     ".claude/rules/index.yaml": {
@@ -120,8 +120,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-completion-verification.md": {
-      "templateHash": "7f647095e0790fd4ced6b4bf499dce0dd7c2071c0dccc189c57f0b4b23186a1d",
-      "size": 32467,
+      "templateHash": "622c60fb6f8e4bdc9c2b689eb485eb41385affab21f60cd1d13cfcfc2bdcf767",
+      "size": 33876,
       "component": "rules"
     },
     ".claude/agents/be-springboot-expert.md": {
@@ -480,8 +480,8 @@
       "component": "skills"
     },
     ".claude/skills/pipeline/workflows/auto-dev.yaml": {
-      "templateHash": "326b6db760284b1fe0125856026cb323b99b5533e365d19ce8350c4ba3794704",
-      "size": 26821,
+      "templateHash": "70b1acb9863ba24cbd62d7711603a13b5bfe2818c4cf1f905ecc5fb33f0bc150",
+      "size": 31337,
       "component": "skills"
     },
     ".claude/skills/pipeline/SKILL.md": {
@@ -1125,8 +1125,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/session-reflection.sh": {
-      "templateHash": "0c9c224368c7a1fb13818c1981b7c7da10bde6f8c7e4c8ca83decdc077207162",
-      "size": 8409,
+      "templateHash": "e0f75ea1cb5150ccb1d43054565a0fbefbbc724f02d81ac177f841141d79a980",
+      "size": 9174,
       "component": "hooks"
     },
     ".claude/hooks/scripts/user-prompt-preprocessor.sh": {
@@ -1164,6 +1164,11 @@
       "size": 2904,
       "component": "hooks"
     },
+    ".claude/hooks/scripts/fail-axis-cause-advisor.sh": {
+      "templateHash": "95d4e97ff8c5c87e40a20c7a95017b574a3b5d8f685a98fdfaa709d972b6b3ee",
+      "size": 4527,
+      "component": "hooks"
+    },
     ".claude/hooks/scripts/model-escalation-advisor.sh": {
       "templateHash": "31940a5d710f3ec624e96738c8c873e83216a84fb48624dfa87808bcd429634a",
       "size": 3486,
@@ -1185,8 +1190,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/r007-r008-drift-advisor.sh": {
-      "templateHash": "e4c390f4b9900501e771e548f7180969f6a907e03fb259bc0982685ae89b7e64",
-      "size": 7198,
+      "templateHash": "f77b9f933897416453c58ebf44857050f94589a1ebaca3b6f06231faff27cb58",
+      "size": 11099,
       "component": "hooks"
     },
     ".claude/hooks/scripts/session-autofix-prompt.sh": {
@@ -1202,6 +1207,11 @@
     ".claude/hooks/scripts/stuck-detector.sh": {
       "templateHash": "38f8f37bc886bd4db7eb2f041df8b8a38fc7ac34ce33680e53430ac4be0b83ab",
       "size": 7463,
+      "component": "hooks"
+    },
+    ".claude/hooks/scripts/failure-ledger.sh": {
+      "templateHash": "50373d5df18ea1944279eed00ddd2d701f245fe6e0611e348cc73c93922d4463",
+      "size": 2537,
       "component": "hooks"
     },
     ".claude/hooks/scripts/agent-start-recorder.sh": {
@@ -1280,8 +1290,8 @@
       "component": "hooks"
     },
     ".claude/hooks/hooks.json": {
-      "templateHash": "7b0b1652c46e358559c724d87a758e0899b98d233fb174e35e38d4e26682c9c3",
-      "size": 28071,
+      "templateHash": "8cda33f2d7d53118da4b6f2a04b77e252c2e36c6aef133065386296811dc0f30",
+      "size": 28723,
       "component": "hooks"
     },
     ".claude/contexts/ecomode.md": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.42",
+  "version": "1.1.43",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.42",
+  "version": "1.1.43",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약

v1.1.43 — 이슈 4건. R007/R008 advisory 훅이 프로젝트 역사상 처음으로 실제 동작하게 되었습니다.

## #1553 — advisory 훅 파서 복구 (High) + 세션 회고 조항

**advisor 는 한 번도 발화한 적이 없었습니다.** 트랜스크립트 셀렉터가 최상위 `.role` 을 읽는데 실제 경로는 `.message.role` 이라, 스크립트가 매 호출마다 조기 종료했습니다.

실측 근거:

| 검사 | 결과 |
|------|------|
| 트랜스크립트 771개 전수 `"additionalContext":` 출현 | **0건** |
| 라이브 프로브 stdout / stderr | **0바이트 / 0바이트** |
| `session-reflection.sh` 동일 결함 | proactive·retroactive **두 계층 모두 미발화** |

v1.1.40(#1547)은 전달 **경로**를, v1.1.41(#1545)은 **배선**을 확인했으나, 그 앞단 **파서가 살아 있다는 전제**는 세 릴리즈 동안 한 번도 검증되지 않았습니다. #1553 회고가 센 "주입 7회"는 다른 문자열이었습니다(이슈에 정정 코멘트 게시).

수정 순서: 셀렉터 교정 → 턴 재구성(연속 assistant 줄 수집 + `isSidechain` 필터) → 성능 경량화(줄당 `jq` 포크 → 단일 패스) → 턴 uuid dedup → `PostToolUse` 배선.

수정 후 실측:

| 항목 | 값 |
|------|-----|
| 발화 | 12개 트랜스크립트 중 **5개 발화(212바이트) / 7개 정상 침묵** |
| payload | `hookSpecificOutput.additionalContext`, 최상위 `decision`/`continue` 부재 (advisory 유지) |
| 성능 | **0.02초** (수정 전 2.80~8.64초) |

테스트 픽스처가 실스키마가 아니라 **버그 있는 셀렉터에 맞춰져 있어** 죽은 스크립트를 상대로 green 이었습니다. 실스키마로 교체하고 dedup / `isSidechain` / 준수턴 케이스를 추가했습니다 (+16 테스트, 2043 → 2059 pass / 0 fail).

그 외 회고 조항:

- **R007** — Insight/분석 블록으로 시작하는 응답도 헤더 선행 필수 (누락 7건 중 5건이 Insight 선행)
- **R020** — 자가 위반 계상도 transcript 실측 기반 (자가보고 2회 vs 실측 7회)
- **R005** — 계수 함정 4번째: 머지 커밋 diff 기본 생략 (`--first-parent`/`-m` 필요)
- **auto-dev.yaml** — 압축 모드는 분석 산출물만 대체하며 상태 변경 부수 효과(마일스톤 생성/할당, 라벨 부여)는 항상 수행. 마일스톤 스텝을 3분기 상태머신 + post-condition 실측으로 명시

## #1556 — R010 위임 프레이밍 교정

이슈는 R010(모든 git 작업은 mgr-gitnerd 경유)과 서브에이전트의 전언-불신 원칙이 교착을 만든다고 보았으나, 진단 결과 **전제가 일부 틀렸습니다**. 거부 문구는 `mgr-gitnerd.md` 에 존재하지 않으며 CC 가 모든 서브에이전트에 주입하는 플랫폼 시스템 프롬프트입니다. 그 문구가 금지하는 것은 전언을 **승인**으로 취급하는 것이지 전언된 **작업**을 수행하는 것이 아닙니다.

따라서 해소는 규칙 완화가 아니라 **프레이밍 교정**입니다 — 위임 프롬프트에서 사용자 원문을 승인 근거로 인용하지 않고, 허용 작업·금지 작업·완료 조건만 전달합니다. 승인 채널은 permission system 이 담당합니다.

**대조 실증**: 승인 인용을 포함한 위임은 mgr-gitnerd 가 2회 거부했고, 동일 에이전트에 허용/금지 작업만 열거한 위임은 이번 세션에서 **2회 모두 거부 없이 완주**했습니다.

## #1559 / #1560 — CC v2.1.221 / v2.1.222 대응

R001(worktree isolation), R002(zsh `[[ ]]` 권한 검사 / auto mode 병렬 검사 / Remote Control 스코프), R006(org-restricted alias step-down, `disable-model-invocation` refusal), R010(background session commit/push), R018(SendMessage classifier 사전평가 / 긴 summary 절단), R021(PreToolUse auto-allow 우회 수정)에 버전노트 반영.

**R006 훅 이벤트 목록 정정**: `PostMessage` 는 문서화된 이벤트가 아니며 실제로는 `MessageDisplay` 입니다. `MessageDisplay` 는 `displayContent` 전용이고 `additionalContext` 를 지원하지 않으므로, 향후 advisory 훅을 여기에 배선하려는 오설계를 차단하는 각주를 함께 넣었습니다.

**R016** 버전노트 보존 기준을 v2.1.208 → v2.1.212 로 상향하고 오래된 v2.1.208 노트 3건을 은퇴(HTML 주석화)했습니다.

**R021 사실 정정**: "Delivery gap resolved (#1547, v1.1.40)" 이 사실과 달라 정정했습니다. 교훈은 **배선 확인 ≠ 전달 확인 ≠ 발화 확인** 입니다.

## 검증

| 게이트 | 결과 |
|--------|------|
| R017 (mgr-sauron) | **PASS** — 원본↔미러 13쌍 + auto-dev 4사본 바이트 동일, R006 이벤트 31=31 / R005 함정 4=4 자기 정합, HTML 주석 구조 무결(전 23파일), 은퇴 노트 dangling 참조 0건 |
| `bun test` | 2059 pass / 0 fail (baseline 2043, +16 신규, 회귀 0) |
| develop CI | run 31007831727 `completed/success`, 8/8 잡 success (`code=true` full run) |
| R022 위키 | 페이지 갱신 + `wiki/.source-hashes.json` 재시딩 양쪽 완료 (sha256 대조) |
| 카운트 | agents 49 / skills 114 / rules 23 / guides 56 실측 일치 |

## 알려진 이월 항목

- R016 보존 기준을 v2.1.212 로 올린 결과 R001 / R005 / R012 에 visible v2.1.208 노트 3건이 잔존합니다. R012 는 이번 변경 범위 밖이고 게이트 통과 후 스코프 확장은 R017 이 경계하는 패턴이므로 3건 전부 다음 회차로 이월합니다.
- 미배선 훅 스크립트 2종(`failure-ledger.sh`, `fail-axis-cause-advisor.sh`)은 #1561 이 소유합니다. 미추적 상태라 `verify-template-sync.sh` 가 로컬에서만 red 이며 clean CI 체크아웃에서는 재현되지 않습니다(git-tracked 기준 38=38).

Closes #1553
Closes #1556
Closes #1559
Closes #1560

🤖 Generated with [Claude Code](https://claude.com/claude-code)
