### PR TITLE
chore(release): bump to v1.1.60

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.59",
-  "generatedAt": "2026-09-02T18:45:33.576Z",
-  "templateVersion": "1.1.59",
+  "generatorVersion": "1.1.60",
+  "generatedAt": "2026-09-02T19:41:55.128Z",
+  "templateVersion": "1.1.60",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "f75d3b7466b67b9e06fb9cb393fee75c1d34bfc11ddfe12a7eea0ab6e8f6a25f",
@@ -15,8 +15,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "1794c24103b6a1cfdaebbe88eac1711e245473e06a22a86233d58eee98eb0d06",
-      "size": 70394,
+      "templateHash": "af457dc1cbd53ab37c7f8c202c890e26bf4397be83aca2c66054fb5ccd5d2a30",
+      "size": 71643,
       "component": "rules"
     },
     ".claude/rules/MUST-intent-transparency.md": {
@@ -55,8 +55,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-agent-identification.md": {
-      "templateHash": "a828d087d98612df86e80b3bac1a6a3d616eda5f02e23d5d02a8616723a194dd",
-      "size": 8009,
+      "templateHash": "c9a00559be5547c309783d1d53ec8abb67a156d422aa2ceab659d4a899fa5764",
+      "size": 8407,
       "component": "rules"
     },
     ".claude/rules/MUST-sync-verification.md": {
@@ -485,8 +485,8 @@
       "component": "skills"
     },
     ".claude/skills/pipeline/workflows/auto-dev.yaml": {
-      "templateHash": "83294c1325f38972bd27b85d1bcf94ea88fa8a384cf4d368c8dd962ee704396d",
-      "size": 40035,
+      "templateHash": "2ffc67f60ab19e2a43e08cf219c015aaa2a4d4630a3b339504dd45f68cb22813",
+      "size": 41156,
       "component": "skills"
     },
     ".claude/skills/pipeline/SKILL.md": {
@@ -785,8 +785,8 @@
       "component": "skills"
     },
     ".claude/skills/fsd/SKILL.md": {
-      "templateHash": "eae17b942cd7a6f2f57d9150f1f19af7c27dd60ddc6345be728ff0a626e8d2df",
-      "size": 9999,
+      "templateHash": "6527383ae4182afb28d570cdc9cc83f86a5c90613a88ea402b99acb1b85a45d9",
+      "size": 10678,
       "component": "skills"
     },
     ".claude/skills/dev-lead-routing/SKILL.md": {
@@ -1250,8 +1250,8 @@
       "component": "hooks"
     },
     ".claude/hooks/scripts/stuck-detector.sh": {
-      "templateHash": "2808b21ad1b8cb83fbf3a0e7490586e9bca6278584cb255f0b844435f53520bd",
-      "size": 22784,
+      "templateHash": "321cedaf70fcfc2321973a71b6bbfac039e3c4bc6ba021845c8564007f58c5b0",
+      "size": 30867,
       "component": "hooks"
     },
     ".claude/hooks/scripts/failure-ledger.sh": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.59",
+  "version": "1.1.60",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.59",
+  "version": "1.1.60",
   "lastUpdated": "2026-09-03",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## v1.1.60 — stuck-detector 하드닝 5건 + FSD 무인 모드 스코프 분리 + 회고 하네스 제안 반영

### 변경 요약
- **stuck-detector.sh (#1647 M-5/M-6/L-1/L-2/L-5 + 리뷰 권고)**: 개행을 세그먼트 구분자로 취급(`git status\nrm -rf build` 오판 해소), heredoc 본문 제거·미종료/인용 오프너는 write 폴백(델리미터 위조 구멍 폐쇄), 300 KB tool_output에서 SIGPIPE로 히스토리 기록이 유실되던 결함 해소, `PATH`/`LD_*`/`DYLD_*`/`GIT_*`/`BASH_ENV` 등 실행환경 변수 접두를 write로, `>&N`은 1/2만 허용, `command`(-v/-V 제외)·`builtin`·`exec`·`find -fprint*/-fls/-ok*/-delete/-exec*`를 write로 분류
- **FSD 무인 모드 (#1646 제안 1)**: auto-dev.yaml scope-selection Step 3에 무인 분기 — `.claude/hooks/**` 이슈는 분리 스코프로 이월하고 반복 경계에서 승인 1회; fsd/SKILL.md 동일 문단
- **docs-only 티어 carve-out (#1646 제안 2)**: 룰 파일 변경 포함 시 mgr-sauron R017 단일 목표 검증 필수
- **R010 사전 실측 리터럴 (#1646 제안 3)**: git 위임 직전 3줄(branch / HEAD / branch --list) 스니펫 + `gh pr merge --delete-branch` 로컬 부수효과 Origin
- **R007 통지 수신 턴 (#1646 제안 4)**: 빈 응답 금지 표에 system-reminder 통지 후 도구만 호출 케이스 추가
- 테스트 +43 (2429 → 2472), wiki r007/r010/fsd/pipeline + 매니페스트 재시딩, 미러·4사본 동기화
- 버전 범프 1.1.59 → 1.1.60 (3파일 원자)

### 검증
- verify-template-sync / verify-wiki-sync(drift 0) / validate-docs PASS
- install / lint / typecheck exit 0, bun test 2472 pass / 0 fail
- mgr-sauron R017 PASS, 적대적 리뷰 PASS(단일행 106건 A/B 회귀 0; 권고 3건 같은 커밋 반영, 이월 → #1650)

### 관련 이슈
Closes #1646
Closes #1647

### 이월
- #1649 edit_hash 정규화 설계(M-1/M-2)
- #1650 라인당 fork 지연·비-JSON stdin rc=5·무인 판별 신호 결정론화

🤖 Generated with [Claude Code](https://claude.com/claude-code)
