### PR TITLE
chore(release): bump to v1.1.61

### DIFF
--- a/.omcustom.lock.json
+++ b/.omcustom.lock.json
@@ -1,8 +1,8 @@
 {
   "lockfileVersion": 1,
-  "generatorVersion": "1.1.60",
-  "generatedAt": "2026-09-02T19:41:55.128Z",
-  "templateVersion": "1.1.60",
+  "generatorVersion": "1.1.61",
+  "generatedAt": "2026-09-03T00:54:30.929Z",
+  "templateVersion": "1.1.61",
   "files": {
     ".claude/rules/SHOULD-interaction.md": {
       "templateHash": "f75d3b7466b67b9e06fb9cb393fee75c1d34bfc11ddfe12a7eea0ab6e8f6a25f",
@@ -15,8 +15,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-orchestrator-coordination.md": {
-      "templateHash": "af457dc1cbd53ab37c7f8c202c890e26bf4397be83aca2c66054fb5ccd5d2a30",
-      "size": 71643,
+      "templateHash": "56fd65bd0fd83946bd0b407ab28750197b869e8847c758ba78683a0e97517bd7",
+      "size": 72706,
       "component": "rules"
     },
     ".claude/rules/MUST-intent-transparency.md": {
@@ -60,8 +60,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-sync-verification.md": {
-      "templateHash": "c4f5c8cb1d07f86fc62b45037d1ac8bb52146cb33ea9e0cfe51438695d26fab2",
-      "size": 28511,
+      "templateHash": "95ca6e8884a4710bbd5f2fddb9d4fb84d2736e9050d03cf9a95a05a1719222bf",
+      "size": 29489,
       "component": "rules"
     },
     ".claude/rules/MUST-agent-teams.md": {
@@ -95,8 +95,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-tool-identification.md": {
-      "templateHash": "8cb9a032dd7df1903636618a5eef52880b23b787e5dc3faaf5b41187fb7b71cf",
-      "size": 9674,
+      "templateHash": "22afeca0eb072a8cfb820cbcfdd8a3e796258aa4dca107ffc594c01af0131105",
+      "size": 11404,
       "component": "rules"
     },
     ".claude/rules/SHOULD-verification-ladder.md": {
@@ -105,8 +105,8 @@
       "component": "rules"
     },
     ".claude/rules/SHOULD-memory-integration.md": {
-      "templateHash": "f7342db1d3505903ecaa3fee68ef4280d2a97abf22bc66267f23d06e1478661b",
-      "size": 25084,
+      "templateHash": "b2fe0763a663219302394d4e0f2e7cd891c01836dce62bd308688942106d2bac",
+      "size": 26940,
       "component": "rules"
     },
     ".claude/rules/MUST-enforcement-policy.md": {
@@ -120,8 +120,8 @@
       "component": "rules"
     },
     ".claude/rules/MUST-completion-verification.md": {
-      "templateHash": "a32d9993f60f3035532f6ee129fe88e513f29b602ae5aa225e5afa2f4c5a7707",
-      "size": 55127,
+      "templateHash": "551f4047fe13e6c6b4a49b756bb98c5ec1a468e5c46a9dce72b2f95279c6ba3e",
+      "size": 56596,
       "component": "rules"
     },
     ".claude/agents/be-springboot-expert.md": {
@@ -485,8 +485,8 @@
       "component": "skills"
     },
     ".claude/skills/pipeline/workflows/auto-dev.yaml": {
-      "templateHash": "2ffc67f60ab19e2a43e08cf219c015aaa2a4d4630a3b339504dd45f68cb22813",
-      "size": 41156,
+      "templateHash": "dca4797e26901c81878383a121a33319e21c21c83747bc280a7891318d4aa6b3",
+      "size": 44215,
       "component": "skills"
     },
     ".claude/skills/pipeline/SKILL.md": {
@@ -610,8 +610,8 @@
       "component": "skills"
     },
     ".claude/skills/post-release-followup/SKILL.md": {
-      "templateHash": "3a4038ed9890ab23f9728d1e203b153518454027cd249ea44eea0fcc22a839e8",
-      "size": 7762,
+      "templateHash": "7b414065c2c598bbe237e8209e41923f85edceb5c4ca03f74ff8691632294432",
+      "size": 8496,
       "component": "skills"
     },
     ".claude/skills/analysis/SKILL.md": {
@@ -785,8 +785,8 @@
       "component": "skills"
     },
     ".claude/skills/fsd/SKILL.md": {
-      "templateHash": "6527383ae4182afb28d570cdc9cc83f86a5c90613a88ea402b99acb1b85a45d9",
-      "size": 10678,
+      "templateHash": "7f36423f2e52e9e0d6df2c5c2c84d5e62dba789aa7b58a45bdd1da59ee33fbbd",
+      "size": 14194,
       "component": "skills"
     },
     ".claude/skills/dev-lead-routing/SKILL.md": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "workspaces": [
     "packages/*"
   ],
-  "version": "1.1.60",
+  "version": "1.1.61",
   "description": "Batteries-included agent harness for Claude Code",
   "type": "module",
   "bin": {

--- a/templates/manifest.json
+++ b/templates/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.60",
+  "version": "1.1.61",
   "lastUpdated": "2026-09-03",
   "omcustomMinClaudeCode": "2.1.121",
   "omcustomMinClaudeCodeReason": "Sensitive-path direct Write/Edit on .claude/** under bypassPermissions (R010 deprecation, #1101)",


### PR DESCRIPTION
## v1.1.61 — 회고 제안 5건 반영 + FSD 무인 판별 결정론화

### 변경
- **R011**: 원인 진단 메모리는 코드 경로를 읽고 판정 로직을 1:1 재현하기 전까지 `[hypothesis: …]` 첫 줄 태그로만 저장
- **R020**: 「통계적 상관 ≠ 코드 인과」 행 + Common Violation (#1652 #1)
- **R008**: 단일 스폰도 Core Rule 접두사(Tool 표기 + Agent) 필수. advisor 계수 3종(Tool 라인·Spawning 헤더 폴백·번호 항목) 열거. 정규식 측 대안은 #1650 E로 이월
- **R010**: PPID 스코프 `/tmp` 런타임 마커 carve-out(1줄 신호는 오케스트레이터 직접, 구조화 상태 JSON은 tracker-checkpoint 위임 유지)
- **R017**: auto-dev.yaml docs-only R017 carve-out과의 양방향 참조 소절
- **fsd**: 무인 모드 마커 `/tmp/.claude-fsd-$PPID`(+ `OMCUSTOM_UNATTENDED=1`), 반복마다 갱신, 6시간 stale 가드, 모든 종료 경로(수렴·cap·classifier 차단·인터럽트)에서 정리, homework 제출 게이트 묶음 opt-in(사용자 지시 전용)
- **auto-dev.yaml (4사본)**: pre-triage Phase 0.6이 `unattended_mode`를 실측(항상 rc=0, present/stale/absent), scope-selection Step 3가 그 상태를 사용, substitution 조건 4(같은 세션 triage 대체 시 앵커 재실측 지시), deep-verify lite 분할 표준(R017 sauron 1 + 변경 성격별 적대적 리뷰 1)
- **post-release-followup**: 후속 이슈 본문은 행 번호 대신 함수명·앵커
- **wiki**: 8페이지 재동기화 + `wiki/.source-hashes.json` 재시딩

### 검증
- `bun test` 2472 pass / 0 fail, lint·typecheck exit 0
- verify-template-sync / verify-wiki-sync / validate-docs 통과
- 적대적 리뷰 PASS-with-findings(High 2·Medium 3·Low 3 — 8건 전부 같은 커밋에서 반영), mgr-sauron R017 재검증 PASS
- Phase 0.6 스니펫 양성/음성 짝 검사 5조합(stale 포함) 통과, `command rm -f` 필요성 실측(이 셸의 `rm`은 `trash` alias)

### 이슈
Closes #1652

Refs #1650 — C(무인 판별 결정론화) 완료. A·B·D·E는 `.claude/hooks/**` 승인 대기로 open 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YQdtbGHqVKPFe8S69KseZ
