### PR TITLE
chore(release): bump to v1.1.55

### DIFF
--- a/.claude/hooks/scripts/r007-r008-drift-advisor.sh
+++ b/.claude/hooks/scripts/r007-r008-drift-advisor.sh
@@ -192,13 +192,26 @@ split("\n")
     # 올바르게 분리되어 0/0이었음). 이 조사에서 확정된 실제 원인은 별도 메커니즘이다:
     # tail -n 200 윈도우 안에 경계가 전혀 없을 때 $b=-1로 폴백해 슬라이딩 윈도우 전체를
     # 하나의 turn으로 병합하는 구조 — 본 수정의 승인 범위(0-tool-use 가드 1건) 밖이므로
-    # 별도 이슈로 보고한다(오케스트레이터 완료 보고 참조).
+    # 별도 이슈로 보고한다(오케스트레이터 완료 보고 참조). → #1628로 등록·수정 완료:
+    # 아래 $b 바인딩 직후의 "(#1628)" 주석 및 $wlc 포화 가드 참조.
     | [ range(0; $last + 1)
         | select( ($L[.].message.role? == "user")
                   and ( (($L[.].message.content | type) == "string")
                         or (([ $L[.].message.content[]? | select(.type? == "tool_result") ] | length) == 0) ) ) ] as $bi
     | (if ($bi | length) > 0 then $bi[-1] else -1 end) as $b
