### PR TITLE
chore(release): bump to v1.1.45

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.44",
-  "generatedAt": "2026-08-10T09:16:52.240Z",
-  "templateVersion": "1.1.44",
+  "generatorVersion": "1.1.45",
+  "generatedAt": "2026-08-10T12:05:42.190Z",
+  "templateVersion": "1.1.45",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",
@@ -15,8 +15,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "19e196eba32bafbcf2c8b068ed8c28ea58c487bcf244defe934c89a8cafe2eb4",
-      "size": 50553,
+      "templateHash": "4fd5560f2d363d57ba9fe6e27b9e734df744a366039f6f89cb55c6b399a48a91",
+      "size": 52707,
       "component": "rules"
     },
     ".claude/rules/MUST-intent-transparency.md": {
@@ -50,8 +50,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
-      "templateHash": "666447cee76e066c799d640e7f3e32902a0858ebd845d695398ca4d0142e1277",
-      "size": 48480,
+      "templateHash": "fcfedfbc3f3b9c3cbee824b833239351a03de17d62083be658ed11837b9ee41f",
+      "size": 48556,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
@@ -60,8 +60,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-sync-verification.md": {
-      "templateHash": "9880dfe27012d68f90c0e76cce85f894366fce761484bcd4d2b01fb3d44e50b9",
-      "size": 16088,
+      "templateHash": "cd5e54137d3b9d97d695c71ec57b446849f94a2539765da76271e100eae2582b",
+      "size": 17355,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-teams.md": {
@@ -70,18 +70,18 @@
       "component": "rules"
     },
     ".claude/rules/MAY-optimization.md": {
-      "templateHash": "9775898e22a48a41b803f39e6cc1b253b3c1669fdf9037e8adb2fc512d758b18",
-      "size": 10858,
+      "templateHash": "7fd13c5a453c0ab47a19199cfa3322affd0e0827ef7d84021e02d4389a79a23a",
+      "size": 10934,
       "component": "rules"
     },
     ".claude/rules/MUST-continuous-improvement.md": {
-      "templateHash": "0cb66ddd7227189a77639e9ced652618221dad634e4652ce7bd276b41efa4781",
-      "size": 10529,
+      "templateHash": "bf1b596931a9055a6cf692f2dfd47ea9fa0ead6de961969044d9ec9896c76c7b",
+      "size": 10707,
       "component": "rules"
     },
     ".claude/rules/MUST-permissions.md": {
-      "templateHash": "544a03ffa872262ece2da327d55634a74b64dcaa43f0772c53fd4503455d6cda",
-      "size": 13623,
+      "templateHash": "ca61895d7c83c098589b866ebdd03030cdf486138cd0c7c3e56dd9b14aa67561",
+      "size": 13699,
       "component": "rules"
     },
     ".claude/rules/SHOULD-ontology-rag-routing.md": {
@@ -100,18 +100,18 @@
       "component": "rules"
     },
     ".claude/rules/SHOULD-verification-ladder.md": {
-      "templateHash": "581c43a0030c62c3c1022cde36fdea6579e68789f11b5ec7499137e924db54bb",
-      "size": 15875,
+      "templateHash": "a19cbd2c50d7794c8295f151e1d1e09ac3613db8c011fa5b719744b4752d6d57",
+      "size": 17116,
       "component": "rules"
     },
     ".claude/rules/SHOULD-memory-integration.md": {
-      "templateHash": "083d6de283891069e7964ed295d80f21e80dc180139760703c076943079573c0",
-      "size": 23329,
+      "templateHash": "90520fc8a94b0160a1577ba9a8e321829e22731284d938af6ed39f9b99090b70",
+      "size": 23405,
       "component": "rules"
     },
     ".claude/rules/MUST-enforcement-policy.md": {
-      "templateHash": "b1a795296063640ed3bcaea06e4e5734c6ae94c29ebfce08d4094ebd223612c7",
-      "size": 8351,
+      "templateHash": "82168b610c7874658fe7d7a1a6a39e5b2bc80b3e496fd0cc7afc14fadeb3a56c",
+      "size": 9801,
       "component": "rules"
     },
     ".claude/rules/index.yaml": {
@@ -120,8 +120,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-completion-verification.md": {
-      "templateHash": "622c60fb6f8e4bdc9c2b689eb485eb41385affab21f60cd1d13cfcfc2bdcf767",
-      "size": 33876,
+      "templateHash": "13f3d76b0fff1d831b3039403f2071f81198638ed7532ab3eb78ca51839e5841",
+      "size": 37132,
       "component": "rules"
     },
     ".claude/agents/be-springboot-expert.md": {
@@ -480,8 +480,8 @@
       "component": "skills"
     },
     ".claude/skills/pipeline/workflows/auto-dev.yaml": {
-      "templateHash": "70b1acb9863ba24cbd62d7711603a13b5bfe2818c4cf1f905ecc5fb33f0bc150",
-      "size": 31337,
+      "templateHash": "3087021956c47960fc8699cfe1dcb88b5cff9f663c94ad4b2e34940a1251a5db",
+      "size": 32449,
       "component": "skills"
     },
     ".claude/skills/pipeline/SKILL.md": {
@@ -1125,13 +1125,13 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/session-reflection.sh": {
-      "templateHash": "5f1c834911415093b63420cedbf2c073dd690d78be9b830f0c46f0bfc50b4cd9",
-      "size": 10832,
+      "templateHash": "6bf31fab89dadd586e444224cb0617d99f87f4308136014bcb32889a4d5bf56c",
+      "size": 11356,
       "component": "hooks"
     },
     ".claude/hooks/scripts/user-prompt-preprocessor.sh": {
-      "templateHash": "71a4e7fec6f830c7c12fbb00f8d1469a8dd92805f06495d31afa1a2ef88532cf",
-      "size": 843,
+      "templateHash": "8beb826ea42f71b2a7f6600e23136c4db11036abda83730261d1bf9f9f35f471",
+      "size": 4521,
       "component": "hooks"
     },
     ".claude/hooks/scripts/rtk-intercept.sh": {
@@ -1190,8 +1190,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/r007-r008-drift-advisor.sh": {
-      "templateHash": "1f397d5cf6f0ee775d280bed3693611c74d75d9581068690837810f69c3c423c",
-      "size": 13538,
+      "templateHash": "e1541135c9967a33bfc1c94bb025721ecda44e3e150e0589d89623a48aead038",
+      "size": 14244,
       "component": "hooks"
     },
     ".claude/hooks/scripts/session-autofix-prompt.sh": {
@@ -1225,8 +1225,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/session-env-check.sh": {
-      "templateHash": "c309410499ca66d6a4a7ebe588b8faf4fa6f2a1e5e5190d8f3ccd3feab749e31",
-      "size": 8665,
+      "templateHash": "94b827c5f62c6248519da2171a2c41105e5b2b0604348474222a40a109c8c371",
+      "size": 10112,
       "component": "hooks"
     },
     ".claude/hooks/scripts/feedback-collector.sh": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.44",
