### PR TITLE
release: v1.1.47 — CC v2.1.233 Todo/Task 도구 제거 반영 + R018 활성 판정 정합화

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,7 +1,7 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.46",
-  "generatedAt": "2026-08-15T01:38:08.996Z",
+  "generatorVersion": "1.1.47",
+  "generatedAt": "2026-08-15T03:06:44.193Z",
   "templateVersion": "1.1.46",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
@@ -15,8 +15,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "9007430ef4d092c8aa7a1c1c8f25ba1cd7198fea22315a3fe3d21e0b22dfcab8",
-      "size": 54390,
+      "templateHash": "5b030f0bd5d3b32fb4614437aa91d12d952adab98c03c77615a66815fd71efad",
+      "size": 56651,
       "component": "rules"
     },
     ".claude/rules/MUST-intent-transparency.md": {
@@ -50,8 +50,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
-      "templateHash": "d360aef848021e5b8943521ea71c0c44c8cf286cc1122e1db3301f3b46445526",
-      "size": 49243,
+      "templateHash": "458a435ab9ae54a763b3871713b3102a8ce44ecd91a10aa7284574030d3b5c35",
+      "size": 49804,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
@@ -60,18 +60,18 @@
       "component": "rules"
     },
     ".claude/rules/MUST-sync-verification.md": {
-      "templateHash": "cd5e54137d3b9d97d695c71ec57b446849f94a2539765da76271e100eae2582b",
-      "size": 17355,
+      "templateHash": "4034afa3e69364dd614f2c5aeba5b6b69f3b6733ac104d02e12f78ddaa5d6a9e",
+      "size": 19970,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-teams.md": {
-      "templateHash": "8bd71ab47c1a787ed5226e6c5b7b5e58e88ebea17dd079fa3ac2d84c38aa9b63",
-      "size": 28615,
+      "templateHash": "2e8baecb1b2666081b19159c1dd26ffe9caa757ef0222d65ac32d9524b5fab50",
+      "size": 31065,
       "component": "rules"
     },
     ".claude/rules/MAY-optimization.md": {
-      "templateHash": "b643125a8c94e14c7dd40bc3250669e136ef3fc1b5646c7b2c421b725dadf526",
-      "size": 12396,
+      "templateHash": "1ede656b6ddc2c5a54eed1e185ddfbbc9c3f2b44ab7fe58060eaa14488f7be1d",
+      "size": 12883,
       "component": "rules"
     },
     ".claude/rules/MUST-continuous-improvement.md": {
@@ -80,8 +80,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-permissions.md": {
-      "templateHash": "9526d7e7b674fc6d86c49ddf305163409b187686ddb3a021c0e77d63e6568e9a",
-      "size": 16228,
+      "templateHash": "54ae04a638712f0b587fe12f447c499eedfcdd7b6ea4e066a7d74a92e24c4f8c",
+      "size": 18926,
       "component": "rules"
     },
     ".claude/rules/SHOULD-ontology-rag-routing.md": {
@@ -120,8 +120,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-completion-verification.md": {
-      "templateHash": "13f3d76b0fff1d831b3039403f2071f81198638ed7532ab3eb78ca51839e5841",
-      "size": 37132,
+      "templateHash": "0874e0136f14cc223a44da89a3c24f3a6348e6a8feb1370367398ba7f3e36a0d",
+      "size": 38915,
       "component": "rules"
     },
     ".claude/agents/be-springboot-expert.md": {
@@ -690,8 +690,8 @@
       "component": "skills"
     },
     ".claude/skills/multi-model-verification/SKILL.md": {
-      "templateHash": "01126cc826eb5afa80d40541c5d3a87ab5cd0f727e780d280013d13ff16c6eb2",
-      "size": 4661,
+      "templateHash": "761fc04591ccd94cd27c32aa548471ce800dc683c550ff3146bf681d6b6244d1",
+      "size": 4884,
       "component": "skills"
     },
     ".claude/skills/claude-code-bible/scripts/fetch-docs.js": {
@@ -750,8 +750,8 @@
       "component": "skills"
     },
     ".claude/skills/dev-lead-routing/SKILL.md": {
-      "templateHash": "9b2580db5132218b522d1baa2183644487f8a4e8010bd511b41b0dc0b5bbcac4",
-      "size": 6852,
+      "templateHash": "fe46f033b0bb58ff84b6fcae048088c3fe5cf75a058ce750ab48b0a2b49b2903",
+      "size": 7068,
       "component": "skills"
     },
     ".claude/skills/scout/SKILL.md": {
@@ -1030,8 +1030,8 @@
       "component": "skills"
     },
     ".claude/skills/de-lead-routing/SKILL.md": {
-      "templateHash": "96c1991f3782fd1a6466fb859fa241319a7e3343c5434733e6148e6e65ae4806",
-      "size": 8324,
+      "templateHash": "c4a9939b70083b19f4d21fdb24039eae0be6796aebe6d26ae24c4da3f7056b59",
+      "size": 8540,
       "component": "skills"
     },
     ".claude/skills/stuck-recovery/SKILL.md": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.46",