-    | [ range($b + 1; $last + 1) | $L[.] | select(.message.role? == "assistant") ] as $turn
+    # (#1628) 경계가 전혀 없는 경우($bi 비어있음)를 두 케이스로 나눈다:
+    #   (a) 윈도우가 포화($wlc >= 200 — tail -n 200이 실제로 200줄을 반환) — 윈도우 밖에
+    #       진짜 경계가 있었을 수 있다. 이 경우 $b=-1로 윈도우 전체를 하나의 turn으로
+    #       병합하면, 서로 독립적이고 각각 컴플라이언트한 여러 응답이 합쳐져 announce/
+    #       tool_use 카운트가 어긋나 R008 위양성이 5~10건대로 요동친다(#1628 실측). 판정
+    #       자체를 스킵한다(empty — 아래에서 result가 비어 exit 0으로 이어진다).
+    #   (b) 윈도우가 포화되지 않음($wlc < 200 — tail이 transcript 전체를 다 읽었다는 뜻) —
+    #       세션이 정말로 짧아 첫 턴부터 지금까지 경계가 없는 것이므로, 기존 $b=-1 폴백을
+    #       그대로 유지한다(#1625 찐빠 #3이 확정한 자율 루프 경계 대체 신호와 동일 로직).
+    | if ($bi | length) == 0 and $wlc >= 200 then empty
+      else
+      (
+      [ range($b + 1; $last + 1) | $L[.] | select(.message.role? == "assistant") ] as $turn
     | [ $turn[] | .message.content[]? | select(.type? != "thinking") ] as $blocks
     | ($turn[0].uuid? // "") as $tuuid
     | ([ $blocks[] | select(.type? == "text") ][0].text? // "") as $ftext
@@ -237,10 +250,20 @@ split("\n")
     # $nall_tools는 위 forward r008 가드에서 이미 바인딩됨 — 재바인딩하지 않고 재사용한다.
     | (if $nall_tools == 0 and $an_anchored > 0 then $an_anchored else 0 end) as $r008rev
     | [$tuuid, ($r007 | tostring), ($r008 | tostring), ($r008rev | tostring)] | @tsv
+      )
+      end
   end
 '
 
-result=$(tail -n 200 "$TRANSCRIPT_PATH" 2>/dev/null | jq -Rsr "$JQ_LAST_TURN" 2>/dev/null) || result=""
+# ── 윈도우 포화 여부 판별 (#1628) ──
+# tail -n 200이 실제로 200줄을 반환했는지(포화 — 윈도우 밖에 잘려나간 내용이 있을 수 있음)를
+# jq 호출 전에 bash에서 측정해 $wlc로 전달한다. awk는 트레일링 개행 유무와 무관하게 정확한
+# 레코드 수를 센다(wc -l은 트레일링 개행이 없는 마지막 줄을 놓칠 수 있음).
+window_content=$(tail -n 200 "$TRANSCRIPT_PATH" 2>/dev/null) || window_content=""
+window_line_count=$(printf '%s' "$window_content" | awk 'END{print NR}')
+: "${window_line_count:=0}"
+
+result=$(printf '%s' "$window_content" | jq -Rsr --argjson wlc "$window_line_count" "$JQ_LAST_TURN" 2>/dev/null) || result=""
 
 if [ -z "$result" ]; then
   exit 0

--- a/.claude/hooks/scripts/stuck-detector.sh
+++ b/.claude/hooks/scripts/stuck-detector.sh
@@ -16,28 +16,27 @@ command -v jq >/dev/null 2>&1 || exit 0
 HARD_BLOCK_THRESHOLD=${CLAUDE_STUCK_THRESHOLD:-3}
 
 # Determine if a Bash command is read-only (metadata/query only, no side effects).
-# Conservative: any ambiguity (chaining, redirection, substitution, or an
+# Conservative: any ambiguity (redirection, substitution, "||", or an
 # unrecognized command/subcommand) is treated as NOT read-only (write).
-# Used ONLY to exclude read-only Bash polling from Hard Block Checks 1 and 3
-# (same-path / same-tool+target consecutive-repeat blocking) below — Signal 1
-# (repeated-error advisory) and Hard Block Check 2 (same error hash) are
-# intentionally unaffected: repeated errors are a genuine stuck signal
-# regardless of read/write (issue #1625).
-is_readonly_bash_command() {
+# Compound commands chained with "&&", ";", or a single "|" are split into
+# segments (#1629) — the whole command is read-only ONLY when EVERY segment
+# is read-only; one write segment (or one unparseable/empty segment) makes
+# the whole command a write.
+# Used to exclude read-only Bash polling from Hard Block Checks 1 and 3
+# (same-path / same-tool+target consecutive-repeat blocking) AND the Signal 3
+# tool-spam advisory below — Signal 1 (repeated-error advisory) and Hard
+# Block Check 2 (same error hash) are intentionally unaffected: repeated
+# errors are a genuine stuck signal regardless of read/write (issue #1625).
+
+# Classify a SINGLE (non-compound) command segment as read-only. Callers
+# (is_readonly_bash_command) are responsible for stripping ambiguous
+# constructs and splitting compound commands before invoking this directly.
+is_readonly_single_command() {
   local cmd="$1"
-  cmd="$(printf '%s' "$cmd" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
   if [ -z "$cmd" ]; then
     echo "false"
     return 0
   fi
-
-  # Any chaining/redirection/substitution metachar => ambiguous, treat as write
-  case "$cmd" in
-    *'>'*|*'|'*|*'&&'*|*';'*|*'$('*|*'`'*|*'<('*)
-      echo "false"
-      return 0
-      ;;
-  esac
 
   local parts=()
   read -ra parts <<< "$cmd"
@@ -117,11 +116,62 @@ is_readonly_bash_command() {
   esac
 }
 
+is_readonly_bash_command() {
+  local cmd="$1"
+  cmd="$(printf '%s' "$cmd" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  if [ -z "$cmd" ]; then
+    echo "false"
+    return 0
+  fi
+
+  # Truly ambiguous constructs: redirection, command/process substitution, or
+  # "||" (conditional-OR — intentionally NOT decomposed into segments, since
+  # its branch that actually runs depends on the first segment's exit code)
+  # => always treated as write.
+  case "$cmd" in
+    *'>'*|*'||'*|*'$('*|*'`'*|*'<('*)
+      echo "false"
+      return 0
+      ;;
+  esac
+
+  # Compound command: split on "&&", ";", or a single "|" into segments and
+  # require EVERY segment to be read-only (#1629). An empty segment (e.g. a
+  # trailing separator) is treated as ambiguous => write, same as any
+  # segment that fails single-command classification.
+  if [[ "$cmd" == *'&&'* || "$cmd" == *';'* || "$cmd" == *'|'* ]]; then
+    local normalized="$cmd"
+    normalized="${normalized//&&/$'\n'}"
+    normalized="${normalized//;/$'\n'}"
+    normalized="${normalized//|/$'\n'}"
+    local seg
+    while IFS= read -r seg; do
+      seg="$(printf '%s' "$seg" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+      if [ -z "$seg" ]; then
+        echo "false"
+        return 0
+      fi
+      if [ "$(is_readonly_single_command "$seg")" != "true" ]; then
+        echo "false"
+        return 0
+      fi
+    done <<< "$normalized"
+    echo "true"
+    return 0
+  fi
+
+  is_readonly_single_command "$cmd"
+}
+
 input=$(cat)
 
 # Extract tool info
 tool_name=$(printf '%s' "$input" | jq -r '.tool_name // "unknown"')
-file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.command // ""' | head -c 120)
+# 300 (not 120): a 120-char cutoff let two genuinely different long Bash
+# commands collide on their shared 120-char prefix, causing a false-positive
+# same-path/same-tool+target hard-block. 300 chars covers the vast majority
+# of real commands without their differing tail being cut off (#1629).
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.command // ""' | head -c 300)
 is_error=$(printf '%s' "$input" | jq -r '.tool_output.is_error // false')
 output_preview=$(printf '%s' "$input" | jq -r '.tool_output.output // ""' | head -c 200)
 raw_command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
@@ -150,7 +200,8 @@ entry=$(jq -cn \
   --arg err "$is_error" \
   --arg hash "$error_hash" \
   --arg preview "$output_preview" \
-  '{timestamp: $ts, tool: $tool, path: $path, is_error: $err, error_hash: $hash, preview: $preview}')
+  --arg readonly "$is_readonly" \
+  '{timestamp: $ts, tool: $tool, path: $path, is_error: $err, error_hash: $hash, preview: $preview, readonly: $readonly}')
 
 echo "$entry" >> "$HISTORY_FILE"
 
@@ -214,8 +265,13 @@ if [ "$stuck_detected" = false ] && { [ "$tool_name" = "Edit" ] || [ "$tool_name
 fi
 
 # Signal 3: Tool spam (same tool 5+ times in last 8 entries)
-if [ "$stuck_detected" = false ]; then
-  tool_repeat=$(tail -8 "$HISTORY_FILE" | grep -c "\"tool\":\"${tool_name}\"" 2>/dev/null || echo "0")
+# Read-only Bash polling is excluded from this count (issue #1629): skip
+# entirely when the CURRENT call is read-only, and exclude prior read-only
+# entries from the historical count so a mix of harmless read-only Bash
+# calls (git status / gh view / ls / ...) doesn't inflate the "same tool
+# called N times" advisory.
+if [ "$stuck_detected" = false ] && [ "$is_readonly" != "true" ]; then
+  tool_repeat=$(tail -8 "$HISTORY_FILE" | grep -v "\"readonly\":\"true\"" | grep -c "\"tool\":\"${tool_name}\"" 2>/dev/null || echo "0")
   if [ "$tool_repeat" -ge 5 ]; then
     stuck_detected=true
     signal_type="Tool loop"

--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.54",
-  "generatedAt": "2026-08-29T23:57:33.129Z",
-  "templateVersion": "1.1.54",
+  "generatorVersion": "1.1.55",
+  "generatedAt": "2026-08-30T00:36:24.699Z",
+  "templateVersion": "1.1.55",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "f75d3b7466b67b9e06fb9cb393fee75c1d34bfc11ddfe12a7eea0ab6e8f6a25f",
@@ -1235,8 +1235,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/r007-r008-drift-advisor.sh": {
-      "templateHash": "71bd2bd38c501ee10fe6a62e806c2a7abaafbbdbe742246023813eda6884b4e6",
-      "size": 19203,
+      "templateHash": "3be4626f9445d6c8bc04de4b113561a41db140b5c0f1cb372f80063404d278ee",
+      "size": 21027,
       "component": "hooks"
     },
     ".claude/hooks/scripts/session-autofix-prompt.sh": {
@@ -1250,8 +1250,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/stuck-detector.sh": {
-      "templateHash": "55a20a9398ea516b03e8d5cbccb27493335bf1bc3a5487fee7d1e9bd10abddc2",
-      "size": 10742,
+      "templateHash": "c89bb8545f239b360c85aaf755db40bcbf2bec2cc21c5106b83678c18ba83073",
+      "size": 13186,
       "component": "hooks"
     },
     ".claude/hooks/scripts/failure-ledger.sh": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.54",
+  "version": "1.1.55",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/.claude/hooks/scripts/r007-r008-drift-advisor.sh
+++ b/templates/.claude/hooks/scripts/r007-r008-drift-advisor.sh
@@ -192,13 +192,26 @@ split("\n")
     # 올바르게 분리되어 0/0이었음). 이 조사에서 확정된 실제 원인은 별도 메커니즘이다:
     # tail -n 200 윈도우 안에 경계가 전혀 없을 때 $b=-1로 폴백해 슬라이딩 윈도우 전체를
     # 하나의 turn으로 병합하는 구조 — 본 수정의 승인 범위(0-tool-use 가드 1건) 밖이므로
-    # 별도 이슈로 보고한다(오케스트레이터 완료 보고 참조).
+    # 별도 이슈로 보고한다(오케스트레이터 완료 보고 참조). → #1628로 등록·수정 완료:
+    # 아래 $b 바인딩 직후의 "(#1628)" 주석 및 $wlc 포화 가드 참조.
     | [ range(0; $last + 1)
         | select( ($L[.].message.role? == "user")
                   and ( (($L[.].message.content | type) == "string")
                         or (([ $L[.].message.content[]? | select(.type? == "tool_result") ] | length) == 0) ) ) ] as $bi
     | (if ($bi | length) > 0 then $bi[-1] else -1 end) as $b
-    | [ range($b + 1; $last + 1) | $L[.] | select(.message.role? == "assistant") ] as $turn
+    # (#1628) 경계가 전혀 없는 경우($bi 비어있음)를 두 케이스로 나눈다:
+    #   (a) 윈도우가 포화($wlc >= 200 — tail -n 200이 실제로 200줄을 반환) — 윈도우 밖에
+    #       진짜 경계가 있었을 수 있다. 이 경우 $b=-1로 윈도우 전체를 하나의 turn으로
+    #       병합하면, 서로 독립적이고 각각 컴플라이언트한 여러 응답이 합쳐져 announce/
+    #       tool_use 카운트가 어긋나 R008 위양성이 5~10건대로 요동친다(#1628 실측). 판정
+    #       자체를 스킵한다(empty — 아래에서 result가 비어 exit 0으로 이어진다).
+    #   (b) 윈도우가 포화되지 않음($wlc < 200 — tail이 transcript 전체를 다 읽었다는 뜻) —
+    #       세션이 정말로 짧아 첫 턴부터 지금까지 경계가 없는 것이므로, 기존 $b=-1 폴백을
+    #       그대로 유지한다(#1625 찐빠 #3이 확정한 자율 루프 경계 대체 신호와 동일 로직).
+    | if ($bi | length) == 0 and $wlc >= 200 then empty
+      else
+      (
+      [ range($b + 1; $last + 1) | $L[.] | select(.message.role? == "assistant") ] as $turn
     | [ $turn[] | .message.content[]? | select(.type? != "thinking") ] as $blocks
     | ($turn[0].uuid? // "") as $tuuid
     | ([ $blocks[] | select(.type? == "text") ][0].text? // "") as $ftext
@@ -237,10 +250,20 @@ split("\n")
     # $nall_tools는 위 forward r008 가드에서 이미 바인딩됨 — 재바인딩하지 않고 재사용한다.
     | (if $nall_tools == 0 and $an_anchored > 0 then $an_anchored else 0 end) as $r008rev
     | [$tuuid, ($r007 | tostring), ($r008 | tostring), ($r008rev | tostring)] | @tsv
+      )
+      end
   end
 '
 
-result=$(tail -n 200 "$TRANSCRIPT_PATH" 2>/dev/null | jq -Rsr "$JQ_LAST_TURN" 2>/dev/null) || result=""
+# ── 윈도우 포화 여부 판별 (#1628) ──
+# tail -n 200이 실제로 200줄을 반환했는지(포화 — 윈도우 밖에 잘려나간 내용이 있을 수 있음)를
+# jq 호출 전에 bash에서 측정해 $wlc로 전달한다. awk는 트레일링 개행 유무와 무관하게 정확한
+# 레코드 수를 센다(wc -l은 트레일링 개행이 없는 마지막 줄을 놓칠 수 있음).
+window_content=$(tail -n 200 "$TRANSCRIPT_PATH" 2>/dev/null) || window_content=""
+window_line_count=$(printf '%s' "$window_content" | awk 'END{print NR}')
+: "${window_line_count:=0}"
+
+result=$(printf '%s' "$window_content" | jq -Rsr --argjson wlc "$window_line_count" "$JQ_LAST_TURN" 2>/dev/null) || result=""
 
 if [ -z "$result" ]; then
   exit 0

--- a/templates/.claude/hooks/scripts/stuck-detector.sh
+++ b/templates/.claude/hooks/scripts/stuck-detector.sh
@@ -16,28 +16,27 @@ command -v jq >/dev/null 2>&1 || exit 0
 HARD_BLOCK_THRESHOLD=${CLAUDE_STUCK_THRESHOLD:-3}
 
 # Determine if a Bash command is read-only (metadata/query only, no side effects).
-# Conservative: any ambiguity (chaining, redirection, substitution, or an
+# Conservative: any ambiguity (redirection, substitution, "||", or an
 # unrecognized command/subcommand) is treated as NOT read-only (write).
-# Used ONLY to exclude read-only Bash polling from Hard Block Checks 1 and 3
-# (same-path / same-tool+target consecutive-repeat blocking) below — Signal 1
-# (repeated-error advisory) and Hard Block Check 2 (same error hash) are
-# intentionally unaffected: repeated errors are a genuine stuck signal
-# regardless of read/write (issue #1625).
-is_readonly_bash_command() {
+# Compound commands chained with "&&", ";", or a single "|" are split into
+# segments (#1629) — the whole command is read-only ONLY when EVERY segment
+# is read-only; one write segment (or one unparseable/empty segment) makes
+# the whole command a write.
+# Used to exclude read-only Bash polling from Hard Block Checks 1 and 3
+# (same-path / same-tool+target consecutive-repeat blocking) AND the Signal 3
+# tool-spam advisory below — Signal 1 (repeated-error advisory) and Hard
+# Block Check 2 (same error hash) are intentionally unaffected: repeated
+# errors are a genuine stuck signal regardless of read/write (issue #1625).
+
+# Classify a SINGLE (non-compound) command segment as read-only. Callers
+# (is_readonly_bash_command) are responsible for stripping ambiguous
+# constructs and splitting compound commands before invoking this directly.
+is_readonly_single_command() {
   local cmd="$1"
-  cmd="$(printf '%s' "$cmd" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
   if [ -z "$cmd" ]; then
     echo "false"
     return 0
   fi
-
-  # Any chaining/redirection/substitution metachar => ambiguous, treat as write
-  case "$cmd" in
-    *'>'*|*'|'*|*'&&'*|*';'*|*'$('*|*'`'*|*'<('*)
-      echo "false"
-      return 0
-      ;;
-  esac
 
   local parts=()
   read -ra parts <<< "$cmd"
@@ -117,11 +116,62 @@ is_readonly_bash_command() {
   esac
 }
 
+is_readonly_bash_command() {
+  local cmd="$1"
+  cmd="$(printf '%s' "$cmd" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  if [ -z "$cmd" ]; then
+    echo "false"
+    return 0
+  fi
+
+  # Truly ambiguous constructs: redirection, command/process substitution, or
+  # "||" (conditional-OR — intentionally NOT decomposed into segments, since
+  # its branch that actually runs depends on the first segment's exit code)
+  # => always treated as write.
+  case "$cmd" in
+    *'>'*|*'||'*|*'$('*|*'`'*|*'<('*)
+      echo "false"
+      return 0
+      ;;
+  esac
+
+  # Compound command: split on "&&", ";", or a single "|" into segments and
+  # require EVERY segment to be read-only (#1629). An empty segment (e.g. a
+  # trailing separator) is treated as ambiguous => write, same as any
+  # segment that fails single-command classification.
+  if [[ "$cmd" == *'&&'* || "$cmd" == *';'* || "$cmd" == *'|'* ]]; then
+    local normalized="$cmd"
+    normalized="${normalized//&&/$'\n'}"
+    normalized="${normalized//;/$'\n'}"
+    normalized="${normalized//|/$'\n'}"
+    local seg
+    while IFS= read -r seg; do
+      seg="$(printf '%s' "$seg" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+      if [ -z "$seg" ]; then
+        echo "false"
+        return 0
+      fi
+      if [ "$(is_readonly_single_command "$seg")" != "true" ]; then
+        echo "false"
+        return 0
+      fi
+    done <<< "$normalized"
+    echo "true"
+    return 0
+  fi
+
+  is_readonly_single_command "$cmd"
+}
+
 input=$(cat)
 
 # Extract tool info
 tool_name=$(printf '%s' "$input" | jq -r '.tool_name // "unknown"')
-file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.command // ""' | head -c 120)
+# 300 (not 120): a 120-char cutoff let two genuinely different long Bash
+# commands collide on their shared 120-char prefix, causing a false-positive
+# same-path/same-tool+target hard-block. 300 chars covers the vast majority
+# of real commands without their differing tail being cut off (#1629).
+file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.command // ""' | head -c 300)
 is_error=$(printf '%s' "$input" | jq -r '.tool_output.is_error // false')
 output_preview=$(printf '%s' "$input" | jq -r '.tool_output.output // ""' | head -c 200)
 raw_command=$(printf '%s' "$input" | jq -r '.tool_input.command // ""')
@@ -150,7 +200,8 @@ entry=$(jq -cn \
   --arg err "$is_error" \
   --arg hash "$error_hash" \
   --arg preview "$output_preview" \
-  '{timestamp: $ts, tool: $tool, path: $path, is_error: $err, error_hash: $hash, preview: $preview}')
+  --arg readonly "$is_readonly" \
+  '{timestamp: $ts, tool: $tool, path: $path, is_error: $err, error_hash: $hash, preview: $preview, readonly: $readonly}')
 
 echo "$entry" >> "$HISTORY_FILE"
 
@@ -214,8 +265,13 @@ if [ "$stuck_detected" = false ] && { [ "$tool_name" = "Edit" ] || [ "$tool_name
 fi
 
 # Signal 3: Tool spam (same tool 5+ times in last 8 entries)
-if [ "$stuck_detected" = false ]; then
-  tool_repeat=$(tail -8 "$HISTORY_FILE" | grep -c "\"tool\":\"${tool_name}\"" 2>/dev/null || echo "0")
+# Read-only Bash polling is excluded from this count (issue #1629): skip
+# entirely when the CURRENT call is read-only, and exclude prior read-only
+# entries from the historical count so a mix of harmless read-only Bash
+# calls (git status / gh view / ls / ...) doesn't inflate the "same tool
+# called N times" advisory.
+if [ "$stuck_detected" = false ] && [ "$is_readonly" != "true" ]; then
+  tool_repeat=$(tail -8 "$HISTORY_FILE" | grep -v "\"readonly\":\"true\"" | grep -c "\"tool\":\"${tool_name}\"" 2>/dev/null || echo "0")
   if [ "$tool_repeat" -ge 5 ]; then
     stuck_detected=true
     signal_type="Tool loop"

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.54",
+  "version": "1.1.55",
   "lastUpdated": "2026-07-14T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",

--- a/tests/unit/core/r007-r008-drift-advisor.test.ts
+++ b/tests/unit/core/r007-r008-drift-advisor.test.ts
@@ -1227,6 +1227,108 @@ describe('r007-r008-drift-advisor.sh — Fixture 3e: #1625 찐빠 #3 forward gua
 });
 
 // ════════════════════════════════════════════════════════════════
+// Fixture 3f: #1628 — window-saturation guard on the $b=-1 boundary fallback
+//
+// When the tail -n 200 window contains NO turn boundary at all, the previous
+// implementation ALWAYS fell back to $b=-1, merging the ENTIRE window into one turn.
+// That is correct only when the window is NOT saturated (the file has fewer than 200
+// lines, so tail returned the whole transcript from session start — there truly is no
+// earlier boundary). When the window IS saturated (tail actually returned 200 lines),
+// a real boundary may exist just outside the window, and merging the whole window
+// misattributes announce/tool_use counts across what are really several independent,
+// individually-compliant responses — producing R008 false positives that swung
+// 5~10 across a live autonomous-loop session (#1628).
+//
+// The fix: bash measures the actual window line count ($wlc) via `awk 'END{print NR}'`
+// and passes it to jq as --argjson wlc. When $bi (candidate boundary indices) is empty
+// AND $wlc >= 200 (saturated), the verdict is skipped entirely (`empty` → no result →
+// exit 0, no advisory). When $bi is empty and $wlc < 200 (genuinely short session), the
+// original $b=-1 fallback is preserved unchanged.
+// ════════════════════════════════════════════════════════════════
+
+describe('r007-r008-drift-advisor.sh — Fixture 3f: #1628 window-saturation guard', () => {
+  it('TP: fires normally when a real boundary exists inside a saturated (>=200 line) window', async () => {
+    // Regression guard: the saturation gate must NOT suppress genuine violations when a
+    // boundary IS present in the window — it only applies when $bi is completely empty.
+    const sid = `g1628-tp-${Date.now()}`;
+    const lines: string[] = [];
+    for (let i = 0; i < 60; i += 1) {
+      lines.push(...userTurn(`Question ${i}`));
+      lines.push(
+        ...assistantTurn([
+          { type: 'text', text: `┌─ Agent: claude (default)\n└─ Task: answer ${i}` },
+          { type: 'text', text: '[claude][sonnet] → Tool: Read' },
+          { type: 'tool_use', id: `g1628-tp-${i}`, name: 'Read', input: { file_path: `f${i}.md` } },
+        ])
+      );
+    }
+    // LAST turn — a genuine violation, preceded by a real boundary.
+    lines.push(...userTurn('Last question'));
+    lines.push(
+      ...assistantTurn([{ type: 'tool_use', id: 'g1628-tp-last', name: 'Bash', input: {} }])
+    );
+    await writeTranscript(sid, lines);
+    // Sanity: the tail-200 window is genuinely saturated for this fixture.
+    expect(lines.length).toBeGreaterThanOrEqual(200);
+
+    const r = await runScript(postToolUseInput(sid), testEnv());
+
+    expect(r.exitCode).toBe(0);
+    const parsed = parseAdvisoryOutput(r.stdout);
+    expect(parsed.hookSpecificOutput.additionalContext).toContain('R008 접두사=1');
+  });
+
+  it('TN1: stays SILENT when the window is saturated (>=200 lines) with NO boundary at all', async () => {
+    // This is the exact false-positive shape from #1628: a long stretch of purely
+    // assistant lines (autonomous-loop re-entry with no UserPromptSubmit boundary) that,
+    // pre-fix, would merge into one mega-turn and misfire on tool_use/announce mismatch.
+    const sid = `g1628-tn1-${Date.now()}`;
+    const lines: string[] = [];
+    for (let i = 0; i < 220; i += 1) {
+      // No text block at all → no announce lines anywhere, only tool_use blocks. Pre-fix
+      // this merges into ONE giant turn with ~220 tool_use and 0 announce → r008=220.
+      lines.push(
+        ...assistantTurn([{ type: 'tool_use', id: `g1628-tn1-${i}`, name: 'Bash', input: {} }])
+      );
+    }
+    await writeTranscript(sid, lines);
+    expect(lines.length).toBeGreaterThanOrEqual(200);
+
+    const r = await runScript(postToolUseInput(sid), testEnv());
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe('');
+    expect(r.stderr).not.toContain('[R007/R008 Advisory]');
+  });
+
+  it('TN2: preserves the pre-fix $b=-1 fallback when the window is NOT saturated (<200 lines)', async () => {
+    // A genuinely short session (no earlier boundary because there IS no earlier content)
+    // must keep firing exactly as before — the saturation gate must not swallow this case.
+    const sid = `g1628-tn2-${Date.now()}`;
+    const lines: string[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      lines.push(
+        ...assistantTurn([{ type: 'tool_use', id: `g1628-tn2-${i}`, name: 'Bash', input: {} }])
+      );
+    }
+    await writeTranscript(sid, lines);
+    expect(lines.length).toBeLessThan(200);
+
+    const r = await runScript(postToolUseInput(sid), testEnv());
+
+    expect(r.exitCode).toBe(0);
+    const parsed = parseAdvisoryOutput(r.stdout);
+    expect(parsed.hookSpecificOutput.additionalContext).toContain('R008 접두사=5');
+  });
+
+  it('source guard: the $wlc saturation check gates the empty-boundary fallback (#1628)', async () => {
+    const src = await Bun.file(SCRIPT).text();
+    expect(src).toContain('$wlc >= 200');
+    expect(src).toContain('--argjson wlc');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════
 // Fixture 4: opt-out
 // ════════════════════════════════════════════════════════════════
 

--- a/tests/unit/core/stuck-detector.test.ts
+++ b/tests/unit/core/stuck-detector.test.ts
@@ -851,6 +851,105 @@ describe('stuck-detector.sh', () => {
   });
 
   // -----------------------------------------------------------------
+  // Compound/piped read-only command classification (#1629)
+  // -----------------------------------------------------------------
+
+  describe('compound command read-only classification (#1629)', () => {
+    it('NEGATIVE: should NOT hard-block on 3 consecutive all-read-only "|"-piped commands', async () => {
+      const input = makeInput({ tool_name: 'Bash', command: 'git status | grep modified' });
+      const result = await runNTimes(input, 3);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('NEGATIVE: should NOT hard-block on 3 consecutive all-read-only "&&"-chained commands', async () => {
+      const input = makeInput({ tool_name: 'Bash', command: 'git status && git log' });
+      const result = await runNTimes(input, 3);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('NEGATIVE: should NOT hard-block on 3 consecutive all-read-only ";"-chained commands', async () => {
+      const input = makeInput({ tool_name: 'Bash', command: 'ls; pwd' });
+      const result = await runNTimes(input, 3);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('NEGATIVE: should NOT hard-block on 3 consecutive mixed "&&"/"|"/";" all-read-only commands', async () => {
+      const input = makeInput({ tool_name: 'Bash', command: 'git status && ls | grep x; pwd' });
+      const result = await runNTimes(input, 3);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it('POSITIVE: should still hard-block on 3 consecutive "|"-piped commands with a write segment', async () => {
+      const input = makeInput({ tool_name: 'Bash', command: 'ls | tee /tmp/agent3b-out.txt' });
+      const result = await runNTimes(input, 3);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('POSITIVE: should still hard-block on 3 consecutive "&&"-chained commands with a write segment', async () => {
+      const input = makeInput({ tool_name: 'Bash', command: 'git status && npm install' });
+      const result = await runNTimes(input, 3);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('POSITIVE: should still hard-block on 3 consecutive ";"-chained commands with a write segment', async () => {
+      const input = makeInput({ tool_name: 'Bash', command: 'ls; npm install' });
+      const result = await runNTimes(input, 3);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('should still hard-block on "||" (conditional-OR, not decomposed) even when both sides look read-only', async () => {
+      const input = makeInput({ tool_name: 'Bash', command: 'git status || echo fail' });
+      const result = await runNTimes(input, 3);
+      expect(result.exitCode).toBe(2);
+    });
+
+    it('should still hard-block on a trailing-separator command (empty segment => conservative write)', async () => {
+      const input = makeInput({ tool_name: 'Bash', command: 'git status;' });
+      const result = await runNTimes(input, 3);
+      expect(result.exitCode).toBe(2);
+    });
+  });
+
+  // -----------------------------------------------------------------
+  // Signal 3 advisory read-only exemption (#1629)
+  // -----------------------------------------------------------------
+
+  describe('Signal 3 advisory read-only exemption (#1629)', () => {
+    it('NEGATIVE: should NOT emit Tool loop advisory for 5 consecutive read-only Bash calls', async () => {
+      const input = makeInput({ tool_name: 'Bash', command: 'git status' });
+      const results = await runNTimesAll(input, 5);
+      for (const r of results) {
+        expect(r.stderr).not.toContain('Tool loop');
+      }
+      const last = results[results.length - 1];
+      expect(last.exitCode).toBe(0);
+    });
+
+    it('NEGATIVE: should NOT emit Tool loop advisory when read-only calls are mixed with a non-triggering write call', async () => {
+      // 4 read-only calls + a 5th write call on a distinct target: the read-only
+      // entries are excluded from the historical count, so the tool-spam
+      // threshold (5) is never reached for either read-only or write history.
+      for (let i = 0; i < 4; i++) {
+        await runStuckDetector(makeInput({ tool_name: 'Bash', command: 'git log' }));
+      }
+      const result = await runStuckDetector(
+        makeInput({ tool_name: 'Bash', command: 'npm run build' })
+      );
+      expect(result.stderr).not.toContain('Tool loop');
+    });
+
+    it('POSITIVE CONTROL: should still emit Tool loop advisory for 5 consecutive non-read-only Bash calls', async () => {
+      for (let i = 0; i < 4; i++) {
+        await runStuckDetector(makeInput({ tool_name: 'Bash', command: `npm run task-${i}` }));
+      }
+      const result = await runStuckDetector(
+        makeInput({ tool_name: 'Bash', command: 'npm run task-4' })
+      );
+      expect(result.stderr).toContain('Tool loop');
+    });
+  });
+
+  // -----------------------------------------------------------------
   // Edge cases
   // -----------------------------------------------------------------
 


### PR DESCRIPTION
## 요약

- #1628: drift-advisor가 트랜스크립트 윈도우 포화 시 판정을 스킵하도록 수정
- #1629: stuck-detector의 복합 명령 read-only 판별 개선 + Signal 3 가드 추가 + 절단 왜곡 완화

테스트 2381 pass.

Closes #1628
Closes #1629