+  "version": "1.1.45",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.44",
+  "version": "1.1.45",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## v1.1.45

훅 스크립트의 **스키마 추정 결함 클래스** 3건을 일괄 해소하고, v1.1.44 세션 회고에서 나온 하네스 조항 11건을 반영합니다.

### 훅 — 스키마 추정 결함 3건 (#1568 #1569 #1570)

세 이슈는 동일 결함 클래스입니다: **스크립트가 페이로드·데이터 스키마를 추정해 작성됐고, 테스트가 그 추정을 그대로 먹여 검증해 결함을 보호**했습니다. 이 저장소에서 반복 관측된 패턴이라 한 단위로 묶어 처리했습니다.

**#1569 — R008 판정이 Skill 도구를 계수해 오탐**
R008 「Tier-3 Interaction Tool Prefix」는 Skill 을 명시 면제합니다(*"NO separate R008 prefix — identified via R007 integrated header instead"*). 그러나 판정식이 Skill `tool_use` 를 계수해, R007 통합 헤더만 있는 준수 턴에서 허위 위반을 보고했습니다. `r007-r008-drift-advisor.sh` 와 `session-reflection.sh` **양쪽 판정식에 동일 제외**를 적용했습니다 — 두 스크립트의 술어가 문자 단위로 동일해 한쪽만 고치면 재오염됩니다.

**#1568 — `user-prompt-preprocessor.sh` 이중 결함**
라이브 프로브로 확정한 두 축을 **함께** 수정했습니다(부분 수정은 훅을 여전히 무기능으로 남깁니다).
- **셀렉터**: `.user_input` 을 읽어 플랫폼의 `prompt` 를 놓치고 pass-through 로 즉시 종료 → `.prompt // .user_input // ""` 로 전환(폴백 유지)
- **전달 채널**: 힌트를 stderr 로만 내보내 모델에 도달하지 않던 문제 → `hookSpecificOutput.additionalContext`(exit 0, `decision` 필드 없음)로 전환
- **pass-through echo 제거**: 같은 `UserPromptSubmit` 에 배선된 다른 3개 스크립트가 모두 stdin 을 echo 하지 않으며, exit-0 stdout 이 모델 컨텍스트로 주입되므로 원시 훅 JSON 반환은 노이즈입니다.

