### PR TITLE
chore(release): bump to v1.1.46

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.45",
-  "generatedAt": "2026-08-10T12:05:42.190Z",
-  "templateVersion": "1.1.45",
+  "generatorVersion": "1.1.46",
+  "generatedAt": "2026-08-15T01:38:08.996Z",
+  "templateVersion": "1.1.46",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "cfdf79b6bb8824107aac24215939aeed087c98aa5a1701f2221a29fa6225e990",
@@ -15,8 +15,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "4fd5560f2d363d57ba9fe6e27b9e734df744a366039f6f89cb55c6b399a48a91",
-      "size": 52707,
+      "templateHash": "9007430ef4d092c8aa7a1c1c8f25ba1cd7198fea22315a3fe3d21e0b22dfcab8",
+      "size": 54390,
       "component": "rules"
     },
     ".claude/rules/MUST-intent-transparency.md": {
@@ -35,8 +35,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-parallel-execution.md": {
-      "templateHash": "e896069cb80f37c69627b53847b56c1ab4558706da26a9e905c789ee42bc0745",
-      "size": 12954,
+      "templateHash": "b49c3caa70bcd9fc2e15d2ae6efe84cf5301bdeaad1917fe2820a774ea805c6c",
+      "size": 14584,
       "component": "rules"
     },
     ".claude/rules/SHOULD-ecomode.md": {
@@ -50,8 +50,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
-      "templateHash": "fcfedfbc3f3b9c3cbee824b833239351a03de17d62083be658ed11837b9ee41f",
-      "size": 48556,
+      "templateHash": "d360aef848021e5b8943521ea71c0c44c8cf286cc1122e1db3301f3b46445526",
+      "size": 49243,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
@@ -65,13 +65,13 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-teams.md": {
-      "templateHash": "5d69566ee0cc7a33fbba040a661aff4a5c1eee29c70fc08091167da1abc242f4",
-      "size": 27338,
+      "templateHash": "8bd71ab47c1a787ed5226e6c5b7b5e58e88ebea17dd079fa3ac2d84c38aa9b63",
+      "size": 28615,
       "component": "rules"
     },
     ".claude/rules/MAY-optimization.md": {
-      "templateHash": "7fd13c5a453c0ab47a19199cfa3322affd0e0827ef7d84021e02d4389a79a23a",
-      "size": 10934,
+      "templateHash": "b643125a8c94e14c7dd40bc3250669e136ef3fc1b5646c7b2c421b725dadf526",
+      "size": 12396,
       "component": "rules"
     },
     ".claude/rules/MUST-continuous-improvement.md": {
@@ -80,8 +80,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-permissions.md": {
-      "templateHash": "ca61895d7c83c098589b866ebdd03030cdf486138cd0c7c3e56dd9b14aa67561",
-      "size": 13699,
+      "templateHash": "9526d7e7b674fc6d86c49ddf305163409b187686ddb3a021c0e77d63e6568e9a",
+      "size": 16228,
       "component": "rules"
     },
     ".claude/rules/SHOULD-ontology-rag-routing.md": {
@@ -90,8 +90,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-safety.md": {
-      "templateHash": "db3f595ffa93a397c0b8680247576e964bb40e404982afc3f54849d7051e71c1",
-      "size": 13585,
+      "templateHash": "ed66d8209fea645242ac36c6e190f7c8d7871b6efa32945f472306401e6bc639",
+      "size": 14589,
       "component": "rules"
     },
     ".claude/rules/MUST-tool-identification.md": {
@@ -100,13 +100,13 @@
       "component": "rules"
     },
     ".claude/rules/SHOULD-verification-ladder.md": {
-      "templateHash": "a19cbd2c50d7794c8295f151e1d1e09ac3613db8c011fa5b719744b4752d6d57",
-      "size": 17116,
+      "templateHash": "b07acc06384554f5b1c052663c4c4442e473b4db5e16999bd4f1b31615c2f40f",
+      "size": 17713,
       "component": "rules"
     },
     ".claude/rules/SHOULD-memory-integration.md": {
-      "templateHash": "90520fc8a94b0160a1577ba9a8e321829e22731284d938af6ed39f9b99090b70",
-      "size": 23405,
+      "templateHash": "ddc14bce27b2f159002cde9e8d3c17fd9bd2a341a42eb589d675d15694e8f351",
+      "size": 24438,
       "component": "rules"
     },
     ".claude/rules/MUST-enforcement-policy.md": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.45",
+  "version": "1.1.46",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.45",
+  "version": "1.1.46",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## v1.1.46

self-update 캐시의 **양방향 스키마 불일치**를 superset envelope 으로 해소하고, Claude Code v2.1.227~233 을 룰에 반영합니다.

### 코드 — self-update 캐시 스키마 통일 (#1575)

동일 캐시 파일(`~/.oh-my-customcode/self-update-cache.json`)에 **서로 다른 스키마를 쓰는 writer 가 둘** 있어 상호 무효화가 발생했습니다.

| 주체 | 스키마 | TTL |
|---|---|---|
| 훅 `omcustom-auto-update.sh` | `{version, timestamp}` (epoch 초) | 3600s |
| CLI `self-update.ts` | `{checkedAt, latestVersion}` (ISO 문자열) | 24h |

**두 writer 는 모두 현행이며 통일할 수 없습니다** — 훅은 SessionStart 에 bash 로만 동작해 CLI writer 로 대체 불가합니다(`/dev/tty` 프롬프트 포함). 실측 확인된 결함은 **양방향**이었습니다: CLI 가 훅 캐시를 못 읽을 뿐 아니라, 훅 리더도 CLI 가 쓴 캐시를 매 세션 미스합니다.

