### PR TITLE
chore(release): bump to v1.1.59

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.58",
-  "generatedAt": "2026-09-02T13:22:55.998Z",
-  "templateVersion": "1.1.58",
+  "generatorVersion": "1.1.59",
+  "generatedAt": "2026-09-02T18:45:33.576Z",
+  "templateVersion": "1.1.59",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "f75d3b7466b67b9e06fb9cb393fee75c1d34bfc11ddfe12a7eea0ab6e8f6a25f",
@@ -15,8 +15,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "2fdddb17463ab479bef418f2f153546135a0ea4bf1937269b7953e6d587290a9",
-      "size": 69448,
+      "templateHash": "1794c24103b6a1cfdaebbe88eac1711e245473e06a22a86233d58eee98eb0d06",
+      "size": 70394,
       "component": "rules"
     },
     ".claude/rules/MUST-intent-transparency.md": {
@@ -80,8 +80,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-permissions.md": {
-      "templateHash": "701270fbfbfab13eae4b8fe055ba27e61da2fb6de300899318fab15b2c2d97dd",
-      "size": 25268,
+      "templateHash": "df56bf403b851022681cf623b7dd7df6bbb734e63dad7e6981b116e1eb512fc7",
+      "size": 25969,
       "component": "rules"
     },
     ".claude/rules/SHOULD-ontology-rag-routing.md": {
@@ -295,8 +295,8 @@
       "component": "agents"
     },
     ".claude/agents/mgr-gitnerd.md": {
-      "templateHash": "7ed0d20c76edeab8ff70358dfe101a3bc8bfec88391224ed3c92dacb5a7326a2",
-      "size": 3045,
+      "templateHash": "34cb0969531da80cdf1e3dc07068d0ea9c8c89ac118a4f2796ca59566e879842",
+      "size": 4432,
       "component": "agents"
     },
     ".claude/agents/mgr-creator.md": {
@@ -485,8 +485,8 @@
       "component": "skills"
     },
     ".claude/skills/pipeline/workflows/auto-dev.yaml": {
-      "templateHash": "c7121d3c255f1715427f7facdfc207e424df001fc86aa502d5969c0e97dd8559",
-      "size": 37253,
+      "templateHash": "83294c1325f38972bd27b85d1bcf94ea88fa8a384cf4d368c8dd962ee704396d",
+      "size": 40035,
       "component": "skills"
     },
     ".claude/skills/pipeline/SKILL.md": {
@@ -785,8 +785,8 @@
       "component": "skills"
     },
     ".claude/skills/fsd/SKILL.md": {
-      "templateHash": "4968355e6b2ccd1bddb7b27c1e4abee1b3da15d76358a26a457cf2766a809a58",
-      "size": 8962,
+      "templateHash": "eae17b942cd7a6f2f57d9150f1f19af7c27dd60ddc6345be728ff0a626e8d2df",
+      "size": 9999,
       "component": "skills"
     },
     ".claude/skills/dev-lead-routing/SKILL.md": {
@@ -1235,8 +1235,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/r007-r008-drift-advisor.sh": {
-      "templateHash": "3be4626f9445d6c8bc04de4b113561a41db140b5c0f1cb372f80063404d278ee",
-      "size": 21027,
+      "templateHash": "abad1ce83759db9a0bcbec0f02a3436c273915d30af38e0eb99632e1bf197e41",
+      "size": 22381,
       "component": "hooks"
     },
     ".claude/hooks/scripts/session-autofix-prompt.sh": {
@@ -1250,8 +1250,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/stuck-detector.sh": {
-      "templateHash": "f8d74b6f93caf485153a164bd37d4e2c29875c7077472fd05849aeed514c1bb7",
-      "size": 13231,
+      "templateHash": "2808b21ad1b8cb83fbf3a0e7490586e9bca6278584cb255f0b844435f53520bd",
+      "size": 22784,
       "component": "hooks"
     },
     ".claude/hooks/scripts/failure-ledger.sh": {
@@ -1330,8 +1330,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/session-autofix.sh": {
-      "templateHash": "d77cfc1b92fdb9cf89d9fea823e8bfeef9e23aec05511a1a650263469f2f7ec4",
-      "size": 5362,
+      "templateHash": "8e416e3ea6f32040c9a1d0759b47b9eabf18b2fa165188130fc67390ca3c88d0",
+      "size": 6583,
       "component": "hooks"
     },
     ".claude/hooks/scripts/subagent-failure-advisor.sh": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.58",
+  "version": "1.1.59",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.1.58",
-  "lastUpdated": "2026-09-02T00:00:00.000Z",
+  "version": "1.1.59",
+  "lastUpdated": "2026-09-03",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",
   "components": [


### PR DESCRIPTION
## v1.1.59 — 훅 3종 오탐 수정 + permission-mode 게이트·커밋 타임아웃 배선

### 변경 요약
- **stuck-detector.sh (#1641)**: `$(...)`/backtick 내부와 `for`/`while` 본문을 같은 whitelist로 재귀 판별, `2>&1`·`>/dev/null`만 read-only 허용. Bash `target_key`를 `file_path`에서 분리하고 `edit_hash`를 도입해 Check 1/3이 **동일 편집 3연속**일 때만 발화. 히스토리 매칭을 JSON 동일 인코딩 + `grep -F`로 교체(BRE 이스케이프 결함으로 `( ) " +?{|` 포함 명령이 조용히 미매칭되던 선존 결함). 명령 길이 4000 캡(`$()` 20 KB 13.6 s → 0.04 s), 키 1000자 + `#len` 태그(접두 충돌), `basename --`, `printf` 표준화
- **session-autofix.sh (#1640)**: YAML 블록 리스트 `skills:` 파싱 — 세션 시작 broken-refs 오탐 35건 → 0건
- **r007-r008-drift-advisor.sh (#1643)**: advisory 레이블이 위반 건수를 명시하고 준수 차원은 생략("R007 헤더=0"이 "헤더 없음"으로 오독되던 문구 결함, 판정 로직 불변)
- **permission-mode 게이트 (#1644)**: CC v2.1.257부터 프로젝트 settings의 `defaultMode: bypassPermissions`가 무시됨(`claude -p --debug-file` 실측 `[WARN] settings defaultMode "bypassPermissions" ignored`). auto-dev.yaml pre-triage Phase 0.5 advisory 게이트, fsd/SKILL.md 사전 확인, settings.json `_comment_defaultMode`, R010 Self-Check 1항 재작성, R002 cross-ref
- **커밋 타임아웃 배선 (#1645)**: auto-dev.yaml implement/release 커밋 지시와 mgr-gitnerd.md에 `git commit` Bash timeout ≥ 400000ms(pre-commit 전체 테스트 ~165초)
- 테스트 +35 (2394 → 2429), wiki 5페이지 + 매니페스트 재시딩, templates 미러·auto-dev.yaml 4사본 동기화
- 버전 범프 1.1.58 → 1.1.59 (package.json / templates/manifest.json / .omcustom.lock.json 원자 갱신)

### 검증
- verify-template-sync / verify-wiki-sync(drift 0) / validate-docs PASS
- bun install --frozen-lockfile / lint / typecheck exit 0, bun test 2429 pass / 0 fail
- mgr-sauron R017 PASS(advisory 없음), 적대적 리뷰 PASS(권고 4건 같은 커밋 반영, 이월 7건 → #1647)

### 관련 이슈
Closes #1640
Closes #1641
Closes #1643
Closes #1644
Closes #1645

### 이월
- #1647 stuck-detector 후속 7건 (edit_hash 정규화 충돌 등)
- #1646 세션 회고 (하네스 제안 4건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