**#1570 — `session-env-check.sh` 가드 없는 grep**
이슈 가설은 `latestVersion` 을 폐기 스키마로 추정했으나, **실측 결과 두 writer 가 현행 공존**합니다 — `omcustom-auto-update.sh` 는 `{version,timestamp,source}`, `src/core/self-update.ts` 는 `{checkedAt,latestVersion}`. 둘 다 읽도록 폴백을 넣었습니다. 아울러 같은 결함 클래스의 가드 없는 grep **2곳을 추가 발견**해 함께 수정했습니다(`INSTALLED_VERSION`, `PROJECT_HASH`) — 셋 다 `set -euo pipefail` + 무매칭 grep 조합으로 SessionStart 훅 전체를 중단시키던 경로였습니다.

### 룰 — R017 검증 지적 + 세션 회고 반영 (#1571 #1574)

**R021 Enforcement Tiers**
- `failure-ledger.sh`(PostToolUseFailure, Advisory/telemetry — stdout·stderr 무출력이라 모델 미도달) · `fail-axis-cause-advisor.sh`(UserPromptSubmit, Advisory/proactive) 2행 추가
- R007/R008 advisory 를 "미발화·수정 **중**"으로 서술하던 stale 표현을 **시제 정정**. v1.1.43 에서 수정 완료·발화 확인됐고 이후 v1.1.44(#1563)·v1.1.45(#1569)가 판정을 더 고쳤습니다. 실증 기록(771 트랜스크립트 전수 0건, 라이브 프로브 0바이트, "배선 확인 ≠ 전달 확인 ≠ 발화 확인" 교훈)은 **전부 보존**하고 시제만 과거형으로 전환했습니다.

**R016** — RETIRED 템플릿을 `(은퇴 릴리즈 vX.Y.Z, <사유>)` 로 일반화(사유 2종 병기). v2.1.210×5 · v2.1.211×1 노트 **6건 무손실 은퇴**(verbatim 보존 확인).

**R020** — 「위임 경계를 Phase 개수로 설계(예방 1차 방어선)」 신설. mid-step 종료 누적 14회에 대해 clause 강화가 아니라 **경계 분할**이 실효 방어선임을 대조 실증으로 기록했습니다(단일 목표 위임 4/4 완주 대 다중 Phase 위임 2/2 종료). 증상→결과 추론 불가를 **3방향 실증**으로 갱신하고, 「자율 루프 세션의 턴 경계 정의」를 신설했습니다.

**R010** — 「고지는 귀속 후보를 늘릴 뿐 증거 등급을 올리지 않는다」(형제 탓 귀속도 개입 실험으로 실증), 「품질 게이트 우회 금지 — 훅 차단은 보고 대상」(`--no-verify` 상시 금지) 신설.

**R023** — 「Delegated Verification Floor — CI 잡 목록에서 도출」 신설. 위임 검증 항목의 하한선이 CI 가 실제로 돌리는 잡 전체임을 명시했습니다.

**R017** — 「메모리 TODO 를 위임 전제로 쓸 때」 신설. 기존 Pre-Release Target Version Gate 의 일반화입니다.

방향 지시어 2건 정정.

### 워크플로 (#1574)

`auto-dev.yaml` `scope-selection` 에 `Step 3 — Approval-required path pre-check (R010)` 신설. 스코프 이슈의 대상 경로를 **implement 진입 전에** 판정해 승인을 일괄 선요청합니다 — 파이프라인이 중간에 멈추던 문제를 막습니다. 4사본 동기화.

### 테스트

**26건 추가, 전부 양성/음성 통제 짝.** 2098 → **2124**. 기존 11 fail(머신 로컬 캐시 스키마 의존) 해소로 **0 fail**.

### 검증

lint / typecheck / verify-template-sync / verify-wiki-sync / validate-docs 전부 exit 0. 카운트 불변(agents 49 / skills 114 / rules 23 / guides 56). 원본↔templates 미러 일치, `auto-dev.yaml` 4사본 md5 동일. 위키 11페이지 갱신 + 매니페스트 재시딩(drift 0).

**mgr-sauron R017 검증: PASS** — 차단 결함 0건. 검증 중 나온 High advisory(R021 자기 서술 staleness)는 같은 커밋에 포함했습니다.

### 후속 이슈

- #1575 self-update 캐시 스키마 불일치 — 훅이 쓴 캐시를 CLI 가 항상 무효 판정

Closes #1568
Closes #1569
Closes #1570
Closes #1571
Closes #1574