+  "version": "1.1.47",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.46",
+  "version": "1.1.47",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## 요약

CC v2.1.233 에서 Todo/Task 도구가 현행 모델(Opus 4.8 · Sonnet 5 · Fable 5 · Mythos 5 이상)에서 기본 제거된 사실을 룰에 반영하고, 그 파급으로 드러난 R018 Agent Teams 활성 판정의 자기모순을 저장소 전반에서 정합화한 릴리즈입니다. 코드 변경은 없고 룰·스킬 문서·진입점·위키만 바뀝니다.

## 주요 변경

### 1. CC v2.1.233 반영 (#1582)

라이브 프로브 실측(`claude -p --output-format stream-json` init 이벤트, 3회 동일 결과)이 CHANGELOG 보다 넓었습니다. CHANGELOG 명시 5종(`TodoWrite` / `TaskCreate` / `TaskGet` / `TaskList` / `TaskUpdate`) 외에 `TeamCreate` / `TeamDelete` 도 부재하며 이는 별도 게이팅입니다. `TaskStop` / `TaskOutput` / `SendMessage` 는 잔존합니다. R002 Tier 표에 부재 표시와 "이 표는 도구 카탈로그이지 가용성 보증이 아니다" 캐비엇을 추가했습니다.

### 2. R018 Detection 개정

`TeamCreate` 부재는 팀 생성 경로 자체가 없다는 뜻이므로 활성 조건을 `env var AND TeamCreate 실재` 로 바꿨습니다. 기존 `or` 조건은 env 만 켜진 이 환경을 활성으로 읽어 R002 결론과 모순됐습니다. `SendMessage` 단독 존재는 활성 근거가 아닙니다(cross-session 메시징은 별개 capability). Detection 이 No 면 R009/R010 이 지배합니다.

### 3. 정합화 범위 확장

위 개정 후 `git grep` 전수로 개정 전 문언 14곳을 찾아 정정했습니다. 룰 2종(+미러), 라우팅 스킬 `dev-lead-routing` / `de-lead-routing`(+미러) — 이들은 런타임 라우팅 결정에 쓰여 잘못된 경로 선택을 유발했습니다 —, `multi-model-verification`(+미러), 그리고 매 세션 주입되는 `CLAUDE.md`(+미러 3).

### 4. `multi-model-verification` 자기모순 해소

전제조건이 "Teams enabled … falls back to **sequential**" 이었으나 같은 파일 `### Agent Tool Fallback` 절은 3 reviewer 를 **병렬** 스폰으로 명시하고 있었습니다. 이 스킬은 Teams 없이 축소 없이 동작하며 Teams 는 reviewer 간 통신에만 영향합니다.

### 5. TaskUpdate 대체 규약 신설

Task 도구 부재 시의 폴백(1줄 `SendMessage` 보고, 아티팩트 경로 핸드오프, 결정론적 완료 판정)을 규정했습니다. 규칙은 존재하지 않는 도구의 호출을 의무화하지 않습니다.

### 6. FSD 회고 조항 6건 (#1584)

- **R017** — CC 버전 노트 반영 전 `npm view` + `claude --version` 실측 게이트(v1.1.46 에서 v2.1.233 롤백을 모르고 배치해 R017 이 차단했습니다)와, sauron advisory 를 판정과 함께 제시하는 조항을 추가했습니다.
- **R020** — 릴리즈 대기 조건 AND 규정(`release.yml` completed **AND** GitHub Release `isDraft=false` — npm publish 가 Release 생성보다 먼저 끝나 v1.1.45 에서 draft 로 남았습니다)과, 자율 루프 자가 계수의 `.message.role` 선행 필터를 추가했습니다.
- **R010** — 위임 브리핑의 저장소 상태 직전 실측과, 우회 플래그 근거 명시를 추가했습니다.

## 검증

- lint / typecheck / template-sync / wiki-sync / validate-docs 전부 exit 0
- `bun test` 2141 pass / 0 fail
- mgr-sauron R017 게이트: 최초 FAIL(차단 2건 — `TaskOutput` 오분류, R002 ↔ R018 자기모순) → 정정 후 통과
- 위키 drift 5건 재동기화 + `wiki/.source-hashes.json` 재시딩
- 카운트 불변: agents 49 / skills 114 / rules 23 / guides 56

## 후속 이슈로 분리

- `ARCHITECTURE.md` / `ARCHITECTURE_ko.md` 의 동일 stale 주장(헤더가 v0.126.1 로 이미 stale — 별개 부채)
- `docs/reference/rules.md`
- `session-env-check.sh` 의 env 단독 기반 Teams 가용 안내
- wiki index `counts.guides: 62` 대 소스 실측 56 의 계수 기준 불일치

Closes #1582
Closes #1584
