### PR TITLE
chore(release): bump to v1.1.44

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.43",
-  "generatedAt": "2026-08-10T08:43:54.378Z",
-  "templateVersion": "1.1.43",
+  "generatorVersion": "1.1.44",
+  "generatedAt": "2026-08-10T09:16:52.240Z",
+  "templateVersion": "1.1.44",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.43",
+  "version": "1.1.44",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.43",
+  "version": "1.1.44",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## v1.1.44

advisor R008 판정이 R009 병렬 실행과 충돌하던 High 결함을 해소하고, 미배선 훅 2종을 처리하며, Claude Code v2.1.223~226을 룰에 반영합니다.

### 훅 — R008 판정 턴 단위 전환 (#1563 찐빠 #1, High)

기존 판정은 **블록 인접성**으로 계산돼, R009가 MUST로 요구하는 병렬 도구 배치에서 2번째 이후 `tool_use`를 무조건 위반으로 보고했습니다. R008 원문은 "For parallel calls: list ALL identifications BEFORE the tool calls" 이므로 스펙과 구현이 불일치했습니다.

새 판정: `violations = max(0, tool_use 수 − announce 라인 수)`

- `→ Target:` 은 `→ Tool:` 의 동반 라인이므로 **미계수** (계수 시 도구당 2로 세어 실제 누락을 은폐)
- R008 「Parallel Spawn Prefix Rule」의 spawn 표기(`→ Spawning:` + `[N] type:model →`)는 **계수** (제외 시 Agent spawn N개 대 `Tool:` 라인 0개가 되어 동일 오탐 재생산)
- 동일 결함이 `session-reflection.sh` 에도 있어 함께 수정 — 두 스크립트의 판정식이 완전 동일함을 확인

**실증** (합성 트랜스크립트 양성/음성 짝):

| 케이스 | 기대 | 신규 | 기존 |
|---|---|---|---|
| 준수 병렬 배치 (announce 3, tool 3) | 0 | **0** | **2 (오탐)** |
| 진성 위반 (announce 1, tool 3) | 2 | **2** | — |
| 준수 spawn 표기 | 0 | **0** | — |

결함 주입 확인: 인접 판정을 임시 복원하면 준수 2-도구 배치에서 212바이트가 발화하며, 이는 원 이슈의 실측치와 일치합니다.

### 훅 — 미배선 2종 처리 (#1561)

`PostToolUseFailure` 라이브 지원을 공식 문서로 확인한 뒤 배선했습니다.

| 스크립트 | 이벤트 | R021 tier |
|---|---|---|
| `failure-ledger.sh` | `PostToolUseFailure` | Advisory (순수 telemetry) |
| `fail-axis-cause-advisor.sh` | `UserPromptSubmit` | Advisory (proactive), `additionalContext` |

배선 **전에** `failure-ledger.sh` 의 결함을 발견해 수정했습니다 — `.tool_response.error` 를 읽는데 `PostToolUseFailure` 는 `tool_response` 를 보내지 않고 최상위 `error` 를 보냅니다. 그대로 배선했다면 모든 원장 레코드가 `err: ""` 로 기록되는 조용한 실패가 됐을 것입니다.

훅 스크립트 미러 불일치 해소: runtime 40 / templates 38 → **40 / 40**.

### 룰 — CC v2.1.223~225 반영 (#1564 #1565 #1566 #1567)

버전노트 12건 배치. 주요 항목:

- **v2.1.224 세션당 200 subagent spawn cap 제거** → R009 (동시성 5 제한은 유효)
- **v2.1.224 `SendMessage` 가 inbox 쓰기 실패에도 "Message sent" 보고하던 결함 수정** → R018 Member Completion Verification
- **v2.1.225 auto mode 가 safety-filter refusal 을 consecutive-block 한도에 계상하던 결함 수정** → R010 Scope-Creep STOP
- v2.1.223 Bash 권한 검사 자기-은닉 / 승인 다이얼로그 유니코드 은닉 수정 → R001 R002
- v2.1.223 agent def `bypassPermissions` 가 org 정책 무시하던 공백 수정 → R010

`v2.1.226` 은 "Bug fixes and reliability improvements" 만 기재돼 반영 대상이 없습니다.

### 룰 — 규약 4건 신설 + 버전노트 3건 은퇴 (#1563 찐빠 #2~#5)

- **R016** 「보존 기준 변경 = 같은 릴리즈 내 전 룰 파일 스윕」
- **R023** 「Conditional-Output Verification — 양성/음성 짝 필수」 (조건부 출력을 "stdout ≠ 0바이트" 단일 프록시로 검증하면 침묵이 정답인 입력에서 오판)
- **R010** 「위임 프롬프트 명령 예시는 실측 확인 후 제공」
- **R011** 「Procedure-Summary Scope Tagging」 (메모리 절차 요약에 적용 스코프 표기)

R001 / R005 / R012 의 v2.1.208 노트 3건을 HTML 주석으로 **무손실** 은퇴 (원문 verbatim 보존 확인).

### 테스트

39건 추가 (전부 양성/음성 통제 짝). 2059 → 2098.

### 검증

`lint` / `typecheck` / `build` / `verify-template-sync` / `verify-wiki-sync` / `validate-docs` 전부 exit 0. 카운트 불변 (agents 49 / skills 114 / rules 23 / guides 56). 원본 ↔ templates 미러 바이트 동일. 위키 12페이지 재동기화 + 매니페스트 재시딩 (drift 12 → 0, 해시 재계산 mismatch 0).

**mgr-sauron R017 검증: PASS** (차단 사유 없음)

> 로컬 `bun test` 는 11 fail 을 보입니다. 전부 `session-env-check.sh` 스위트이며 원인은 `~/.oh-my-customcode/self-update-cache.json` 에 `latestVersion` 키가 없는데 스크립트가 가드 없이 `grep` + `set -euo pipefail` 인 점입니다. 해당 스크립트는 v1.1.17 이후 미수정이고 캐시 파일 제거 시 2098 pass / 0 fail 로 확인됐습니다 — 머신 로컬 환경 유래이며 CI 러너에는 캐시 파일이 없어 재현되지 않습니다. 별도 이슈 #1570 으로 추적합니다.

### 후속 이슈

- #1568 `user-prompt-preprocessor.sh` 이중 결함 (셀렉터 + 전달 채널)
- #1569 R008 판정이 Skill 도구 계수 → 오탐 (R008 Tier-3 면제 미반영)
- #1570 `session-env-check.sh` 가드 없는 grep
- #1571 R017 비차단 지적 4건

Closes #1561
Closes #1563
Closes #1564
Closes #1565
Closes #1566
Closes #1567