해법:
- `readSelfUpdateCache()` 가 **두 키셋을 모두 수용**(CLI 우선, 훅 폴백 — v1.1.45 `session-env-check.sh` 선례와 동일 순서)
- `writeCache()` 가 **superset envelope** 으로 양쪽 키를 함께 기록 → 훅 리더의 역방향 미스도 해소. `timestamp` 는 훅이 `date +%s` 와 비교하므로 **초 단위 유지**
- 타입: `{ checkedAt: string; latestVersion: string; schema: 'cli' | 'hook' }` — `unknown` + 타입 가드로 narrowing, `any` 미사용

**부수 결함 1건 동시 수정**: 밀리초 스케일 timestamp 를 초로 오독하면 `checkedAt` 이 먼 미래가 되어 `now - checkedAt` 이 음수 → 항상 TTL 미만 → **캐시가 영구 fresh** 로 남던 fail-open 결함을, 단위 판별(`MS_EPOCH_THRESHOLD`)과 TTL 초과 미래 가드로 차단했습니다. 정확히는 **TTL 초과 미래만 차단**하며 ±TTL 범위의 시계 오차는 의도적으로 허용합니다.

테스트 **17건** 추가 — 양성 6(전부 반환값 단언, "크래시 안 함"류 0건) / 음성 7 / TTL·통합 4. 2124 → **2141, fail 0**.

### 룰 — CC v2.1.227~233 반영 (#1577 #1578 #1579 #1580 #1581)

**13블록**을 9개 룰에 배치했습니다. v2.1.227 · v2.1.231 은 규칙 영향이 없어 반영하지 않았고, **v2.1.230 은 릴리즈 자체가 발행되지 않았습니다**(GitHub API 404, CHANGELOG 도 231 → 229 로 건너뜀).

**v2.1.232 subagent forking 기본값 변경 — 세 축으로 분리**

원문이 두 개의 독립 사실을 한 문장에 담고 있어(`fork 가 전체 대화·prompt cache 상속` + `non-teammate 스폰이 기본 background`), 각 사실이 **무력화하는 기존 조항이 있는 곳**으로 귀속했습니다.

| 축 | 무력화되는 기존 조항 |
|---|---|
| **R009** | Execution Rules 표의 `Instance independence \| Isolated context, no shared state` — fork 에 대해 거짓 |
| **R010** | "Agent 도구 반환 = 완료" 암묵 전제 — 반환이 착수 신호일 수 있음 |
| **R018** | stall handling "~2분 무진행" 휴리스틱 — `non-teammate` 한정어가 경계, Teams member 에 오적용 금지 |

R009 의 표는 일반 subagent 에는 여전히 유효하므로 수정하지 않고, 노트가 그 행을 지목해 fork 예외를 명시하는 방식을 택했습니다.

**v2.1.229** — `/commit-push-pr` 의 위험 플래그(`--force`/`--amend`/`--no-verify`) auto-approve 중단은 v1.1.45 에서 신설한 R010 「품질 게이트 우회 금지」와 같은 방향이라 교차 기록했습니다. 그 외 workflow fan-out prefix stagger, CPU 제한 컨테이너 코어 수, 비문자열 도구 인자 크래시, `ListAgents` offline/cloud 라벨.

**v2.1.228** — session cleanup 의 memory 폴더 삭제 결함(R011), claude.ai 동기화 스킬 하드닝(R006), Write 도구 read-before-write 완화(R005), deferred-tools reminder 중복(R005).

**v2.1.233 롤백 반영** — R002 의 v2.1.232 Bash 권한 노트 중 두 항목(Windows Cygwin-style symlink, 입력 리다이렉션 `< file`)이 233 에서 되돌려졌습니다:

> Reverted the 2.1.232 Bash permission changes for Cygwin-style symlinks on Windows and for input redirections (`< file`); a narrower version will return in a later release

표기를 `v2.1.232/233+` 로 바꾸고 **현재 권한 검사되지 않는다**는 사실과 재도입 예정을 명시했습니다. 롤백되지 않은 항목(PowerShell `$PSDefaultParameterValues`, 중첩 git trust, `sandbox.ripgrep` 스코프)은 유지했습니다.

### 위키

룰 9페이지 갱신 후 `wiki/.source-hashes.json` 재시딩(순서 준수 — 재시딩만 하면 false-green). 소스→페이지 매핑은 각 페이지의 `sources:` frontmatter 로 확정했습니다.

### 검증

lint / typecheck / verify-template-sync / verify-wiki-sync / validate-docs 전부 exit 0. `bun test` **2141 pass / 0 fail**. 카운트 불변(agents 49 / skills 114 / rules 23 / guides 56). 미러 9/9 일치.

**mgr-sauron R017: 최초 FAIL → 정정 후 재통과.** 차단 사유는 위 v2.1.233 롤백 미반영이었습니다 — 이슈 생성(8/11~14)과 작업(8/15) 사이에 나온 233 이 조사 범위 밖이었고, 저장소 전역 `2.1.233` 언급이 0건이었습니다. 코드 검증 7개 항목(스키마·단위·우선순위·fail-closed·타입 안전성·무효화 경로·테스트 품질)은 전건 통과했습니다.

### 후속 이슈

- #1582 CC v2.1.233 영향 검토 — Task/Todo 도구가 Opus 4.8 · Sonnet 5 · Fable 5 · Mythos 5 에서 제거(R002 Tier 표 · R018 TaskUpdate Discipline 직접 영향), v2.1.232 Bash 권한 변경의 "narrower version" 재도입 추적

Closes #1575
Closes #1577
Closes #1578
Closes #1579
Closes #1580
Closes #1581
