### PR TITLE
chore(release): bump to v1.1.58

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.57",
-  "generatedAt": "2026-08-30T02:39:58.173Z",
-  "templateVersion": "1.1.57",
+  "generatorVersion": "1.1.58",
+  "generatedAt": "2026-09-02T13:22:55.998Z",
+  "templateVersion": "1.1.58",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "f75d3b7466b67b9e06fb9cb393fee75c1d34bfc11ddfe12a7eea0ab6e8f6a25f",
@@ -15,8 +15,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "95a80ec92fd9e736da6b627dae309b52a4447b8857a0341d191c6e8437e20565",
-      "size": 67943,
+      "templateHash": "2fdddb17463ab479bef418f2f153546135a0ea4bf1937269b7953e6d587290a9",
+      "size": 69448,
       "component": "rules"
     },
     ".claude/rules/MUST-intent-transparency.md": {
@@ -25,8 +25,8 @@
       "component": "rules"
     },
     ".claude/rules/SHOULD-error-handling.md": {
-      "templateHash": "61b66beded007d9b717c98071bd5fff5f88f8a472ec982dd0eda16206b0f4304",
-      "size": 1706,
+      "templateHash": "8619e3b932dfa1b05f9b2c01a97c8905fb8f59ccb311d6c26fd98d1bbfd3084d",
+      "size": 2246,
       "component": "rules"
     },
     ".claude/rules/SHOULD-wiki-sync.md": {
@@ -50,8 +50,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-design.md": {
-      "templateHash": "dead77388334c4308874b3ebf4726d64a40bd7f89e489b170e877472b49ba43f",
-      "size": 53769,
+      "templateHash": "3500fe40b5aaea03fd7993c06b0e2a45c9dc9586d3a5b4b49c815ccf774cd293",
+      "size": 55777,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
@@ -65,13 +65,13 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-teams.md": {
-      "templateHash": "3d32c52d42bc45d5cb7046d978d0d2736629f35e0641f2538f69e5f6d532b269",
-      "size": 35046,
+      "templateHash": "0b100933e639ce1674ac6443e73c3b5aa5ef26f98d959e9975b562bbcced223c",
+      "size": 35942,
       "component": "rules"
     },
     ".claude/rules/MAY-optimization.md": {
-      "templateHash": "ae234dd08c7a4275199e3ef599bd3b6f4477a90131103abc4e052b82027cfa32",
-      "size": 18050,
+      "templateHash": "8e9d315bec1186f735f4f3cfdb25f203a14abf290ba57f10ed2710c4dad7c9c9",
+      "size": 18945,
       "component": "rules"
     },
     ".claude/rules/MUST-continuous-improvement.md": {
@@ -80,8 +80,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-permissions.md": {
-      "templateHash": "743a235630d8af27248d1a3c9139b238e1793885bf020e5605a3e28536c09255",
-      "size": 22185,
+      "templateHash": "701270fbfbfab13eae4b8fe055ba27e61da2fb6de300899318fab15b2c2d97dd",
+      "size": 25268,
       "component": "rules"
     },
     ".claude/rules/SHOULD-ontology-rag-routing.md": {
@@ -90,8 +90,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-safety.md": {
-      "templateHash": "6954228f98b0e761dcd23de25919e4acff5ac46167a3f14d83a14469a0455c93",
-      "size": 17250,
+      "templateHash": "f9212254292f2b171c1966e586bba4baa09c73f730e1cada560fcfe47779b9a2",
+      "size": 19168,
       "component": "rules"
     },
     ".claude/rules/MUST-tool-identification.md": {
@@ -120,8 +120,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-completion-verification.md": {
-      "templateHash": "08d009e72c80362e4c258c4633381b71da95577408d67ad6c8134224187c6efa",
-      "size": 52743,
+      "templateHash": "a32d9993f60f3035532f6ee129fe88e513f29b602ae5aa225e5afa2f4c5a7707",
+      "size": 55127,
       "component": "rules"
     },
     ".claude/agents/be-springboot-expert.md": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.57",
+  "version": "1.1.58",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.1.57",
-  "lastUpdated": "2026-07-14T00:00:00.000Z",
+  "version": "1.1.58",
+  "lastUpdated": "2026-09-02T00:00:00.000Z",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",
   "components": [


### PR DESCRIPTION
## v1.1.58 — Claude Code v2.1.252 / v2.1.257 / v2.1.258 호환성 노트 반영

### 변경 요약
- **R006**: `claude-fable-5-1` Tier-2 행 추가 — Fable 5.1이 기본 Fable 모델(v2.1.257), `CLAUDE_CODE_SUBAGENT_MODEL_FORCE` 신설로 v2.1.251 "env는 model pin을 못 깨뜨림" 노트를 FORCE 미설정 시 한정으로 정정, `/add-dir` 하위 디렉토리 로드 수정
- **R010**: 프로젝트 settings의 `defaultMode: "bypassPermissions"`가 v2.1.257부터 무시됨 — 이 저장소 실측(2026-09-02) 유효 모드는 user settings `auto`. 무인 실행 통제점이 user/managed settings·`--permission-mode`로 이동
- **R002**: `< file` 리다이렉션 deny 검사 재도입(v2.1.233 롤백 해소), `permissions.ask` 복합명령 우회 수정, zsh `[[ ]]` 3차 보강, `blockReadsOutsideWorkingDirectories`, 워크트리 Bash 루프 거부 수정, "always allow" 저장 실패 수정(v2.1.252); `--restricted` 상호배타 서술을 scope 조건부로 정정
- **R001**: Containment Escape 규칙, Remote Control 동의 dismiss 결함, 자격증명 전송·로그 redaction 4건, 플러그인 symlink 경로 거부
- **R020**: 서브에이전트 mid-stream 절단 자동 이어감으로 "판정 없이 종료" 원인 축 하나 소멸(maxTurns와 구분), 대형 실패 알림 API 한도 초과(v2.1.252), 원격 세션 재전송 승인 실패(v2.1.258)
- **R004 / R018 / R005**: 서브에이전트 자동 이어감, teammate 승인 이중응답·tmux pane 잔존·`/fork` prompt cache, Darwin "task output swap refused" 수정, `timeout`/`setsid` 백그라운드 정리
- templates 미러 동기화, wiki/rules 8페이지 갱신 + source-hash 매니페스트 재시딩
- 버전 범프 1.1.57 → 1.1.58 (package.json / templates/manifest.json / .omcustom.lock.json 원자 갱신)

### 검증
- verify-template-sync / verify-wiki-sync(drift 0) / validate-docs PASS
- bun install --frozen-lockfile / lint / typecheck exit 0, bun test 2394 pass / 0 fail
- mgr-sauron R017 PASS (advisory 1건 같은 커밋에 반영)

### 관련 이슈
Closes #1637
Closes #1638
Closes #1639

### 이월
- #1640 / #1641 (`.claude/hooks/**` 수정 — 사용자 승인 대기)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
